### PR TITLE
Don't automatically create buckets when running integration tests.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 steps:
-- id: Initialize git
-  name: gcr.io/cloud-builders/git
+- name: gcr.io/cloud-builders/git
   entrypoint: /bin/bash
   args:
   - -exc
@@ -28,8 +27,7 @@ steps:
     git -C tmp checkout -qf FETCH_HEAD
     mv tmp/.git .git
     rm -rf tmp
-- id: Lint
-  name: 'gcr.io/clusterfuzz-images/ci'
+- name: 'gcr.io/clusterfuzz-images/ci'
   args: ['python', 'butler.py', 'lint']
   env:
     - 'GOOGLE_CLOUDBUILD=1'
@@ -40,6 +38,9 @@ steps:
     - 'bash'
     - '-ex'
     - 'local/tests/run_all_tests'
+  env:
+    - TEST_BLOBS_BUCKET=clusterfuzz-ci-blobs
+    - TEST_BUCKET=clusterfuzz-ci-test
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_32

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,6 +41,10 @@ steps:
   env:
     - TEST_BLOBS_BUCKET=clusterfuzz-ci-blobs
     - TEST_BUCKET=clusterfuzz-ci-test
+    - TEST_CORPUS_BUCKET=clusterfuzz-ci-corpus
+    - TEST_QUARANTINE_BUCKET=clusterfuzz-ci-quarantine
+    - TEST_BACKUP_BUCKET=clusterfuzz-ci-backup
+    - TEST_COVERAGE_BUCKET=clusterfuzz-ci-coverage
 timeout: 3600s
 options:
   machineType: N1_HIGHCPU_32

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
 RUN apt-get update && \
     apt-get install -y \
         git \
+        golang-go \
         google-cloud-sdk-app-engine-go \
         google-cloud-sdk-app-engine-python \
         google-cloud-sdk-app-engine-python-extras \

