### PR TITLE
List output from all processes when invoking ps on Android devices.

### DIFF
--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -398,8 +398,7 @@ def get_package_name(apk_path=None):
 def get_process_and_child_pids(process_name):
   """Return process and child pids matching a process name."""
   pids = []
-  ps_output = get_ps_output()
-  ps_output_lines = ps_output.splitlines()
+  ps_output_lines = get_ps_output().splitlines()
 
   while True:
     old_pids_length = len(pids)
@@ -908,8 +907,7 @@ def wait_until_package_optimization_complete():
   start_time = time.time()
 
   while time.time() - start_time < REBOOT_TIMEOUT:
-    ps_output = get_ps_output()
-    package_optimization_finished = 'dex2oat' not in ps_output
+    package_optimization_finished = 'dex2oat' not in get_ps_output()
     if package_optimization_finished:
       return
 

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -359,9 +359,9 @@ def get_file_checksum(file_path):
   return None
 
 
-def get_memory_usage_info():
-  """Return memory stats."""
-  return run_adb_shell_command(['ps'])
+def get_ps_output():
+  """Return ps output for all processes."""
+  return run_adb_shell_command(['ps', '-A'])
 
 
 def get_package_name(apk_path=None):
@@ -398,7 +398,7 @@ def get_package_name(apk_path=None):
 def get_process_and_child_pids(process_name):
   """Return process and child pids matching a process name."""
   pids = []
-  ps_output = get_memory_usage_info()
+  ps_output = get_ps_output()
   ps_output_lines = ps_output.splitlines()
 
   while True:
@@ -908,8 +908,8 @@ def wait_until_package_optimization_complete():
   start_time = time.time()
 
   while time.time() - start_time < REBOOT_TIMEOUT:
-    memory_output = get_memory_usage_info()
-    package_optimization_finished = 'dex2oat' not in memory_output
+    ps_output = get_ps_output()
+    package_optimization_finished = 'dex2oat' not in ps_output
     if package_optimization_finished:
       return
 

--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -336,10 +336,10 @@ def run_process(cmdline,
 
   # If a crash is found, then we add the memory state as well.
   if return_code and plt == 'ANDROID':
-    memory_usage_info = android.adb.get_memory_usage_info()
+    process_info = android.adb.get_ps_output()
     if memory_usage_info:
       output += utils.get_line_seperator('Memory Statistics')
-      output += memory_usage_info
+      output += process_info
 
   logs.log(
       'Process (%s) ended, exit code (%s), output (%s).' %

--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -336,10 +336,10 @@ def run_process(cmdline,
 
   # If a crash is found, then we add the memory state as well.
   if return_code and plt == 'ANDROID':
-    process_info = android.adb.get_ps_output()
-    if memory_usage_info:
+    ps_output = android.adb.get_ps_output()
+    if ps_output:
       output += utils.get_line_seperator('Memory Statistics')
-      output += process_info
+      output += ps_output
 
   logs.log(
       'Process (%s) ended, exit code (%s), output (%s).' %


### PR DESCRIPTION
PTAL. I'm not totally sure if this is correct in all cases, but seemed small enough to draft the CL so we could discuss it here.

I am sure that for the dex2oat case in wait_until_package_optimization_complete that this wasn't working correctly. Running ps only seems to show a very limited number of processes. I'm not sure if this would have caused any issues in the other 2 places it was used, and it seemed like it could be very noisy in the memory statistics printing case.