### PR TITLE
Finish futurize Py2->3 stage 1, use absolute imports (#183)

### DIFF
--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -35,17 +35,17 @@ from bot.fuzzers import dictionary_manager
 from bot.fuzzers import engine_common
 from bot.fuzzers import options
 from bot.fuzzers import utils as fuzzer_utils
+from bot.fuzzers.afl import constants
+from bot.fuzzers.afl import stats
+from bot.fuzzers.afl import strategies
+from bot.fuzzers.afl.fuzzer import write_dummy_file
 from datastore import data_types
-from fuzzer import write_dummy_file
 from metrics import logs
 from metrics import profiler
 from system import environment
 from system import minijail
 from system import new_process
 from system import shell
-import constants
-import stats
-import strategies
 
 # Allow 30 minutes to merge the testcases back into the corpus. This matches
 # libFuzzer's merge timeout.

--- a/src/python/bot/fuzzers/afl/stats.py
+++ b/src/python/bot/fuzzers/afl/stats.py
@@ -17,10 +17,9 @@ from __future__ import print_function
 import os
 import re
 
-import strategies
-
 from bot.fuzzers import dictionary_manager
 from bot.fuzzers import engine_common
+from bot.fuzzers.afl import strategies
 from metrics import logs
 
 SANITIZER_START_REGEX = re.compile(r'.*ERROR: [A-z]+Sanitizer:.*')

--- a/src/python/bot/fuzzers/libFuzzer/fuzzer.py
+++ b/src/python/bot/fuzzers/libFuzzer/fuzzer.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """libFuzzer fuzzer."""
-import constants
-
 from bot.fuzzers import builtin
 from bot.fuzzers import options
+from bot.fuzzers.libFuzzer import constants
 
 
 class LibFuzzer(builtin.EngineFuzzer):

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -40,6 +40,8 @@ from bot.fuzzers import libfuzzer
 from bot.fuzzers import mutator_plugin
 from bot.fuzzers import strategy
 from bot.fuzzers import utils as fuzzer_utils
+from bot.fuzzers.libFuzzer import constants
+from bot.fuzzers.libFuzzer import stats
 from bot.fuzzers.ml.rnn import generator as ml_rnn_generator
 from datastore import data_types
 from metrics import logs
@@ -48,8 +50,6 @@ from system import environment
 from system import minijail
 from system import new_process
 from system import shell
-import constants
-import stats
 
 # Regex to find testcase path from a crash.
 CRASH_TESTCASE_REGEX = (r'.*Test unit written to\s*'

--- a/src/python/bot/fuzzers/libFuzzer/stats.py
+++ b/src/python/bot/fuzzers/libFuzzer/stats.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Performance stats constants and helpers for libFuzzer."""
-
 import re
-
-import constants
 
 from bot.fuzzers import dictionary_manager
 from bot.fuzzers import strategy
 from bot.fuzzers import utils as fuzzer_utils
+from bot.fuzzers.libFuzzer import constants
 from crash_analysis.stack_parsing import stack_analyzer
 from metrics import logs
 

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """libFuzzer runners."""
-
 import copy
-import engine_common
 import os
 import shutil
 
 from base import retry
-from libFuzzer import constants
+from bot.fuzzers import engine_common
+from bot.fuzzers.libFuzzer import constants
 from platforms import fuchsia
 from system import environment
 from system import minijail

--- a/src/python/bot/fuzzers/ml/rnn/generate.py
+++ b/src/python/bot/fuzzers/ml/rnn/generate.py
@@ -16,14 +16,14 @@ from __future__ import print_function
 
 import argparse
 import math
+import numpy as np
 import os
 import sys
+import tensorflow as tf
 import time
 
-import constants
-import numpy as np
-import tensorflow as tf
-import utils
+from bot.fuzzers.ml.rnn import constants
+from bot.fuzzers.ml.rnn import utils
 
 # Reset batch_size for generation: generate multiple inputs in each run.
 BATCH_SIZE = 50

--- a/src/python/bot/fuzzers/ml/rnn/generator.py
+++ b/src/python/bot/fuzzers/ml/rnn/generator.py
@@ -22,13 +22,12 @@ except ImportError:
 
 import os
 
+from bot.fuzzers.ml.rnn import constants
 from google_cloud_utils import storage
 from metrics import logs
 from system import environment
 from system import new_process
 from system import shell
-
-import constants
 
 # Model script directory absolute path.
 ML_RNN_SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -16,16 +16,17 @@ from __future__ import print_function
 
 import argparse
 import math
+import numpy as np
 import os
 import sys
+import tensorflow as tf
 import time
 
-import constants
-import numpy as np
-import tensorflow as tf
 from tensorflow.contrib import layers
 from tensorflow.contrib import rnn
-import utils
+
+from bot.fuzzers.ml.rnn import constants
+from bot.fuzzers.ml.rnn import utils
 
 # Training suggestions
 #

--- a/src/python/bot/fuzzers/ml/rnn/utils.py
+++ b/src/python/bot/fuzzers/ml/rnn/utils.py
@@ -14,12 +14,12 @@
 """Utility functions for ml rnn model."""
 from __future__ import print_function
 
+import numpy as np
 import os
 import random
 import sys
 
-import constants
-import numpy as np
+from bot.fuzzers.ml.rnn import constants
 
 
 def validate_model_path(model_path):


### PR DESCRIPTION
Absolute imports are used since libFuzzer, AFL launchers
and ml/rnn/generate,train scripts are launched as new
python processes and relative imports don't work in
non-packages.