### PR TITLE
Don't mark build as bad when leaks are detected.

### DIFF
--- a/src/python/crash_analysis/crash_result.py
+++ b/src/python/crash_analysis/crash_result.py
@@ -71,6 +71,12 @@ class CrashResult(object):
 
     return state.crash_stacktrace
 
+  def get_type(self):
+    """Return the crash type."""
+    # It does not matter whether we use symbolized or unsymbolized data.
+    state = self.get_unsymbolized_data()
+    return state.crash_type
+
   def is_crash(self, ignore_state=False):
     """Return True if this result was a crash."""
     crashed = crash_analyzer.is_crash(self.return_code, self.output)

--- a/src/python/fuzzing/tests.py
+++ b/src/python/fuzzing/tests.py
@@ -944,10 +944,13 @@ def check_for_bad_build(job_type, crash_revision):
       current_working_directory=app_directory)
   crash_result = CrashResult(return_code, crash_time, output)
 
-  # Need to account for startup crashes with no crash state. E.g. failed to load
-  # shared library.
+  # 1. Need to account for startup crashes with no crash state. E.g. failed to
+  #    load shared library. So, ignore state for comparison.
+  # 2. Ignore leaks as they don't block a build from reporting regular crashes
+  #    and also don't impact regression range calculations.
   if (crash_result.is_crash(ignore_state=True) and
-      not crash_result.should_ignore()):
+      not crash_result.should_ignore() and
+      not crash_result.get_type() in ['Direct-leak', 'Indirect-leak']):
     is_bad_build = True
     build_run_console_output = utils.get_crash_stacktrace_output(
         command,


### PR DESCRIPTION
Leaks can be frequent, however they don't impact reproducing
of regular crashes (as they are reported during shutdown). So,
instead of marking build as bad and blocking fuzzing, we instead
let the build go through which helps with regular fuzzing and
then report the leak with a proper testcase report.