### PR TITLE
Don't Use Minijail With AFL

### DIFF
--- a/local/tests/run_afl_tests
+++ b/local/tests/run_afl_tests
@@ -8,4 +8,4 @@ if [ "$(cat /proc/sys/kernel/core_pattern)" != "core" ]; then
 fi
 
 AFL_INTEGRATION_TESTS=1 python butler.py py_unittest \
-    -t core -p '*afl_launcher_integration*' "$@"
+  -t core -p '*afl_launcher_integration*' "$@"

--- a/local/tests/run_afl_tests
+++ b/local/tests/run_afl_tests
@@ -8,4 +8,4 @@ if [ "$(cat /proc/sys/kernel/core_pattern)" != "core" ]; then
 fi
 
 AFL_INTEGRATION_TESTS=1 python butler.py py_unittest \
-  -t core -p '*afl_launcher_integration*' "$@"
+  -t core -p '*afl_launcher_integration*' -m "$@"

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -667,6 +667,8 @@ class AflRunnerCommon(object):
     ]
 
     if use_showmap:
+      # We don't need to pass afl-showmap an input directory or additional afl
+      # arguments (e.g. dict).
       num_executions = '1'
     else:
       afl_args.append(constants.INPUT_FLAG + self.afl_input.input_directory)

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -38,7 +38,6 @@ from datastore import data_types
 from fuzzer import write_dummy_file
 from metrics import logs
 from system import environment
-from system import minijail
 from system import new_process
 from system import shell
 import constants
@@ -58,8 +57,6 @@ BOT_NAME = environment.get_value('BOT_NAME', '')
 STDERR_FILENAME = 'stderr.out'
 
 MAX_OUTPUT_LEN = 1 * 1024 * 1024  # 1 MB
-
-USE_MINIJAIL = environment.get_value('USE_MINIJAIL')
 
 # .options file option for the number of persistent executions.
 PERSISTENT_EXECUTIONS_OPTION = 'n'
@@ -536,12 +533,8 @@ class AflRunnerCommon(object):
     # Initialize _showmap_output_path lazily since MiniJailRunner needs to
     # execute its __init__ before it can be set.
     if self._showmap_output_path is None:
-      if USE_MINIJAIL:
-        self._showmap_output_path = os.path.join(self.chroot.directory,
-                                                 self.SHOWMAP_FILENAME)
-      else:
-        self._showmap_output_path = os.path.join(fuzzer_utils.get_temp_dir(),
-                                                 self.SHOWMAP_FILENAME)
+      self._showmap_output_path = os.path.join(fuzzer_utils.get_temp_dir(),
+                                               self.SHOWMAP_FILENAME)
 
     return self._showmap_output_path
 
@@ -1003,11 +996,7 @@ class AflRunnerCommon(object):
     self.remove_arg(showmap_args, constants.DICT_FLAG)
     self.remove_arg(showmap_args, constants.SKIP_DETERMINISTIC_FLAG)
 
-    # Replace -o argument.
-    if USE_MINIJAIL:
-      showmap_output_path = '/' + self.SHOWMAP_FILENAME
-    else:
-      showmap_output_path = self.showmap_output_path
+    showmap_output_path = self.showmap_output_path
     idx = self.get_arg_index(showmap_args, constants.OUTPUT_FLAG)
     assert idx != -1
     self.set_arg(showmap_args, constants.OUTPUT_FLAG, showmap_output_path)
@@ -1079,19 +1068,6 @@ class AflRunnerCommon(object):
     """Make corpus directories libFuzzer compatible, merge new testcases
     if needed and return the number of new testcases added to corpus.
     """
