### PR TITLE
Run the linter on CloudBuild CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,26 @@
 # limitations under the License.
 
 steps:
+- id: Initialize git
+  name: gcr.io/cloud-builders/git
+  entrypoint: /bin/bash
+  args:
+  - -exc
+  - |
+    # Cloud Build x GitHub integration uses source archives to fetch
+    # the source, rather than Git source fetching, and as a consequence
+    # does not include the .git/ directory. As a workaround, we clone
+    # the repository to grab the .git directory.
+    git clone 'https://github.com/google/clusterfuzz' tmp
+    git -C tmp fetch origin "$COMMIT_SHA"
+    git -C tmp checkout -qf FETCH_HEAD
+    mv tmp/.git .git
+    rm -rf tmp
+- id: Lint
+  name: 'gcr.io/clusterfuzz-images/ci'
+  args: ['python', 'butler.py', 'lint']
+  env:
+    - 'GOOGLE_CLOUDBUILD=1'
 - name: 'gcr.io/clusterfuzz-images/ci'
   args: ['setup']
 - name: 'gcr.io/clusterfuzz-images/ci'

--- a/src/local/butler/lint.py
+++ b/src/local/butler/lint.py
@@ -21,7 +21,11 @@ from local.butler import common
 
 def execute(_):
   """Lint changed code."""
-  _, output = common.execute('git diff --name-only FETCH_HEAD')
+  if "GOOGLE_CLOUDBUILD" in os.environ:
+    # Explicitly compare against master if we're running on the CI
+    _, output = common.execute('git diff --name-only master FETCH_HEAD')
+  else:
+    _, output = common.execute('git diff --name-only FETCH_HEAD')
 
   py_changed_file_paths = [
       f for f in output.splitlines() if f.endswith('.py') and


### PR DESCRIPTION
This was a quick solution I came up with to run the CI on CloudBuild. Please feel free to close if there's an easier or more straightforward way I'm missing. Here it is in action breaking on the lint step: https://github.com/ammaraskar/clusterfuzz/pull/4

Some things of note:

---

CloudBuild with Github integration actually doesn't pull over the `.git` folder. It simply downloads the source as a tarball (see here: https://github.com/GoogleCloudPlatform/cloud-builders/issues/401)

Thus, I took a note out of the kubernetes example here: https://github.com/GoogleCloudPlatform/marketplace-k8s-app-example/blob/master/cloudbuild.yaml and performed a git clone to get the history out as the first step.

---

For pull requests, I explicitly compare against master which may or may not be good. Unlike say travis which provides a TRAVIS_COMMIT_RANGE [variable](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables), CloudBuild has no way of providing what commits are part of the pull request.