### PR TITLE
 Add reporting for CSP violations.

### DIFF
--- a/src/appengine/handlers/csp_reports.py
+++ b/src/appengine/handlers/csp_reports.py
@@ -26,11 +26,13 @@ class CspReportHandler(base_handler.Handler):
     logs.log_error('CSP violation: {}'.format(self.request.get('csp-report')))
 
   @handler.get(handler.JSON)
+  @handler.check_user_access(need_privileged_access=False)
   def get(self):
     """Handle a GET request."""
     self.log_csp_violation()
 
   @handler.post(handler.JSON, handler.JSON)
+  @handler.check_user_access(need_privileged_access=False)
   def post(self):
     """Handle a POST request."""
     self.log_csp_violation()

--- a/src/appengine/handlers/csp_reports.py
+++ b/src/appengine/handlers/csp_reports.py
@@ -1,0 +1,36 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Log incoming reports of CSP violations.."""
+
+from handlers import base_handler
+from libs import handler
+from metrics import logs
+
+
+class CspReportHandler(base_handler.Handler):
+  """Redirect to documentation."""
+
+  def log_csp_violation(self):
+    """Create an error log for a CSP violation."""
+    logs.log_error('CSP violation: {}'.format(self.request.get('csp-report')))
+
+  @handler.get(handler.JSON)
+  def get(self):
+    """Handle a GET request."""
+    self.log_csp_violation()
+
+  @handler.post(handler.JSON, handler.JSON)
+  def post(self):
+    """Handle a POST request."""
+    self.log_csp_violation()

--- a/src/appengine/handlers/report_csp_failure.py
+++ b/src/appengine/handlers/report_csp_failure.py
@@ -20,7 +20,7 @@ from metrics import logs
 
 
 class ReportCspFailureHandler(base_handler.Handler):
-  """Redirect to documentation."""
+  """Log failures on HTML pages caused by CSP."""
 
   @handler.post(handler.JSON, handler.JSON)
   @handler.check_user_access(need_privileged_access=False)

--- a/src/appengine/handlers/report_csp_failure.py
+++ b/src/appengine/handlers/report_csp_failure.py
@@ -15,24 +15,19 @@
 
 from handlers import base_handler
 from libs import handler
+from libs import helpers
 from metrics import logs
 
 
-class CspReportHandler(base_handler.Handler):
+class ReportCspFailureHandler(base_handler.Handler):
   """Redirect to documentation."""
-
-  def log_csp_violation(self):
-    """Create an error log for a CSP violation."""
-    logs.log_error('CSP violation: {}'.format(self.request.get('csp-report')))
-
-  @handler.get(handler.JSON)
-  @handler.check_user_access(need_privileged_access=False)
-  def get(self):
-    """Handle a GET request."""
-    self.log_csp_violation()
 
   @handler.post(handler.JSON, handler.JSON)
   @handler.check_user_access(need_privileged_access=False)
   def post(self):
     """Handle a POST request."""
-    self.log_csp_violation()
+    report = self.request.get('csp-report')
+    if not report:
+      raise helpers.EarlyExitException('No CSP report.', 400)
+
+    logs.log_error('CSP violation: {}'.format(report))

--- a/src/appengine/libs/csp.py
+++ b/src/appengine/libs/csp.py
@@ -33,6 +33,13 @@ class CSPBuilder(object):
             source=source, directive=directive))
     self.directives[directive].append(source)
 
+  def add_sourceless(self, directive):
+    assert directive not in self.directives, (
+        'Sourceless directive "{directive}" already exists.'.format(
+            directive=directive))
+
+    self.directives[directive] = []
+
   def remove(self, directive, source, quote=False):
     """Remove a source for a given directive."""
     if quote:
@@ -83,6 +90,18 @@ def get_default_builder():
 
   # Some upload forms require us to connect to the cloud storage API.
   builder.add('connect-src', 'storage.googleapis.com')
+
+  # Mixed content is unexpected and should be considered a bug.
+  builder.add_sourceless('block-all-mixed-content')
+
+  # We don't expect object to be used, but it doesn't fall back to default-src.
+  builder.add('object-src', 'none', quote=True)
+
+  # We don't expect workers to be used, but they fall back to script-src.
+  builder.add('worker-src', 'none', quote=True)
+
+  # Add reporting so that violations don't break things silently.
+  builder.add('report-uri', '/csp-reports')
 
   # TODO(mbarbella): Try to improve the policy by limiting the additions below.
 

--- a/src/appengine/libs/csp.py
+++ b/src/appengine/libs/csp.py
@@ -101,7 +101,7 @@ def get_default_builder():
   builder.add('worker-src', 'none', quote=True)
 
   # Add reporting so that violations don't break things silently.
-  builder.add('report-uri', '/csp-reports')
+  builder.add('report-uri', '/report-csp-failure')
 
   # TODO(mbarbella): Try to improve the policy by limiting the additions below.
 

--- a/src/appengine/libs/csp.py
+++ b/src/appengine/libs/csp.py
@@ -91,8 +91,8 @@ def get_default_builder():
   # Some upload forms require us to connect to the cloud storage API.
   builder.add('connect-src', 'storage.googleapis.com')
 
-  # Mixed content is unexpected and should be considered a bug.
-  builder.add_sourceless('block-all-mixed-content')
+  # Mixed content is unexpected, but upgrade requests rather than block.
+  builder.add_sourceless('upgrade-insecure-requests')
 
   # We don't expect object to be used, but it doesn't fall back to default-src.
   builder.add('object-src', 'none', quote=True)

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -25,6 +25,7 @@ from handlers import configuration
 from handlers import corpora
 from handlers import coverage_report
 from handlers import crash_stats
+from handlers import csp_reports
 from handlers import domain_verifier
 from handlers import download
 from handlers import fuzzer_stats
@@ -162,6 +163,7 @@ _ROUTES = [
     ('/corpora', corpora.Handler),
     ('/corpora/create', corpora.CreateHandler),
     ('/corpora/delete', corpora.DeleteHandler),
+    ('/csp-reports', csp_reports.CspReportHandler),
     ('/docs', help_redirector.DocumentationHandler),
     ('/download/?([^/]+)?', download.Handler),
     ('/fuzzers', fuzzers.Handler),

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -25,7 +25,6 @@ from handlers import configuration
 from handlers import corpora
 from handlers import coverage_report
 from handlers import crash_stats
-from handlers import csp_reports
 from handlers import domain_verifier
 from handlers import download
 from handlers import fuzzer_stats
@@ -36,6 +35,7 @@ from handlers import home
 from handlers import issue_redirector
 from handlers import jobs
 from handlers import parse_stacktrace
+from handlers import report_csp_failure
 from handlers import revisions_info
 from handlers import testcase_list
 from handlers import upload_testcase
@@ -163,7 +163,6 @@ _ROUTES = [
     ('/corpora', corpora.Handler),
     ('/corpora/create', corpora.CreateHandler),
     ('/corpora/delete', corpora.DeleteHandler),
-    ('/csp-reports', csp_reports.CspReportHandler),
     ('/docs', help_redirector.DocumentationHandler),
     ('/download/?([^/]+)?', download.Handler),
     ('/fuzzers', fuzzers.Handler),
@@ -182,6 +181,7 @@ _ROUTES = [
     ('/update-job-template', jobs.UpdateJobTemplate),
     ('/parse_stacktrace', parse_stacktrace.Handler),
     ('/performance-report/(.+)/(.+)/(.+)', show_performance_report.Handler),
+    ('/report-csp-failure', report_csp_failure.ReportCspFailureHandler),
     ('/testcase', show_testcase.DeprecatedHandler),
     ('/testcase-detail/([0-9]+)', show_testcase.Handler),
     ('/testcase-detail/crash-stats', crash_stats_on_testcase.Handler),

--- a/src/python/tests/appengine/libs/csp_test.py
+++ b/src/python/tests/appengine/libs/csp_test.py
@@ -29,11 +29,11 @@ class CSPBuilderTest(unittest.TestCase):
     builder.add('connect-src', 'self', quote=True)
     builder.add('script-src', 'self', quote=True)
     builder.add('script-src', 'scripts.test.tld')
-    builder.add_sourceless('block-all-mixed-content')
+    builder.add_sourceless('upgrade-insecure-requests')
 
     self.assertEqual(
-        str(builder), "block-all-mixed-content; connect-src 'self'; "
-        "default-src 'none'; script-src 'self' scripts.test.tld;")
+        str(builder), "connect-src 'self'; default-src 'none'; "
+        "script-src 'self' scripts.test.tld; upgrade-insecure-requests;")
 
   def test_policy_modification(self):
     """Ensure that policies can be modified."""

--- a/src/python/tests/appengine/libs/csp_test.py
+++ b/src/python/tests/appengine/libs/csp_test.py
@@ -29,10 +29,11 @@ class CSPBuilderTest(unittest.TestCase):
     builder.add('connect-src', 'self', quote=True)
     builder.add('script-src', 'self', quote=True)
     builder.add('script-src', 'scripts.test.tld')
+    builder.add_sourceless('block-all-mixed-content')
 
     self.assertEqual(
-        str(builder), "connect-src 'self'; default-src 'none'; "
-        "script-src 'self' scripts.test.tld;")
+        str(builder), "block-all-mixed-content; connect-src 'self'; "
+        "default-src 'none'; script-src 'self' scripts.test.tld;")
 
   def test_policy_modification(self):
     """Ensure that policies can be modified."""
@@ -58,6 +59,13 @@ class CSPBuilderTest(unittest.TestCase):
     with self.assertRaises(AssertionError):
       builder.add('default-src', 'none', quote=True)
 
+    with self.assertRaises(AssertionError):
+      builder.add_sourceless('default-src')
+
+    builder.add_sourceless('block-all-mixed-content')
+    with self.assertRaises(AssertionError):
+      builder.add_sourceless('block-all-mixed-content')
+
   def test_exception_on_bad_removal(self):
     """Ensure that an exception is thrown if we remove a nonexistent item."""
     builder = csp.CSPBuilder()
@@ -70,3 +78,7 @@ class CSPBuilderTest(unittest.TestCase):
 
     with self.assertRaises(AssertionError):
       builder.remove('script-src', 'unadded.domain')
+
+  def test_no_exception_from_default_policy(self):
+    """Ensure that no exceptions are raised building the default policy."""
+    csp.get_default()


### PR DESCRIPTION
This still needs some testing to ensure the policy changes don't break anything, but the reporting aspect of it should be ready for review. A few of the policy changes have some pretty nice benefits.

PTAL when you have time. I'll ensure that pages don't break on staging before landing.