-    # Remove the input directory binding as it isn't needed for merging and
-    # may actually break merging if it was temporary and gets deleted.
-    if USE_MINIJAIL:
-      input_directory = self.afl_input.input_directory
-      input_bindings = [
-          binding for binding in self.chroot.bindings
-          if binding.src_path == input_directory
-      ]
-
-      assert len(input_bindings) == 1
-      input_binding = input_bindings[0]
-      self.chroot.bindings.remove(input_binding)
-
     self.afl_input.restore_if_needed()
     # Number of new units created during fuzzing.
     new_units_generated = self.afl_output.count_new_units(self.afl_output.queue)
@@ -1123,84 +1099,6 @@ class AflRunner(AflRunnerCommon, new_process.ProcessRunner):
                                     input_directory, afl_tools_path)
 
     new_process.ProcessRunner.__init__(self, self.afl_fuzz_path)
-
-
-class MinijailAflRunner(AflRunnerCommon,
-                        engine_common.MinijailEngineFuzzerRunner):
-  """Minijail AFL runer."""
-
-  def __init__(self,
-               chroot,
-               target_path,
-               config,
-               testcase_file_path,
-               input_directory,
-               afl_tools_path=None):
-    super(MinijailAflRunner,
-          self).__init__(target_path, config, testcase_file_path,
-                         input_directory, afl_tools_path)
-
-    minijail.MinijailProcessRunner.__init__(self, chroot, self.afl_fuzz_path)
-
-  def _get_or_create_chroot_binding(self, corpus_directory):
-    """Return chroot relative paths for the given corpus directories.
-
-    Args:
-      corpus_directories: A list of host corpus directories.
-
-    Returns:
-      A list of chroot relative paths.
-    """
-    chroot_rel_dir = os.path.relpath(corpus_directory, self.chroot.directory)
-    if not chroot_rel_dir.startswith(os.pardir):
-      # Already in chroot.
-      return '/' + chroot_rel_dir
-
-    binding = self.chroot.get_binding(corpus_directory)
-    if binding:
-      return binding.dest_path
-
-    dest_path = '/' + os.path.basename(corpus_directory)
-    self.chroot.add_binding(
-        minijail.ChrootBinding(corpus_directory, dest_path, True))
-
-    return dest_path
-
-  def run_single_testcase(self, testcase_path):
-    with self._chroot_testcase(testcase_path) as chroot_testcase_path:
-      return super(MinijailAflRunner,
-                   self).run_single_testcase(chroot_testcase_path)
-
-  def generate_afl_args(self,
-                        afl_input=None,
-                        afl_output=None,
-                        mem_limit=constants.MAX_MEMORY_LIMIT):
-    """Overriden generate_afl_args."""
-    if afl_input:
-      minijail_afl_input = self._get_or_create_chroot_binding(afl_input)
-    else:
-      minijail_afl_input = self._get_or_create_chroot_binding(
-          self.afl_input.input_directory)
-
-    if afl_output:
-      minijail_afl_output = self._get_or_create_chroot_binding(afl_output)
-    else:
-      minijail_afl_output = self._get_or_create_chroot_binding(
-          self.afl_output.output_directory)
-
-    return super(MinijailAflRunner, self).generate_afl_args(
-        minijail_afl_input, minijail_afl_output, mem_limit)
-
-  @property
-  def stderr_file_path(self):
-    """Overriden stderr_file_path."""
-    return os.path.join(self.chroot.directory, STDERR_FILENAME)
-
-  def set_environment_variables(self):
-    """Overridden set_environment_variables."""
-    super(MinijailAflRunner, self).set_environment_variables()
-    environment.set_value(constants.STDERR_FILENAME_ENV_VAR,
-                          '/' + STDERR_FILENAME)
 
 
 def load_testcase_if_exists(fuzzer_runner, testcase_file_path):
@@ -1343,41 +1241,7 @@ def main(argv):
 
   config = AflConfig.from_target_path(fuzzer_path)
 
