### PR TITLE
Fix corpus merging on libFuzzer and refactor

### DIFF
--- a/src/python/base/persistent_cache.py
+++ b/src/python/base/persistent_cache.py
@@ -34,8 +34,7 @@ def initialize():
   if os.path.exists(cache_directory_path):
     clear_values()
   else:
-    shell.create_directory_if_needed(
-        cache_directory_path, create_intermediates=True)
+    shell.create_directory(cache_directory_path, create_intermediates=True)
 
 
 def clear_values():

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -986,12 +986,9 @@ def main(argv):
   new_units_added = parsed_stats.get('new_units_added', 0)
   merge_error = None
   if new_units_added:
-    # Merge the new units back into the corpus.
-    # For merge, main corpus directory should be passed first of all corpus
-    # directories.
-    if corpus_directory in corpus_directories:
-      corpus_directories.remove(corpus_directory)
-    corpus_directories = [corpus_directory] + corpus_directories
+    # Merge the new units with the initial corpus.
+    if corpus_directory not in corpus_directories:
+      corpus_directories.append(corpus_directory)
 
     # If this times out, it's possible that we will miss some units. However, if
     # we're taking >10 minutes to load/merge the corpus something is going very

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -718,8 +718,8 @@ def get_merge_directory():
 def create_merge_directory():
   """Create the merge directory and return its path."""
   merge_directory_path = get_merge_directory()
-  shell.create_directory(merge_directory_path, create_intermediates=True,
-                         recreate=True)
+  shell.create_directory(
+      merge_directory_path, create_intermediates=True, recreate=True)
   return merge_directory_path
 
 
@@ -728,8 +728,8 @@ def is_sha1_hash(string):
   if len(string) != 40:
     return False
 
-  valid_chars = set(
-      ['a', 'b', 'c', 'd', 'e', 'f'] + [str(num) for num in range(10)])
+  valid_chars = set(['a', 'b', 'c', 'd', 'e', 'f'] +
+                    [str(num) for num in range(10)])
 
   for char in string:
     if char not in valid_chars:

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -728,7 +728,7 @@ def is_sha1_hash(string):
     return False
 
   valid_chars = set(['a', 'b', 'c', 'd', 'e', 'f'] +
-                    [str(num) for num in range(10)])
+                    [str(num) for num in xrange(10)])
 
   for char in string:
     if char not in valid_chars:

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -746,9 +746,9 @@ def move_mergeable_units(merge_directory, corpus_directory):
 
   for unit_path in shell.get_files_list(merge_directory):
     unit_name = os.path.basename(unit_path)
-    if unit_name in initial_units and _is_sha1_hash(unit_name):
+    if unit_name in initial_units and is_sha1_hash(unit_name):
       continue
-    dest_path = os.path.join(initial_corpus_dir, unit_name)
+    dest_path = os.path.join(corpus_directory, unit_name)
     shell.move(unit_path, dest_path)
 
 

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -31,9 +31,6 @@ import stat
 import sys
 import time
 
-import constants
-import stats
-
 from base import utils
 from bot.fuzzers import dictionary_manager
 from bot.fuzzers import engine_common
@@ -49,6 +46,8 @@ from system import environment
 from system import minijail
 from system import new_process
 from system import shell
