### PR TITLE
Don't reimage gce bot for hard_reset, only reboot.

### DIFF
--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -444,20 +444,17 @@ def get_property(property_name):
 
 def hard_reset():
   """Perform a hard reset of the device."""
-  if is_gce():
-    recreate_gce_device()
-  else:
-    # Physical device.
-    # Try hard-reset via sysrq-trigger (requires root).
+  # For physical device, try hard-reset via sysrq-trigger (requires root).
+  if not is_gce():
     hard_reset_sysrq_cmd = get_adb_command_line(
         'shell echo b \\> /proc/sysrq-trigger')
     execute_command(
         hard_reset_sysrq_cmd, timeout=RECOVERY_CMD_TIMEOUT, log_error=True)
 
-    # Try soft-reset now (does not require root).
-    soft_reset_cmd = get_adb_command_line('reboot')
-    execute_command(
-        soft_reset_cmd, timeout=RECOVERY_CMD_TIMEOUT, log_error=True)
+  # Try soft-reset now (does not require root).
+  soft_reset_cmd = get_adb_command_line('reboot')
+  execute_command(
+      soft_reset_cmd, timeout=RECOVERY_CMD_TIMEOUT, log_error=True)
 
 
 def is_gce():

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -453,8 +453,7 @@ def hard_reset():
 
   # Try soft-reset now (does not require root).
   soft_reset_cmd = get_adb_command_line('reboot')
-  execute_command(
-      soft_reset_cmd, timeout=RECOVERY_CMD_TIMEOUT, log_error=True)
+  execute_command(soft_reset_cmd, timeout=RECOVERY_CMD_TIMEOUT, log_error=True)
 
 
 def is_gce():


### PR DESCRIPTION
This was an incorrect change done for gce. hard_reset can be called for minor reasons like ooms, so it is ok to just reboot the bot, and not needs reimage.