-  if USE_MINIJAIL:
-    # Set up chroot and runner.
-    minijail_chroot = minijail.MinijailChroot(
-        base_dir=fuzzer_utils.get_temp_dir())
-
-    build_dir = environment.get_value('BUILD_DIR')
-
-    # While it's possible for dynamic binaries to run without this, they need to
-    # be accessible for symbolization etc. For simplicity we bind BUILD_DIR to
-    # the same location within the chroot, which leaks the directory structure
-    # of CF but this shouldn't be a big deal.
-    minijail_chroot.add_binding(
-        minijail.ChrootBinding(build_dir, build_dir, False))
-
-    # AFL expects various things in /bin.
-    minijail_chroot.add_binding(minijail.ChrootBinding('/bin', '/bin', False))
-
-    # And /usr/bin.
-    minijail_chroot.add_binding(
-        minijail.ChrootBinding('/usr/bin', '/usr/bin', False))
-
-    # Also bind the build dir to /out to make it easier to hardcode references
-    # to data files.
-    minijail_chroot.add_binding(
-        minijail.ChrootBinding(build_dir, '/out', False))
-
-    # map /proc/self/fd -> /dev/fd
-    os.symlink('/proc/self/fd',
-               os.path.join(minijail_chroot.directory, 'dev', 'fd'))
-
-    runner = MinijailAflRunner(minijail_chroot, fuzzer_path, config,
-                               testcase_file_path, input_directory)
-
-  else:
-    runner = AflRunner(fuzzer_path, config, testcase_file_path, input_directory)
+  runner = AflRunner(fuzzer_path, config, testcase_file_path, input_directory)
 
   # Add *SAN_OPTIONS overrides from .options file.
   engine_common.process_sanitizer_options_overrides(fuzzer_path)
@@ -1393,11 +1257,8 @@ def main(argv):
   # Execute afl-fuzz on the fuzzing target.
   fuzz_result = runner.fuzz()
 
-  command = fuzz_result.command
-  if USE_MINIJAIL:
-    command = engine_common.strip_minijail_command(command,
-                                                   runner.afl_fuzz_path)
   # Print info for the fuzzer logs.
+  command = fuzz_result.command
   print('Command: {0}\n'
         'Bot: {1}\n'
         'Time ran: {2}\n').format(

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -669,9 +669,9 @@ class AflRunnerCommon(object):
     if use_showmap:
       num_executions = '1'
     else:
-      num_executions = str(self.config.num_persistent_executions)
-      afl_args.extend(self.config.additional_afl_arguments)
       afl_args.append(constants.INPUT_FLAG + self.afl_input.input_directory)
+      afl_args.extend(self.config.additional_afl_arguments)
+      num_executions = str(self.config.num_persistent_executions)
 
     afl_args.extend([self.target_path, num_executions])
     return afl_args

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -527,7 +527,6 @@ class AflRunnerCommon(object):
                                             self.SHOWMAP_FILENAME)
     self.merge_timeout = engine_common.get_merge_timeout(DEFAULT_MERGE_TIMEOUT)
     self.showmap_no_output_logged = False
-    self._fuzz_args = []
 
   @property
   def stderr_file_path(self):
@@ -902,7 +901,7 @@ class AflRunnerCommon(object):
 
     assert self.initial_max_total_time > 0
 
-    self._fuzz_args = self.generate_afl_args()
+    fuzz_args = self.generate_afl_args()
 
     # Enable AFL's 'quick & dirty mode' which disable deterministic steps if
     # we have already done them. See
@@ -913,9 +912,9 @@ class AflRunnerCommon(object):
     # chance to run again if terminated early. This is only conceivable for
     # fuzzers with large seed corpora and short timeouts.
     if self.afl_input.skip_deterministic:
-      self._fuzz_args.insert(0, constants.SKIP_DETERMINISTIC_FLAG)
+      fuzz_args.insert(0, constants.SKIP_DETERMINISTIC_FLAG)
 