+import constants
+import stats
 
 # Regex to find testcase path from a crash.
 CRASH_TESTCASE_REGEX = (r'.*Test unit written to\s*'

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -717,9 +717,10 @@ def get_merge_directory():
 
 def create_merge_directory():
   """Create the merge directory and return its path."""
-  merge_directory = get_merge_directory()
-  shell.create_directory(path, create_intermediates=True, recreate=True)
-  return path
+  merge_directory_path = get_merge_directory()
+  shell.create_directory(merge_directory_path, create_intermediates=True,
+                         recreate=True)
+  return merge_directory_path
 
 
 def is_sha1_hash(string):
@@ -737,7 +738,7 @@ def is_sha1_hash(string):
   return True
 
 
-def move_mergable_units(merge_directory, corpus_directory):
+def move_mergeable_units(merge_directory, corpus_directory):
   """Move new units in |merge_directory| into |corpus_directory|."""
   initial_units = set(
       os.path.basename(filename)
@@ -1009,7 +1010,8 @@ def main(argv):
 
     if use_minijail:
       target = '/' + MERGE_DIRECTORY_NAME
-      minijail_chroot.add_binding(merge_directory, target, True)
+      minijail_chroot.add_binding(
+          minijail.ChrootBinding(merge_directory, target, True))
 
     merge_result = runner.merge(
         corpus_directories,

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -105,6 +105,8 @@ MUTATOR_PLUGIN_PROBABILITY = 0.50
 
 MERGE_DIRECTORY_NAME = 'merge-corpus'
 
+HEXDIGITS_SET = set(string.hexdigits)
+
 
 class Generator(object):
   """Generators we can use."""
@@ -728,7 +730,7 @@ def is_sha1_hash(possible_hash):
   if len(possible_hash) != 40:
     return False
 
-  return all(char in string.hexdigits for char in possible_hash)
+  return all(char in HEXDIGITS_SET for char in possible_hash)
 
 
 def move_mergeable_units(merge_directory, corpus_directory):
@@ -999,9 +1001,7 @@ def main(argv):
     corpus_directories.insert(0, merge_directory)
 
     if use_minijail:
-      target = '/' + MERGE_DIRECTORY_NAME
-      minijail_chroot.add_binding(
-          minijail.ChrootBinding(merge_directory, target, True))
+      bind_corpus_dirs(minijail_chroot, [merge_directory])
 
     merge_result = runner.merge(
         corpus_directories,

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import signal
 import stat
+import string
 import sys
 import time
 
@@ -722,19 +723,12 @@ def create_merge_directory():
   return merge_directory_path
 
 
-def is_sha1_hash(string):
-  """Returns True if |string| looks like a valid sha1 hash."""
-  if len(string) != 40:
+def is_sha1_hash(possible_hash):
+  """Returns True if |possible_hash| looks like a valid sha1 hash."""
+  if len(possible_hash) != 40:
     return False
 
-  valid_chars = set(['a', 'b', 'c', 'd', 'e', 'f'] +
-                    [str(num) for num in xrange(10)])
-
-  for char in string:
-    if char not in valid_chars:
-      return False
-
-  return True
+  return all(char in string.hexdigits for char in possible_hash)
 
 
 def move_mergeable_units(merge_directory, corpus_directory):

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -23,7 +23,6 @@ from system import minijail
 from system import new_process
 from system import shell
 import engine_common
-import utils as fuzzer_utils
 
 MAX_OUTPUT_LEN = 1 * 1024 * 1024  # 1 MB
 

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -185,17 +185,16 @@ class LibFuzzerCommon(object):
           '%s%s' % (constants.ARTIFACT_PREFIX_FLAG,
                     self._normalize_artifact_prefix(artifact_prefix)))
 
-    env = None
+    extra_env = {}
     if tmp_dir:
-      env = os.environ.copy()
-      env['TMPDIR'] = tmp_dir
+      extra_env['TMPDIR'] = tmp_dir
 
     additional_args.extend(corpus_directories)
     return self.run_and_wait(
         additional_args=additional_args,
         timeout=merge_timeout,
         max_stdout_len=MAX_OUTPUT_LEN,
-        env=env)
+        extra_env=extra_env)
 
   def run_single_testcase(self,
                           testcase_path,

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -26,7 +26,6 @@ import engine_common
 import utils as fuzzer_utils
 
 MAX_OUTPUT_LEN = 1 * 1024 * 1024  # 1 MB
-MERGE_DIRECTORY_NAME = 'merged-corpus'
 
 
 class LibFuzzerException(Exception):
@@ -188,8 +187,6 @@ class LibFuzzerCommon(object):
     extra_env = {}
     if tmp_dir:
       extra_env['TMPDIR'] = tmp_dir
-
-    merge_dir = create_merge_dir()
 
     additional_args.extend(corpus_directories)
     return self.run_and_wait(
@@ -508,10 +505,3 @@ def get_runner(fuzzer_path, temp_dir=None):
     runner = LibFuzzerRunner(fuzzer_path)
 
   return runner
-
-
-def create_merge_directory():
-  temp_dir = fuzzer_utils.get_temp_dir()
-  path = os.path.join(temp_dir, MERGE_DIRECTORY_NAME)
-  shell.create_directory(directory_path, create_intermediates=True)
-  shell.remove_directory(directory_path, recreate=True)

--- a/src/python/bot/fuzzers/mutator_plugin.py
+++ b/src/python/bot/fuzzers/mutator_plugin.py
@@ -115,13 +115,18 @@ class PluginGetter(object):
     """Creates directories needed to use mutator plugins."""
     # TODO(320): Change mutator plugin downloads so that they don't need to be
     # deleted and redownloaded on each run of launcher.py.
-    shell.create_directory(environment.get_value('MUTATOR_PLUGINS_DIR'),
-                           create_intermediates=True,
-                           recreate=True)
-    shell.create_directory(_get_mutator_plugins_archives_dir(),
-                           create_intermediates=True, recreate=True)
-    shell.create_directory(_get_mutator_plugins_unpacked_dir(),
-                           create_intermediates=True, recreate=True)
+    shell.create_directory(
+        environment.get_value('MUTATOR_PLUGINS_DIR'),
+        create_intermediates=True,
+        recreate=True)
+    shell.create_directory(
+        _get_mutator_plugins_archives_dir(),
+        create_intermediates=True,
+        recreate=True)
+    shell.create_directory(
+        _get_mutator_plugins_unpacked_dir(),
+        create_intermediates=True,
+        recreate=True)
 
   def _is_plugin_usable(self, plugin_archive_filename):
     """Returns True if |plugin_archive_filename| is a usable plugin for this

--- a/src/python/bot/fuzzers/mutator_plugin.py
+++ b/src/python/bot/fuzzers/mutator_plugin.py
@@ -113,17 +113,15 @@ class PluginGetter(object):
 
   def create_directories(self):
     """Creates directories needed to use mutator plugins."""
-
     # TODO(320): Change mutator plugin downloads so that they don't need to be
     # deleted and redownloaded on each run of launcher.py.
-    def recreate_directory(directory_path):
-      shell.create_directory_if_needed(
-          directory_path, create_intermediates=True)
-      shell.remove_directory(directory_path, recreate=True)
-
-    recreate_directory(environment.get_value('MUTATOR_PLUGINS_DIR'))
-    recreate_directory(_get_mutator_plugins_archives_dir())
-    recreate_directory(_get_mutator_plugins_unpacked_dir())
+    shell.create_directory(environment.get_value('MUTATOR_PLUGINS_DIR'),
+                           create_intermediates=True,
+                           recreate=True)
+    shell.create_directory(_get_mutator_plugins_archives_dir(),
+                           create_intermediates=True, recreate=True))
+    shell.create_directory(_get_mutator_plugins_unpacked_dir(),
+                           create_intermediates=True, recreate=True)
 
   def _is_plugin_usable(self, plugin_archive_filename):
     """Returns True if |plugin_archive_filename| is a usable plugin for this

--- a/src/python/bot/fuzzers/mutator_plugin.py
+++ b/src/python/bot/fuzzers/mutator_plugin.py
@@ -119,7 +119,7 @@ class PluginGetter(object):
                            create_intermediates=True,
                            recreate=True)
     shell.create_directory(_get_mutator_plugins_archives_dir(),
-                           create_intermediates=True, recreate=True))
+                           create_intermediates=True, recreate=True)
     shell.create_directory(_get_mutator_plugins_unpacked_dir(),
                            create_intermediates=True, recreate=True)
 

--- a/src/python/bot/fuzzers/utils.py
+++ b/src/python/bot/fuzzers/utils.py
@@ -125,7 +125,7 @@ def get_temp_dir():
   temp_dirname = 'temp-' + str(os.getpid())
   temp_directory = os.path.join(
       environment.get_value('FUZZ_INPUTS_DISK'), temp_dirname)
-  shell.create_directory_if_needed(temp_directory)
+  shell.create_directory(temp_directory)
   return temp_directory
 
 

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -205,7 +205,7 @@ class Context(object):
     directory."""
     testcases_directory = environment.get_value('FUZZ_INPUTS_DISK')
     directory_path = os.path.join(testcases_directory, name)
-    shell.create_directory_if_needed(directory_path)
+    shell.create_directory(directory_path)
     self._created_directories.append(directory_path)
 
     return directory_path
@@ -267,7 +267,7 @@ class Context(object):
 
       corpus_backup_output_directory = os.path.join(self.shared_corpus_path,
                                                     project_qualified_name)
-      shell.create_directory_if_needed(corpus_backup_output_directory)
+      shell.create_directory(corpus_backup_output_directory)
       archive.unpack(corpus_backup_local_path, corpus_backup_output_directory)
       shell.remove_file(corpus_backup_local_path)
 

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -322,7 +322,7 @@ def update_data_bundle(fuzzer, data_bundle):
     logs.log_error('Failed to setup data bundle %s.' % data_bundle.name)
     return False
 
-  if not shell.create_directory_if_needed(
+  if not shell.create_directory(
       data_bundle_directory, create_intermediates=True):
     logs.log_error(
         'Failed to create data bundle %s directory.' % data_bundle.name)

--- a/src/python/bot/untrusted_runner/file_impl.py
+++ b/src/python/bot/untrusted_runner/file_impl.py
@@ -24,8 +24,7 @@ from system import shell
 
 def create_directory(request, _):
   """Create a directory."""
-  result = shell.create_directory_if_needed(request.path,
-                                            request.create_intermediates)
+  result = shell.create_directory(request.path, request.create_intermediates)
   return untrusted_runner_pb2.CreateDirectoryResponse(result=result)
 
 

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -397,7 +397,7 @@ def _set_random_fuzz_target_for_fuzzing_if_needed(fuzz_targets, target_weights):
 def _setup_build_directories(base_build_dir):
   """Set up build directories for a job."""
   # Create the root build directory for this job.
-  shell.create_directory_if_needed(base_build_dir, create_intermediates=True)
+  shell.create_directory(base_build_dir, create_intermediates=True)
 
   custom_binary_directory = os.path.join(base_build_dir, 'custom')
   revision_build_directory = os.path.join(base_build_dir, 'revisions')
@@ -409,7 +409,7 @@ def _setup_build_directories(base_build_dir):
       sym_debug_build_directory, sym_release_build_directory
   ]
   for build_directory in build_directories:
-    shell.create_directory_if_needed(build_directory)
+    shell.create_directory(build_directory)
 
 
 def set_environment_vars(search_directories, app_path='APP_PATH'):

--- a/src/python/fuzzing/corpus_manager.py
+++ b/src/python/fuzzing/corpus_manager.py
@@ -276,7 +276,7 @@ class GcsCorpus(object):
     Returns:
       A bool indicating whether or not the command succeeded.
     """
-    shell.create_directory_if_needed(directory, create_intermediates=True)
+    shell.create_directory(directory, create_intermediates=True)
 
     corpus_gcs_url = self.get_gcs_url()
     result = self._gsutil_runner.rsync(corpus_gcs_url, directory, timeout,

--- a/src/python/fuzzing/tests.py
+++ b/src/python/fuzzing/tests.py
@@ -856,7 +856,7 @@ def setup_user_profile_directory_if_needed(user_profile_directory):
     # User profile directory already exists. Bail out.
     return
 
-  shell.create_directory_if_needed(user_profile_directory)
+  shell.create_directory(user_profile_directory)
 
   # Create a file in user profile directory based on format:
   # filename;base64 encoded zlib compressed file contents.
@@ -876,7 +876,7 @@ def setup_user_profile_directory_if_needed(user_profile_directory):
   if app_name.startswith('firefox'):
     # Create extensions directory.
     extensions_directory = os.path.join(user_profile_directory, 'extensions')
-    shell.create_directory_if_needed(extensions_directory)
+    shell.create_directory(extensions_directory)
 
     # Unpack the fuzzPriv extension.
     extension_archive = os.path.join(environment.get_resources_directory(),

--- a/src/python/google_cloud_utils/storage.py
+++ b/src/python/google_cloud_utils/storage.py
@@ -374,7 +374,7 @@ class FileSystemProvider(StorageProvider):
           'Bucket {bucket} does not exist.'.format(bucket=bucket))
 
     fs_path = self._fs_path(bucket, path, directory)
-    shell.create_directory_if_needed(
+    shell.create_directory(
         os.path.dirname(fs_path), create_intermediates=True)
 
     return fs_path
@@ -955,8 +955,7 @@ def store_file_in_cache(file_path,
   filename = os.path.basename(file_path)
 
   if not os.path.exists(cache_directory):
-    if not shell.create_directory_if_needed(
-        cache_directory, create_intermediates=True):
+    if not shell.create_directory(cache_directory, create_intermediates=True):
       logs.log_error('Failed to create cache directory %s.' % cache_directory)
       return
 

--- a/src/python/google_cloud_utils/storage.py
+++ b/src/python/google_cloud_utils/storage.py
@@ -374,8 +374,7 @@ class FileSystemProvider(StorageProvider):
           'Bucket {bucket} does not exist.'.format(bucket=bucket))
 
     fs_path = self._fs_path(bucket, path, directory)
-    shell.create_directory(
-        os.path.dirname(fs_path), create_intermediates=True)
+    shell.create_directory(os.path.dirname(fs_path), create_intermediates=True)
 
     return fs_path
 

--- a/src/python/scripts/other-bots/chromium-tests-syncer/run.py
+++ b/src/python/scripts/other-bots/chromium-tests-syncer/run.py
@@ -91,7 +91,7 @@ def unpack_crash_testcases(crash_testcases_directory):
     shell.move(input_directory, crash_testcase_directory)
 
     # Re-create input directory for unpacking testcase in next iteration.
-    shell.create_directory_if_needed(input_directory)
+    shell.create_directory(input_directory)
 
     STORED_TESTCASES_LIST.append(testcase_id)
 
@@ -214,12 +214,12 @@ def main():
   tests_directory = environment.get_value('TESTS_DIR')
   sync_interval = environment.get_value('SYNC_INTERVAL')  # in seconds.
 
-  shell.create_directory_if_needed(tests_directory)
+  shell.create_directory(tests_directory)
 
   # Sync old crash tests.
   logs.log('Syncing old crash tests.')
   crash_testcases_directory = os.path.join(tests_directory, 'CrashTests')
-  shell.create_directory_if_needed(crash_testcases_directory)
+  shell.create_directory(crash_testcases_directory)
   unpack_crash_testcases(crash_testcases_directory)
 
   # Sync web tests.

--- a/src/python/system/minijail.py
+++ b/src/python/system/minijail.py
@@ -159,7 +159,7 @@ class MinijailChroot(object):
     if directory[0] == '/':
       directory = directory[1:]
 
-    shell.create_directory_if_needed(
+    shell.create_directory(
         os.path.join(self._chroot_dir, directory), create_intermediates=True)
 
   @property

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -208,10 +208,15 @@ def close_open_file_handles_if_needed(path):
                     (handle_executable_path, file_handle_id, process_id))
 
 
-def create_directory_if_needed(directory, create_intermediates=False):
-  """Create a directory, ignore if it already exists."""
+def create_directory(directory, create_intermediates=False, recreate=False):
+  """Creates |directory|. Create intermediate directories if
+  |create_intermediates|. Ignore if it already exists and |recreate| is
+   False."""
   if os.path.exists(directory):
-    return True
+    if recreate:
+      remove_directory(directory)
+    else:
+      return True
 
   try:
     if create_intermediates:

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -456,7 +456,7 @@ class TestLauncher(BaseLauncherTest):
   def test_merge_reductions(self, mock_get_timeout):
     """Tests merging reductions. Wrapper around _test_merge_reductions."""
     mock_get_timeout.return_value = get_fuzz_timeout(1.0)
-    self._test_merge('nominijail-merge')
+    self._test_merge_reductions('nominijail-merge')
 
 
 @test_utils.integration
@@ -661,4 +661,4 @@ class TestLauncherMinijail(BaseLauncherTest):
   def test_merge_reductions(self, mock_get_timeout):
     """Tests merging. Wrapper around _test_merge_reductions."""
     mock_get_timeout.return_value = get_fuzz_timeout(1.0)
-    self._test_merge('minijail-merge')
+    self._test_merge_reductions('minijail-merge')

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -183,7 +183,7 @@ class BaseLauncherTest(unittest.TestCase):
     fuzz_target_name = 'analyze_dict_fuzzer'
     test_helpers.patch(self, [
         'bot.fuzzers.libFuzzer.launcher.create_merge_directory',
-        'bot.fuzzers.libFuzzer.launcher.get_merge_directory'
+        'bot.fuzzers.libFuzzer.launcher.get_merge_directory',
         'bot.fuzzers.libFuzzer.launcher.parse_log_stats',
     ])
 
@@ -191,7 +191,7 @@ class BaseLauncherTest(unittest.TestCase):
     log_stats['new_units_added'] = 1
     self.mock.parse_log_stats.side_effect = lambda logs: log_stats
 
-    self.mock.get_merge_directory.side_effect = os.path.join(
+    self.mock.get_merge_directory.side_effect = lambda: os.path.join(
         fuzzer_utils.get_temp_dir(), temp_subdir, launcher.MERGE_DIRECTORY_NAME)
 
     minimal_unit_contents = 'APPLE'

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -1283,7 +1283,8 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '/fake/corpus_oom'
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/fake/corpus_oom', '/fake/inputs-disk/temp-1337/new'
+          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/corpus_oom', '/fake/inputs-disk/temp-1337/new'
       ]])
 
   @mock.patch('bot.fuzzers.libFuzzer.launcher.add_recommended_dictionary',
@@ -1387,7 +1388,8 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '/fake/main_corpus_dir'
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/fake/main_corpus_dir', '/fake/inputs-disk/temp-1337/new'
+          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/main_corpus_dir', '/fake/inputs-disk/temp-1337/new'
       ]])
 
   @mock.patch('bot.fuzzers.libFuzzer.launcher.add_recommended_dictionary',
@@ -1550,9 +1552,10 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-b', '/lib64,/lib64,0', '-b', '/usr/lib,/usr/lib,0', '-b',
           '/fake/build_dir,/fake/build_dir,0', '-b', '/fake/build_dir,/out,0',
           '-b', '/fake/inputs-disk/temp-1337/new,/new,1', '-b',
-          '/fake/main_corpus_dir,/main_corpus_dir,1',
+          '/fake/main_corpus_dir,/main_corpus_dir,1', '-b',
+          '/fake/inputs-disk/temp-1337/merge-corpus,/merge-corpus,1',
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/main_corpus_dir', '/new'
+          '-merge=1', '/merge-corpus', '/main_corpus_dir', '/new'
       ]])
 
     del os.environ['USE_MINIJAIL']
