### PR TITLE
Fix exception.

### DIFF
--- a/src/python/bot/untrusted_runner/untrusted.py
+++ b/src/python/bot/untrusted_runner/untrusted.py
@@ -205,8 +205,8 @@ def _get_tls_cert_and_key():
 
     return cert_contents, key_contents
 
-  return (compute_metadata.get('instance/attributes/tls-cert'),
-          compute_metadata.get('instance/attributes/tls-key'))
+  return (str(compute_metadata.get('instance/attributes/tls-cert')),
+          str(compute_metadata.get('instance/attributes/tls-key')))
 
 
 def start_server():


### PR DESCRIPTION
TypeError: Argument 'private_key' has incorrect type (expected str, got unicode)
at ssl_server_credentials (/mnt/scratch0/clusterfuzz/src/third_party/grpc/__init__.py:1496)
at start_server (/mnt/scratch0/clusterfuzz/src/python/bot/untrusted_runner/untrusted.py:222)