### PR TITLE
Remove stack_clean_regex (#245).

### DIFF
--- a/src/appengine/handlers/configuration.py
+++ b/src/appengine/handlers/configuration.py
@@ -118,7 +118,6 @@ class Handler(base_handler.Handler):
         'relax_testcase_restrictions')
     reproduction_help_url = self.request.get('reproduction_help_url')
     revision_vars_url = self.request.get('revision_vars_url')
-    stack_clean_regex = self.request.get('stack_clean_regex')
     test_account_email = self.request.get('test_account_email')
     test_account_password = self.request.get('test_account_password')
     wifi_ssid = self.request.get('wifi_ssid')
@@ -141,7 +140,6 @@ class Handler(base_handler.Handler):
     config.relax_testcase_restrictions = bool(relax_testcase_restrictions)
     config.reproduction_help_url = reproduction_help_url
     config.revision_vars_url = revision_vars_url
-    config.stack_clean_regex = stack_clean_regex
     config.test_account_email = test_account_email
     config.test_account_password = test_account_password
     config.wifi_ssid = wifi_ssid

--- a/src/appengine/private/components/configuration/configuration.html
+++ b/src/appengine/private/components/configuration/configuration.html
@@ -128,17 +128,6 @@
 
               <tr>
                 <td class="label">
-                  <div class="help" title="Stacktrace cleaning signatures (one regex per line). These signatures will be removed from display in crash stacktraces (but not the crash state).">
-                    Stacktrace cleaning signatures
-                  </div>
-                </td>
-                <td>
-                  <paper-textarea name="stack_clean_regex" max-rows="5" value="[[config.stack_clean_regex]]" no-label-float></paper-textarea>
-                </td>
-              </tr>
-
-              <tr>
-                <td class="label">
                   <div class="help" title="Revision vars url (one per line - job;url). The url (with %s for revision) should point to source map containing list of component revisions used (as json).">
                     Revision vars url
                   </div>

--- a/src/go/cloud/db/types/types.go
+++ b/src/go/cloud/db/types/types.go
@@ -94,7 +94,6 @@ type Config struct {
 	TestAccountEmail                    string         `datastore:"test_account_email"`
 	TestAccountPassword                 string         `datastore:"test_account_password"`
 	PrivilegedUsers                     string         `datastore:"privileged_users,noindex"`
-	StackCleanRegex                     string         `datastore:"stack_clean_regex,noindex"`
 	ContactString                       string         `datastore:"contact_string"`
 	RevisionVarsURL                     string         `datastore:"revision_vars_url,noindex"`
 	ComponentRepositoryMappings         string         `datastore:"component_repository_mappings,noindex"`

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -685,9 +685,6 @@ class Config(Model):
   # Privileged users.
   privileged_users = ndb.TextProperty(default='')
 
-  # Stacktrace clean regexes.
-  stack_clean_regex = ndb.TextProperty(default='')
-
   # Admin contact string.
   contact_string = ndb.StringProperty(default='')
 

--- a/src/python/tests/appengine/handlers/testcase_detail/show_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/show_test.py
@@ -294,17 +294,11 @@ class FilterStacktraceTest(unittest.TestCase):
 
     self.mock.highlight_common_stack_frames.side_effect = highlight
 
-  def test_clean(self):
-    """Ensure it cleans trace with stack_clean_regex."""
-    stack = 'aaaa\nbbbb\ncccc\naaaa\nbbbb\ncccc'
-    expected = 'aaaa\ncccc\naaaa\ncccc'
-    self.assertEqual(show.filter_stacktrace(stack, 'type', 'bb', {}), expected)
-
   def test_xss(self):
     """Ensure that we escape untrusted stacktrace."""
     stack = 'aaaa\n<script>alert("XSS")</script>\ncccc'
     expected = 'aaaa\n&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;\ncccc'
-    self.assertEqual(show.filter_stacktrace(stack, 'type', '', {}), expected)
+    self.assertEqual(show.filter_stacktrace(stack, 'type', {}), expected)
 
   def test_asan_chromium(self):
     """Ensure it linkifies asan trace for chromium."""
@@ -328,7 +322,7 @@ class FilterStacktraceTest(unittest.TestCase):
                 '</a>\n'
                 'random')
     self.assertEqual(
-        show.filter_stacktrace(stack, 'type', '', revisions_dict), expected)
+        show.filter_stacktrace(stack, 'type', revisions_dict), expected)
 
   def test_asan_oss_fuzz(self):
     """Ensure it linkifies asan trace for oss-fuzz."""
@@ -354,7 +348,7 @@ class FilterStacktraceTest(unittest.TestCase):
                 '</a>\n'
                 'random')
     self.assertEqual(
-        show.filter_stacktrace(stack, 'type', '', revisions_dict), expected)
+        show.filter_stacktrace(stack, 'type', revisions_dict), expected)
 
   def test_asan_v8(self):
     """Ensure it linkifies v8 win trace for chromium."""
@@ -374,7 +368,7 @@ class FilterStacktraceTest(unittest.TestCase):
                 'random')
 
     self.assertEqual(
-        show.filter_stacktrace(stack, 'type', '', revisions_dict), expected)
+        show.filter_stacktrace(stack, 'type', revisions_dict), expected)
 
   def test_no_linkify(self):
     """Ensure that we don't linkify a non-stack frame line."""
@@ -396,7 +390,7 @@ class FilterStacktraceTest(unittest.TestCase):
     expected = stack
 
     self.assertEqual(
-        show.filter_stacktrace(stack, 'type', '', revisions_dict), expected)
+        show.filter_stacktrace(stack, 'type', revisions_dict), expected)
 
 
 @test_utils.with_cloud_emulators('datastore')


### PR DESCRIPTION
None of the remaining uses is important enough to justify this.