--- a/src/go/testing/config/config.go
+++ b/src/go/testing/config/config.go
@@ -29,7 +29,7 @@ func IntegrationTestBucketStatic() string {
 // integration tests.
 func IntegrationTestBucketMutable() string {
 	// TODO(ochang): Before running tests, clear this bucket.
-	return os.Getenv("CLUSTERFUZZ_MUTABLE_TEST_BUCKET")
+	return os.Getenv("TEST_BUCKET")
 }
 
 // IntegrationTestsEnabled returns whether or not integration tests are enabled.

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -311,32 +311,26 @@ def has_file_in_path(filename):
   return False
 
 
+def _get_test_bucket(env_var):
+  """Get the integration test bucket."""
+  bucket = os.getenv(env_var)
+  if not bucket:
+    raise RuntimeError(
+        'You need to specify {var} for integration testing'.format(var=env_var))
+
+  return bucket
+
+
 def blobs_bucket_for_user():
   """Get the blobs bucket for the current user. Creates one if it doesn't not
   exist."""
-  blobs_bucket = create_user_bucket('clusterfuzz-testing-blobs')
-  execute('gsutil cors set {cors_file_path} gs://{bucket}'.format(
-      cors_file_path=os.path.join('local', 'blobs_cors.json'),
-      bucket=blobs_bucket))
-
-  return blobs_bucket
+  return _get_test_bucket('TEST_BLOBS_BUCKET')
 
 
 def test_bucket_for_user():
   """Get the test bucket for the current user. Creates one if it doesn't not
   exist."""
-  test_bucket = create_user_bucket('clusterfuzz-testing')
-  return test_bucket
-
-
-def create_user_bucket(bucket):
-  """Create a user-specific bucket for testing purposes."""
-  bucket += '-' + getpass.getuser()
-  execute(
-      'gsutil defstorageclass get gs://{bucket} || '
-      'gsutil mb -p clusterfuzz-testing gs://{bucket}'.format(bucket=bucket))
-
-  return bucket
+  return _get_test_bucket('TEST_BUCKET')
 
 
 def kill_leftover_emulators():

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -320,16 +320,6 @@ def test_bucket(env_var):
   return bucket
 
 
-def blobs_bucket_for_user():
-  """Get the blobs bucket for the current user."""
-  return test_bucket('TEST_BLOBS_BUCKET')
-
-
-def test_bucket_for_user():
-  """Get the test bucket for the current user."""
-  return test_bucket('TEST_BUCKET')
-
-
 def kill_leftover_emulators():
   """Kill leftover instances of cloud emulators and dev_appserver."""
   kill_process('dev_appserver.py')

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -17,7 +17,6 @@
 from __future__ import print_function
 
 import datetime
-import getpass
 import os
 import platform
 import shutil

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -310,7 +310,7 @@ def has_file_in_path(filename):
   return False
 
 
-def _get_test_bucket(env_var):
+def test_bucket(env_var):
   """Get the integration test bucket."""
   bucket = os.getenv(env_var)
   if not bucket:
@@ -321,15 +321,13 @@ def _get_test_bucket(env_var):
 
 
 def blobs_bucket_for_user():
-  """Get the blobs bucket for the current user. Creates one if it doesn't not
-  exist."""
-  return _get_test_bucket('TEST_BLOBS_BUCKET')
+  """Get the blobs bucket for the current user."""
+  return test_bucket('TEST_BLOBS_BUCKET')
 
 
 def test_bucket_for_user():
-  """Get the test bucket for the current user. Creates one if it doesn't not
-  exist."""
-  return _get_test_bucket('TEST_BUCKET')
+  """Get the test bucket for the current user."""
+  return test_bucket('TEST_BUCKET')
 
 
 def kill_leftover_emulators():

--- a/src/local/butler/go_unittest.py
+++ b/src/local/butler/go_unittest.py
@@ -34,11 +34,11 @@ def execute(args):
       '--test_env=CONFIG_DIR_OVERRIDE={config_dir_override} '
       '--test_env=ROOT_DIR={root_dir} '
       '--test_env=INTEGRATION={integration} '
-      '--test_env=CLUSTERFUZZ_MUTABLE_TEST_BUCKET={test_bucket} //...'.format(
+      '--test_env=TEST_BUCKET={test_bucket} //...'.format(
           home=os.getenv('HOME'),
           test_output_arg=test_output_arg,
           config_dir_override=os.path.abspath(os.path.join('configs', 'test')),
           root_dir=os.getenv('ROOT_DIR'),
           integration=os.getenv('INTEGRATION', '0'),
-          test_bucket=common.test_bucket_for_user()),
+          test_bucket=common.test_bucket('TEST_BUCKET')),
       cwd=go_directory)

--- a/src/local/butler/go_unittest.py
+++ b/src/local/butler/go_unittest.py
@@ -28,6 +28,11 @@ def execute(args):
   else:
     test_output_arg = '--test_output=errors'
 
+  if os.getenv('INTEGRATION') == '1':
+    test_bucket = common.test_bucket('TEST_BUCKET')
+  else:
+    test_bucket = ''
+
   common.execute(
       'bazel test --sandbox_writable_path={home} '  # Necessary for gcloud.
       '{test_output_arg} '
@@ -40,5 +45,5 @@ def execute(args):
           config_dir_override=os.path.abspath(os.path.join('configs', 'test')),
           root_dir=os.getenv('ROOT_DIR'),
           integration=os.getenv('INTEGRATION', '0'),
-          test_bucket=common.test_bucket('TEST_BUCKET')),
+          test_bucket=test_bucket),
       cwd=go_directory)

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -236,14 +236,11 @@ def execute(args):
   if os.getenv('INTEGRATION') or os.getenv('UNTRUSTED_RUNNER_TESTS'):
     # Set up per-user buckets used by integration tests.
     os.environ['BLOBS_BUCKET_FOR_TESTING'] = common.blobs_bucket_for_user()