@@ -1595,6 +1598,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-rss_limit_mb=2048',
           '-timeout=25',
           '-merge=1',
+          '/fake/inputs-disk/temp-1337/merge-corpus',
           '/fake/corpus_mutations',
           '/fake/inputs-disk/temp-1337/new',
           '/fake/inputs-disk/temp-1337/mutations',
@@ -1640,6 +1644,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-rss_limit_mb=2048',
           '-timeout=25',
           '-merge=1',
+          '/fake/inputs-disk/temp-1337/merge-corpus',
           '/fake/corpus_mutations',
           '/fake/inputs-disk/temp-1337/new',
           '/fake/inputs-disk/temp-1337/mutations',

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -42,6 +42,9 @@ FUZZ_INPUTS_DISK = '/fake/inputs-disk'
 GSUTIL_PATH = '/fake/gsutil_path'
 FAKE_ROOT_DIR = '/fake_root'
 
+# An arbirtrary SHA1 sum.
+ARBITRARY_SHA1_HASH = 'dd122581c8cd44d0227f9c305581ffcb4b6f1b46'
+
 
 def _read_test_data(name):
   """Read test data."""
@@ -1788,19 +1791,18 @@ class RecommendedDictionaryTest(fake_fs_unittest.TestCase):
 
 class IsSha1HashTest(unittest.TestCase):
   """Tests for is_sha1_hash."""
