### PR TITLE
Use a stricter build directory match when killing processes.

### DIFF
--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -623,5 +623,5 @@ def terminate_processes_matching_cmd_line(match_strings, kill=False):
     except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
       continue
 
-    if any(x in process_path for x in match_strings):
+    if any(process_path.startswith(x) for x in match_strings):
       terminate_process(process_info['pid'], kill)


### PR DESCRIPTION
I haven't looked at this too closely but figured it was easiest to ask a question by preparing this change.

Is there a reason we match build directory in the full path here rather than at the start? This is causing some issues with the reproduce tool, where we might run something like "python <whatever> --build-dir /path/to/build". The python process for the tool ends up matching this regular expression (because it contains the build directory), so the tool ends up killing itself. Alternatively the tool could avoid setting the environment variable used here since it doesn't seem to be necessary, but that feels like a hack.