### PR TITLE
AppEngine: do not use debug mode for WSGIApplication.

### DIFF
--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -223,5 +223,5 @@ if main_domain and redirect_domains:
         ]))
 
 app = webapp2.WSGIApplication(
-    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES, debug=False)
-#    debug=environment.is_running_on_app_engine_development())
+    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES,
+    debug=environment.is_running_on_app_engine_development())

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -223,5 +223,5 @@ if main_domain and redirect_domains:
         ]))
 
 app = webapp2.WSGIApplication(
-    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES,
-    debug=environment.is_running_on_app_engine_development())
+    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES, debug=False)
+#    debug=environment.is_running_on_app_engine_development())

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -70,6 +70,7 @@ from handlers.testcase_detail import remove_group
 from handlers.testcase_detail import remove_issue
 from handlers.testcase_detail import update_from_trunk
 from handlers.testcase_detail import update_issue
+from system import environment
 
 
 class _TrailingSlashRemover(webapp2.RequestHandler):
@@ -222,4 +223,5 @@ if main_domain and redirect_domains:
         ]))
 
 app = webapp2.WSGIApplication(
-    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES, debug=False)
+    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES,
+    debug=environment.is_running_on_app_engine_development())

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -222,4 +222,4 @@ if main_domain and redirect_domains:
         ]))
 
 app = webapp2.WSGIApplication(
-    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES, debug=True)
+    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES, debug=False)


### PR DESCRIPTION
Debug mode enables surfacing stacktraces to the users and maybe some other stuff. I think we log everything into StackDriver, so it's better to return 500 Internal Server Error in case of an exception.