-  REAL_HASH = 'dd122581c8cd44d0227f9c305581ffcb4b6f1b46'
 
   def test_non_hashes(self):
     """Tests that False is returned for non hashes."""
     self.assertFalse(launcher.is_sha1_hash(''))
     self.assertFalse(launcher.is_sha1_hash('z' * 40))
     self.assertFalse(launcher.is_sha1_hash('a' * 50))
-    fake_hash = str('z' + self.REAL_HASH[1:])
+    fake_hash = str('z' + ARBITRARY_SHA1_HASH[1:])
     self.assertFalse(launcher.is_sha1_hash(fake_hash))
 
   def test_hash(self):
     """Tests that False is returned for a real hash."""
-    self.assertTrue(launcher.is_sha1_hash(self.REAL_HASH))
+    self.assertTrue(launcher.is_sha1_hash(ARBITRARY_SHA1_HASH))
 
 
 class MoveMergeableUnitsTest(fake_fs_unittest.TestCase):
@@ -1817,9 +1819,29 @@ class MoveMergeableUnitsTest(fake_fs_unittest.TestCase):
 
   def test_duplicate_not_moved(self):
     """Tests that a duplicated file is not moved into the corpus directory."""
-    sha1_sum = 'dd122581c8cd44d0227f9c305581ffcb4b6f1b46'
-    self.fs.CreateFile(os.path.join(self.CORPUS_DIRECTORY, sha1_sum))
-    self.fs.CreateFile(os.path.join(self.MERGE_DIRECTORY, sha1_sum))
+    self.fs.CreateFile(os.path.join(self.CORPUS_DIRECTORY, ARBITRARY_SHA1_HASH))
+    merge_corpus_file = os.path.join(self.MERGE_DIRECTORY, ARBITRARY_SHA1_HASH)
+    self.fs.CreateFile(merge_corpus_file)
+    self.move_mergeable_units()
+    # File will be deleted from merge directory if it isn't a duplicate.
+    self.assertTrue(os.path.exists(merge_corpus_file))
+
+  def test_new_file_moved(self):
+    """Tests that a new file is moved into the corpus directory."""
+    # Make a file that looks like a sha1 hash but is different from
+    # ARBITRARY_SHA1_HASH.
+    filename = ARBITRARY_SHA1_HASH.replace('d', 'a')
+    self.fs.CreateFile(os.path.join(self.CORPUS_DIRECTORY, filename))
+    # Create an arbitrary file with a hash name that is different from this
+    # filename.
+    merge_corpus_file = os.path.join(self.MERGE_DIRECTORY, ARBITRARY_SHA1_HASH)
+    self.fs.CreateFile(merge_corpus_file)
+    self.move_mergeable_units()
+    # File will be deleted from merge directory if it isn't a duplicate.
+    self.assertFalse(os.path.exists(merge_corpus_file))
+    self.assertTrue(
+        os.path.exists(os.path.join(self.CORPUS_DIRECTORY, filename)))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -1803,5 +1803,23 @@ class IsSha1HashTest(unittest.TestCase):
     self.assertTrue(launcher.is_sha1_hash(self.REAL_HASH))
 
 
