### PR TITLE
Make it easier to run CI image locally.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -100,5 +100,5 @@ WORKDIR $INSTALL_DIRECTORY
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
-COPY setup_common.sh setup_clusterfuzz.sh setup_nfs.sh start_clusterfuzz.sh start.sh /data/
+COPY setup_common.sh setup_clusterfuzz.sh setup_nfs.sh start_clusterfuzz.sh setup_mock_metadata.sh start.sh /data/
 CMD ["bash", "-ex", "/data/start.sh"]

--- a/docker/base/setup_common.sh
+++ b/docker/base/setup_common.sh
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set up mock metadata server.
-if [[ -n "$LOCAL_METADATA_SERVER" ]]; then
-  ip addr add 169.254.169.254/32 dev lo
-  socat TCP-LISTEN:80,fork,reuseaddr TCP:$LOCAL_METADATA_SERVER:$LOCAL_METADATA_PORT &
-  echo "127.0.0.1 metadata metadata.google.internal" >> /etc/hosts
-fi
+source /data/setup_mock_metadata.sh
 
 # Create user with matching UID as host
 export HOST_UID=${HOST_UID:-1337}

--- a/docker/base/setup_mock_metadata.sh
+++ b/docker/base/setup_mock_metadata.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-#
+#!/bin/bash -ex
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,5 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source /data/setup_mock_metadata.sh
-python butler.py bootstrap
+# Set up mock metadata server.
+if [[ -n "$LOCAL_METADATA_SERVER" ]]; then
+  ip addr add 169.254.169.254/32 dev lo
+  socat TCP-LISTEN:80,fork,reuseaddr TCP:$LOCAL_METADATA_SERVER:$LOCAL_METADATA_PORT &
+  echo "127.0.0.1 metadata metadata.google.internal" >> /etc/hosts
+fi
+

--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,34 @@
+This directory contains scripts for running ClusterFuzz docker images locally.
+
+# Prerequisites
+
+## Running a local metadata server
+To emulate a local GCE metadata server using your own account's credentials
+(through `gcloud auth application-default login`), run:
+
+```bash
+$ ./run_metadata.bash
+```
+
+# Running bot locally
+To run a bot image locally, run:
+
+```bash
+$ ./run_docker.bash gcr.io/clusterfuzz-images/base
+```
+
+By default this uses the latest deployed source, but you can also use your local
+checkout by doing:
+
+```bash
+$ LOCAL_SRC=1 ./run_docker.bash gcr.io/clusterfuzz-images/base
+```
+
+# Running CI locally
+To run the CI environment locally, run
+
+```bash
+$ ./run_ci.bash
+# (inside container)
+$ setup
+```

--- a/local/run_ci.sh
+++ b/local/run_ci.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+docker_ip=$(ip -4 addr show docker0 | grep -P inet | head -1 | awk '{print $2}' | cut -d/ -f1)
+
+docker run -ti --rm --privileged \
+  -e LOCAL_METADATA_SERVER=$docker_ip -e LOCAL_METADATA_PORT=8080 \
+  -e TEST_BLOBS_BUCKET=clusterfuzz-ci-blobs \
+  -e TEST_BUCKET=clusterfuzz-ci-test \
+  -e TEST_CORPUS_BUCKET=clusterfuzz-ci-corpus \
+  -e TEST_QUARANTINE_BUCKET=clusterfuzz-ci-quarantine \
+  -e TEST_BACKUP_BUCKET=clusterfuzz-ci-backup \
+  -e TEST_COVERAGE_BUCKET=clusterfuzz-ci-coverage \
+  -v $(pwd)/..:/workspace \
+  gcr.io/clusterfuzz-images/ci /bin/bash

--- a/local/run_ci.sh
+++ b/local/run_ci.sh
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/bin/bash -e
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 docker_ip=$(ip -4 addr show docker0 | grep -P inet | head -1 | awk '{print $2}' | cut -d/ -f1)
 


### PR DESCRIPTION
Add a script to run the CI image locally, and support for using the fake
GCE metadata server.