### PR TITLE
Add an android serial argument to butler's run_bot command.

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -217,7 +217,7 @@ def main():
   parser_run_bot.add_argument(
       '--android-serial',
       help='Serial number of an Android device to connect to instead of '
-           'running normally.')
+      'running normally.')
 
   parser_remote = subparsers.add_parser(
       'remote', help=('Run command-line tasks on a remote bot.'))

--- a/butler.py
+++ b/butler.py
@@ -214,6 +214,10 @@ def main():
       default='local/storage',
       help='Server storage path.')
   parser_run_bot.add_argument('directory', help='Directory to create bot in.')
+  parser_run_bot.add_argument(
+      '--android-serial',
+      help='Serial number of an Android device to connect to instead of '
+           'running normally.')
 
   parser_remote = subparsers.add_parser(
       'remote', help=('Run command-line tasks on a remote bot.'))

--- a/src/local/butler/run_bot.py
+++ b/src/local/butler/run_bot.py
@@ -106,6 +106,10 @@ def _setup_environment_and_configs(args, appengine_path):
 
     os.environ['LOCAL_GCS_BUCKETS_PATH'] = local_gcs_buckets_path
 
+  if args.android_serial:
+    os.environ['OS_OVERRIDE'] = 'ANDROID'
+    os.environ['ANDROID_SERIAL'] = args.android_serial
+
 
 def execute(args):
   """Run the bot."""

--- a/src/python/platforms/android/device.py
+++ b/src/python/platforms/android/device.py
@@ -1044,6 +1044,10 @@ def unlock_screen_if_locked():
 
 def flash_to_latest_build_if_needed():
   """Wipes user data, resetting the device to original factory state."""
+  if environment.get_value('LOCAL_DEVELOPMENT'):
+    # Don't reimage local development devices.
+    return
+
   run_timeout = environment.get_value('RUN_TIMEOUT')
   if run_timeout:
     # If we have a run timeout, then we are already scheduled to bail out and


### PR DESCRIPTION
This seems to at least run, but we still have a lot of assumptions that break if the device isn't rooted (the one I'm testing with at the moment isn't). It's probably not worth supporting that use case in the very short term, but do you think this is something we should try to handle?