+class MoveMergeableUnitsTest(fake_fs_unittest.TestCase):
+  """Tests for move_mergeable_units."""
+  CORPUS_DIRECTORY = '/corpus'
+  MERGE_DIRECTORY = '/corpus-merge'
+
+  def setUp(self):
+    test_utils.set_up_pyfakefs(self)
+
+  def move_mergeable_units(self):
+    """Helper function for move_mergeable_units."""
+    launcher.move_mergeable_units(self.MERGE_DIRECTORY, self.CORPUS_DIRECTORY)
+
+  def test_duplicate_not_moved(self):
+    """Tests that a duplicated file is not moved into the corpus directory."""
+    sha1_sum = 'dd122581c8cd44d0227f9c305581ffcb4b6f1b46'
+    self.fs.CreateFile(os.path.join(self.CORPUS_DIRECTORY, sha1_sum))
+    self.fs.CreateFile(os.path.join(self.MERGE_DIRECTORY, sha1_sum))
+
 if __name__ == '__main__':
   unittest.main()

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -1326,8 +1326,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
           '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/main_corpus_dir',
-          '/fake/inputs-disk/temp-1337/new',
+          '/fake/main_corpus_dir', '/fake/inputs-disk/temp-1337/new',
           '/fake/inputs-disk/temp-1337/subset'
       ]])
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -293,7 +293,8 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '/fake/corpus_basic'
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/fake/corpus_basic', '/fake/inputs-disk/temp-1337/new'
+          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/corpus_basic', '/fake/inputs-disk/temp-1337/new'
       ]])
 
       # Check new testcases added.
@@ -490,6 +491,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-only_ascii=1',
           '-rss_limit_mb=2048',
           '-merge=1',
+          '/fake/inputs-disk/temp-1337/merge-corpus',
           '/fake/corpus_basic',
           '/fake/inputs-disk/temp-1337/new',
       ]])
