### PR TITLE
Remove README from Fuchsia resources dir.

### DIFF
--- a/bot/resources/fuchsia/README.md
+++ b/bot/resources/fuchsia/README.md
@@ -1,1 +1,0 @@
-Placeholder for external resources for fuzzing on Fuchsia.


### PR DESCRIPTION
Downloading the Fuchsia resources, which is done as part of integration
testing, clobbers the placeholder README file, causing annoying diffs.

Since we attempt to create the resources/fuchsia directory anyway, let's
just rely on that to ensure our directory exists, rather than leaving a
placeholder file there.