### PR TITLE
Store daily fuzzer weights in bigquery.

### DIFF
--- a/configs/test/bigquery/datasets.yaml
+++ b/configs/test/bigquery/datasets.yaml
@@ -193,3 +193,19 @@ resources:
             type: INTEGER
           - name: regression_range_end
             type: INTEGER
+  - name: fuzzer-weights-table
+    type: gcp-types/bigquery-v2:tables
+    properties:
+      datasetId: $(ref.main-dataset.datasetReference.datasetId)
+      tableReference:
+        tableId: fuzzer_weights
+      timePartitioning:
+        type: DAY
+      schema:
+        fields:
+          - name: fuzzer
+            type: STRING
+          - name: job
+            type: STRING
+          - name: weight
+            type: FLOAT

--- a/src/appengine/handlers/cron/fuzzer_weights.py
+++ b/src/appengine/handlers/cron/fuzzer_weights.py
@@ -325,7 +325,7 @@ def store_current_weights_in_bigquery():
         'job': target_job.job,
         'weight': target_job.weight
     }
-    rows.append(big_query.Insert(row, None))
+    rows.append(big_query.Insert(row=row, insert_id=None))
 
   client = big_query.Client(dataset_id='main', table_id='fuzzer_weights')
   client.insert(rows)

--- a/src/appengine/handlers/cron/fuzzer_weights.py
+++ b/src/appengine/handlers/cron/fuzzer_weights.py
@@ -292,9 +292,9 @@ def update_target_weights_for_engine(client, engine, specifications):
   # All fuzzers with non-default weights must be tracked with a special
   # specification. This ensures that they will be restored to normal weight
   # once conditions causing adjustments are no longer met.
-  target_jobs = ndb_utils.get_all_from_query(
-      data_types.FuzzTargetJob.query(data_types.FuzzTarget.engine == engine)
-      .filter(data_types.FuzzTargetJob.weight != 1.0))
+  target_jobs = data_types.FuzzTargetJob.query(
+      data_types.FuzzTarget.engine == engine).filter(
+          data_types.FuzzTargetJob.weight != 1.0)
 
   for target_job in target_jobs:
     matched_specifications[(target_job.fuzz_target_name,

--- a/src/python/metrics/monitoring_metrics.py
+++ b/src/python/metrics/monitoring_metrics.py
@@ -146,10 +146,3 @@ TASK_COUNT = monitor.CounterMetric(
         monitor.StringField('task'),
         monitor.StringField('job'),
     ])
-
-WEIGHT_ADJUSTMENT = monitor.CounterMetric(
-    'cron/weight_adjusments',
-    description='Fuzzer weight adjustments',
-    field_spec=[
-        monitor.StringField('reason'),
-    ])

--- a/src/python/tests/appengine/handlers/cron/fuzzer_weights_test.py
+++ b/src/python/tests/appengine/handlers/cron/fuzzer_weights_test.py
@@ -140,6 +140,7 @@ class TestUpdateChildWeightsForParentFuzzer(unittest.TestCase):
     test_helpers.patch_environ(self)
     test_helpers.patch(self, [
         'handlers.cron.fuzzer_weights._query_helper',
+        'handlers.cron.fuzzer_weights.store_current_weights_in_bigquery',
         'handlers.cron.fuzzer_weights.update_weight_for_target',
     ])
 


### PR DESCRIPTION
PTAL when you have time.

I'm having trouble finding docs on how exactly _PARTITIONTIME gets populated if you happen to know. It looks like it's null for newly added rows, and I'm guessing it updates those in a batch once per interval (daily in our cases)? If so, I think this seems to be working, but if not it may need a fix.