@@ -1323,7 +1325,8 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '/fake/inputs-disk/temp-1337/subset'
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/fake/main_corpus_dir',
+          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/main_corpus_dir',
           '/fake/inputs-disk/temp-1337/new',
           '/fake/inputs-disk/temp-1337/subset'
       ]])
@@ -1472,9 +1475,10 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '/fake/build_dir,/fake/build_dir,0', '-b', '/fake/build_dir,/out,0',
           '-b', '/fake/main_corpus_dir,/main_corpus_dir,1', '-b',
           '/fake/inputs-disk/temp-1337/new,/new,1', '-b',
-          '/fake/inputs-disk/temp-1337/subset,/subset,1',
+          '/fake/inputs-disk/temp-1337/subset,/subset,1', '-b',
+          '/fake/inputs-disk/temp-1337/merge-corpus,/merge-corpus,1',
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/main_corpus_dir', '/new', '/subset'
+          '-merge=1', '/merge-corpus', '/main_corpus_dir', '/new', '/subset'
       ]])
 
     del os.environ['USE_MINIJAIL']

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -297,7 +297,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
           '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/corpus_basic', '/fake/inputs-disk/temp-1337/new'
+          '/fake/inputs-disk/temp-1337/new', '/fake/corpus_basic',
       ]])
 
       # Check new testcases added.
@@ -495,8 +495,8 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-rss_limit_mb=2048',
           '-merge=1',
           '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/corpus_basic',
           '/fake/inputs-disk/temp-1337/new',
+          '/fake/corpus_basic',
       ]])
 
       # Check new testcases added.
@@ -1289,7 +1289,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
           '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/corpus_oom', '/fake/inputs-disk/temp-1337/new'
+           '/fake/inputs-disk/temp-1337/new', '/fake/corpus_oom'
       ]])
 
   @mock.patch('bot.fuzzers.libFuzzer.launcher.add_recommended_dictionary',
@@ -1329,8 +1329,8 @@ class LauncherTest(fake_fs_unittest.TestCase):
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
           '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/main_corpus_dir', '/fake/inputs-disk/temp-1337/new',
-          '/fake/inputs-disk/temp-1337/subset'
+          '/fake/inputs-disk/temp-1337/new',
+          '/fake/inputs-disk/temp-1337/subset', '/fake/main_corpus_dir',
       ]])
 
   @mock.patch('metrics.logs.log_error')
@@ -1394,7 +1394,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
           '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/main_corpus_dir', '/fake/inputs-disk/temp-1337/new'
+          '/fake/inputs-disk/temp-1337/new', '/fake/main_corpus_dir',
       ]])
 
   @mock.patch('bot.fuzzers.libFuzzer.launcher.add_recommended_dictionary',
@@ -1480,7 +1480,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '/fake/inputs-disk/temp-1337/subset,/subset,1', '-b',
           '/fake/inputs-disk/temp-1337/merge-corpus,/merge-corpus,1',
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/merge-corpus', '/main_corpus_dir', '/new', '/subset'
+          '-merge=1', '/merge-corpus', '/new', '/subset', '/main_corpus_dir',
       ]])
 
     del os.environ['USE_MINIJAIL']
@@ -1561,7 +1561,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '/fake/main_corpus_dir,/main_corpus_dir,1', '-b',
           '/fake/inputs-disk/temp-1337/merge-corpus,/merge-corpus,1',
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/merge-corpus', '/main_corpus_dir', '/new'
+          '-merge=1', '/merge-corpus', '/new', '/main_corpus_dir',
       ]])
 
     del os.environ['USE_MINIJAIL']
@@ -1605,8 +1605,8 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-timeout=25',
           '-merge=1',
           '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/corpus_mutations',
           '/fake/inputs-disk/temp-1337/new',
+          '/fake/corpus_mutations',
           '/fake/inputs-disk/temp-1337/mutations',
       ]])
 
@@ -1651,8 +1651,8 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-timeout=25',
           '-merge=1',
           '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/corpus_mutations',
           '/fake/inputs-disk/temp-1337/new',
+          '/fake/corpus_mutations',
           '/fake/inputs-disk/temp-1337/mutations',
       ]])
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -295,9 +295,13 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-print_final_stats=1', '/fake/inputs-disk/temp-1337/new',
           '/fake/corpus_basic'
       ], [
-          '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/inputs-disk/temp-1337/new', '/fake/corpus_basic',
+          '/fake/build_dir/fake_fuzzer',
+          '-rss_limit_mb=2048',
+          '-timeout=25',
+          '-merge=1',
+          '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/inputs-disk/temp-1337/new',
+          '/fake/corpus_basic',
       ]])
 
       # Check new testcases added.
@@ -1289,7 +1293,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
       ], [
           '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
           '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-           '/fake/inputs-disk/temp-1337/new', '/fake/corpus_oom'
+          '/fake/inputs-disk/temp-1337/new', '/fake/corpus_oom'
       ]])
 
   @mock.patch('bot.fuzzers.libFuzzer.launcher.add_recommended_dictionary',
@@ -1327,10 +1331,14 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-print_final_stats=1', '/fake/inputs-disk/temp-1337/new',
           '/fake/inputs-disk/temp-1337/subset'
       ], [
-          '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/build_dir/fake_fuzzer',
+          '-rss_limit_mb=2048',
+          '-timeout=25',
+          '-merge=1',
+          '/fake/inputs-disk/temp-1337/merge-corpus',
           '/fake/inputs-disk/temp-1337/new',
-          '/fake/inputs-disk/temp-1337/subset', '/fake/main_corpus_dir',
+          '/fake/inputs-disk/temp-1337/subset',
+          '/fake/main_corpus_dir',
       ]])
 
   @mock.patch('metrics.logs.log_error')
