### PR TITLE
Fix grouping bug with duplicates.

### DIFF
--- a/src/appengine/handlers/cron/grouper.py
+++ b/src/appengine/handlers/cron/grouper.py
@@ -107,6 +107,11 @@ def group_testcases():
       testcase.key.delete()
       continue
 
+    # Wait for minimization to finish as this might change crash params such
+    # as type and may mark it as duplicate / closed.
+    if not testcase.minimized_keys:
+      continue
+
     # Store needed testcase attributes into |testcase_map|.
     testcase_map[testcase_id] = TestcaseAttributes()
     testcase_attributes = testcase_map[testcase_id]

--- a/src/python/tests/appengine/handlers/cron/grouper_test.py
+++ b/src/python/tests/appengine/handlers/cron/grouper_test.py
@@ -68,6 +68,31 @@ class GrouperTest(unittest.TestCase):
     self.assertEqual(testcases[0].group_id, 0)
     self.assertTrue(testcases[0].is_leader)
 
+  def test_unminimized(self):
+    """Test that unminimized testcase is not processed for grouping."""
+    self.testcases[0].security_flag = True
+    self.testcases[0].crash_state = 'abc\ndef'
+    self.testcases[0].crash_type = 'Heap-buffer-overflow\nREAD {*}'
+    self.testcases[0].minimized_keys = None
+    self.testcases[1].security_flag = True
+    self.testcases[1].crash_state = 'abc\ndef'
+    self.testcases[1].crash_type = 'Heap-buffer-overflow\nREAD 3'
+
+    for t in self.testcases:
+      t.put()
+
+    grouper.group_testcases()
+
+    testcases = []
+    for testcase_id in data_handler.get_open_testcase_id_iterator():
+      testcases.append(data_handler.get_testcase_by_id(testcase_id))
+
+    self.assertEqual(len(testcases), 2)
+    self.assertEqual(testcases[0].group_id, 0)
+    self.assertFalse(testcases[0].is_leader)
+    self.assertEqual(testcases[1].group_id, 0)
+    self.assertTrue(testcases[1].is_leader)
+
   def test_different_crash_same_security(self):
     """Test that crashes with different crash states and same security flags
       don't get grouped together."""

--- a/src/python/tests/test_libs/test_utils.py
+++ b/src/python/tests/test_libs/test_utils.py
@@ -59,6 +59,7 @@ def create_generic_testcase(created_days_ago=28):
   testcase.crash_type = 'fake type'
   testcase.comments = 'Fuzzer: test'
   testcase.fuzzed_keys = 'abcd'
+  testcase.minimized_keys = 'efgh'
   testcase.fuzzer_name = 'fuzzer1'
   testcase.open = True
   testcase.one_time_crasher_flag = False


### PR DESCRIPTION
A testcase which is not minimized yet can get marked as leader
and then once it is minimized, it can get duped to another testcase
causing a group to have no leader at all.