### PR TITLE
Replace App Engine users module with Firebase Auth (#399).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Next Version
 - Various bug fixes.
+- Removing various dependencies on App Engine SDK.
+- Using Firebase auth for authentication.
 
 ## Version 1.1.0
 - Various bug fixes.

--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,9 @@
     "polymer": "Polymer/polymer#^2.1.0",
     "test-fixture": "PolymerElements/test-fixture#^2.0.0",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0",
-    "shadycss": "^1.0.6"
+    "shadycss": "^1.0.6",
+    "firebaseui": "^3.6.0",
+    "firebase": "^5.9.4"
   },
   "resolutions": {
     "iron-flex-layout": "^2.0.0",
@@ -62,6 +64,7 @@
     "iron-collapse": "^2.0.0",
     "polymer": "^2.1.0",
     "iron-selector": "^2.0.0",
-    "paper-ripple": "^2.0.0"
+    "paper-ripple": "^2.0.0",
+    "firebase": "^5.9.4"
   }
 }

--- a/butler.py
+++ b/butler.py
@@ -238,6 +238,11 @@ def main():
   parser_create_config.add_argument(
       '--project-id', type=str, required=True, help='Your Cloud Project ID.')
   parser_create_config.add_argument(
+      '--firebase-api-key',
+      type=str,
+      required=True,
+      help='Firebase web API key.')
+  parser_create_config.add_argument(
       '--oauth-client-secrets-path',
       type=str,
       required=True,

--- a/butler.py
+++ b/butler.py
@@ -241,7 +241,7 @@ def main():
       '--firebase-api-key',
       type=str,
       required=True,
-      help='Firebase web API key.')
+      help='Firebase web API key (for authentication).')
   parser_create_config.add_argument(
       '--oauth-client-secrets-path',
       type=str,

--- a/configs/test/gae/prod/cron.yaml
+++ b/configs/test/gae/prod/cron.yaml
@@ -107,3 +107,8 @@ cron:
     url: /triage
     schedule: every 1 hours
     target: cron-service
+
+  - description: Sync admin users.
+    url: /sync-admins
+    schedule: every 1 hours
+    target: cron-service

--- a/configs/test/project.yaml
+++ b/configs/test/project.yaml
@@ -42,6 +42,10 @@ monitoring:
   # Flag to indicate if Stackdriver monitoring is enabled or not (disabled by default).
   enabled: false
 
+firebase:
+  # API key for Firebase (public).
+  api_key: firebase-api-key
+
 env:
   # Application ID for the Google Cloud Project. In production, this will have a s~ prefix.
   APPLICATION_ID: test-clusterfuzz

--- a/docs/production-setup/clusterfuzz.md
+++ b/docs/production-setup/clusterfuzz.md
@@ -48,6 +48,10 @@ for authentication and should not incur any additional charges.
 
 2. In the [Firebase console], go to the **Auth** section and enable "Google" as a Sign-in provider.
 
+3. In the same section, go to the **Usage** tab and add the domains you plan on
+   using to the "Authorized domains" list. The default domain for App Engine
+   looks like `<project ID>.appspot.com`.
+
 ### Web API Key
 To obtain a web API key,
 1. Go to the [Firebase console] and select your project.

--- a/docs/production-setup/clusterfuzz.md
+++ b/docs/production-setup/clusterfuzz.md
@@ -41,6 +41,21 @@ If you're new to Google Cloud you may be eligible for [trial credit].
 
 [trial credit]: https://cloud.google.com/free/docs/gcp-free-tier#free-trial
 
+## Enable Firebase
+Follow [these instructions](https://cloud.google.com/appengine/docs/standard/python3/building-app/adding-firebase)
+to add Firebase to the Google Cloud project you just created. **Important**: You
+will also need to enable "Google" as a Sign-in provider.
+
+### Web API Key
+To obtain a web API key,
+1. Go to the [Firebase console](https://console.firebase.google.com/) and select your project.
+2. From the project overview page, click **Add Firebase to your web app** to display the customized code snippet.
+3. Copy the `apiKey` value, and export it like so
+
+```bash
+export FIREBASE_API_KEY=<your api key>
+```
+
 ## Create OAuth credentials
 Follow [these instructions](https://developers.google.com/identity/protocols/OAuth2InstalledApp#creatingcred)
 to create OAuth credentials for our project setup script. Choose
@@ -67,7 +82,7 @@ settings for your deployment and can be later updated.
 ```bash
 mkdir /path/to/myconfig  # Any EMPTY directory outside the ClusterFuzz source repository.
 export CONFIG_DIR=/path/to/myconfig
-python butler.py create_config --oauth-client-secrets-path=$CLIENT_SECRETS_PATH --project-id=$CLOUD_PROJECT_ID $CONFIG_DIR
+python butler.py create_config --oauth-client-secrets-path=$CLIENT_SECRETS_PATH --firebase-api-key=$FIREBASE_API_KEY --project-id=$CLOUD_PROJECT_ID $CONFIG_DIR
 ```
 
 This can take a few minutes to finish, so please be patient. The script also

--- a/docs/production-setup/clusterfuzz.md
+++ b/docs/production-setup/clusterfuzz.md
@@ -42,19 +42,23 @@ If you're new to Google Cloud you may be eligible for [trial credit].
 [trial credit]: https://cloud.google.com/free/docs/gcp-free-tier#free-trial
 
 ## Enable Firebase
-Follow [these instructions](https://cloud.google.com/appengine/docs/standard/python3/building-app/adding-firebase)
-to add Firebase to the Google Cloud project you just created. **Important**: You
-will also need to enable "Google" as a Sign-in provider.
+1. Follow [these instructions](https://cloud.google.com/appengine/docs/standard/python3/building-app/adding-firebase)
+to add Firebase to the Google Cloud project you just created. This will be used
+for authentication and should not incur any additional charges.
+
+2. In the [Firebase console], go to the **Auth** section and enable "Google" as a Sign-in provider.
 
 ### Web API Key
 To obtain a web API key,
-1. Go to the [Firebase console](https://console.firebase.google.com/) and select your project.
+1. Go to the [Firebase console] and select your project.
 2. From the project overview page, click **Add Firebase to your web app** to display the customized code snippet.
 3. Copy the `apiKey` value, and export it like so
 
 ```bash
 export FIREBASE_API_KEY=<your api key>
 ```
+
+[Firebase console]: https://console.firebase.google.com/
 
 ## Create OAuth credentials
 Follow [these instructions](https://developers.google.com/identity/protocols/OAuth2InstalledApp#creatingcred)
@@ -82,7 +86,8 @@ settings for your deployment and can be later updated.
 ```bash
 mkdir /path/to/myconfig  # Any EMPTY directory outside the ClusterFuzz source repository.
 export CONFIG_DIR=/path/to/myconfig
-python butler.py create_config --oauth-client-secrets-path=$CLIENT_SECRETS_PATH --firebase-api-key=$FIREBASE_API_KEY --project-id=$CLOUD_PROJECT_ID $CONFIG_DIR
+python butler.py create_config --oauth-client-secrets-path=$CLIENT_SECRETS_PATH \
+  --firebase-api-key=$FIREBASE_API_KEY --project-id=$CLOUD_PROJECT_ID $CONFIG_DIR
 ```
 
 This can take a few minutes to finish, so please be patient. The script also

--- a/docs/production-setup/clusterfuzz.md
+++ b/docs/production-setup/clusterfuzz.md
@@ -48,9 +48,9 @@ for authentication and should not incur any additional charges.
 
 2. In the [Firebase console], go to the **Auth** section and enable "Google" as a Sign-in provider.
 
-3. In the same section, go to the **Usage** tab and add the domains you plan on
-   using to the "Authorized domains" list. The default domain for App Engine
-   looks like `<project ID>.appspot.com`.
+3. In the same section, add the domains you plan on using to the "Authorized
+   domains" list. The default domain for App Engine looks like `<project
+   ID>.appspot.com`.
 
 ### Web API Key
 To obtain a web API key,

--- a/src/appengine/appengine_config.py
+++ b/src/appengine/appengine_config.py
@@ -109,8 +109,11 @@ if IS_RUNNING_IN_PRODUCTION or IS_RUNNING_IN_DEV_APPSERVER:
   # running tasks such as cron jobs.
   ndb.get_context().set_cache_policy(False)
 
-# Use the App Engine Requests adapter. This makes sure that Requests uses
-# URLFetch. This is a workaround till we migrate to Python 3 on App Engine Flex.
-if IS_RUNNING_IN_PRODUCTION:
+  # Use the App Engine Requests adapter. This makes sure that Requests uses
+  # URLFetch. This is a workaround till we migrate to Python 3 on App Engine
+  # Flex.
   import requests_toolbelt.adapters.appengine
   requests_toolbelt.adapters.appengine.monkeypatch()
+
+  import firebase_admin
+  firebase_admin.initialize_app()

--- a/src/appengine/handlers/cron/sync_admins.py
+++ b/src/appengine/handlers/cron/sync_admins.py
@@ -1,0 +1,87 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cron to sync admin users."""
+
+import googleapiclient
+
+from base import utils
+from datastore import data_types
+from datastore import ndb
+from datastore import ndb_utils
+from handlers import base_handler
+from libs import handler
+
+
+def admins_from_iam_policy(iam_policy):
+  """Get a list of admins from the IAM policy."""
+  # Per
+  # https://cloud.google.com/appengine/docs/standard/python/users/adminusers, An
+  # administrator is a user who has the Viewer, Editor, or Owner primitive role,
+  # or the App Engine App Admin predefined role
+  roles = [
+      'roles/editor',
+      'roles/owner',
+      'roles/viewer',
+      'roles/appengine.appAdmin',
+  ]
+
+  admins = []
+  for binding in iam_policy['bindings']:
+    if binding['role'] not in roles:
+      continue
+
+    for member in binding['members']:
+      user_type, email = member.split(':', 2)
+      if user_type == 'user':
+        admins.append(email)
+
+  return admins
+
+
+def update_admins(new_admins):
+  """Update list of admins."""
+  existing_admins = ndb_utils.get_all_from_model(data_types.Admin)
+
+  to_remove = []
+  existing_admin_emails = set()
+  for admin in existing_admins:
+    if admin.email not in new_admins:
+      to_remove.append(admin.key)
+
+    existing_admin_emails.add(admin.email)
+
+  ndb.delete_multi(to_remove)
+
+  to_add = []
+  for admin in new_admins:
+    if admin not in existing_admin_emails:
+      to_add.append(data_types.Admin(id=admin, email=admin))
+
+  ndb.put_multi(to_add)
+
+
+class Handler(base_handler.Handler):
+  """Admin user syncing cron."""
+
+  @handler.check_cron()
+  def get(self):
+    """Handle a get request."""
+    resource_manager = googleapiclient.discovery.build('cloudresourcemanager',
+                                                       'v1')
+    project_id = utils.get_application_id()
+    policy = resource_manager.projects().getIamPolicy(
+        resource=project_id, body={}).execute()
+
+    admins = admins_from_iam_policy(policy)
+    update_admins(admins)

--- a/src/appengine/handlers/cron/sync_admins.py
+++ b/src/appengine/handlers/cron/sync_admins.py
@@ -21,6 +21,7 @@ from datastore import ndb
 from datastore import ndb_utils
 from handlers import base_handler
 from libs import handler
+from metrics import logs
 
 
 def admins_from_iam_policy(iam_policy):
@@ -57,6 +58,7 @@ def update_admins(new_admins):
   existing_admin_emails = set()
   for admin in existing_admins:
     if admin.email not in new_admins:
+      logs.log('Removing admin ' + admin.email)
       to_remove.append(admin.key)
 
     existing_admin_emails.add(admin.email)
@@ -67,6 +69,7 @@ def update_admins(new_admins):
   for admin in new_admins:
     if admin not in existing_admin_emails:
       to_add.append(data_types.Admin(id=admin, email=admin))
+      logs.log('Adding admin ' + admin)
 
   ndb.put_multi(to_add)
 

--- a/src/appengine/handlers/login.py
+++ b/src/appengine/handlers/login.py
@@ -1,0 +1,81 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Login page."""
+
+import datetime
+
+from base import utils
+from config import local_config
+from handlers import base_handler
+from libs import auth
+from libs import handler
+from libs import helpers
+from metrics import logs
+
+SESSION_EXPIRY_DAYS = 14
+
+
+class Handler(base_handler.Handler):
+  """Login page."""
+
+  @handler.get(handler.HTML)
+  def get(self):
+    """Handle a get request."""
+    self.render(
+        'login.html', {
+            'apiKey': local_config.ProjectConfig().get('firebase.api_key'),
+            'projectId': utils.get_application_id(),
+            'dest': self.request.get('dest'),
+        })
+
+
+class SessionLoginHandler(base_handler.Handler):
+  """Session login handler."""
+
+  @handler.post(handler.JSON, handler.JSON)
+  def post(self):
+    """Handle a post request."""
+    id_token = self.request.get('idToken')
+    expires_in = datetime.timedelta(days=SESSION_EXPIRY_DAYS)
+    try:
+      session_cookie = auth.create_session_cookie(id_token, expires_in)
+    except auth.AuthError:
+      raise helpers.EarlyExitException('Failed to create session cookie.', 401)
+
+    expires = datetime.datetime.now() + expires_in
+    self.response.set_cookie(
+        'session',
+        session_cookie,
+        expires=expires,
+        httponly=True,
+        secure=True,
+        overwrite=True)
+    self.render_json({'status': 'success'})
+
+
+class LogoutHandler(base_handler.Handler):
+  """Log out handler."""
+
+  @handler.require_csrf_token
+  @handler.get(handler.HTML)
+  def get(self):
+    """Handle a get request."""
+    try:
+      auth.revoke_session_cookie(auth.get_session_cookie())
+    except auth.AuthError:
+      # Even if the revoke failed, remove the cookie.
+      logs.log_error('Failed to revoke session cookie.')
+
+    self.response.delete_cookie('session')
+    self.redirect(self.request.get('dest'))

--- a/src/appengine/handlers/testcase_detail/show.py
+++ b/src/appengine/handlers/testcase_detail/show.py
@@ -18,8 +18,6 @@ import datetime
 import jinja2
 import re
 
-from google.appengine.api import users
-
 from base import utils
 from build_management import revisions
 from build_management import source_mapper
@@ -32,6 +30,7 @@ from handlers import base_handler
 from issue_management import issue_tracker_utils
 from issue_management import label_utils
 from libs import access
+from libs import auth
 from libs import form
 from libs import handler
 from libs import helpers
@@ -551,7 +550,7 @@ def get_testcase_detail(testcase):
       'issue_url':
           issue_url,
       'is_admin':
-          users.is_current_user_admin(),
+          auth.is_current_user_admin(),
       'metadata':
           metadata,
       'minimized_testcase_size':
@@ -638,7 +637,7 @@ def get_testcase_detail(testcase):
 
 def is_admin_or_not_oss_fuzz():
   """Return True if the current user is an admin or if this is not OSS-Fuzz."""
-  return not utils.is_oss_fuzz() or users.is_current_user_admin()
+  return not utils.is_oss_fuzz() or auth.is_current_user_admin()
 
 
 class Handler(base_handler.Handler):

--- a/src/appengine/libs/access.py
+++ b/src/appengine/libs/access.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """access.py contains static methods around access permissions."""
 
-from google.appengine.api import users
-
 from base import errors
 from base import external_users
 from base import utils
@@ -22,6 +20,7 @@ from config import db_config
 from config import local_config
 from datastore import data_handler
 from issue_management import issue_tracker_utils
+from libs import auth
 from libs import helpers
 
 
@@ -79,14 +78,14 @@ def has_access(need_privileged_access=False, job_type=None, fuzzer_name=None):
 
 def get_access(need_privileged_access=False, job_type=None, fuzzer_name=None):
   """Return 'allowed', 'redirected', or 'failed'."""
-  if users.is_current_user_admin():
+  if auth.is_current_user_admin():
     return UserAccess.Allowed
 
-  user = users.get_current_user()
+  user = auth.get_current_user()
   if not user:
     return UserAccess.Redirected
 
-  email = user.email()
+  email = user.email
   if _is_privileged_user(email):
     return UserAccess.Allowed
 

--- a/src/appengine/libs/auth.py
+++ b/src/appengine/libs/auth.py
@@ -1,0 +1,97 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Authentication helpers."""
+
+import collections
+
+from firebase_admin import auth
+import webapp2
+
+from datastore import data_types
+from datastore import ndb
+from metrics import logs
+
+User = collections.namedtuple('User', ['email'])
+
+
+class AuthError(Exception):
+  """Auth error."""
+
+
+def is_current_user_admin():
+  """Returns whether or not the current logged in user is an admin."""
+  user = get_current_user()
+  if not user:
+    return False
+
+  key = ndb.Key(data_types.Admin, user.email)
+  return bool(key.get())
+
+
+def get_current_user():
+  """Get the current logged in user, or None."""
+  oauth_email = getattr(get_current_request(), '_oauth_email', None)
+  if oauth_email:
+    return User(oauth_email)
+
+  session_cookie = get_session_cookie()
+  if not session_cookie:
+    return None
+
+  try:
+    decoded_claims = decode_claims(get_session_cookie())
+  except AuthError:
+    logs.log_error('Invalid session cookie.')
+    return None
+
+  if not decoded_claims.get('email_verified'):
+    return None
+
+  email = decoded_claims.get('email')
+  if not email:
+    return None
+
+  return User(email)
+
+
+def create_session_cookie(id_token, expires_in):
+  """Create a new session cookie."""
+  try:
+    return auth.create_session_cookie(id_token, expires_in=expires_in)
+  except auth.AuthError:
+    raise AuthError('Failed to create session cookie.')
+
+
+def get_current_request():
+  """Get the current request."""
+  return webapp2.get_request()
+
+
+def get_session_cookie():
+  """Get the current session cookie."""
+  return get_current_request().cookies.get('session')
+
+
+def revoke_session_cookie(session_cookie):
+  """Revoke a session cookie."""
+  decoded_claims = decode_claims(session_cookie)
+  auth.revoke_refresh_tokens(decoded_claims['sub'])
+
+
+def decode_claims(session_cookie):
+  """Decode the claims for the current session cookie."""
+  try:
+    return auth.verify_session_cookie(session_cookie, check_revoked=True)
+  except (ValueError, auth.AuthError):
+    raise AuthError('Invalid session cookie.')

--- a/src/appengine/libs/csp.py
+++ b/src/appengine/libs/csp.py
@@ -80,9 +80,15 @@ def get_default_builder():
   # External scripts. Google analytics, charting libraries.
   builder.add('script-src', 'www.google-analytics.com')
   builder.add('script-src', 'www.gstatic.com')
+  builder.add('script-src', 'apis.google.com')
 
   # Google Analytics also uses img-src.
   builder.add('img-src', 'www.google-analytics.com')
+
+  # Firebase.
+  builder.add('img-src', 'www.gstatic.com')
+  builder.add('connect-src', 'www.googleapis.com')
+  builder.add('frame-src', 'cluster-fuzz.firebaseapp.com')
 
   # External style. Used for fonts, charting libraries.
   builder.add('style-src', 'fonts.googleapis.com')

--- a/src/appengine/libs/csp.py
+++ b/src/appengine/libs/csp.py
@@ -14,6 +14,8 @@
 """Helpers used to generate Content Security Policies for pages."""
 import collections
 
+from base import utils
+
 
 class CSPBuilder(object):
   """Helper to build a Content Security Policy string."""
@@ -88,7 +90,7 @@ def get_default_builder():
   # Firebase.
   builder.add('img-src', 'www.gstatic.com')
   builder.add('connect-src', 'www.googleapis.com')
-  builder.add('frame-src', 'cluster-fuzz.firebaseapp.com')
+  builder.add('frame-src', utils.get_application_id() + '.firebaseapp.com')
 
   # External style. Used for fonts, charting libraries.
   builder.add('style-src', 'fonts.googleapis.com')

--- a/src/appengine/libs/helpers.py
+++ b/src/appengine/libs/helpers.py
@@ -18,11 +18,10 @@ import logging
 import sys
 import traceback
 
-from google.appengine.api import users
-
 from base import errors
 from datastore import data_handler
 from issue_management import issue_tracker_utils
+from libs import auth
 
 VIEW_OPERATION = 'View'
 MODIFY_OPERATION = 'Modify'
@@ -152,7 +151,7 @@ def get_or_exit(fn,
 def get_user_email():
   """Returns currently logged-in user's email."""
   try:
-    return users.get_current_user().email()
+    return auth.get_current_user().email
   except Exception:
     return ''
 

--- a/src/appengine/private/templates/login.html
+++ b/src/appengine/private/templates/login.html
@@ -1,0 +1,90 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+{% extends "layout-with-toolbar.html" %}
+{% block import_element %}
+  {% raw %}
+    <script src="/private/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="/private/bower_components/firebase/firebase.js"></script>
+    <script src="/private/bower_components/firebaseui/dist/firebaseui.js"></script>
+    <link type="text/css" rel="stylesheet" href="/private/bower_components/firebaseui/dist/firebaseui.css">
+    <link rel="import" href="/private/bower_components/polymer/polymer.html">
+    <link rel="import" href="/private/bower_components/iron-icons/iron-icons.html">
+    <link rel="import" href="/private/bower_components/iron-icon/iron-icon.html">
+    <link rel="import" href="/private/bower_components/paper-icon-button/paper-icon-button.html">
+    <link rel="import" href="/private/bower_components/paper-item/paper-item.html">
+    <link rel="import" href="/private/bower_components/paper-listbox/paper-listbox.html">
+    <link rel="import" href="/private/bower_components/app-layout/app-layout.html">
+
+    <link rel="import" href="/private/components/technology/technology.html">
+    <link rel="stylesheet" type="text/css" href="/private/stylesheets/main.css">
+  {% endraw %}
+{% endblock %}
+{% block page_title %}
+  Log in
+{% endblock %}
+{% block toolbar_title %}
+  Log in
+{% endblock %}
+{% block main_content %}
+  <script>
+    // Initialize Firebase
+    var config = {
+    apiKey: '{{apiKey}}',
+      authDomain: '{{projectId}}.firebaseapp.com',
+    };
+    firebase.initializeApp(config);
+
+    var uiConfig = {
+      signInOptions: [
+          {
+              provider: firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+              customParameters: {
+                // Forces account selection even when one account
+                // is available.
+                prompt: 'select_account',
+              },
+          },
+      ],
+      callbacks: {
+        signInSuccessWithAuthResult: function(authResult, redirectUrl) {
+          authResult.user.getIdToken().then(function(idToken) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('POST', '/session-login');
+            xhr.setRequestHeader('content-type', 'application/json');
+
+            xhr.onreadystatechange = function() {
+              if (this.readyState == XMLHttpRequest.DONE && this.status == 200) {
+                window.location.assign('{{dest}}');
+              }
+            }
+
+            xhr.send(JSON.stringify({
+              idToken: idToken,
+            }));
+          });
+
+          return false;
+        },
+      },
+    };
+
+    var ui = new firebaseui.auth.AuthUI(firebase.auth());
+    ui.start('#login-container', uiConfig);
+  </script>
+  <div id="login-container">
+  </div>
+{% endblock %}
+

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -34,6 +34,7 @@ from handlers import help_redirector
 from handlers import home
 from handlers import issue_redirector
 from handlers import jobs
+from handlers import login
 from handlers import parse_stacktrace
 from handlers import report_csp_failure
 from handlers import revisions_info
@@ -54,6 +55,7 @@ from handlers.cron import oss_fuzz_setup
 from handlers.cron import predator_pull
 from handlers.cron import recurring_tasks
 from handlers.cron import schedule_corpus_pruning
+from handlers.cron import sync_admins
 from handlers.cron import triage
 from handlers.performance_report import (show as show_performance_report)
 from handlers.testcase_detail import (crash_stats as crash_stats_on_testcase)
@@ -133,6 +135,7 @@ _CRON_ROUTES = [
     ('/schedule-progression-tasks', recurring_tasks.ProgressionTasksScheduler),
     ('/schedule-upload-reports-tasks',
      recurring_tasks.UploadReportsTaskScheduler),
+    ('/sync-admins', sync_admins.Handler),
     ('/testcases/cache', testcase_list.CacheHandler),
     ('/triage', triage.Handler),
 ]
@@ -169,11 +172,14 @@ _ROUTES = [
     ('/issue/([0-9]+)/(.+)', issue_redirector.Handler),
     ('/jobs', jobs.Handler),
     ('/jobs/.*', jobs.Handler),
+    ('/login', login.Handler),
+    ('/logout', login.LogoutHandler),
     ('/update-job', jobs.UpdateJob),
     ('/update-job-template', jobs.UpdateJobTemplate),
     ('/parse_stacktrace', parse_stacktrace.Handler),
     ('/performance-report/(.+)/(.+)/(.+)', show_performance_report.Handler),
     ('/report-csp-failure', report_csp_failure.ReportCspFailureHandler),
+    ('/session-login', login.SessionLoginHandler),
     ('/testcase', show_testcase.DeprecatedHandler),
     ('/testcase-detail/([0-9]+)', show_testcase.Handler),
     ('/testcase-detail/crash-stats', crash_stats_on_testcase.Handler),

--- a/src/go/cloud/db/types/types.go
+++ b/src/go/cloud/db/types/types.go
@@ -22,6 +22,12 @@ import (
 	"cloud.google.com/go/datastore"
 )
 
+// Admin is auto-generated from data_types.py.
+type Admin struct {
+	Key   *datastore.Key `datastore:"__key__"`
+	Email string         `datastore:"email"`
+}
+
 // Blacklist is auto-generated from data_types.py.
 type Blacklist struct {
 	Key          *datastore.Key `datastore:"__key__"`

--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -248,7 +248,9 @@ def execute(args):
 
   blobs_bucket = project_bucket(args.project_id, 'blobs')
   deployment_bucket = project_bucket(args.project_id, 'deployment')
+
   bucket_replacements = (
+      ('firebase-api-key', args.firebase_api_key),
       ('test-blobs-bucket', blobs_bucket),
       ('test-deployment-bucket', deployment_bucket),
       ('test-bigquery-bucket', project_bucket(args.project_id, 'bigquery')),

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -1303,3 +1303,8 @@ class OssFuzzBuildFailure(Model):
 
   # Build type (fuzzing, coverage, etc).
   build_type = ndb.StringProperty()
+
+
+class Admin(Model):
+  """Records an admin user."""
+  email = ndb.StringProperty()

--- a/src/python/tests/appengine/handlers/cron/sync_admins_test.py
+++ b/src/python/tests/appengine/handlers/cron/sync_admins_test.py
@@ -1,0 +1,94 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for sync_admins."""
+
+import unittest
+
+import webapp2
+import webtest
+
+from datastore import data_types
+from handlers.cron import sync_admins
+from tests.test_libs import helpers as test_helpers
+from tests.test_libs import test_utils
+
+
+@test_utils.with_cloud_emulators('datastore')
+class SyncAdminsTest(unittest.TestCase):
+  """Tests for sync_admins."""
+
+  def setUp(self):
+    self.app = webtest.TestApp(
+        webapp2.WSGIApplication([('/sync-admins', sync_admins.Handler)]))
+
+    test_helpers.patch(self, [
+        'googleapiclient.discovery.build',
+        'handlers.base_handler.Handler.is_cron',
+    ])
+
+    data_types.Admin(id='remove@email.com', email='remove@email.com').put()
+    data_types.Admin(id='user1@email.com', email='keep@email.com').put()
+
+    self.mock.is_cron.return_value = True
+    self.mock.build().projects().getIamPolicy().execute.return_value = {
+        'version':
+            1,
+        'etag':
+            'etag',
+        'bindings': [
+            {
+                'role':
+                    'roles/appengine.appAdmin',
+                'members': [
+                    'user:user1@email.com',
+                    'serviceAccount:service_account@gserviceaccount.com',
+                ]
+            },
+            {
+                'role': 'roles/appengine.deployer',
+                'members': ['user:not_added@email.com',]
+            },
+            {
+                'role': 'roles/appengine.serviceAdmin',
+                'members': ['user:not_added@email.com',]
+            },
+            {
+                'role': 'roles/editor',
+                'members': [
+                    'user:user2@email.com',
+                    'user:user3@email.com',
+                ]
+            },
+            {
+                'role': 'roles/owner',
+                'members': ['user:user4@email.com',]
+            },
+            {
+                'role': 'roles/viewer',
+                'members': ['user:user5@email.com',]
+            },
+        ]
+    }
+
+  def test_sync_admins(self):
+    """Test syncing admins."""
+    self.app.get('/sync-admins')
+    admins = data_types.Admin.query()
+    self.assertItemsEqual([
+        'user1@email.com',
+        'user2@email.com',
+        'user3@email.com',
+        'user4@email.com',
+        'user5@email.com',
+    ], [admin.email for admin in admins])

--- a/src/python/tests/appengine/handlers/download_test.py
+++ b/src/python/tests/appengine/handlers/download_test.py
@@ -44,8 +44,6 @@ class DownloadTest(unittest.TestCase):
     test_helpers.patch(self, [
         'base.utils.is_oss_fuzz',
         'google_cloud_utils.blobs.get_blob_info',
-        'google.appengine.api.users.create_login_url',
-        'google.appengine.api.users.create_logout_url',
         'issue_management.issue_tracker_utils.get_issue_tracker_manager',
         'libs.access.can_user_access_testcase',
         'libs.access.has_access',

--- a/src/python/tests/appengine/handlers/fuzzer_stats_test.py
+++ b/src/python/tests/appengine/handlers/fuzzer_stats_test.py
@@ -275,8 +275,8 @@ class TestPermissions(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch(self, [
-        'google.appengine.api.users.is_current_user_admin',
-        'google.appengine.api.users.get_current_user',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
         'handlers.fuzzer_stats.build_results',
     ])
 
@@ -336,7 +336,7 @@ class TestPermissions(unittest.TestCase):
   def test_external_user_with_job(self):
     """Test external user access (job specified)."""
     self.mock.is_current_user_admin.return_value = False
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
     response = self.app.post_json(
         '/fuzzer-stats/load', {
@@ -372,7 +372,7 @@ class TestPermissions(unittest.TestCase):
   def test_external_user_without_job(self):
     """Test external user access (no job specified)."""
     self.mock.is_current_user_admin.return_value = False
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
     response = self.app.post_json(
         '/fuzzer-stats/load', {

--- a/src/python/tests/appengine/handlers/issue_redirector_test.py
+++ b/src/python/tests/appengine/handlers/issue_redirector_test.py
@@ -19,7 +19,6 @@ import webtest
 
 import server
 from datastore import data_types
-from google.appengine.ext import testbed
 from tests.test_libs import helpers as test_helpers
 
 
@@ -32,14 +31,7 @@ class HandlerTest(unittest.TestCase):
         'libs.helpers.get_testcase',
     ])
 
-    self.testbed = testbed.Testbed()
-    self.testbed.activate()
-    self.testbed.init_user_stub()
-
     self.app = webtest.TestApp(server.app)
-
-  def tearDown(self):
-    self.testbed.deactivate()
 
   def test_succeed(self):
     """Test redirection succeeds."""

--- a/src/python/tests/appengine/handlers/testcase_detail/create_issue_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/create_issue_test.py
@@ -32,13 +32,13 @@ class HandlerTest(unittest.TestCase):
     test_helpers.patch(self, [
         'issue_management.issue_filer.file_issue',
         'issue_management.issue_tracker_utils.get_issue_tracker_manager',
-        'google.appengine.api.users.get_current_user',
+        'libs.auth.get_current_user',
         'handlers.testcase_detail.show.get_testcase_detail',
         'libs.access.has_access',
     ])
     self.mock.has_access.return_value = True
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
     self.app = webtest.TestApp(
         webapp2.WSGIApplication([('/', create_issue.Handler)]))

--- a/src/python/tests/appengine/handlers/testcase_detail/delete_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/delete_test.py
@@ -29,11 +29,11 @@ class HandlerTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch(self, [
-        'google.appengine.api.users.get_current_user',
-        'google.appengine.api.users.is_current_user_admin',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
     ])
     self.mock.is_current_user_admin.return_value = True
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
     self.app = webtest.TestApp(webapp2.WSGIApplication([('/', delete.Handler)]))
 
   def test_assigned_issue(self):

--- a/src/python/tests/appengine/handlers/testcase_detail/mark_fixed_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/mark_fixed_test.py
@@ -30,8 +30,8 @@ class HandlerTest(unittest.TestCase):
   def setUp(self):
     test_helpers.patch(self, [
         'handlers.testcase_detail.show.get_testcase_detail',
-        'google.appengine.api.users.get_current_user',
-        'google.appengine.api.users.is_current_user_admin',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
     ])
 
     self.app = webtest.TestApp(
@@ -41,7 +41,7 @@ class HandlerTest(unittest.TestCase):
 
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
     self.mock.is_current_user_admin = True
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
   def test_succeed(self):
     """Mark a testcase as fixed."""

--- a/src/python/tests/appengine/handlers/testcase_detail/mark_security_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/mark_security_test.py
@@ -29,8 +29,8 @@ class HandlerTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch(self, [
-        'google.appengine.api.users.get_current_user',
-        'google.appengine.api.users.is_current_user_admin',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
         'handlers.testcase_detail.show.get_testcase_detail',
     ])
     self.app = webtest.TestApp(
@@ -40,7 +40,7 @@ class HandlerTest(unittest.TestCase):
     self.testcase.put()
     self.mock.is_current_user_admin.return_value = True
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
   def test_succeed(self):
     """Mark a testcase as security-related."""

--- a/src/python/tests/appengine/handlers/testcase_detail/mark_unconfirmed_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/mark_unconfirmed_test.py
@@ -29,8 +29,8 @@ class HandlerTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch(self, [
-        'google.appengine.api.users.get_current_user',
-        'google.appengine.api.users.is_current_user_admin',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
         'handlers.testcase_detail.show.get_testcase_detail',
     ])
     self.app = webtest.TestApp(
@@ -40,7 +40,7 @@ class HandlerTest(unittest.TestCase):
     self.testcase.put()
     self.mock.is_current_user_admin.return_value = True
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
   def test_succeed(self):
     """Mark a testcase as unconfirmed."""

--- a/src/python/tests/appengine/handlers/testcase_detail/redo_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/redo_test.py
@@ -33,8 +33,7 @@ class HandlerTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch(self, [
-        'base.tasks.redo_testcase',
-        'google.appengine.api.users.get_current_user',
+        'base.tasks.redo_testcase', 'libs.auth.get_current_user',
         'handlers.testcase_detail.show.get_testcase_detail',
         'libs.access.check_access_and_get_testcase'
     ])
@@ -44,7 +43,7 @@ class HandlerTest(unittest.TestCase):
     self.testcase = data_types.Testcase()
     self.testcase.put()
     self.mock.check_access_and_get_testcase.return_value = self.testcase
-    self.mock.get_current_user().email.return_value = self.USER_EMAIL
+    self.mock.get_current_user().email = self.USER_EMAIL
 
   def test_redo(self):
     """Redo all tasks."""

--- a/src/python/tests/appengine/handlers/testcase_detail/remove_duplicate_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/remove_duplicate_test.py
@@ -29,8 +29,8 @@ class HandlerTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch(self, [
-        'google.appengine.api.users.get_current_user',
-        'google.appengine.api.users.is_current_user_admin',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
         'handlers.testcase_detail.show.get_testcase_detail',
     ])
     self.app = webtest.TestApp(
@@ -40,7 +40,7 @@ class HandlerTest(unittest.TestCase):
     self.testcase.put()
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
     self.mock.is_current_user_admin.return_value = True
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
   def test_succeed(self):
     """Remove the duplicate status."""

--- a/src/python/tests/appengine/handlers/testcase_detail/remove_group_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/remove_group_test.py
@@ -30,12 +30,12 @@ class HandlerTest(unittest.TestCase):
   def setUp(self):
     test_helpers.patch(self, [
         'handlers.testcase_detail.show.get_testcase_detail',
-        'google.appengine.api.users.get_current_user',
-        'google.appengine.api.users.is_current_user_admin',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
     ])
     self.mock.is_current_user_admin.return_value = True
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
     self.app = webtest.TestApp(
         webapp2.WSGIApplication([('/', remove_group.Handler)]))

--- a/src/python/tests/appengine/handlers/testcase_detail/remove_issue_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/remove_issue_test.py
@@ -30,12 +30,12 @@ class HandlerTest(unittest.TestCase):
   def setUp(self):
     test_helpers.patch(self, [
         'handlers.testcase_detail.show.get_testcase_detail',
-        'google.appengine.api.users.get_current_user',
-        'google.appengine.api.users.is_current_user_admin',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
     ])
     self.mock.is_current_user_admin.return_value = True
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
     self.app = webtest.TestApp(
         webapp2.WSGIApplication([('/', remove_issue.Handler)]))

--- a/src/python/tests/appengine/handlers/testcase_detail/show_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/show_test.py
@@ -406,20 +406,21 @@ class GetTestcaseTest(unittest.TestCase):
   def setUp(self):
     test_helpers.patch_environ(self)
     test_helpers.patch(self, [
-        'metrics.crash_stats.get_last_crash_time',
-        'datastore.data_types.Job.get_environment',
+        'build_management.revisions.get_component_range_list',
+        'build_management.revisions.get_component_revisions_dict',
         'config.db_config.get',
         'config.db_config.get_value',
         'config.db_config.get_value_for_job',
-        'build_management.revisions.get_component_range_list',
-        'build_management.revisions.get_component_revisions_dict',
         'datastore.data_handler.get_stacktrace',
-        'issue_management.issue_tracker_utils.get_issue_url',
-        'libs.access.has_access',
-        'libs.helpers.get_user_email',
-        'libs.access.can_user_access_testcase',
+        'datastore.data_types.Job.get_environment',
         'handlers.testcase_detail.show.filter_stacktrace',
+        'issue_management.issue_tracker_utils.get_issue_url',
+        'libs.access.can_user_access_testcase',
+        'libs.access.has_access',
+        'libs.auth.is_current_user_admin',
         'libs.form.generate_csrf_token',
+        'libs.helpers.get_user_email',
+        'metrics.crash_stats.get_last_crash_time',
     ])
 
     self.mock.has_access.return_value = False
@@ -436,6 +437,8 @@ class GetTestcaseTest(unittest.TestCase):
             'rev': 'revision'
         }
     }
+
+    self.mock.is_current_user_admin.return_value = False
 
     self.make_token().put()
     os.environ['ISSUE_TRACKER'] = 'test-issue-tracker'

--- a/src/python/tests/appengine/handlers/testcase_detail/update_from_trunk_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/update_from_trunk_test.py
@@ -31,7 +31,7 @@ class HandlerTest(unittest.TestCase):
     test_helpers.patch(self, [
         'base.tasks.add_task',
         'base.tasks.queue_for_job',
-        'google.appengine.api.users.get_current_user',
+        'libs.auth.get_current_user',
         'handlers.testcase_detail.show.get_testcase_detail',
         'libs.access.check_access_and_get_testcase',
     ])
@@ -42,7 +42,7 @@ class HandlerTest(unittest.TestCase):
     self.testcase.put()
     self.mock.check_access_and_get_testcase.return_value = self.testcase
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
-    self.mock.get_current_user().email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'test@user.com'
 
   def test_succeed(self):
     """Update from trunk"""

--- a/src/python/tests/appengine/handlers/testcase_detail/update_issue_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/update_issue_test.py
@@ -40,13 +40,13 @@ class HandlerTest(unittest.TestCase):
         'datastore.data_handler.get_stacktrace',
         'datastore.data_handler.update_group_bug',
         'issue_management.issue_tracker_utils.get_issue_tracker_manager',
-        'google.appengine.api.users.get_current_user',
+        'libs.auth.get_current_user',
         'handlers.testcase_detail.show.get_testcase_detail',
         'libs.access.get_access',
     ])
     self.mock.get_access.return_value = access.UserAccess.Allowed
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
-    self.mock.get_current_user().email.return_value = 'test@test.com'
+    self.mock.get_current_user().email = 'test@test.com'
 
     self.app = webtest.TestApp(
         webapp2.WSGIApplication([('/', update_issue.Handler)]))

--- a/src/python/tests/appengine/libs/access_test.py
+++ b/src/python/tests/appengine/libs/access_test.py
@@ -16,12 +16,11 @@
 import mock
 import unittest
 
-from google.appengine.api import users
-
 from datastore import data_types
 from issue_management import issue
 from issue_management import issue_tracker_manager
 from libs import access
+from libs import auth
 from libs import helpers
 from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils
@@ -108,14 +107,14 @@ class GetAccessTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch(self, [
-        'google.appengine.api.users.get_current_user',
-        'google.appengine.api.users.is_current_user_admin',
+        'libs.auth.get_current_user',
+        'libs.auth.is_current_user_admin',
         'libs.access._is_privileged_user',
         'libs.access._is_domain_allowed',
         'base.external_users.is_fuzzer_allowed_for_user',
         'base.external_users.is_job_allowed_for_user',
     ])
-    self.user = users.User('test@test.com', _auth_domain='test')
+    self.user = auth.User('test@test.com')
 
   def test_get_access_access_redirect(self):
     """Ensure it redirects when user is None."""

--- a/src/python/tests/appengine/libs/helpers_test.py
+++ b/src/python/tests/appengine/libs/helpers_test.py
@@ -16,8 +16,7 @@
 
 import unittest
 
-from google.appengine.api import users
-
+from libs import auth
 from libs import helpers
 from tests.test_libs import helpers as test_helpers
 
@@ -119,12 +118,11 @@ class GetUserEmailTest(unittest.TestCase):
   """Test get_user_email."""
 
   def setUp(self):
-    test_helpers.patch(self, ['google.appengine.api.users.get_current_user'])
+    test_helpers.patch(self, ['libs.auth.get_current_user'])
 
   def test_get_user_email_success(self):
     """Ensure it gets the email when a user is valid."""
-    self.mock.get_current_user.return_value = (
-        users.User('TeSt@Test.com', _auth_domain='domain'))
+    self.mock.get_current_user.return_value = (auth.User('TeSt@Test.com'))
     self.assertEqual(helpers.get_user_email(), 'TeSt@Test.com')
 
   def test_get_user_email_failure(self):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
 backports.lzma==0.0.13
+firebase-admin==2.16.0
 future==0.17.1
 google-api-python-client==1.7.4
 google-auth-oauthlib==0.2.0


### PR DESCRIPTION
- Implement our own libs.auth module, which provide similar
  functionality to the App Engine users module.
- Add a login page which uses
  https://github.com/firebase/firebaseui-web. This gives us a token that
  we store as a cookie and validate on every request.
- Add a sync-admins cron job to periodically update the list of admin
  users.
- Update docs and create_config to include firebase setup.