-    return self.run_afl_fuzz(self._fuzz_args)
+    return self.run_afl_fuzz(fuzz_args)
 
   def get_file_features(self, input_file_path, showmap_args):
     """Get the features (edge hit counts) of |input_file_path| using

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -256,10 +256,9 @@ class LauncherTest(unittest.TestCase):
 
     output = run_launcher(testcase_path, 'easy_crash_fuzzer')
     self.assertIn(
-        'Command: {0}/afl-fuzz -i{1}/corpus '
-        '-o{1}/temp-1337/afl_output_dir -mnone '
-        '{0}/easy_crash_fuzzer 2147483647'.format(DATA_DIRECTORY,
-                                                  TEMP_DIRECTORY), output)
+        'Command: {0}/afl-fuzz -mnone -o{1}/temp-1337/afl_output_dir '
+        '-i{1}/corpus {0}/easy_crash_fuzzer 2147483647'.format(
+            DATA_DIRECTORY, TEMP_DIRECTORY), output)
 
     self.assertIn('ERROR: AddressSanitizer: heap-use-after-free on address',
                   output)
@@ -283,10 +282,9 @@ class LauncherTest(unittest.TestCase):
         f.write('A' * 256)
     output = run_launcher(testcase_path, 'test_fuzzer')
     self.assertIn(
-        'Command: {0}/afl-fuzz -d -i{1}/redundant_corpus '
-        '-o{1}/temp-1337/afl_output_dir -mnone '
-        '{0}/test_fuzzer 2147483647'.format(DATA_DIRECTORY, TEMP_DIRECTORY),
-        output)
+        'Command: {0}/afl-fuzz -d -mnone -o{1}/temp-1337/afl_output_dir '
+        '-i{1}/redundant_corpus {0}/test_fuzzer 2147483647'.format(
+            DATA_DIRECTORY, TEMP_DIRECTORY), output)
 
     self.assertIn('Merging corpus.', self.logged_messages)
     self.assertNotIn('Timed out in merge', ' '.join(self.logged_messages))
@@ -299,9 +297,9 @@ class LauncherTest(unittest.TestCase):
     testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
     output = run_launcher(testcase_path, 'test_fuzzer')
     self.assertIn(
-        'Command: {0}/afl-fuzz -i{1}/corpus '
-        '-o{1}/temp-1337/afl_output_dir -mnone '
-        '{0}/test_fuzzer 2147483647'.format(DATA_DIRECTORY, TEMP_DIRECTORY),
+        'Command: {0}/afl-fuzz -mnone -o{1}/temp-1337/afl_output_dir '
+        '-i{1}/corpus {0}/test_fuzzer 2147483647'.format(
+            DATA_DIRECTORY, TEMP_DIRECTORY),
         output)
 
     # New items should've been added to the corpus.
@@ -314,10 +312,9 @@ class LauncherTest(unittest.TestCase):
     testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
     output = run_launcher(testcase_path, 'always_crash_fuzzer')
     self.assertIn(
-        'Command: {0}/afl-fuzz -i{1}/corpus '
-        '-o{1}/temp-1337/afl_output_dir -mnone '
-        '{0}/always_crash_fuzzer 2147483647'.format(DATA_DIRECTORY,
-                                                    TEMP_DIRECTORY), output)
+        'Command: {0}/afl-fuzz -mnone -o{1}/temp-1337/afl_output_dir '
+        '-i{1}/corpus {0}/always_crash_fuzzer 2147483647'.format(
+            DATA_DIRECTORY, TEMP_DIRECTORY), output)
 
     self.assertIn(
         'ERROR: AddressSanitizer: SEGV on unknown address '

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Integration tests for AFL launcher.py."""
 
-import getpass
 import mock
 import os
 import re
@@ -35,18 +34,12 @@ DATA_DIRECTORY = os.path.join(TEST_PATH, 'data')
 
 # Running AFL tests require potential changes to the system, so only run this
 # behind a flag.
