### PR TITLE
Mock data_handler.update_heartbeat in tasks_test.py (#155)

### DIFF
--- a/src/python/tests/appengine/common/tasks_test.py
+++ b/src/python/tests/appengine/common/tasks_test.py
@@ -142,6 +142,7 @@ class GetTaskTest(unittest.TestCase):
     self.assertEqual('test override job', task.payload())
 
 
+@test_utils.with_cloud_emulators('datastore')
 class LeaseTaskTest(unittest.TestCase):
   """Tests for leasing tasks."""
 

--- a/src/python/tests/appengine/common/tasks_test.py
+++ b/src/python/tests/appengine/common/tasks_test.py
@@ -142,7 +142,6 @@ class GetTaskTest(unittest.TestCase):
     self.assertEqual('test override job', task.payload())
 
 
-@test_utils.with_cloud_emulators('datastore')
 class LeaseTaskTest(unittest.TestCase):
   """Tests for leasing tasks."""
 
@@ -151,11 +150,11 @@ class LeaseTaskTest(unittest.TestCase):
 
     helpers.patch(self, [
         'time.time',
+        'data_handler.update_heartbeat'
     ])
 
     self.temp_dir = tempfile.mkdtemp()
     os.environ['CACHE_DIR'] = self.temp_dir
-    os.environ['BOT_NAME'] = 'bot'
 
   def tearDown(self):
     shutil.rmtree(self.temp_dir, ignore_errors=True)

--- a/src/python/tests/appengine/common/tasks_test.py
+++ b/src/python/tests/appengine/common/tasks_test.py
@@ -149,8 +149,8 @@ class LeaseTaskTest(unittest.TestCase):
     helpers.patch_environ(self)
 
     helpers.patch(self, [
+        'datastore.data_handler.update_heartbeat',
         'time.time',
-        'data_handler.update_heartbeat'
     ])
 
     self.temp_dir = tempfile.mkdtemp()

--- a/src/python/tests/appengine/common/tasks_test.py
+++ b/src/python/tests/appengine/common/tasks_test.py
@@ -154,6 +154,7 @@ class LeaseTaskTest(unittest.TestCase):
 
     self.temp_dir = tempfile.mkdtemp()
     os.environ['CACHE_DIR'] = self.temp_dir
+    os.environ['BOT_NAME'] = 'bot'
 
   def tearDown(self):
     shutil.rmtree(self.temp_dir, ignore_errors=True)


### PR DESCRIPTION
* data_handler.update_heartbeat uses time.time() which is mocked in tasks_test and its side_effect
return values order gets messed up. So, mocking update_heartbeat since test just tests tasks's leasing behavior.