-    os.environ['CORPUS_BUCKET'] = common.create_user_bucket(
-        'clusterfuzz-corpus')
-    os.environ['QUARANTINE_BUCKET'] = common.create_user_bucket(
-        'clusterfuzz-quarantine')
-    os.environ['BACKUP_BUCKET'] = common.create_user_bucket(
-        'clusterfuzz-backup')
-    os.environ['COVERAGE_BUCKET'] = common.create_user_bucket(
-        'clusterfuzz-coverage')
+    os.environ['CORPUS_BUCKET'] = common.test_bucket('TEST_CORPUS_BUCKET')
+    os.environ['QUARANTINE_BUCKET'] = common.test_bucket(
+        'TEST_QUARANTINE_BUCKET')
+    os.environ['BACKUP_BUCKET'] = common.test_bucket('TEST_BACKUP_BUCKET')
+    os.environ['COVERAGE_BUCKET'] = common.test_bucket('TEST_COVERAGE_BUCKET')
 
   # Kill leftover instances of emulators and dev appserver.
   common.kill_leftover_emulators()

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -235,7 +235,6 @@ def execute(args):
 
   if os.getenv('INTEGRATION') or os.getenv('UNTRUSTED_RUNNER_TESTS'):
     # Set up per-user buckets used by integration tests.
-    os.environ['BLOBS_BUCKET_FOR_TESTING'] = common.blobs_bucket_for_user()
     os.environ['CORPUS_BUCKET'] = common.test_bucket('TEST_CORPUS_BUCKET')
     os.environ['QUARANTINE_BUCKET'] = common.test_bucket(
         'TEST_QUARANTINE_BUCKET')

--- a/src/python/google_cloud_utils/storage.py
+++ b/src/python/google_cloud_utils/storage.py
@@ -1078,9 +1078,9 @@ def get_object_size(cloud_storage_file_path):
 def blobs_bucket():
   """Get the blobs bucket name."""
   # Allow tests to override blobs bucket name safely.
-  blobs_bucket_for_testing = environment.get_value('BLOBS_BUCKET_FOR_TESTING')
-  if blobs_bucket_for_testing:
-    return blobs_bucket_for_testing
+  test_blobs_bucket = environment.get_value('TEST_BLOBS_BUCKET')
+  if test_blobs_bucket:
+    return test_blobs_bucket
 
   assert not environment.get_value('PY_UNITTESTS')
   return local_config.ProjectConfig().get('blobs.bucket')

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
@@ -35,9 +35,9 @@ from tests.test_libs import untrusted_runner_helpers
 TEST_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'corpus_pruning_task_data')
 
-TEST_BUCKET_GLOBAL = 'clusterfuzz-test-global-bundle'
-TEST_BUCKET_SHARED = 'clusterfuzz-test-shared-corpus'
-TEST_BUCKET_TEST2_BACKUP = 'clusterfuzz-test2-backup-bucket'
+TEST_GLOBAL_BUCKET = 'clusterfuzz-test-global-bundle'
+TEST_SHARED_BUCKET = 'clusterfuzz-test-shared-corpus'
+TEST2_BACKUP_BUCKET = 'clusterfuzz-test2-backup-bucket'
 
 
 # TODO(unassigned): Support macOS.
@@ -294,7 +294,7 @@ class CorpusPruningTestUntrusted(
         last_run=datetime.datetime.now()).put()
 
     environment.set_value('USE_MINIJAIL', True)
-    environment.set_value('SHARED_CORPUS_BUCKET', TEST_BUCKET_SHARED)
+    environment.set_value('SHARED_CORPUS_BUCKET', TEST_SHARED_BUCKET)
 
     # Set up remote corpora.
     self.corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'test_fuzzer')
@@ -305,7 +305,7 @@ class CorpusPruningTestUntrusted(
     self.quarantine_corpus.rsync_from_disk(
         os.path.join(TEST_DIR, 'quarantine'), delete=True)
 
-    self.mock.get_data_bundle_bucket_name.return_value = TEST_BUCKET_GLOBAL
+    self.mock.get_data_bundle_bucket_name.return_value = TEST_GLOBAL_BUCKET
     data_types.DataBundle(
         name='bundle', is_local=True, sync_to_worker=True).put()
 
@@ -327,7 +327,7 @@ class CorpusPruningTestUntrusted(
     corpus_backup_dir = ('gs://{bucket}/corpus/libfuzzer/test2_fuzzer/')
     gsutil.GSUtilRunner().run_gsutil([
         'cp', (corpus_backup_dir +
-               'backup.zip').format(bucket=TEST_BUCKET_TEST2_BACKUP),
+               'backup.zip').format(bucket=TEST2_BACKUP_BUCKET),
         (corpus_backup_dir +
          '%s.zip' % corpus_backup_date).format(bucket=self.backup_bucket)
     ])

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
@@ -326,8 +326,8 @@ class CorpusPruningTestUntrusted(
         datetime.timedelta(days=data_types.CORPUS_BACKUP_PUBLIC_LOOKBACK_DAYS))
     corpus_backup_dir = ('gs://{bucket}/corpus/libfuzzer/test2_fuzzer/')
     gsutil.GSUtilRunner().run_gsutil([
-        'cp', (corpus_backup_dir +
-               'backup.zip').format(bucket=TEST2_BACKUP_BUCKET),
+        'cp',
+        (corpus_backup_dir + 'backup.zip').format(bucket=TEST2_BACKUP_BUCKET),
         (corpus_backup_dir +
          '%s.zip' % corpus_backup_date).format(bucket=self.backup_bucket)
     ])

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
@@ -35,6 +35,10 @@ from tests.test_libs import untrusted_runner_helpers
 TEST_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'corpus_pruning_task_data')
 
