### PR TITLE
Fix launcher handling

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -33,7 +33,6 @@ from base import retry
 from config import local_config
 from metrics import logs
 from system import environment
-from system import shell
 
 try:
   import psutil
@@ -306,21 +305,6 @@ def get_file_contents_with_fatal_error_on_failure(path):
     logs.log_error('Unable to read file `%s\'' % path)
 
   raise errors.BadStateError
-
-
-def get_execute_command(file_to_execute):
-  """Return command to execute |file_to_execute|."""
-  interpreter_path = shell.get_interpreter_for_command(file_to_execute)
-
-  # Hack for Java scripts.
-  file_to_execute = file_to_execute.replace('.class', '')
-
-  if interpreter_path:
-    execute_command = '%s %s' % (interpreter_path, file_to_execute)
-  else:
-    # Handle executables that don't need an interpreter.
-    execute_command = file_to_execute
-  return execute_command
 
 
 def get_line_seperator(label=''):

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -308,15 +308,19 @@ def get_file_contents_with_fatal_error_on_failure(path):
   raise errors.BadStateError
 
 
-def get_launch_path_for_script(script_directory, script_filename):
-  """Return launch path for a script."""
-  # Hack for Java Scripts.
-  script_filename = script_filename.replace('.class', '')
+def get_execute_command(file_to_execute):
+  """Return command to execute |file_to_execute|."""
+  interpreter_path = shell.get_interpreter_for_command(file_to_execute)
 
-  interpreter_path = shell.get_interpreter_for_command(script_filename)
-  script_absolute_path = os.path.join(script_directory, script_filename)
-  script_launch_path = '%s %s' % (interpreter_path, script_absolute_path)
-  return script_launch_path
+  # Hack for Java scripts.
+  file_to_execute = file_to_execute.replace('.class', '')
+
+  if interpreter_path:
+    execute_command = '%s %s' % (interpreter_path, file_to_execute)
+  else:
+    # Handle executables that don't need an interpreter.
+    execute_command = file_to_execute
+  return execute_command
 
 
 def get_line_seperator(label=''):

--- a/src/python/bot/startup/run.py
+++ b/src/python/bot/startup/run.py
@@ -178,11 +178,13 @@ def main():
 
   bot_script_path = os.path.join(base_directory, BOT_SCRIPT)
   bot_interpreter = shell.get_interpreter_for_command(bot_script_path)
+  assert bot_interpreter
   bot_command = '%s %s' % (bot_interpreter, bot_script_path)
 
   heartbeat_script_path = os.path.join(base_directory, HEARTBEAT_SCRIPT)
   heartbeat_interpreter = shell.get_interpreter_for_command(
       heartbeat_script_path)
+  assert heartbeat_interpreter
   heartbeat_command = '%s %s %s' % (heartbeat_interpreter,
                                     heartbeat_script_path, bot_log)
 

--- a/src/python/bot/startup/run.py
+++ b/src/python/bot/startup/run.py
@@ -177,13 +177,12 @@ def main():
   bot_log = os.path.join(log_directory, 'bot.log')
 
   bot_script_path = os.path.join(base_directory, BOT_SCRIPT)
-  bot_interpreter = shell.get_interpreter_for_command(bot_script_path)
+  bot_interpreter = shell.get_interpreter(bot_script_path)
   assert bot_interpreter
   bot_command = '%s %s' % (bot_interpreter, bot_script_path)
 
   heartbeat_script_path = os.path.join(base_directory, HEARTBEAT_SCRIPT)
-  heartbeat_interpreter = shell.get_interpreter_for_command(
-      heartbeat_script_path)
+  heartbeat_interpreter = shell.get_interpreter(heartbeat_script_path)
   assert heartbeat_interpreter
   heartbeat_command = '%s %s %s' % (heartbeat_interpreter,
                                     heartbeat_script_path, bot_log)

--- a/src/python/bot/startup/run_heartbeat.py
+++ b/src/python/bot/startup/run_heartbeat.py
@@ -52,7 +52,7 @@ def main():
   # Get absolute path to heartbeat script and interpreter needed to execute it.
   startup_scripts_directory = environment.get_startup_scripts_directory()
   beat_script_path = os.path.join(startup_scripts_directory, BEAT_SCRIPT)
-  beat_interpreter = shell.get_interpreter_for_command(beat_script_path)
+  beat_interpreter = shell.get_interpreter(beat_script_path)
   assert beat_interpreter
 
   while True:

--- a/src/python/bot/startup/run_heartbeat.py
+++ b/src/python/bot/startup/run_heartbeat.py
@@ -53,6 +53,7 @@ def main():
   startup_scripts_directory = environment.get_startup_scripts_directory()
   beat_script_path = os.path.join(startup_scripts_directory, BEAT_SCRIPT)
   beat_interpreter = shell.get_interpreter_for_command(beat_script_path)
