### PR TITLE
 Don't filter filename at archive iteration time

### DIFF
--- a/src/python/system/archive.py
+++ b/src/python/system/archive.py
@@ -75,9 +75,8 @@ def iterator(archive_path,
           if not file_match_callback(info.filename):
             continue
 
-          yield ArchiveFile(
-              info.filename, info.file_size,
-              maybe_extract(zip_file.open, info))
+          yield ArchiveFile(info.filename, info.file_size,
+                            maybe_extract(zip_file.open, info))
 
     except (zipfile.BadZipfile, zipfile.LargeZipFile):
       logs.log_error('Bad zip file %s.' % archive_path)
@@ -93,9 +92,8 @@ def iterator(archive_path,
         if not file_match_callback(info.name):
           continue
 
-        yield ArchiveFile(
-            info.name, info.size,
-            maybe_extract(tar_file.extractfile, info))
+        yield ArchiveFile(info.name, info.size,
+                          maybe_extract(tar_file.extractfile, info))
       tar_file.close()
     except tarfile.TarError:
       logs.log_error('Bad tar file %s.' % archive_path)
@@ -118,9 +116,8 @@ def iterator(archive_path,
             continue
 
           try:
-            yield ArchiveFile(
-                info.name, info.size,
-                maybe_extract(tar_file.extractfile, info))
+            yield ArchiveFile(info.name, info.size,
+                              maybe_extract(tar_file.extractfile, info))
 
           except KeyError:  # Handle broken links gracefully.
             error_filepaths.append(info.name)
@@ -198,6 +195,7 @@ def unpack(archive_path,
            trusted=False,
            file_match_callback=None):
   """Extracts an archive into the target directory."""
+
   def _filter_name(filename):
     """Filters './' from start if exists. This is needed to avoid confusion
     that the path is not intending path traversal."""
@@ -228,7 +226,8 @@ def unpack(archive_path,
   # traversals.
   if not trusted:
     for filename in file_list:
-      absolute_file_path = os.path.join(output_directory, _filter_name(filename))
+      absolute_file_path = os.path.join(output_directory,
+                                        _filter_name(filename))
       absolute_file_path = absolute_file_path.encode('ascii', 'ignore')
       if os.path.altsep:
         absolute_file_path = absolute_file_path.replace(os.path.altsep,

--- a/src/python/system/archive.py
+++ b/src/python/system/archive.py
@@ -68,12 +68,6 @@ def iterator(archive_path,
       return extract_func(info)
     return None
 
-  def filter_name(filename):
-    """Filters './' from start if exists."""
-    if filename.startswith('./'):
-      return filename[2:]
-    return filename
-
   if archive_type == ArchiveType.ZIP:
     try:
       with zipfile.ZipFile(archive_obj or archive_path) as zip_file:
@@ -82,7 +76,7 @@ def iterator(archive_path,
             continue
 
           yield ArchiveFile(
-              filter_name(info.filename), info.file_size,
+              info.filename, info.file_size,
               maybe_extract(zip_file.open, info))
 
     except (zipfile.BadZipfile, zipfile.LargeZipFile):
@@ -100,7 +94,7 @@ def iterator(archive_path,
           continue
 
         yield ArchiveFile(
-            filter_name(info.name), info.size,
+            info.name, info.size,
             maybe_extract(tar_file.extractfile, info))
       tar_file.close()
     except tarfile.TarError:
@@ -125,12 +119,12 @@ def iterator(archive_path,
 
           try:
             yield ArchiveFile(
-                filter_name(info.name), info.size,
+                info.name, info.size,
                 maybe_extract(tar_file.extractfile, info))
 
           except KeyError:  # Handle broken links gracefully.
             error_filepaths.append(info.name)
-            yield ArchiveFile(filter_name(info.name), info.size, None)
+            yield ArchiveFile(info.name, info.size, None)
 
         if error_filepaths:
           logs.log_warn(
@@ -204,6 +198,13 @@ def unpack(archive_path,
            trusted=False,
            file_match_callback=None):
   """Extracts an archive into the target directory."""
+  def _filter_name(filename):
+    """Filters './' from start if exists. This is needed to avoid confusion
+    that the path is not intending path traversal."""
+    if filename.startswith('./'):
+      return filename[2:]
+    return filename
+
   if not os.path.exists(archive_path):
     logs.log_error('Archive %s not found.' % archive_path)
     return
@@ -227,8 +228,8 @@ def unpack(archive_path,
   # traversals.
   if not trusted:
     for filename in file_list:
-      absolute_file_path = os.path.join(output_directory, filename).encode(
-          'ascii', 'ignore')
+      absolute_file_path = os.path.join(output_directory, _filter_name(filename))
+      absolute_file_path = absolute_file_path.encode('ascii', 'ignore')
       if os.path.altsep:
         absolute_file_path = absolute_file_path.replace(os.path.altsep,
                                                         os.path.sep)

--- a/src/python/tests/core/system/archive_test.py
+++ b/src/python/tests/core/system/archive_test.py
@@ -56,7 +56,7 @@ class IteratorTest(unittest.TestCase):
   def test_cwd_prefix(self):
     """Test that a .tgz file with cwd prefix is handled."""
     tgz_path = os.path.join(TESTDATA_PATH, 'cwd-prefix.tgz')
-    expected_results = {'test': 'abc\n'}
+    expected_results = {'./test': 'abc\n'}
     actual_results = {
         archive_file.name: archive_file.handle.read()
         for archive_file in archive.iterator(tgz_path)


### PR DESCRIPTION
since we pass file list to extract function, need to have exact filename as-is with './'. instead filter './' at traversal check time.