### PR TITLE
Fix exception.

### DIFF
--- a/src/python/fuzzing/tests.py
+++ b/src/python/fuzzing/tests.py
@@ -390,7 +390,7 @@ def upload_testcase(testcase_path):
   if not fuzz_logs_bucket:
     return
 
-  with open(testcase_path) as file_handle:
+  with open(testcase_path, 'rb') as file_handle:
     testcase_contents = file_handle.read()
 
   # This matches the time of the log file.


### PR DESCRIPTION
This should fix

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1061: character maps to <undefined>
at decode (c:\python27\lib\encodings\cp1252.py:23)
at upload_testcase (c:\clusterfuzz\src\python\fuzzing\tests.py:394)
at run_testcase_and_return_result_in_queue (c:\clusterfuzz\src\python\fuzzing\tests.py:474)
```