+  assert beat_interpreter
 
   while True:
     beat_command = [

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -759,10 +759,7 @@ def run_fuzzer(fuzzer, fuzzer_directory, testcase_directory, data_directory,
       return error_occurred, None, None, None, None
 
     # Build the fuzzer command execution string.
-    command = shell.get_interpreter_for_command(fuzzer.executable_path)
-    command += ' '
-    command += fuzzer_executable.replace('.class', '')
-
+    command = shell.get_execute_command(fuzzer.executable_path)
     # NodeJS and shell script expect space seperator for arguments.
     if command.startswith('node ') or command.startswith('sh '):
       argument_seperator = ' '

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -471,7 +471,7 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
 
   # Setup environment variable for launcher script path.
   if fuzzer.launcher_script:
-    fuzzer_launcher_path = utils.get_execute_command(
+    fuzzer_launcher_path = shell.get_execute_command(
         os.path.join(fuzzer_directory, fuzzer.launcher_script))
     environment.set_value('LAUNCHER_PATH', fuzzer_launcher_path)
 

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -471,8 +471,8 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
 
   # Setup environment variable for launcher script path.
   if fuzzer.launcher_script:
-    fuzzer_launcher_path = utils.get_launch_path_for_script(
-        fuzzer_directory, fuzzer.launcher_script)
+    fuzzer_launcher_path = utils.get_execute_command(
+        os.path.join(fuzzer_directory, fuzzer.launcher_script))
     environment.set_value('LAUNCHER_PATH', fuzzer_launcher_path)
 
   return True

--- a/src/python/fuzzing/tests.py
+++ b/src/python/fuzzing/tests.py
@@ -689,7 +689,7 @@ def get_command_line_for_application(file_to_run='',
     app_path = '"%s"' % app_path
 
   # Prepend command with interpreter if it is a script.
-  interpreter = shell.get_interpreter_for_command(app_name)
+  interpreter = shell.get_interpreter(app_name)
   if interpreter:
     app_path = '%s %s' % (interpreter, app_path)
 

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -310,7 +310,7 @@ def get_interpreter_for_command(command):
   try:
     return interpreter_extension_map[os.path.splitext(command)[1]]
   except KeyError:
-    return ''
+    return None
 
 
 def move(src, dst):

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -295,8 +295,8 @@ def get_free_disk_space(path='/'):
   return psutil.disk_usage(path).free
 
 
-def get_interpreter_for_command(command):
-  """Gives the interpreter needed to run the command."""
+def get_interpreter(file_to_execute):
+  """Gives the interpreter needed to execute |file_to_execute|."""
   interpreter_extension_map = {
       '.bash': 'bash',
       '.class': 'java',
@@ -308,9 +308,24 @@ def get_interpreter_for_command(command):
   }
 
   try:
-    return interpreter_extension_map[os.path.splitext(command)[1]]
+    return interpreter_extension_map[os.path.splitext(file_to_execute)[1]]
   except KeyError:
     return None
+
+
+def get_execute_command(file_to_execute):
+  """Return command to execute |file_to_execute|."""
+  interpreter_path = get_interpreter(file_to_execute)
+
+  # Hack for Java scripts.
+  file_to_execute = file_to_execute.replace('.class', '')
+
+  if interpreter_path:
+    command = '%s %s' % (interpreter_path, file_to_execute)
+  else:
+    # Handle executables that don't need an interpreter.
+    command = file_to_execute
+  return command
 
 
 def move(src, dst):

--- a/src/python/tests/core/base/utils_test.py
+++ b/src/python/tests/core/base/utils_test.py
@@ -453,3 +453,33 @@ class FileHashTest(fake_filesystem_unittest.TestCase):
       file_handle.write('A' * 60000)
     self.assertEqual('8360c01cef8aa7001d1dd8964b9921d4c187da29',
                      utils.file_hash(self.test_file))
+
+
+class GetExecuteCommand(unittest.TestCase):
+  """Test that the correct commands to run a script are returned."""
+
+  def call_and_assert_helper(self, expected_command, file_to_execute):
+    """Call utils.get_execute_command on |file_to_execute| and assert result
+    equal to |expected_command|."""
+    self.assertEqual(expected_command,
+                     utils.get_execute_command(file_to_execute))
+
+  def test_standard_script(self):
+    """Test correct command returned for python script."""
+    script_name = 'script.py'
+    expected_command = 'python %s' % script_name
+    self.call_and_assert_helper(expected_command, script_name)
+
+  def test_java(self):
+    """Test correct launch command returned for Java class."""
+    script_name = 'javaclassfile.class'
+    expected_command = 'java javaclassfile'
+    self.call_and_assert_helper(expected_command, script_name)
+
+  def test_binary(self):
+    """Test correct launch command returned for a binary (executable) file."""
+    executable_name = 'executable'
+    self.call_and_assert_helper(executable_name, executable_name)
+
+    executable_name += '.exe'
+    self.call_and_assert_helper(executable_name, executable_name)

--- a/src/python/tests/core/base/utils_test.py
+++ b/src/python/tests/core/base/utils_test.py
@@ -453,33 +453,3 @@ class FileHashTest(fake_filesystem_unittest.TestCase):
       file_handle.write('A' * 60000)
     self.assertEqual('8360c01cef8aa7001d1dd8964b9921d4c187da29',
                      utils.file_hash(self.test_file))
-
-
-class GetExecuteCommand(unittest.TestCase):
-  """Test that the correct commands to run a script are returned."""
-
-  def call_and_assert_helper(self, expected_command, file_to_execute):
-    """Call utils.get_execute_command on |file_to_execute| and assert result
-    equal to |expected_command|."""
-    self.assertEqual(expected_command,
-                     utils.get_execute_command(file_to_execute))
-
-  def test_standard_script(self):
-    """Test correct command returned for python script."""
-    script_name = 'script.py'
-    expected_command = 'python %s' % script_name
-    self.call_and_assert_helper(expected_command, script_name)
-
-  def test_java(self):
-    """Test correct launch command returned for Java class."""
-    script_name = 'javaclassfile.class'
-    expected_command = 'java javaclassfile'
-    self.call_and_assert_helper(expected_command, script_name)
-
-  def test_binary(self):
-    """Test correct launch command returned for a binary (executable) file."""
-    executable_name = 'executable'
-    self.call_and_assert_helper(executable_name, executable_name)
-
-    executable_name += '.exe'
-    self.call_and_assert_helper(executable_name, executable_name)

--- a/src/python/tests/core/system/process_handler_test.py
+++ b/src/python/tests/core/system/process_handler_test.py
@@ -34,7 +34,7 @@ class MockProcess(object):
     return self._info
 
 
-class TerminateProcessesMatchingName(unittest.TestCase):
+class TerminateProcessesMatchingNameTest(unittest.TestCase):
   """Tests terminate_processes_matching_names."""
 
   def setUp(self):
@@ -96,7 +96,7 @@ class TerminateProcessesMatchingName(unittest.TestCase):
     self.assertEqual(0, self.mock.terminate_process.call_count)
 
 
-class TerminateProcessesMatchingPath(unittest.TestCase):
+class TerminateProcessesMatchingPathTest(unittest.TestCase):
   """Tests terminate_processes_matching_names."""
 
   def setUp(self):

--- a/src/python/tests/core/system/shell_test.py
+++ b/src/python/tests/core/system/shell_test.py
@@ -241,3 +241,46 @@ class ClearSystemTempDirectoryTest(fake_filesystem_unittest.TestCase):
     self.assertFalse(os.path.exists('/tmp/cc/dd/ee.txt'))
     self.assertFalse(os.path.exists('/tmp/ff/gg'))
     self.assertFalse(os.path.exists('/tmp/hh'))
+
+
+class GetExecuteCommand(unittest.TestCase):
+  """Test that the correct commands to run files are returned."""
+
+  def call_and_assert_helper(self, expected_command, file_to_execute):
+    """Call get_execute_command on |file_to_execute| and assert result equal to
+    |expected_command|."""
+    self.assertEqual(expected_command,
+                     shell.get_execute_command(file_to_execute))
+
+  def test_standard_script(self):
+    """Test correct command returned for python script."""
+    script_name = 'script.py'
+    expected_command = 'python %s' % script_name
+    self.call_and_assert_helper(expected_command, script_name)
+
+  def test_java(self):
+    """Test correct launch command returned for Java class."""
+    script_name = 'javaclassfile.class'
+    expected_command = 'java javaclassfile'
+    self.call_and_assert_helper(expected_command, script_name)
+
+  def test_binary(self):
+    """Test correct launch command returned for a binary (executable) file."""
+    executable_name = 'executable'
+    self.call_and_assert_helper(executable_name, executable_name)
+
+    executable_name += '.exe'
+    self.call_and_assert_helper(executable_name, executable_name)
+
+
+class GetInterpreter(object):
+  """Test that the correct interpreters to execute a file are returned."""
+
+  def get_interpreted_file_test(self):
+    """Test correct interpreter is returned for a file that needs one."""
+    self.assertEqual('python', shell.get_interpreter('run.py'))
+
+  def get_non_interpreter_file_test(self):
+    """Test that None is returned for a file that doesn't need one. We don't
+    want empty string since this is easier to than None. """
+    self.assertIsNone(shell.get_interpreter('executable'))


### PR DESCRIPTION
Fix handling of executable and Java launchers.

Rename get_launch_path_for_script to get_executable_command, and make it reusable.
Add tests for get_launch_path_for_script.
Make tests in process_handler_test.py obey conventions.

Bug: crbug.com/925988