### PR TITLE
Use ':' for fuzz target project qualified name separator if project name is a path

### DIFF
--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -1063,7 +1063,8 @@ def fuzz_target_project_qualified_name(project, binary):
     # Don't prefix with project name if it's the default project.
     return binary
 
-  project_prefix = project + '_'
+  seperator = '/' if project.startswith('/') else '_'
+  project_prefix = project + seperator
   if binary.startswith(project_prefix):
     return binary
 

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -1063,8 +1063,10 @@ def fuzz_target_project_qualified_name(project, binary):
     # Don't prefix with project name if it's the default project.
     return binary
 
-  seperator = '/' if project.startswith('/') else '_'
-  project_prefix = project + seperator
+  # E.g. for project names that are in the form of paths like:
+  # //third_party/llvm, the result will be //third_party/llvm:fuzz_target
+  separator = ':' if project.startswith('/') else '_'
+  project_prefix = project + separator
   if binary.startswith(project_prefix):
     return binary
 


### PR DESCRIPTION
path.