### PR TITLE
Fix stack overflow caused by rewrapping sys.stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Next Version
 
+- Bug fix to prevent local development from breaking after running for a long time.
+
 ## Version 1.0.1
 - Bug fixes to improve local development.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log
 
 ## Next Version
 
-- Bug fix to prevent local development from breaking after running for a long time.
+- Bug fixes to improve local development.
 
 ## Version 1.0.1
 - Bug fixes to improve local development.

--- a/src/python/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -138,11 +138,14 @@ def chrome_dsym_hints(binary):
 
 def disable_buffering():
   """Make this process and child processes stdout unbuffered."""
-  if not os.environ.get('PYTHONUNBUFFERED'):
-    # Since sys.stdout is a C++ object, it's impossible to do
-    # sys.stdout.write = lambda...
+  os.environ['PYTHONUNBUFFERED'] = 'x'
+
+  if not isinstance(sys.stdout, LineBuffered):
+    # Don't wrap sys.stdout if it is already wrapped.
+    # See https://github.com/google/clusterfuzz/issues/234 for why.
+    # Since sys.stdout is a C++ object, it's impossible to do sys.stdout.write =
+    # lambda...
     sys.stdout = LineBuffered(sys.stdout)
-    os.environ['PYTHONUNBUFFERED'] = 'x'
 
 
 def fix_filename(file_name):

--- a/src/python/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -138,7 +138,7 @@ def chrome_dsym_hints(binary):
 
 def disable_buffering():
   """Make this process and child processes stdout unbuffered."""
-  os.environ['PYTHONUNBUFFERED'] = 'x'
+  os.environ['PYTHONUNBUFFERED'] = '1'
 
   if not isinstance(sys.stdout, LineBuffered):
     # Don't wrap sys.stdout if it is already wrapped.


### PR DESCRIPTION
Fixes #234
Don't wrap `sys.stdout` if it is already wrapped. 
Previous assumptions that it would only be wrapped if env var `PYTHONUNBUFFERED` was set, this is no longer true, so explicitly check if it is already wrapped before wrapping.

