### PR TITLE
Add a CSP builder class and use it to generate policy.

### DIFF
--- a/src/appengine/libs/csp.py
+++ b/src/appengine/libs/csp.py
@@ -1,0 +1,104 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers used to generate Content Security Policies for pages."""
+import collections
+
+
+class CSPBuilder(object):
+  """Helper to build a Content Security Policy string."""
+
+  def __init__(self):
+    self.directives = collections.defaultdict(list)
+
+  def add(self, directive, source, quote=False):
+    """Add a source for a given directive."""
+    # Some values for sources are expected to be quoted. No escaping is done
+    # since these are specific literal values that don't require it.
+    if quote:
+      source = '\'{}\''.format(source)
+
+    assert source not in self.directives[directive], (
+        'Duplicate source "{source}" for directive "{directive}"'.format(
+            source=source, directive=directive))
+    self.directives[directive].append(source)
+
+  def remove(self, directive, source, quote=False):
+    """Remove a source for a given directive."""
+    if quote:
+      source = '\'{}\''.format(source)
+
+    assert source in self.directives[directive], (
+        'Removing nonexistent "{source}" for directive "{directive}"'.format(
+            source=source, directive=directive))
+    self.directives[directive].remove(source)
+
+  def __str__(self):
+    """Convert to a string to send with a Content-Security-Policy header."""
+    parts = []
+
+    # Sort directives for deterministic results.
+    for directive, sources in sorted(self.directives.items()):
+      # Each policy part has the form "directive source1 source2 ...;".
+      parts.append(' '.join([directive] + sources) + ';')
+
+    return ' '.join(parts)
+
+
+def get_default_builder():
+  """Get a CSPBuilder object for the default policy.
+
+  Can be modified for specific pages if needed."""
+  builder = CSPBuilder()
+
+  # By default, disallow everything. Whitelist only features that are needed.
+  builder.add('default-src', 'none', quote=True)
+
+  # Allow various directives if sourced from self.
+  builder.add('font-src', 'self', quote=True)
+  builder.add('connect-src', 'self', quote=True)
+  builder.add('img-src', 'self', quote=True)
+  builder.add('manifest-src', 'self', quote=True)
+
+  # External scripts. Google analytics and charting libraries we depend on.
+  builder.add('script-src', 'www.google-analytics.com')
+  builder.add('script-src', 'www.gstatic.com')
+
+  # External style. Used for fonts and charting libraries.
+  builder.add('style-src', 'fonts.googleapis.com')
+  builder.add('style-src', 'www.gstatic.com')
+
+  # External fonts.
+  builder.add('font-src', 'fonts.gstatic.com')
+
+  # Some upload forms require us to connect to the cloud storage API.
+  builder.add('connect-src', 'storage.googleapis.com')
+
+  # TODO(mbarbella): Try to improve the policy by limiting the additions below.
+
+  # Because we use Polymer Bundler to create large files containing all of our
+  # scripts inline, our policy requires this (which weakens CSP significantly).
+  builder.add('script-src', 'unsafe-inline', quote=True)
+
+  # Some of the pages that read responses from json handlers require this.
+  builder.add('script-src', 'unsafe-eval', quote=True)
+
+  # Our Polymer Bundler usage also requires inline style.
+  builder.add('style-src', 'unsafe-inline', quote=True)
+
+  return builder
+
+
+def get_default():
+  """Get the default Content Security Policy as a string."""
+  return str(get_default_builder())

--- a/src/appengine/libs/handler.py
+++ b/src/appengine/libs/handler.py
@@ -27,6 +27,7 @@ from config import db_config
 from config import local_config
 from datastore import data_types
 from libs import access
+from libs import csp
 from libs import helpers
 from system import environment
 
@@ -39,16 +40,6 @@ CLUSTERFUZZ_AUTHORIZATION_HEADER = 'x-clusterfuzz-authorization'
 CLUSTERFUZZ_AUTHORIZATION_IDENTITY = 'x-clusterfuzz-identity'
 VERIFICATION_CODE_PREFIX = 'VerificationCode '
 BEARER_PREFIX = 'Bearer '
-
-DEFAULT_CSP = (
-    'default-src \'none\'; '
-    'script-src \'unsafe-inline\' \'unsafe-eval\' '
-    'www.google-analytics.com www.gstatic.com; '
-    'style-src \'unsafe-inline\' fonts.googleapis.com www.gstatic.com; '
-    'font-src \'self\' fonts.gstatic.com; '
-    'connect-src \'self\' storage.googleapis.com; '
-    'img-src \'self\'; '
-    'manifest-src \'self\';')
 
 _auth_config_obj = None
 
@@ -364,7 +355,7 @@ def post(request_content_type, response_content_type):
       elif response_content_type == TEXT:
         self.response.headers['Content-Type'] = 'text/plain'
       elif response_content_type == HTML:
-        self.response.headers['Content-Security-Policy'] = DEFAULT_CSP
+        self.response.headers['Content-Security-Policy'] = csp.get_default()
 
       if request_content_type == JSON:
         extend_json_request(self.request)
@@ -392,7 +383,7 @@ def get(response_content_type):
       elif response_content_type == TEXT:
         self.response.headers['Content-Type'] = 'text/plain'
       elif response_content_type == HTML:
-        self.response.headers['Content-Security-Policy'] = DEFAULT_CSP
+        self.response.headers['Content-Security-Policy'] = csp.get_default()
 
       extend_request(self.request, self.request.params)
       return func(self, *args, **kwargs)

--- a/src/python/tests/appengine/libs/csp_test.py
+++ b/src/python/tests/appengine/libs/csp_test.py
@@ -1,0 +1,72 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for CSP."""
+
+import unittest
+
+from libs import csp
+
+
+class CSPBuilderTest(unittest.TestCase):
+  """Tests for CSPBuilder."""
+
+  def test_simple_policy(self):
+    """Ensure that generating a simple policy works as expected."""
+    builder = csp.CSPBuilder()
+
+    builder.add('default-src', 'none', quote=True)
+    builder.add('connect-src', 'self', quote=True)
+    builder.add('script-src', 'self', quote=True)
+    builder.add('script-src', 'scripts.test.tld')
+
+    self.assertEqual(
+        str(builder), "connect-src 'self'; default-src 'none'; "
+        "script-src 'self' scripts.test.tld;")
+
+  def test_policy_modification(self):
+    """Ensure that policies can be modified."""
+    builder = csp.CSPBuilder()
+
+    builder.add('default-src', 'none', quote=True)
+    builder.add('script-src', 'self', quote=True)
+    builder.add('script-src', 'unsafe-inline', quote=True)
+    builder.add('script-src', 'external.site')
+    self.assertEqual(
+        str(builder),
+        "default-src 'none'; script-src 'self' 'unsafe-inline' external.site;")
+
+    builder.remove('script-src', 'unsafe-inline', quote=True)
+    builder.remove('script-src', 'external.site')
+    self.assertEqual(str(builder), "default-src 'none'; script-src 'self';")
+
+  def test_exception_on_duplicate_add(self):
+    """Ensure that an exception is thrown if we add a duplicate item."""
+    builder = csp.CSPBuilder()
+    builder.add('default-src', 'none', quote=True)
+
+    with self.assertRaises(AssertionError):
+      builder.add('default-src', 'none', quote=True)
+
+  def test_exception_on_bad_removal(self):
+    """Ensure that an exception is thrown if we remove a nonexistent item."""
+    builder = csp.CSPBuilder()
+
+    builder.add('default-src', 'none', quote=True)
+    builder.remove('default-src', 'none', quote=True)
+
+    with self.assertRaises(AssertionError):
+      builder.remove('default-src', 'none', quote=True)
+
+    with self.assertRaises(AssertionError):
+      builder.remove('script-src', 'unadded.domain')


### PR DESCRIPTION
This serves a few purposes:
* It is now easier to add a specific policy to a page (though we don't
do this yet).
* When we do use page-specific (or project-specific) policies, they
can build off of the default instead of duplicating the entire policy
with small modifications.
* The policy is explained better through comments in the
get_default_builder function.