+TEST_BUCKET_GLOBAL = 'clusterfuzz-test-global-bundle'
+TEST_BUCKET_SHARED = 'clusterfuzz-test-shared-corpus'
+TEST_BUCKET_TEST2_BACKUP = 'clusterfuzz-test2-backup-bucket'
+
 
 # TODO(unassigned): Support macOS.
 @test_utils.supported_platforms('LINUX')
@@ -267,8 +271,9 @@ class CorpusPruningTestUntrusted(
     job = data_types.Job(
         name='libfuzzer_asan_job2',
         environment_string=('APP_NAME = test2_fuzzer\n'
-                            'BACKUP_BUCKET = clusterfuzz-test2-backup-bucket\n'
-                            'CORPUS_FUZZER_NAME_OVERRIDE = libfuzzer\n'))
+                            'BACKUP_BUCKET = {backup_bucket}\n'
+                            'CORPUS_FUZZER_NAME_OVERRIDE = libfuzzer\n'.format(
+                                backup_bucket=self.backup_bucket)))
     job.put()
 
     os.environ['PROJECT_NAME'] = 'oss-fuzz'
@@ -289,8 +294,7 @@ class CorpusPruningTestUntrusted(
         last_run=datetime.datetime.now()).put()
 
     environment.set_value('USE_MINIJAIL', True)
-    environment.set_value('SHARED_CORPUS_BUCKET',
-                          'clusterfuzz-test-shared-corpus')
+    environment.set_value('SHARED_CORPUS_BUCKET', TEST_BUCKET_SHARED)
 
     # Set up remote corpora.
     self.corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'test_fuzzer')
