### PR TITLE
Fix AFL stat upload to Bigquery.

### DIFF
--- a/src/python/bot/fuzzers/afl/stats.py
+++ b/src/python/bot/fuzzers/afl/stats.py
@@ -197,7 +197,7 @@ class StatsGetter(object):
       self.stats[clusterfuzz_stat] = self.get_afl_stat(afl_stat)
 
     try:
-      self.stats['average_exec_per_sec'] = (
+      self.stats['average_exec_per_sec'] = int(
           self.get_afl_stat('execs_done') // actual_duration)
 
     except ZeroDivisionError:  # Fail gracefully if actual_duration is 0.


### PR DESCRIPTION
This is a regression from
https://github.com/google/clusterfuzz/commit/6d9f9e76a1bb37a8c2a5cdd451b14dec4e58dd4a
a // b is float when b is a float. Causes bigquery error - "Invalid schema update. Field average_exec_per_sec has changed type from INTEGER to FLOAT"