### PR TITLE
 Fix check failure comparison regex in stack parsing.

### DIFF
--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -868,8 +868,8 @@ def fix_check_failure_string(failure_string):
   # CHECK_FAILURE_PATTERN, so we looked for "failed:" as preceding string.
   failure_string = re.sub(r'(?<=failed): .*vs\..*$', r'', failure_string)
 
-  # Cover example like len > 0 (-1 vs. 0).".
-  failure_string = re.sub(r' \(.*vs\..*\)\.?$', r'', failure_string)
+  # Cover example like len > 0 (-1 vs. 0)".
+  failure_string = re.sub(r' \(.*vs\..*\).*', r'', failure_string)
 
   # Strip unneeded chars at end.
   return failure_string.strip(' .\'"[]')

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -866,10 +866,10 @@ def fix_check_failure_string(failure_string):
   # Cover example like "CHECK_EQ( (unsigned)ptr[0],1u) failed: 25 vs. 1".
   # This only happens on Android, where we cannot strip the
   # CHECK_FAILURE_PATTERN, so we looked for "failed:" as preceding string.
-  failure_string = re.sub(r'(?<=failed): .* vs\. .*$', r'', failure_string)
+  failure_string = re.sub(r'(?<=failed): .*\svs\.\s.*$', r'', failure_string)
 
   # Cover example like len > 0 (-1 vs. 0)".
-  failure_string = re.sub(r' \(.* vs\. .*\).*', r'', failure_string)
+  failure_string = re.sub(r' \(.*\svs\.\s.*\).*', r'', failure_string)
 
   # Strip unneeded chars at end.
   return failure_string.strip(' .\'"[]')

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -866,10 +866,10 @@ def fix_check_failure_string(failure_string):
   # Cover example like "CHECK_EQ( (unsigned)ptr[0],1u) failed: 25 vs. 1".
   # This only happens on Android, where we cannot strip the
   # CHECK_FAILURE_PATTERN, so we looked for "failed:" as preceding string.
-  failure_string = re.sub(r'(?<=failed): .*vs\..*$', r'', failure_string)
+  failure_string = re.sub(r'(?<=failed): .* vs\. .*$', r'', failure_string)
 
   # Cover example like len > 0 (-1 vs. 0)".
-  failure_string = re.sub(r' \(.*vs\..*\).*', r'', failure_string)
+  failure_string = re.sub(r' \(.* vs\. .*\).*', r'', failure_string)
 
   # Strip unneeded chars at end.
   return failure_string.strip(' .\'"[]')

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/check_failure_with_comparison2.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/check_failure_with_comparison2.txt
@@ -1,0 +1,1 @@
+[1:1:0412/075451.163515:FATAL:compositing_layer_property_updater.cc(57)] Check failed: layout_snapped_paint_offset == snapped_paint_offset ("9,134.016" vs. "9,134")"LayoutHTMLCanvas CANVAS id='htmlvar00020'"

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1973,9 +1973,8 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('check_failure_with_comparison2.txt')
     expected_type = 'CHECK failure'
     expected_address = ''
-    expected_state = (
-        'layout_snapped_paint_offset == snapped_paint_offset '
-        'in compositing_layer_propert\n')
+    expected_state = ('layout_snapped_paint_offset == snapped_paint_offset '
+                      'in compositing_layer_propert\n')
     expected_stacktrace = data
     expected_security_flag = False
 

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1968,6 +1968,21 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_check_failure_with_comparison2(self):
+    """Test for special CHECK failure formats (CHECK_EQ, CHECK_LE, etc.)."""
+    data = self._read_test_data('check_failure_with_comparison2.txt')
+    expected_type = 'CHECK failure'
+    expected_address = ''
+    expected_state = (
+        'layout_snapped_paint_offset == snapped_paint_offset '
+        'in compositing_layer_propert\n')
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_check_failure_with_handle_sigill_disabled(self):
     """Test the CHECK failure crash with ASAN_OPTIONS=handle_sigill=0."""
     data = self._read_test_data('check_failure_with_handle_sigill=0.txt')


### PR DESCRIPTION
This is causing flakiness in linux_debug_chrome job testcases.