-if (environment.get_value('AFL_INTEGRATION_TESTS') and
+if (environment.get_value('INTEGRATION') and
     not environment.get_value('TEST_BOT_ENVIRONMENT')):
   if os.path.exists('/proc/sys/kernel/core_pattern'):
     assert open('/proc/sys/kernel/core_pattern').read().strip() == 'core', (
         'AFL needs core_pattern to be set to core. '
         'Please run \'echo core | sudo tee /proc/sys/kernel/core_pattern\'')
-
-  # mknod needs to run as sudo to create /dev/null and /dev/urandom.
-  print 'AFL integration tests require sudo to run.'
-  SUDO_PASSWORD = getpass.getpass('please enter your password (for sudo): ')
-else:
-  SUDO_PASSWORD = ''
 
 
 def clear_temp_dir():
@@ -142,8 +135,8 @@ def mocked_fuzz(runner):
       command=[], return_code=0, output='', time_executed=1)
 
 
-@unittest.skipIf(not environment.get_value('AFL_INTEGRATION_TESTS'),
-                 'AFL_INTEGRATION_TESTS=1 must be set')
+@unittest.skipIf(not environment.get_value('INTEGRATION'),
+                 'INTEGRATION=1 must be set')
 class LauncherTest(unittest.TestCase):
   """AFL launcher tests."""
 

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -34,7 +34,7 @@ DATA_DIRECTORY = os.path.join(TEST_PATH, 'data')
 
 # Running AFL tests require potential changes to the system, so only run this
 # behind a flag.
-if (environment.get_value('INTEGRATION') and
+if (environment.get_value('AFL_INTEGRATION_TESTS') and
     not environment.get_value('TEST_BOT_ENVIRONMENT')):
   if os.path.exists('/proc/sys/kernel/core_pattern'):
     assert open('/proc/sys/kernel/core_pattern').read().strip() == 'core', (
@@ -135,8 +135,8 @@ def mocked_fuzz(runner):
       command=[], return_code=0, output='', time_executed=1)
 
 
-@unittest.skipIf(not environment.get_value('INTEGRATION'),
-                 'INTEGRATION=1 must be set')
+@unittest.skipIf(not environment.get_value('AFL_INTEGRATION_TESTS'),
+                 'AFL_INTEGRATION_TESTS=1 must be set')
 class LauncherTest(unittest.TestCase):
   """AFL launcher tests."""
 

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -19,7 +19,6 @@ import os
 import re
 import shutil
 import StringIO
-import subprocess
 import unittest
 
 from bot.fuzzers import engine_common

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -145,8 +145,8 @@ def mocked_fuzz(runner):
 
 @unittest.skipIf(not environment.get_value('AFL_INTEGRATION_TESTS'),
                  'AFL_INTEGRATION_TESTS=1 must be set')
-class BaseLauncherTest(unittest.TestCase):
-  """Base AFL launcher tests."""
+class LauncherTest(unittest.TestCase):
+  """AFL launcher tests."""
 
   def setUp(self):
     os.environ['BUILD_DIR'] = DATA_DIRECTORY
@@ -172,7 +172,7 @@ class BaseLauncherTest(unittest.TestCase):
   def tearDown(self):
     clear_temp_dir()
 
-  def _test_abnormal_return_code(self):
+  def test_abnormal_return_code(self):
     """Test that abnormal return codes from single runs of the fuzz target (eg:
     not 0 or 1, which is ASAN's return code for errors) are logged."""
     test_helpers.patch(self, ['metrics.logs.log_error'])
@@ -182,7 +182,17 @@ class BaseLauncherTest(unittest.TestCase):
         'AFL target exited with abnormal exit code: 255.',
         output='ERROR: returning 255\n')
 