@@ -301,8 +305,7 @@ class CorpusPruningTestUntrusted(
     self.quarantine_corpus.rsync_from_disk(
         os.path.join(TEST_DIR, 'quarantine'), delete=True)
 
-    self.mock.get_data_bundle_bucket_name.return_value = (
-        'clusterfuzz-test-global-bundle')
+    self.mock.get_data_bundle_bucket_name.return_value = TEST_BUCKET_GLOBAL
     data_types.DataBundle(
         name='bundle', is_local=True, sync_to_worker=True).put()
 
@@ -321,11 +324,12 @@ class CorpusPruningTestUntrusted(
     corpus_backup_date = (
         datetime.datetime.utcnow().date() -
         datetime.timedelta(days=data_types.CORPUS_BACKUP_PUBLIC_LOOKBACK_DAYS))
-    corpus_backup_dir = (
-        'gs://clusterfuzz-test2-backup-bucket/corpus/libfuzzer/test2_fuzzer/')
+    corpus_backup_dir = ('gs://{bucket}/corpus/libfuzzer/test2_fuzzer/')
     gsutil.GSUtilRunner().run_gsutil([
-        'cp', (corpus_backup_dir + 'backup.zip'),
-        (corpus_backup_dir + '%s.zip' % corpus_backup_date)
+        'cp', (corpus_backup_dir +
+               'backup.zip').format(bucket=TEST_BUCKET_TEST2_BACKUP),
+        (corpus_backup_dir +
+         '%s.zip' % corpus_backup_date).format(bucket=self.backup_bucket)
     ])
 
   def tearDown(self):

--- a/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -42,6 +42,8 @@ TEST_FILE_CONTENTS = ('A' * config.FILE_TRANSFER_CHUNK_SIZE +
                       'B' * config.FILE_TRANSFER_CHUNK_SIZE +
                       'C' * (config.FILE_TRANSFER_CHUNK_SIZE / 2))
 
+TEST_BUCKET_BUNDLE = 'cf_test_bundle'
+
 
 def _dirs_equal(dircmp):
   if dircmp.left_only or dircmp.right_only or dircmp.diff_files:
@@ -507,7 +509,7 @@ class UntrustedRunnerIntegrationTest(
 
   def test_update_data_bundle(self):
     """Test update_data_bundle."""
-    self.mock.get_data_bundle_bucket_name.return_value = 'cf_test_bundle'
+    self.mock.get_data_bundle_bucket_name.return_value = TEST_BUCKET_BUNDLE
     fuzzer = data_types.Fuzzer.query(data_types.Fuzzer.name == 'fuzzer').get()
     bundle = data_types.DataBundle.query(
         data_types.DataBundle.name == 'bundle').get()

--- a/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -42,7 +42,7 @@ TEST_FILE_CONTENTS = ('A' * config.FILE_TRANSFER_CHUNK_SIZE +
                       'B' * config.FILE_TRANSFER_CHUNK_SIZE +
                       'C' * (config.FILE_TRANSFER_CHUNK_SIZE / 2))
 
-TEST_BUCKET_BUNDLE = 'cf_test_bundle'
+TEST_BUNDLE_BUCKET = 'clusterfuzz-test-bundle'
 
 
 def _dirs_equal(dircmp):
@@ -509,7 +509,7 @@ class UntrustedRunnerIntegrationTest(
 
   def test_update_data_bundle(self):
     """Test update_data_bundle."""
-    self.mock.get_data_bundle_bucket_name.return_value = TEST_BUCKET_BUNDLE
+    self.mock.get_data_bundle_bucket_name.return_value = TEST_BUNDLE_BUCKET
     fuzzer = data_types.Fuzzer.query(data_types.Fuzzer.name == 'fuzzer').get()
     bundle = data_types.DataBundle.query(
         data_types.DataBundle.name == 'bundle').get()

--- a/src/python/tests/core/google_cloud_utils/blobs_test.py
+++ b/src/python/tests/core/google_cloud_utils/blobs_test.py
@@ -40,6 +40,7 @@ class BlobsTest(unittest.TestCase):
     ])
 
     self.mock.is_running_on_app_engine.return_value = True
+    os.environ['TEST_BLOBS_BUCKET'] = 'blobs-bucket'
 
     blobs.BlobInfo(
         id='legacyblobkey',

--- a/src/python/tests/core/google_cloud_utils/blobs_test.py
+++ b/src/python/tests/core/google_cloud_utils/blobs_test.py
@@ -40,8 +40,6 @@ class BlobsTest(unittest.TestCase):
         'google_cloud_utils.storage.get',
     ])
 
-    os.environ['BLOBS_BUCKET_FOR_TESTING'] = 'blobs-bucket'
-
     self.mock.is_running_on_app_engine.return_value = True
 
     blobs.BlobInfo(

--- a/src/python/tests/core/google_cloud_utils/blobs_test.py
+++ b/src/python/tests/core/google_cloud_utils/blobs_test.py
@@ -14,7 +14,6 @@
 """Tests for blobs."""
 
 import mock
-import os
 import unittest
 
 from google_cloud_utils import blobs

--- a/src/python/tests/core/google_cloud_utils/blobs_test.py
+++ b/src/python/tests/core/google_cloud_utils/blobs_test.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 """Tests for blobs."""
 
-import mock
+import os
 import unittest
+
+import mock
 
 from google_cloud_utils import blobs
 from tests.test_libs import helpers


### PR DESCRIPTION
Require env vars instead:
- TEST_BLOBS_BUCKET
- TEST_BUCKET
- TEST_CORPUS_BUCKET
- TEST_QUARANTINE_BUCKET
- TEST_BACKUP_BUCKET
- TEST_COVERAGE_BUCKET

Also make it clearer which read-only test buckets we depend on in test, and fix corpus pruning task test to use own backup bucket rather than a global one.