### PR TITLE
Don't change environment in check_for_bad_build.

### DIFF
--- a/bot/env.yaml
+++ b/bot/env.yaml
@@ -37,7 +37,8 @@ APP_PATH_DEBUG: ''
 # Flag to indicate if the crashing ASSERTs are security issues.
 ASSERTS_HAVE_SECURITY_IMPLICATION: false
 
-# Flag to indicate if we want to do bad build check on the application build.
+# Flag to indicate if we want to do bad build check on the application build. This launches an
+# application without a testcase and verifies that it does not crash on startup.
 BAD_BUILD_CHECK: true
 
 # Store build artifacts in cache to save network bandwidth.
@@ -80,6 +81,9 @@ FUZZER_TIMEOUT: 5400
 # Increase GCE metadata server timeout to mitigate transient errors.
 GCE_METADATA_TIMEOUT: 60
 
+# Enable leak detection for ASan builds.
+LSAN: false
+
 # Maximum number of simultaneous fuzzing / testcase execution threads.
 MAX_FUZZ_THREADS: 4
 
@@ -107,9 +111,6 @@ REINSTALL_APP_BEFORE_EACH_TASK: false
 # List of command line arguments that must not be minimized in minimization task, i.e. are always
 # necessary to reproduce most crashes.
 REQUIRED_APP_ARGS: ''
-
-# Default quarantine size for ASan.
-QUARANTINE_SIZE_MB: 256
 
 # Default testcase crash timeout.
 TEST_TIMEOUT: 10

--- a/src/python/fuzzing/tests.py
+++ b/src/python/fuzzing/tests.py
@@ -903,9 +903,6 @@ def check_for_bad_build(job_type, crash_revision):
   if not environment.get_value('BAD_BUILD_CHECK'):
     return False
 
-  # Do not detect leaks while checking for bad builds.
-  environment.reset_current_memory_tool_options(leaks=False)
-
   # Create a blank command line with no file to run and no http.
   command = get_command_line_for_application(file_to_run='', needs_http=False)
 
@@ -966,8 +963,5 @@ def check_for_bad_build(job_type, crash_revision):
       not crash_result.should_ignore()):
     data_handler.add_build_metadata(job_type, crash_revision, is_bad_build,
                                     build_run_console_output)
-
-  # Reset memory tool options.
-  environment.reset_current_memory_tool_options()
 
   return is_bad_build

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -156,9 +156,8 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
     asan_options['detect_container_overflow'] = 0
 
   # Enable stack use-after-return if not already specified.
-  if 'detect_stack_use_after_return' not in asan_options:
-    asan_options['detect_stack_use_after_return'] = 1
-    asan_options['max_uar_stack_size_log'] = 16
+  asan_options['detect_stack_use_after_return'] = 1
+  asan_options['max_uar_stack_size_log'] = 16
 
   # Other less important default options for all cases.
   asan_options.update({

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -155,7 +155,7 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
   if bot_platform == 'ANDROID':
     asan_options['detect_container_overflow'] = 0
 
-  # Enable stack use-after-return if not already specified.
+  # Enable stack use-after-return.
   asan_options['detect_stack_use_after_return'] = 1
   asan_options['max_uar_stack_size_log'] = 16
 

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -138,8 +138,8 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
   if malloc_context_size:
     asan_options['malloc_context_size'] = malloc_context_size
 
-  # Set quarantine size if different than the 256 mb default.
-  if quarantine_size_mb != 256 and bot_platform != 'ANDROID':
+  # Set quarantine size.
+  if quarantine_size_mb:
     asan_options['quarantine_size_mb'] = quarantine_size_mb
 
   # Test for leaks if this is an LSan-enabled job type.
@@ -151,23 +151,14 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
     remove_key('LSAN_OPTIONS')
     asan_options['detect_leaks'] = 0
 
-  # FIXME: Support container overflow on all platforms.
-  if bot_platform == 'LINUX':
-    asan_options['detect_container_overflow'] = 1
-  else:
-    # Broken on multiple platforms. E.g. Android tracked in b/25228125.
+  # FIXME: Support container overflow on Android.
+  if bot_platform == 'ANDROID':
     asan_options['detect_container_overflow'] = 0
 
-  # Stack use-after-return.
-  # FIXME: Support Stack UAR on all platforms.
-  if (bot_platform in ['LINUX', 'MAC'] and
-      'detect_stack_use_after_return=' not in asan_options):
-    max_uar_stack_size_log = 16
+  # Enable stack use-after-return if not already specified.
+  if 'detect_stack_use_after_return' not in asan_options:
     asan_options['detect_stack_use_after_return'] = 1
-    asan_options['max_uar_stack_size_log'] = max_uar_stack_size_log
-  elif bot_platform == 'WINDOWS':
-    # FIXME: See crbug.com/915245. Disable this explicitly on Windows.
-    asan_options['detect_stack_use_after_return'] = 0
+    asan_options['max_uar_stack_size_log'] = 16
 
   # Other less important default options for all cases.
   asan_options.update({
@@ -746,10 +737,6 @@ def reset_current_memory_tool_options(redzone_size=0,
   set_value('MEMORY_TOOL', tool_name)
 
   bot_platform = platform()
-
-  # Get default quarantine size from environment (if not provided already).
-  if quarantine_size_mb is None:
-    quarantine_size_mb = get_value('QUARANTINE_SIZE_MB', 256)
 
   # Default options for memory debuggin tool used.
   if tool_name == 'ASAN':


### PR DESCRIPTION
check_for_bad_build is used in progression and regression task
and this messes up the profile (e.g. redzone) that is set by
testcase itself.