### PR TITLE
Use ADB instead of ADB_PATH, matches upstream asan_device_setup

### DIFF
--- a/resources/platform/android/third_party/asan_device_setup.sh
+++ b/resources/platform/android/third_party/asan_device_setup.sh
@@ -148,12 +148,7 @@ while [[ $# > 0 ]]; do
   shift
 done
 
-if [[ x$ADB_PATH != x ]]; then
-    ADB="$ADB_PATH"
-else
-    ADB="$HERE/adb"
-fi
-
+ADB=${ADB:-adb}
 if [[ x$device != x ]]; then
     ADB="$ADB -s $device"
 fi

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -240,10 +240,6 @@ def get_adb_command_line(adb_cmd):
 
 def get_adb_path():
   """Return path to ADB binary."""
-  adb_path = environment.get_value('ADB_PATH')
-  if adb_path:
-    return adb_path
-
   return os.path.join(environment.get_platform_resources_directory(), 'adb')
 
 
@@ -768,8 +764,7 @@ def setup_adb():
   adb_binary_path = get_adb_path()
 
   # Make sure that ADB_PATH is set.
-  if not environment.get_value('ADB_PATH'):
-    environment.set_value('ADB_PATH', adb_binary_path)
+  environment.set_value('ADB_PATH', adb_binary_path)
 
 
 def stop_application():

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -240,6 +240,10 @@ def get_adb_command_line(adb_cmd):
 
 def get_adb_path():
   """Return path to ADB binary."""
+  adb_path = environment.get_value('ADB')
+  if adb_path:
+    return adb_path
+
   return os.path.join(environment.get_platform_resources_directory(), 'adb')
 
 
@@ -763,8 +767,9 @@ def setup_adb():
   """Sets up ADB binary for use."""
   adb_binary_path = get_adb_path()
 
-  # Make sure that ADB_PATH is set.
-  environment.set_value('ADB_PATH', adb_binary_path)
+  # Make sure that ADB env var is set.
+  if not environment.get_value('ADB'):
+    environment.set_value('ADB', adb_binary_path)
 
 
 def stop_application():


### PR DESCRIPTION
This configuration is unsupported and is currently
causing confusion when people set it incorrectly as
a directory.