### PR TITLE
Clear build urls directory on OSS-Fuzz worker.

### DIFF
--- a/src/python/bot/untrusted_runner/file_host.py
+++ b/src/python/bot/untrusted_runner/file_host.py
@@ -192,6 +192,13 @@ def clear_testcase_directories():
       recreate=True)
 
 
+def clear_build_urls_directory():
+  """Clear the build urls directory on the worker."""
+  remove_directory(
+      rebase_to_worker_root(environment.get_value('BUILD_URLS_DIR')),
+      recreate=True)
+
+
 def push_testcases_to_worker():
   """Push all testcases to the worker."""
   local_testcases_directory = environment.get_value('FUZZ_INPUTS')

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -72,6 +72,10 @@ def clear_build_urls_directory():
   """Clears the build url directory."""
   remove_directory(environment.get_value('BUILD_URLS_DIR'), recreate=True)
 
+  if environment.is_trusted_host():
+    from bot.untrusted_runner import file_host
+    file_host.clear_build_urls_directory()
+
 
 def clear_crash_stacktraces_directory():
   """Clears the crash stacktraces directory."""


### PR DESCRIPTION
When a task starts on OSS-Fuzz, only host's build urls dir
is cleared. However, we download the urls on worker and if
a stale list is present, we reuse it. So, new revisions result
in a "Error getting build url for job" error.