@@ -1392,9 +1400,13 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-print_final_stats=1', '/fake/inputs-disk/temp-1337/new',
           '/fake/main_corpus_dir'
       ], [
-          '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/inputs-disk/temp-1337/new', '/fake/main_corpus_dir',
+          '/fake/build_dir/fake_fuzzer',
+          '-rss_limit_mb=2048',
+          '-timeout=25',
+          '-merge=1',
+          '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/inputs-disk/temp-1337/new',
+          '/fake/main_corpus_dir',
       ]])
 
   @mock.patch('bot.fuzzers.libFuzzer.launcher.add_recommended_dictionary',
@@ -1469,18 +1481,53 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-print_final_stats=1', '/new', '/subset'
       ], [
           '/fake_root/resources/platform/{}/minijail0'.format(
-              environment.platform().lower()), '-f', '/tmpfile', '-U', '-m',
-          '0 1000 1', '-T', 'static', '-c', '0', '-n', '-v', '-p', '-l', '-I',
-          '-k', 'proc,/proc,proc,1', '-P', '/fake/inputs-disk/temp-1337/CHROOT',
-          '-b', '/fake/inputs-disk/temp-1337/TEMP,/tmp,1', '-b', '/lib,/lib,0',
-          '-b', '/lib64,/lib64,0', '-b', '/usr/lib,/usr/lib,0', '-b',
-          '/fake/build_dir,/fake/build_dir,0', '-b', '/fake/build_dir,/out,0',
-          '-b', '/fake/main_corpus_dir,/main_corpus_dir,1', '-b',
-          '/fake/inputs-disk/temp-1337/new,/new,1', '-b',
-          '/fake/inputs-disk/temp-1337/subset,/subset,1', '-b',
+              environment.platform().lower()),
+          '-f',
+          '/tmpfile',
+          '-U',
+          '-m',
+          '0 1000 1',
+          '-T',
+          'static',
+          '-c',
+          '0',
+          '-n',
+          '-v',
+          '-p',
+          '-l',
+          '-I',
+          '-k',
+          'proc,/proc,proc,1',
+          '-P',
+          '/fake/inputs-disk/temp-1337/CHROOT',
+          '-b',
+          '/fake/inputs-disk/temp-1337/TEMP,/tmp,1',
+          '-b',
+          '/lib,/lib,0',
+          '-b',
+          '/lib64,/lib64,0',
+          '-b',
+          '/usr/lib,/usr/lib,0',
+          '-b',
+          '/fake/build_dir,/fake/build_dir,0',
+          '-b',
+          '/fake/build_dir,/out,0',
+          '-b',
+          '/fake/main_corpus_dir,/main_corpus_dir,1',
+          '-b',
+          '/fake/inputs-disk/temp-1337/new,/new,1',
+          '-b',
+          '/fake/inputs-disk/temp-1337/subset,/subset,1',
+          '-b',
           '/fake/inputs-disk/temp-1337/merge-corpus,/merge-corpus,1',
-          '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/merge-corpus', '/new', '/subset', '/main_corpus_dir',
+          '/fake/build_dir/fake_fuzzer',
+          '-rss_limit_mb=2048',
+          '-timeout=25',
+          '-merge=1',
+          '/merge-corpus',
+          '/new',
+          '/subset',
+          '/main_corpus_dir',
       ]])
 
     del os.environ['USE_MINIJAIL']
@@ -1551,17 +1598,50 @@ class LauncherTest(fake_fs_unittest.TestCase):
           '-print_final_stats=1', '/new', '/main_corpus_dir'
       ], [
           '/fake_root/resources/platform/{}/minijail0'.format(
-              environment.platform().lower()), '-f', '/tmpfile', '-U', '-m',
-          '0 1000 1', '-T', 'static', '-c', '0', '-n', '-v', '-p', '-l', '-I',
-          '-k', 'proc,/proc,proc,1', '-P', '/fake/inputs-disk/temp-1337/CHROOT',
-          '-b', '/fake/inputs-disk/temp-1337/TEMP,/tmp,1', '-b', '/lib,/lib,0',
-          '-b', '/lib64,/lib64,0', '-b', '/usr/lib,/usr/lib,0', '-b',
-          '/fake/build_dir,/fake/build_dir,0', '-b', '/fake/build_dir,/out,0',
-          '-b', '/fake/inputs-disk/temp-1337/new,/new,1', '-b',
-          '/fake/main_corpus_dir,/main_corpus_dir,1', '-b',
+              environment.platform().lower()),
+          '-f',
+          '/tmpfile',
+          '-U',
+          '-m',
+          '0 1000 1',
+          '-T',
+          'static',
+          '-c',
+          '0',
+          '-n',
+          '-v',
+          '-p',
+          '-l',
+          '-I',
+          '-k',
+          'proc,/proc,proc,1',
+          '-P',
+          '/fake/inputs-disk/temp-1337/CHROOT',
+          '-b',
+          '/fake/inputs-disk/temp-1337/TEMP,/tmp,1',
+          '-b',
+          '/lib,/lib,0',
+          '-b',
+          '/lib64,/lib64,0',
+          '-b',
+          '/usr/lib,/usr/lib,0',
+          '-b',
+          '/fake/build_dir,/fake/build_dir,0',
+          '-b',
+          '/fake/build_dir,/out,0',
+          '-b',
+          '/fake/inputs-disk/temp-1337/new,/new,1',
+          '-b',
+          '/fake/main_corpus_dir,/main_corpus_dir,1',
+          '-b',
           '/fake/inputs-disk/temp-1337/merge-corpus,/merge-corpus,1',
-          '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/merge-corpus', '/new', '/main_corpus_dir',
+          '/fake/build_dir/fake_fuzzer',
+          '-rss_limit_mb=2048',
+          '-timeout=25',
+          '-merge=1',
+          '/merge-corpus',
+          '/new',
+          '/main_corpus_dir',
       ]])
 
     del os.environ['USE_MINIJAIL']

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -1786,5 +1786,22 @@ class RecommendedDictionaryTest(fake_fs_unittest.TestCase):
         self.mock.download_recommended_dictionary_from_gcs.call_args[0])
 
 
