### PR TITLE
Copy third_party/ directory to appengine/ instead of symlinking.

### DIFF
--- a/src/local/butler/appengine.py
+++ b/src/local/butler/appengine.py
@@ -120,7 +120,11 @@ def symlink_dirs():
   common.symlink(
       src=os.path.join('src', 'python'),
       target=os.path.join(SRC_DIR_PY, 'python'))
-  common.symlink(
+  # While importing third party modules, we may call pkg_resources.
+  # pkg_resources normalizes paths by calling os.path.realpath on them, which is
+  # incompatible with the App Engine sandbox since the resulting path will no
+  # longer be under appengine/.
+  common.copy_dir(
       src=os.path.join('src', 'third_party'),
       target=os.path.join(SRC_DIR_PY, 'third_party'))
 

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -300,6 +300,17 @@ def symlink(src, target):
       src=src, target=target))
 
 
+def copy_dir(src, target):
+  """Copy directory."""
+  if os.path.islink(target):
+    os.remove(target)
+
+  if os.path.isdir(target):
+    shutil.rmtree(target, ignore_errors=True)
+
+  shutil.copytree(src, target)
+
+
 def has_file_in_path(filename):
   """Check to see if filename exists in the user's PATH."""
   path = os.getenv('PATH')


### PR DESCRIPTION
A recent change somewhere seems to have surfaced an issue with
the dev_appserver sandbox preventing packages from being found properly.

Fixes #258.