### PR TITLE
Make decision of new units by relying on new tests dir size.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -441,7 +441,7 @@ def get_corpus_directories(main_corpus_directory,
   if minijail_chroot:
     bind_corpus_dirs(minijail_chroot, corpus_directories)
 
-  return corpus_directories
+  return corpus_directories, new_testcases_directory
 
 
 def generate_new_testcase_mutations_using_radamsa(
@@ -859,7 +859,7 @@ def main(argv):
   fuzz_timeout = get_fuzz_timeout(is_mutations_run)
 
   # Get list of corpus directories.
-  corpus_directories = get_corpus_directories(
+  corpus_directories, new_testcases_directory = get_corpus_directories(
       corpus_directory, fuzzer_path, fuzzing_strategies, minijail_chroot)
 
   # Bind corpus directories in minijail.
@@ -980,7 +980,9 @@ def main(argv):
 
   # Make a decision on whether merge step is needed at all. If there are no
   # new units added by libFuzzer run, then no need to do merge at all.
-  new_units_added = parsed_stats.get('new_units_added', 0)
+  new_units_added = (
+      shell.get_directory_file_count(new_testcases_directory) or
+      parsed_stats.get('new_units_added'))  # redundant, but needed for tests.
   merge_error = None
   if new_units_added:
     # Merge the new units with the initial corpus.

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -100,7 +100,7 @@ def create_mock_popen(output,
 
     def communicate(self, input_data=None):
       """Mock subprocess.Popen.communicate."""
-      if self.command[0].endswith('_fuzzer'):
+      if '/fake/build_dir/fake_fuzzer' in self.command:
         if '-merge=1' in self.command:
           # Mock merge.
           self._do_merge()
@@ -1190,8 +1190,11 @@ class LauncherTest(fake_fs_unittest.TestCase):
     self.fs.CreateDirectory('/fake/corpus_oom')
     os.environ['FUZZ_CORPUS_DIR'] = '/fake/corpus_oom'
 
-    with mock.patch('subprocess.Popen',
-                    create_mock_popen(self.oom_output)) as mock_popen:
+    new_units_added = 11
+    with mock.patch(
+        'subprocess.Popen',
+        create_mock_popen(self.oom_output, '/fake/inputs-disk/temp-1337/new',
+                          None, new_units_added)) as mock_popen:
       launcher.main([
           'launcher.py',
           '/fake/testcase_oom',
@@ -1347,8 +1350,12 @@ class LauncherTest(fake_fs_unittest.TestCase):
 
     os.environ['FUZZ_CORPUS_DIR'] = '/fake/main_corpus_dir'
 
-    with mock.patch('subprocess.Popen',
-                    create_mock_popen(self.no_crash_output)) as mock_popen:
+    new_units_added = 11
+    with mock.patch(
+        'subprocess.Popen',
+        create_mock_popen(
+            self.no_crash_output, '/fake/inputs-disk/temp-1337/new',
+            '/fake/main_corpus_dir', new_units_added)) as mock_popen:
       launcher.main([
           'launcher.py',
           '/fake/testcase_subset',
@@ -1416,8 +1423,12 @@ class LauncherTest(fake_fs_unittest.TestCase):
     os.environ['FUZZ_CORPUS_DIR'] = '/fake/main_corpus_dir'
     # Main corpus directory is empty, we should fall back to regular fuzzing.
 
-    with mock.patch('subprocess.Popen',
-                    create_mock_popen(self.no_crash_output)) as mock_popen:
+    new_units_added = 11
+    with mock.patch(
+        'subprocess.Popen',
+        create_mock_popen(
+            self.no_crash_output, '/fake/inputs-disk/temp-1337/new',
+            '/fake/main_corpus_dir', new_units_added)) as mock_popen:
       launcher.main([
           'launcher.py',
           '/fake/testcase_subset',
@@ -1464,8 +1475,12 @@ class LauncherTest(fake_fs_unittest.TestCase):
     for i in range(1 + max(strategy.CORPUS_SUBSET_NUM_TESTCASES)):
       self.fs.CreateFile('/fake/main_corpus_dir/sub/%d' % i)
 
-    with mock.patch('subprocess.Popen',
-                    create_mock_popen(self.no_crash_output)) as mock_popen:
+    new_units_added = 11
+    with mock.patch(
+        'subprocess.Popen',
+        create_mock_popen(
+            self.no_crash_output, '/fake/inputs-disk/temp-1337/new',
+            '/fake/main_corpus_dir', new_units_added)) as mock_popen:
       launcher.main([
           'launcher.py',
           '/fake/testcase_subset',
@@ -1582,8 +1597,12 @@ class LauncherTest(fake_fs_unittest.TestCase):
     self.fs.CreateDirectory('/fake/main_corpus_dir')
     os.environ['FUZZ_CORPUS_DIR'] = '/fake/main_corpus_dir'
 
-    with mock.patch('subprocess.Popen',
-                    create_mock_popen(self.no_crash_output)) as mock_popen:
+    new_units_added = 11
+    with mock.patch(
+        'subprocess.Popen',
+        create_mock_popen(
+            self.no_crash_output, '/fake/inputs-disk/temp-1337/new',
+            '/fake/main_corpus_dir', new_units_added)) as mock_popen:
       launcher.main([
           'launcher.py',
           '/fake/testcase_subset',
@@ -1690,8 +1709,12 @@ class LauncherTest(fake_fs_unittest.TestCase):
     self.fs.CreateDirectory('/fake/corpus_mutations')
     os.environ['FUZZ_CORPUS_DIR'] = '/fake/corpus_mutations'
 
-    with mock.patch('subprocess.Popen',
-                    create_mock_popen(self.no_crash_output)) as mock_popen:
+    new_units_added = 11
+    with mock.patch(
+        'subprocess.Popen',
+        create_mock_popen(
+            self.no_crash_output, '/fake/inputs-disk/temp-1337/new',
+            '/fake/corpus_mutations', new_units_added)) as mock_popen:
       launcher.main([
           'launcher.py',
           '/fake/testcase_mutations',
@@ -1733,8 +1756,12 @@ class LauncherTest(fake_fs_unittest.TestCase):
     self.fs.CreateDirectory('/fake/corpus_mutations')
     os.environ['FUZZ_CORPUS_DIR'] = '/fake/corpus_mutations'
 
-    with mock.patch('subprocess.Popen',
-                    create_mock_popen(self.no_crash_output)) as mock_popen:
+    new_units_added = 11
+    with mock.patch(
+        'subprocess.Popen',
+        create_mock_popen(
+            self.no_crash_output, '/fake/inputs-disk/temp-1337/new',
+            '/fake/corpus_mutations', new_units_added)) as mock_popen:
       launcher.main([
           'launcher.py',
           '/fake/testcase_mutations',


### PR DESCRIPTION
new_units_added metric is not always available, esp in fork mode.