### PR TITLE
Use crash_result.is_crash since it ignores empty crash state.

### DIFF
--- a/src/python/fuzzing/tests.py
+++ b/src/python/fuzzing/tests.py
@@ -22,7 +22,6 @@ import zlib
 
 from base import utils
 from build_management import revisions
-from crash_analysis import crash_analyzer
 from crash_analysis.crash_comparer import CrashComparer
 from crash_analysis.crash_result import CrashResult
 from datastore import data_handler

--- a/src/python/fuzzing/tests.py
+++ b/src/python/fuzzing/tests.py
@@ -436,7 +436,8 @@ def run_testcase_and_return_result_in_queue(crash_queue,
 
     # Analyze the crash.
     crash_output = _get_crash_output(output)
-    if crash_analyzer.is_crash(return_code, crash_output):
+    crash_result = CrashResult(return_code, crash_time, crash_output)
+    if crash_result.is_crash():
       # Initialize resource list with the testcase path.
       resource_list = [file_path]
       resource_list += get_resource_paths(crash_output)
@@ -463,9 +464,10 @@ def run_testcase_and_return_result_in_queue(crash_queue,
       if upload_output:
         upload_testcase(file_path)
 
-    crash_result = CrashResult(return_code, crash_time, output)
     if upload_output:
-      upload_testcase_output(crash_result, file_path)
+      # Include full output for uploaded logs (crash output, merge output, etc).
+      crash_result_full = CrashResult(return_code, crash_time, output)
+      upload_testcase_output(crash_result_full, file_path)
   except Exception:
     logs.log_error('Exception occurred while running '
                    'run_testcase_and_return_result_in_queue.')


### PR DESCRIPTION
This is a regression from
https://github.com/google/clusterfuzz/commit/46643f0954cfff32a3685e6cbd6c8bb6b3157002#diff-6bbe1ef1dddc4f3eedadcee180e3e41f
but we should have done this properly in first place
using crash_result. This also avoid filling up the crash
queue with such crashes which should have been ignored
in the first place.