### PR TITLE
Fix for empty logs field in fuzzer stats page.

### DIFF
--- a/src/appengine/handlers/performance_report/show.py
+++ b/src/appengine/handlers/performance_report/show.py
@@ -110,8 +110,9 @@ def _get_performance_features(fuzzer_name, job_type, datetime_start,
 
 def _get_performance_report(fuzzer_name, job_type, performance_report_data):
   """Return performance report."""
-  bucket_name = data_handler.get_value_from_job_definition(
+  bucket_name = data_handler.get_value_from_job_definition_or_environment(
       job_type, 'FUZZ_LOGS_BUCKET')
+
   # Load performance data as JSON.
   performance_report = json.loads(performance_report_data)
 

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -495,9 +495,7 @@ def is_first_retry_for_task(testcase, reset_after_retry=False):
 @memoize.wrap(memoize.Memcache(MEMCACHE_TTL_IN_SECONDS))
 def get_issue_tracker_name(job_type=None):
   """Return issue tracker name for a job type."""
-  default_issue_tracker_name = environment.get_value('ISSUE_TRACKER')
-  return get_value_from_job_definition(job_type, 'ISSUE_TRACKER',
-                                       default_issue_tracker_name)
+  return get_value_from_job_definition_or_environment(job_type, 'ISSUE_TRACKER')
 
 
 @memoize.wrap(memoize.Memcache(MEMCACHE_TTL_IN_SECONDS))

--- a/src/python/metrics/fuzzer_stats.py
+++ b/src/python/metrics/fuzzer_stats.py
@@ -536,8 +536,8 @@ class FuzzerRunLogsContext(BuiltinFieldContext):
   @memoize.wrap(memoize.FifoInMemory(256))
   def _get_logs_bucket_from_job(self, job_type):
     """Get logs bucket from job."""
-    return data_handler.get_value_from_job_definition(job_type,
-                                                      'FUZZ_LOGS_BUCKET')
+    return data_handler.get_value_from_job_definition_or_environment(
+        job_type, 'FUZZ_LOGS_BUCKET')
 
   @memoize.wrap(memoize.Memcache(MEMCACHE_TTL, key_fn=_logs_bucket_key_fn))
   def _get_logs_bucket_from_fuzzer(self, fuzzer_name):

--- a/src/python/tests/appengine/handlers/fuzzer_stats_data/by_job_expected.txt
+++ b/src/python/tests/appengine/handlers/fuzzer_stats_data/by_job_expected.txt
@@ -39,7 +39,8 @@
                        'v': 3},
                      { 'f': u'<a href="https://report_for_1_fuzzer/20161020">Coverage</a>',
                        'v': 'Coverage'},
-                     { 'f': '--', 'v': ''},
+                     { 'f': '<a href="/gcs-redirect?path=gs%3A%2F%2Ftest-fuzz-logs-bucket%2FtestFuzzer_1_fuzzer%2Fjob2">Logs</a>',
+                       'v': 'Logs'},
                      { 'f': '<a href="/performance-report/testFuzzer_1_fuzzer/job2/latest">Performance</a>',
                        'v': 'Performance'}]},
             { 'c': [ { 'v': u'job3'},
@@ -54,6 +55,7 @@
                        'v': 3},
                      { 'f': u'<a href="https://report_for_1_fuzzer/20161020">Coverage</a>',
                        'v': 'Coverage'},
-                     { 'f': '--', 'v': ''},
+                     { 'f': '<a href="/gcs-redirect?path=gs%3A%2F%2Ftest-fuzz-logs-bucket%2FtestFuzzer_1_fuzzer%2Fjob3">Logs</a>',
+                       'v': 'Logs'},
                      { 'f': '<a href="/performance-report/testFuzzer_1_fuzzer/job3/latest">Performance</a>',
                        'v': 'Performance'}]}]}


### PR DESCRIPTION
This happens on projects which use the default logs bucket.