### PR TITLE
Use empty directory for config (#244)

### DIFF
--- a/docs/production-setup/clusterfuzz.md
+++ b/docs/production-setup/clusterfuzz.md
@@ -65,7 +65,7 @@ This script also creates a config directory for you, which contains some default
 settings for your deployment and can be later updated.
 
 ```bash
-mkdir /path/to/myconfig  # Any directory outside the ClusterFuzz source repository will work.
+mkdir /path/to/myconfig  # Any EMPTY directory outside the ClusterFuzz source repository.
 export CONFIG_DIR=/path/to/myconfig
 python butler.py create_config --oauth-client-secrets-path=$CLIENT_SECRETS_PATH --project-id=$CLOUD_PROJECT_ID $CONFIG_DIR
 ```


### PR DESCRIPTION
To avoid confusion with putting creds initially in a config directory, that get deleted by create_config command