-  def _test_libfuzzerize_corpus(self, mock_get_timeout):
+  def test_assert(self):
+    """Tests launcher with a crashing testcase(assert)."""
+    os.environ['ASAN_OPTIONS'] = 'handle_abort=1'
+    testcase_path = setup_testcase_and_corpus('crash', 'empty_corpus')
+    output = run_launcher(testcase_path, 'assert_fail')
+    self.assertIn('Assertion `false\' failed.', output)
+    self.assertIn('ERROR: AddressSanitizer: ABRT on unknown address', output)
+
+  @no_errors
+  @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
+  def test_libfuzzerize_corpus(self, mock_get_timeout):
     """Test that libfuzzerize_corpus properly merges new testcases back into
     the corpus."""
     mock_get_timeout.return_value = get_fuzz_timeout(5.0)
@@ -235,66 +245,6 @@ class BaseLauncherTest(unittest.TestCase):
         sorted(os.listdir(input_corpus)))
     self.assertIn('Merge completed successfully.', self.logged_messages)
 
-
-class TestLauncher(BaseLauncherTest):
-  """AFL launcher tests."""
-
-  def test_abnormal_return_code(self):
-    self._test_abnormal_return_code()
-
-  def test_single_testcase_crash(self):
-    """Tests launcher with a crashing testcase."""
-    testcase_path = setup_testcase_and_corpus('crash', 'empty_corpus')
-    output = run_launcher(testcase_path, 'test_fuzzer')
-    self.assertIn(
-        'ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000',
-        output)
-
-    # Make sure we didn't fuzz.
-    self.assertNotIn('afl-fuzz', output)
-
-  def test_assert(self):
-    """Tests launcher with a crashing testcase(assert)."""
-    os.environ['ASAN_OPTIONS'] = 'handle_abort=1'
-    testcase_path = setup_testcase_and_corpus('crash', 'empty_corpus')
-    output = run_launcher(testcase_path, 'assert_fail')
-    self.assertIn('Assertion `false\' failed.', output)
-    self.assertIn('ERROR: AddressSanitizer: ABRT on unknown address', output)
-
-  @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
-  def test_fuzz_no_crash(self, mock_get_timeout):
-    """Tests fuzzing (no crash)."""
-    mock_get_timeout.return_value = get_fuzz_timeout(5.0)
-    testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
-    output = run_launcher(testcase_path, 'test_fuzzer')
-    self.assertIn(
-        'Command: {0}/afl-fuzz -i{1}/corpus '
-        '-o{1}/temp-1337/afl_output_dir -mnone '
-        '{0}/test_fuzzer 2147483647'.format(DATA_DIRECTORY, TEMP_DIRECTORY),
-        output)
-
-    # New items should've been added to the corpus.
-    self.assertNotEqual(len(os.listdir(os.environ['FUZZ_CORPUS_DIR'])), 0)
-
-  @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
-  def test_fuzz_input_crash(self, mock_get_timeout):
-    """Tests fuzzing (crash in input)."""
-    mock_get_timeout.return_value = get_fuzz_timeout(5.0)
-    testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
-    output = run_launcher(testcase_path, 'always_crash_fuzzer')
-    self.assertIn(
-        'Command: {0}/afl-fuzz -i{1}/corpus '
-        '-o{1}/temp-1337/afl_output_dir -mnone '
-        '{0}/always_crash_fuzzer 2147483647'.format(DATA_DIRECTORY,
-                                                    TEMP_DIRECTORY), output)
-
-    self.assertIn(
-        'ERROR: AddressSanitizer: SEGV on unknown address '
-        '0x000000000000', output)
-
-    # Testcase (non-zero) should've been copied back.
-    self.assertNotEqual(os.path.getsize(testcase_path), 0)
-
   @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
   def test_fuzz_crash(self, mock_get_timeout):
     """Tests fuzzing (crash)."""
@@ -342,44 +292,39 @@ class TestLauncher(BaseLauncherTest):
     self.assertNotIn('Timed out in merge', ' '.join(self.logged_messages))
     self.assertIn('Merge completed successfully.', self.logged_messages)
 
-  @no_errors
   @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
