### PR TITLE
Fix OSS-Fuzz host image breakage.

### DIFF
--- a/docker/oss-fuzz/host/start_host.py
+++ b/docker/oss-fuzz/host/start_host.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Start host."""
 from __future__ import print_function
-from builtins import range
 import os
 import shutil
 import socket


### PR DESCRIPTION
future package is not installed during docker setup. This
is not needed since range call is not expensive here, skip.