+class IsSha1HashTest(unittest.TestCase):
+  """Tests for is_sha1_hash."""
+  REAL_HASH = 'dd122581c8cd44d0227f9c305581ffcb4b6f1b46'
+
+  def test_non_hashes(self):
+    """Tests that False is returned for non hashes."""
+    self.assertFalse(launcher.is_sha1_hash(''))
+    self.assertFalse(launcher.is_sha1_hash('z' * 40))
+    self.assertFalse(launcher.is_sha1_hash('a' * 50))
+    fake_hash = str('z' + self.REAL_HASH[1:])
+    self.assertFalse(launcher.is_sha1_hash(fake_hash))
+
+  def test_hash(self):
+    """Tests that False is returned for a real hash."""
+    self.assertTrue(launcher.is_sha1_hash(self.REAL_HASH))
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -1286,23 +1286,14 @@ class LauncherTest(fake_fs_unittest.TestCase):
 
       # Tests that merge command is run here.
       self.assertEqual(mock_popen.commands, [[
-          '/fake/build_dir/fake_fuzzer',
-          '-max_len=80',
-          '-rss_limit_mb=2048',
-          '-timeout=25',
-          '-artifact_prefix=/fake/',
-          '-max_total_time=2650',
-          '-print_final_stats=1',
-          '/fake/inputs-disk/temp-1337/new',
+          '/fake/build_dir/fake_fuzzer', '-max_len=80', '-rss_limit_mb=2048',
+          '-timeout=25', '-artifact_prefix=/fake/', '-max_total_time=2650',
+          '-print_final_stats=1', '/fake/inputs-disk/temp-1337/new',
           '/fake/corpus_oom'
       ], [
-          '/fake/build_dir/fake_fuzzer',
-          '-rss_limit_mb=2048',
-          '-timeout=25',
-          '-merge=1',
-          '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/inputs-disk/temp-1337/new',
-          '/fake/corpus_oom'
+          '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
+          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/inputs-disk/temp-1337/new', '/fake/corpus_oom'
       ]])
 
   @mock.patch('bot.fuzzers.libFuzzer.launcher.add_recommended_dictionary',

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -1286,14 +1286,23 @@ class LauncherTest(fake_fs_unittest.TestCase):
 
       # Tests that merge command is run here.
       self.assertEqual(mock_popen.commands, [[
-          '/fake/build_dir/fake_fuzzer', '-max_len=80', '-rss_limit_mb=2048',
-          '-timeout=25', '-artifact_prefix=/fake/', '-max_total_time=2650',
-          '-print_final_stats=1', '/fake/inputs-disk/temp-1337/new',
+          '/fake/build_dir/fake_fuzzer',
+          '-max_len=80',
+          '-rss_limit_mb=2048',
+          '-timeout=25',
+          '-artifact_prefix=/fake/',
+          '-max_total_time=2650',
+          '-print_final_stats=1',
+          '/fake/inputs-disk/temp-1337/new',
           '/fake/corpus_oom'
       ], [
-          '/fake/build_dir/fake_fuzzer', '-rss_limit_mb=2048', '-timeout=25',
-          '-merge=1', '/fake/inputs-disk/temp-1337/merge-corpus',
-          '/fake/inputs-disk/temp-1337/new', '/fake/corpus_oom'
+          '/fake/build_dir/fake_fuzzer',
+          '-rss_limit_mb=2048',
+          '-timeout=25',
+          '-merge=1',
+          '/fake/inputs-disk/temp-1337/merge-corpus',
+          '/fake/inputs-disk/temp-1337/new',
+          '/fake/corpus_oom'
       ]])
 
   @mock.patch('bot.fuzzers.libFuzzer.launcher.add_recommended_dictionary',

--- a/src/python/tests/core/platforms/android/adb_test.py
+++ b/src/python/tests/core/platforms/android/adb_test.py
@@ -53,7 +53,7 @@ class TestFileOperations(unittest.TestCase):
   def test_directory_exists(self):
     """Tests directory_exists."""
     utils.write_data_to_file('a', os.path.join(self.local_temp_dir, 'a'))
-    shell.create_directory_if_needed(os.path.join(self.local_temp_dir, 'b'))
+    shell.create_directory(os.path.join(self.local_temp_dir, 'b'))
     utils.write_data_to_file('c', os.path.join(self.local_temp_dir, 'b', 'c'))
 
     adb.copy_local_directory_to_remote(self.local_temp_dir,
@@ -72,7 +72,7 @@ class TestFileOperations(unittest.TestCase):
   def test_file_exists(self):
     """Tests file_exists."""
     utils.write_data_to_file('a', os.path.join(self.local_temp_dir, 'a'))
-    shell.create_directory_if_needed(os.path.join(self.local_temp_dir, 'b'))
+    shell.create_directory(os.path.join(self.local_temp_dir, 'b'))
     utils.write_data_to_file('c', os.path.join(self.local_temp_dir, 'b', 'c'))
 
     adb.copy_local_directory_to_remote(self.local_temp_dir,
@@ -91,7 +91,7 @@ class TestFileOperations(unittest.TestCase):
   def test_copy_local_directory_to_remote(self):
     """Tests copy_local_directory_to_remote."""
     utils.write_data_to_file('a', os.path.join(self.local_temp_dir, 'a'))
-    shell.create_directory_if_needed(os.path.join(self.local_temp_dir, 'b'))
+    shell.create_directory(os.path.join(self.local_temp_dir, 'b'))
     utils.write_data_to_file('c', os.path.join(self.local_temp_dir, 'b', 'c'))
     adb.copy_local_directory_to_remote(self.local_temp_dir,
                                        self.device_temp_dir)


### PR DESCRIPTION
Merge units into an empty directory and then copy new units into the corpus. Do this so that reduced files for features can be added to the corpus, even if the initial version isn't removed until merging.

Refactor:
Rename `create_directory_if_needed` to `create_directory` and add a `recreate` option.
Fix some import orders.
Use `extra_env` instead of copying `os.environ`.