-  def test_libfuzzerize_corpus(self, mock_get_timeout):
-    self._test_libfuzzerize_corpus(mock_get_timeout)
+  def test_fuzz_no_crash(self, mock_get_timeout):
+    """Tests fuzzing (no crash)."""
+    mock_get_timeout.return_value = get_fuzz_timeout(5.0)
+    testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
+    output = run_launcher(testcase_path, 'test_fuzzer')
+    self.assertIn(
+        'Command: {0}/afl-fuzz -i{1}/corpus '
+        '-o{1}/temp-1337/afl_output_dir -mnone '
+        '{0}/test_fuzzer 2147483647'.format(DATA_DIRECTORY, TEMP_DIRECTORY),
+        output)
 
+    # New items should've been added to the corpus.
+    self.assertNotEqual(len(os.listdir(os.environ['FUZZ_CORPUS_DIR'])), 0)
 
-def _run_with_sudo(command):
-  """Run a command (list) with sudo privileges."""
-  print 'Running (with sudo): %s' % ' '.join(command)
-  popen = subprocess.Popen(
-      ['sudo', '-S'] + command,
-      stdin=subprocess.PIPE,
-      stdout=subprocess.PIPE,
-      stderr=subprocess.STDOUT)
-  popen.communicate(input=SUDO_PASSWORD + '\n')
-  assert popen.returncode == 0
+  @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
+  def test_fuzz_input_crash(self, mock_get_timeout):
+    """Tests fuzzing (crash in input)."""
+    mock_get_timeout.return_value = get_fuzz_timeout(5.0)
+    testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
+    output = run_launcher(testcase_path, 'always_crash_fuzzer')
+    self.assertIn(
+        'Command: {0}/afl-fuzz -i{1}/corpus '
+        '-o{1}/temp-1337/afl_output_dir -mnone '
+        '{0}/always_crash_fuzzer 2147483647'.format(DATA_DIRECTORY,
+                                                    TEMP_DIRECTORY), output)
 
+    self.assertIn(
+        'ERROR: AddressSanitizer: SEGV on unknown address '
+        '0x000000000000', output)
 
-def _mknod(_, path, file_type, major, minor):
-  """Creates a special file."""
-  _run_with_sudo(
-      ['mknod', '-m', '666', path, file_type,
-       str(major),
-       str(minor)])
-
-
-class TestLauncherMinijail(BaseLauncherTest):
-  """AFL launcher tests."""
-
-  def setUp(self):
-    super(TestLauncherMinijail, self).setUp()
-    launcher.USE_MINIJAIL = True
-    test_helpers.patch(self, ['system.minijail.MinijailChroot._mknod'])
-
-    self.mock._mknod.side_effect = _mknod  # pylint: disable=protected-access
-
-  def test_abnormal_return_code(self):
-    self._test_abnormal_return_code()
+    # Testcase (non-zero) should've been copied back.
+    self.assertNotEqual(os.path.getsize(testcase_path), 0)
 
   def test_single_testcase_crash(self):
     """Tests launcher with a crashing testcase."""
@@ -391,68 +336,3 @@ class TestLauncherMinijail(BaseLauncherTest):
 
     # Make sure we didn't fuzz.
     self.assertNotIn('afl-fuzz', output)
