### PR TITLE
Revert "Add logging to debug windows libfuzzer backup failures."

### DIFF
--- a/src/python/fuzzing/corpus_manager.py
+++ b/src/python/fuzzing/corpus_manager.py
@@ -102,12 +102,6 @@ def backup_corpus(backup_bucket_name, corpus, directory):
   try:
     backup_archive_path = shutil.make_archive(backup_archive_path,
                                               BACKUP_ARCHIVE_FORMAT, directory)
-    logs.log(
-        'Created corpus backup file.',
-        backup_archive_path=backup_archive_path,
-        directory=directory,
-        size=os.path.getsize(backup_archive_path))
-
     dated_backup_url = gcs_url_for_backup_file(
         backup_bucket_name, corpus.engine, corpus.project_qualified_target_name,
         timestamp)


### PR DESCRIPTION
Reverts google/clusterfuzz#383.

Underlying bug is now fixed in https://github.com/google/clusterfuzz/commit/94becba53359f6d010a29fd7513267315237f73b
This logging is not needed anymore.