### PR TITLE
Android fixes for cuttlefish.

### DIFF
--- a/src/python/bot/webserver/http_server.py
+++ b/src/python/bot/webserver/http_server.py
@@ -143,11 +143,6 @@ def start_server_thread(host, port):
 def start():
   """Initialize the HTTP server on the specified ports."""
   http_host = 'localhost'
-  if environment.get_value('ANDROID_GCE'):
-    # Android on GCE doesn't rely on forwarding, and device instances connect
-    # directly to the host ip/port through the internal network.
-    http_host = environment.get_value('ANDROID_GCE_HOST_IP')
-
   http_port_1 = environment.get_value('HTTP_PORT_1', 8000)
   http_port_2 = environment.get_value('HTTP_PORT_2', 8080)
   if not port_is_open(http_host, http_port_1):

--- a/src/python/fuzzing/tests.py
+++ b/src/python/fuzzing/tests.py
@@ -748,9 +748,6 @@ def get_command_line_for_application(file_to_run='',
     # Check if the testcase needs to be loaded over http.
     # TODO(ochang): Make this work for trusted/untrusted.
     http_ip = '127.0.0.1'
-    if environment.get_value('ANDROID_GCE'):
-      http_ip = environment.get_value('ANDROID_GCE_HOST_IP')
-
     http_port_1 = environment.get_value('HTTP_PORT_1', 8000)
     relative_testcase_path = file_to_run[len(input_directory + os.path.sep):]
     relative_testcase_path = relative_testcase_path.replace('\\', '/')


### PR DESCRIPTION
- ANDROID_GCE_HOST_IP is unneeded, port forwarding using adb reverse works with 127.0.0.1
- Use available virtual wifi