### PR TITLE
Replace list_full_file_paths_recursive with shell.get_files_list.

### DIFF
--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -385,7 +385,7 @@ class AflFuzzInputDirectory(object):
     # it doesn't have to be fixed every time by AFL.
     # TODO(metzman): Copy testcases in subdirectories so AFL can use them, even
     # when there are no oversized files.
-    corpus_file_paths = list_full_file_paths_recursive(self.input_directory)
+    corpus_file_paths = shell.get_files_list(self.input_directory)
     usable_files_and_sizes = [
         (path, os.path.getsize(path))
         for path in corpus_file_paths
@@ -1017,7 +1017,7 @@ class AflRunnerCommon(object):
     corpus_features = set()
     input_inodes = set()
     input_filenames = set()
-    for file_path in list_full_file_paths_recursive(input_dir):
+    for file_path in shell.get_files_list(input_dir):
       file_features, timed_out = self.get_file_features(file_path, showmap_args)
       if timed_out:
         logs.log_warn('Timed out in merge while processing initial corpus.')
@@ -1258,16 +1258,6 @@ def remove_path(path):
   elif os.path.isdir(path):
     shutil.rmtree(path)
   # Else path doesn't exist. Do nothing.
-
-
-def list_full_file_paths_recursive(directory):
-  """List the absolute paths of files in |directory| and its subdirectories."""
-  paths = []
-
-  for root, _, filenames in os.walk(directory):
-    for filename in filenames:
-      paths.append(os.path.join(root, filename))
-  return paths
 
 
 def list_full_file_paths(directory):

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_test.py
@@ -863,8 +863,7 @@ class AlfConfigTest(LauncherTestBase):
 
 
 class ListFullFilePathsTest(LauncherTestBase):
-  """Tests for list_full_file_paths and list_full_file_paths_recursive
-  functions."""
+  """Tests for list_full_file_paths."""
   DUMMY_2_FILENAME = 'dummyfile2'
   DUMMY_3_FILENAME = 'dummyfile3'
 
@@ -888,25 +887,6 @@ class ListFullFilePathsTest(LauncherTestBase):
     self._assert_elements_equal(
         launcher.list_full_file_paths(self.INPUT_DIR),
         [self.dummy_file_path, self.dummy_3_file_path])
-
-  def test_list_full_file_paths_recursive(self):
-    """Test that list_full_file_paths_recursive works as intended."""
-
-    # Test it works with just files:
-    self._assert_elements_equal(
-        launcher.list_full_file_paths_recursive(self.INPUT_DIR),
-        [self.dummy_file_path, self.dummy_3_file_path])
-
-    # Test it works with a directory:
-    dummy_dir = os.path.join(self.INPUT_DIR, 'dummydir')
-    self.fs.CreateDirectory(dummy_dir)
-
-    dummy_2_path = os.path.join(dummy_dir, self.DUMMY_2_FILENAME)
-    self.fs.CreateFile(dummy_2_path)
-
-    self._assert_elements_equal(
-        launcher.list_full_file_paths_recursive(self.INPUT_DIR),
-        [self.dummy_file_path, dummy_2_path, self.dummy_3_file_path])
 
 
 def dont_use_strategies(obj):


### PR DESCRIPTION
Remove `list_full_file_paths_recursive` since it implements same functionality as `shell.get_files_list`