### PR TITLE
correct odd bug in oss_fuzz_setup

### DIFF
--- a/src/appengine/handlers/cron/oss_fuzz_setup.py
+++ b/src/appengine/handlers/cron/oss_fuzz_setup.py
@@ -149,8 +149,7 @@ def _get_build_bucket_for_engine(engine):
   if engine == 'none':
     return NO_ENGINE_BUILD_BUCKET
 
-  assert OssFuzzSetupException('Invalid fuzzing engine.')
-  return None  # Otherwise pylint is not happy.
+  raise OssFuzzSetupException('Invalid fuzzing engine.')
 
 
 def _to_experimental_job(job_info):


### PR DESCRIPTION
assert exception was used instead of raise exception. the assert would always pass because the exception is always truthy