### PR TITLE
Automatically redirect to login page.

### DIFF
--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -129,12 +129,18 @@ class Handler(webapp2.RequestHandler):
 
   def render_forbidden(self, message):
     """Write HTML response for 403."""
+    login_url = make_login_url(dest_url=self.request.url)
+    user_email = helpers.get_user_email()
+    if not user_email:
+      self.redirect(login_url)
+      return
+
     contact_string = db_config.get_value('contact_string')
     template_values = {
         'message': message,
         'user_email': helpers.get_user_email(),
-        'login_url': make_login_url(dest_url=self.request.url),
-        'switch_account_url': make_login_url(self.request.url),
+        'login_url': login_url,
+        'switch_account_url': login_url,
         'logout_url': make_logout_url(dest_url=self.request.url),
         'contact_string': contact_string,
     }

--- a/src/appengine/private/templates/error-403.html
+++ b/src/appengine/private/templates/error-403.html
@@ -32,19 +32,15 @@
 {% block page_title %}Access Denied{% endblock %}
 {% block toolbar_title %}Access Denied{% endblock %}
 {% block main_content %}
-  {% if user_email %}
-    <p>You (email={{user_email}}) are not authorized to access this page!</p>
-    {% if message %}
-      <p>{{message}}</p>
-    {% endif %}
-    <p>Please contact {{contact_string}}.</p>
-    <p>
-      <a href="{{switch_account_url}}">Switch account</a><br />
-      <a href="{{logout_url}}">Logout</a>
-    </p>
-  {% else %}
-    <p>Please <a href="{{login_url}}">log in</a> to see this page.</p>
+  <p>You (email={{user_email}}) are not authorized to access this page!</p>
+  {% if message %}
+    <p>{{message}}</p>
   {% endif %}
+  <p>Please contact {{contact_string}}.</p>
+  <p>
+    <a href="{{switch_account_url}}">Switch account</a><br />
+    <a href="{{logout_url}}">Logout</a>
+  </p>
   {% if is_oss_fuzz %}
     <p class="access-denied-remark">
       OSS-Fuzz is an effort to provide continuous fuzzing infrastructure for open-source software.

--- a/src/python/tests/appengine/handlers/base_handler_test.py
+++ b/src/python/tests/appengine/handlers/base_handler_test.py
@@ -127,11 +127,9 @@ class HandlerTest(unittest.TestCase):
     app = webtest.TestApp(
         webapp2.WSGIApplication([('/', AccessDeniedExceptionHandler)]))
     response = app.get('/', expect_errors=True)
-    self.assertEqual(response.status_int, 403)
-    self.assertRegexpMatches(response.body, '.*login.*')
-    self.assertRegexpMatches(response.body, '.*see this page.*')
-    self.assertRegexpMatches(response.body, '.*Access Denied.*')
-    self.assertNotRegexpMatches(response.body, '.*this_random_message.*')
+    self.assertEqual(response.status_int, 302)
+    self.assertEqual('http://localhost/login?dest=http%3A%2F%2Flocalhost%2F',
+                     response.headers['Location'])
 
   def test_forbidden_logged_in(self):
     """Ensure it renders forbidden response correctly (when logged in)."""

--- a/src/python/tests/appengine/handlers/download_test.py
+++ b/src/python/tests/appengine/handlers/download_test.py
@@ -103,23 +103,23 @@ class DownloadTest(unittest.TestCase):
     """Test download (not logged in)."""
     self.mock.get_user_email.return_value = ''
     self._test_download(
-        self.minimized_key, expect_status=403, expect_blob=False)
-    self._test_download(self.fuzzed_key, expect_status=403, expect_blob=False)
-    self._test_download(self.unused_key, expect_status=403, expect_blob=False)
+        self.minimized_key, expect_status=302, expect_blob=False)
+    self._test_download(self.fuzzed_key, expect_status=302, expect_blob=False)
+    self._test_download(self.unused_key, expect_status=302, expect_blob=False)
 
     self._test_download(
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
     self._test_download(
         self.minimized_key,
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
     self._test_download(
         self.fuzzed_key,
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
 
   def test_download_user(self):
@@ -192,20 +192,20 @@ class DownloadTest(unittest.TestCase):
     mock_issue.has_label.side_effect = mock_has_label
 
     self._test_download(
-        self.minimized_key, expect_status=403, expect_blob=False)
+        self.minimized_key, expect_status=302, expect_blob=False)
     self._test_download(
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
     self._test_download(
         self.minimized_key,
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
     self._test_download(
         self.fuzzed_key,
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
 
   def test_public_download_oss_fuzz(self):
@@ -220,7 +220,7 @@ class DownloadTest(unittest.TestCase):
     mock_issue.has_label.side_effect = mock_has_label
 
     self._test_download(
-        self.minimized_key, expect_status=403, expect_blob=False)
+        self.minimized_key, expect_status=302, expect_blob=False)
     self._test_download(
         testcase_id=self.testcase.key.id(),
         expect_filename='clusterfuzz-testcase-minimized-1.ext')
@@ -232,23 +232,23 @@ class DownloadTest(unittest.TestCase):
     self._test_download(
         self.fuzzed_key,
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
 
     mock_issue.has_label.side_effect = lambda _: True
     self._test_download(
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
     self._test_download(
         self.minimized_key,
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
     self._test_download(
         self.fuzzed_key,
         testcase_id=self.testcase.key.id(),
-        expect_status=403,
+        expect_status=302,
         expect_blob=False)
 
     # Privileged users should still be able to access everything.


### PR DESCRIPTION
Instead of showing the access denied page first.