### PR TITLE
Handle IOErrors from get_device_path in reset_usb.

### DIFF
--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -604,7 +604,12 @@ def reset_usb():
 
   # We need to get latest device path since it could be changed in reboots or
   # adb root restarts.
-  device_path = get_device_path()
+  try:
+    device_path = get_device_path()
+  except IOError:
+    # We may reach this state if the device is no longer available.
+    device_path = None
+
   if not device_path:
     # Try pulling from cache (if available).
     device_path = environment.get_value('DEVICE_PATH')


### PR DESCRIPTION
PTAL. This will still cause an error if we run into the exception when trying to store the path as DEVICE_PATH (which I think is desired), but will fall back to using it if we hit the exception later.