### PR TITLE
Minor fuzzer weight adjustments based on recent data.

### DIFF
--- a/src/appengine/handlers/cron/fuzzer_weights.py
+++ b/src/appengine/handlers/cron/fuzzer_weights.py
@@ -198,7 +198,7 @@ WHERE
 """
 
 COVERAGE_UNCHANGED_SPECIFICATION = QuerySpecification(
-    adjusted_weight=0.65,
+    adjusted_weight=0.70,
     threshold=1.0,
     query_format=COVERAGE_UNCHANGED_FORMAT,
     formatter=_coverage_formatter,

--- a/src/appengine/handlers/cron/fuzzer_weights.py
+++ b/src/appengine/handlers/cron/fuzzer_weights.py
@@ -81,7 +81,7 @@ GROUP BY
 # we'll find anything during fuzzing.
 STARTUP_CRASH_SPECIFICATION = QuerySpecification(
     adjusted_weight=0.10,
-    threshold=0.80,
+    threshold=0.90,
     query_format=GENERIC_QUERY_FORMAT.format(field_name='startup_crash_count'),
     formatter=_past_day_formatter,
     reason='frequent startup crashes')
@@ -91,7 +91,7 @@ STARTUP_CRASH_SPECIFICATION = QuerySpecification(
 # fuzzer is not making good use of its cycles while running or needs a fix.
 SLOW_UNIT_SPECIFICATION = QuerySpecification(
     adjusted_weight=0.50,
-    threshold=0.80,
+    threshold=0.90,
     query_format=GENERIC_QUERY_FORMAT.format(field_name='slow_unit_count'),
     formatter=_past_day_formatter,
     reason='frequent slow units')
@@ -100,17 +100,17 @@ SLOW_UNIT_SPECIFICATION = QuerySpecification(
 # included for the same reason.
 TIMEOUT_SPECIFICATION = QuerySpecification(
     adjusted_weight=0.50,
-    threshold=0.80,
+    threshold=0.95,
     query_format=GENERIC_QUERY_FORMAT.format(field_name='timeout_count'),
     formatter=_past_day_formatter,
     reason='frequent timeouts')
 
-# Fuzzers which are crashing frequently may not be making full use of their
-# allotted time for fuzzing, and may end up being more effective once the known
-# issues are fixed.
+# Fuzzers which are crashing on almost every run are not making full use of
+# their allotted time for fuzzing, and may end up being more effective once the
+# known issues are fixed.
 CRASH_SPECIFICATION = QuerySpecification(
     adjusted_weight=0.50,
-    threshold=0.90,
+    threshold=0.99,
     query_format=GENERIC_QUERY_FORMAT.format(field_name='crash_count'),
     formatter=_past_day_formatter,
     reason='frequent crashes')
@@ -120,7 +120,7 @@ CRASH_SPECIFICATION = QuerySpecification(
 # until the issues are fixed.
 OOM_SPECIFICATION = QuerySpecification(
     adjusted_weight=0.50,
-    threshold=0.90,
+    threshold=0.95,
     query_format=GENERIC_QUERY_FORMAT.format(field_name='oom_count'),
     formatter=_past_day_formatter,
     reason='frequent OOMs')
@@ -198,7 +198,7 @@ WHERE
 """
 
 COVERAGE_UNCHANGED_SPECIFICATION = QuerySpecification(
-    adjusted_weight=0.5,
+    adjusted_weight=0.65,
     threshold=1.0,
     query_format=COVERAGE_UNCHANGED_FORMAT,
     formatter=_coverage_formatter,


### PR DESCRIPTION
The intention of this change is to have fewer cases where weights
fluctuate wildly from day to day for fuzzers near a threshold. New
thresholds are meant to be cutoffs where something is very obviously
wrong in nearly all cases. It also reduces the penalty slightly for the
coverage growth rule, as a very large number of fuzzer/job pairs match
it.

Of ~3500 internal fuzzer/job pairs with data, these changes would cause
us to make the following adjustments for pairs matched:
startup_crash_count: 101 -> 101 (no change, this one is nearly binary)
slow_unit_count: 55 -> 14
timeout_count: 15 -> 5
crash_count: 83 -> 49
oom_count: 96 -> 76