-
-  @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
-  def test_fuzz_no_crash(self, mock_get_timeout):
-    """Tests fuzzing (no crash)."""
-    mock_get_timeout.return_value = get_fuzz_timeout(5.0)
-    testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
-    output = run_launcher(testcase_path, 'test_fuzzer')
-    self.assertIn(
-        'Command: {0}/afl-fuzz -i/corpus '
-        '-o/afl_output_dir -mnone {0}/test_fuzzer '
-        '2147483647'.format(DATA_DIRECTORY), output)
-
-    # New items should've been added to the corpus.
-    self.assertIn('FUZZ_CORPUS_DIR', os.environ)
-    self.assertNotEqual(len(os.listdir(os.environ['FUZZ_CORPUS_DIR'])), 0)
-
-  @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
-  def test_fuzz_crash(self, mock_get_timeout):
-    """Tests fuzzing (crash)."""
-    # *WARNING* Do not lower the fuzz timeout unless you really know what you
-    # are doing. Doing so will cause the test to fail on rare ocassion, which
-    # will break deploys.
-    mock_get_timeout.return_value = get_fuzz_timeout(90.0)
-    testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
-
-    output = run_launcher(testcase_path, 'easy_crash_fuzzer')
-    self.assertIn(
-        'Command: {0}/afl-fuzz -i/corpus '
-        '-o/afl_output_dir -mnone '
-        '{0}/easy_crash_fuzzer 2147483647'.format(DATA_DIRECTORY), output)
-
-    self.assertIn('ERROR: AddressSanitizer: heap-use-after-free on address',
-                  output)
-
-    # Testcase should've been copied back.
-    self.assertGreaterEqual(os.path.getsize(testcase_path), 3)
-    with open(testcase_path) as f:
-      self.assertEqual(f.read()[:3], 'ABC')
-
-  @no_errors
-  @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
-  def test_fuzz_merge(self, mock_get_timeout):
-    """Tests fuzzing with merge."""
-    mock_get_timeout.return_value = get_fuzz_timeout(5.0)
-    testcase_path = setup_testcase_and_corpus(
-        'empty', 'redundant_corpus', fuzz=True)
-    corpus_path = os.environ['FUZZ_CORPUS_DIR']
-    for i in xrange(100):
-      with open(os.path.join(corpus_path, '%04d' % i), 'w') as f:
-        f.write('A' * 256)
-
-    output = run_launcher(testcase_path, 'test_fuzzer')
-    self.assertIn(
-        'Command: {0}/afl-fuzz -d -i/redundant_corpus '
-        '-o/afl_output_dir -mnone '
-        '{0}/test_fuzzer 2147483647'.format(DATA_DIRECTORY), output)
-
-    self.assertIn('Merging corpus.', self.logged_messages)
-    self.assertNotIn('Timed out in merge', ' '.join(self.logged_messages))
-    self.assertIn('Merge completed successfully.', self.logged_messages)
-
-  @no_errors
-  @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
-  def test_libfuzzerize_corpus(self, mock_get_timeout):
-    self._test_libfuzzerize_corpus(mock_get_timeout)

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -317,6 +317,10 @@ class LauncherTest(unittest.TestCase):
   def test_single_testcase_crash(self):
     """Tests launcher with a crashing testcase."""
     testcase_path = setup_testcase_and_corpus('crash', 'empty_corpus')
+
+    # Save original contents of testcase.
+    with open(testcase_path) as file_handle:
+      testcase_data = file_handle.read()
     output = run_launcher(testcase_path, 'test_fuzzer')
     self.assertIn(
         'ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000',
@@ -324,3 +328,7 @@ class LauncherTest(unittest.TestCase):
 
     # Make sure we didn't fuzz.
     self.assertNotIn('afl-fuzz', output)
+
+    # Ensure the testcase didn't change.
+    with open(testcase_path) as file_handle:
+      self.assertEqual(testcase_data, file_handle.read())

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -299,8 +299,7 @@ class LauncherTest(unittest.TestCase):
     self.assertIn(
         'Command: {0}/afl-fuzz -mnone -o{1}/temp-1337/afl_output_dir '
         '-i{1}/corpus {0}/test_fuzzer 2147483647'.format(
-            DATA_DIRECTORY, TEMP_DIRECTORY),
-        output)
+            DATA_DIRECTORY, TEMP_DIRECTORY), output)
 
     # New items should've been added to the corpus.
     self.assertNotEqual(len(os.listdir(os.environ['FUZZ_CORPUS_DIR'])), 0)


### PR DESCRIPTION
Remove use of minijail when USE_MINIJAIL is True for AFL fuzzing.
Also, refactor code that was made ugly because of minijail, particularly wrt merging the corpus
and AFL argument generation.