### PR TITLE
Move cleanup and update_issue to new issue tracker iterface (#504).

### DIFF
--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -338,14 +338,14 @@ def get_issue_for_testcase(testcase):
   if not testcase.bug_information:
     return None
 
-  issue_tracker_manager = issue_tracker_utils.get_issue_tracker_manager(
-      testcase=testcase, use_cache=True)
-  if not issue_tracker_manager:
+  issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(
+      testcase, use_cache=True)
+  if not issue_tracker:
     return None
 
   try:
-    issue_id = int(testcase.bug_information)
-    issue = issue_tracker_manager.get_original_issue(issue_id)
+    issue_id = testcase.bug_information
+    issue = issue_tracker.get_original_issue(issue_id)
   except:
     logs.log_error(
         'Error occurred when fetching issue %s.' % testcase.bug_information)
@@ -420,11 +420,13 @@ def mark_issue_as_closed_if_testcase_is_fixed(testcase, issue):
   # As a last check, do the expensive call of actually checking all issue
   # comments to make sure we didn't do the verification already and we didn't
   # get called out on issue mistriage.
-  if (issue.has_comment_with_label(data_types.ISSUE_VERIFIED_LABEL) or
-      issue.has_comment_with_label(data_types.ISSUE_MISTRIAGED_LABEL)):
+  if (issue_tracker_utils.was_label_added(issue,
+                                          data_types.ISSUE_VERIFIED_LABEL) or
+      issue_tracker_utils.was_label_added(issue,
+                                          data_types.ISSUE_MISTRIAGED_LABEL)):
     return
 
-  issue.add_label(data_types.ISSUE_VERIFIED_LABEL)
+  issue.labels.add(data_types.ISSUE_VERIFIED_LABEL)
   comment = ('ClusterFuzz testcase %d is verified as fixed, '
              'so closing issue as verified.' % testcase.key.id())
   if utils.is_oss_fuzz():
@@ -433,10 +435,8 @@ def mark_issue_as_closed_if_testcase_is_fixed(testcase, issue):
     comment += INTERNAL_INCORRECT_COMMENT
     comment += ' and re-open the issue.'
 
-  issue.comment = comment
   issue.status = 'Verified'
-  issue.open = False
-  issue.save(send_email=True)
+  issue.save(new_comment=comment, notify=True)
   logs.log(
       'Closed issue %d for fixed testcase %d.' % (issue.id, testcase.key.id()))
 
@@ -528,7 +528,8 @@ def mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
 
   # As a last check, do the expensive call of actually checking all issue
   # comments to make sure we we didn't get called out on issue mistriage.
-  if issue.has_comment_with_label(data_types.ISSUE_MISTRIAGED_LABEL):
+  if issue_tracker_utils.was_label_added(issue,
+                                         data_types.ISSUE_MISTRIAGED_LABEL):
     return
 
   # Close associated issue and testcase.
@@ -540,10 +541,8 @@ def mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
     comment += INTERNAL_INCORRECT_COMMENT
     comment += ' and re-open the issue.'
 
-  issue.comment = comment
   issue.status = 'WontFix'
-  issue.open = False
-  issue.save(send_email=True)
+  issue.save(new_comment=comment, notify=True)
   testcase.fixed = 'NA'
   testcase.open = False
   testcase.put()
@@ -591,7 +590,7 @@ def mark_testcase_as_closed_if_issue_is_closed(testcase, issue):
 
   # If the issue has an ignore label, don't close the testcase and bail out.
   # This helps to prevent new bugs from getting filed for legit WontFix cases.
-  if issue.has_comment_with_label(data_types.ISSUE_IGNORE_LABEL):
+  if issue_tracker_utils.was_label_added(issue, data_types.ISSUE_IGNORE_LABEL):
     return
 
   testcase.open = False
@@ -643,16 +642,17 @@ def notify_closed_issue_if_testcase_is_open(testcase, issue):
     return
 
   # Check if there is ignore label on issue already. If yes, bail out.
-  if issue.has_comment_with_label(data_types.ISSUE_IGNORE_LABEL):
+  if issue_tracker_utils.was_label_added(issue, data_types.ISSUE_IGNORE_LABEL):
     return
 
   # Check if we did add the notification comment already. If yes, bail out.
-  if issue.has_comment_with_label(data_types.ISSUE_NEEDS_FEEDBACK_LABEL):
+  if issue_tracker_utils.was_label_added(issue,
+                                         data_types.ISSUE_NEEDS_FEEDBACK_LABEL):
     return
 
-  issue.add_label(data_types.ISSUE_NEEDS_FEEDBACK_LABEL)
+  issue.labels.add(data_types.ISSUE_NEEDS_FEEDBACK_LABEL)
   if issue.status in ['Fixed', 'Verified']:
-    issue.comment = (
+    issue_comment = (
         'ClusterFuzz testcase %d is still reproducing on tip-of-tree build '
         '(trunk).\n\nPlease re-test your fix against this testcase and if the '
         'fix was incorrect or incomplete, please re-open the bug. Otherwise, '
@@ -660,7 +660,7 @@ def notify_closed_issue_if_testcase_is_open(testcase, issue):
         (testcase.key.id(), data_types.ISSUE_MISTRIAGED_LABEL))
   else:
     # Covers WontFix, Archived cases.
-    issue.comment = (
+    issue_comment = (
         'ClusterFuzz testcase %d is still reproducing on tip-of-tree build '
         '(trunk).\n\nIf this testcase was not reproducible locally or '
         'unworkable, ignore this notification and we will file another '
@@ -669,7 +669,7 @@ def notify_closed_issue_if_testcase_is_open(testcase, issue):
         'intentional crash), please add %s label to prevent future bug filing '
         'with similar crash stacktrace.' % (testcase.key.id(),
                                             data_types.ISSUE_IGNORE_LABEL))
-  issue.save(send_email=True)
+  issue.save(new_comment=issue_comment, notify=True)
   logs.log('Notified closed issue for open testcase %d.' % testcase.key.id())
 
 
@@ -688,15 +688,16 @@ def notify_issue_if_testcase_is_invalid(testcase, issue):
     return
 
   # Check if we added this message once. If yes, bail out.
-  if issue.has_comment_with_label(data_types.ISSUE_INVALID_FUZZER_LABEL):
+  if issue_tracker_utils.was_label_added(issue,
+                                         data_types.ISSUE_INVALID_FUZZER_LABEL):
     return
 
-  issue.comment = (
+  issue_comment = (
       'ClusterFuzz testcase %d is associated with an obsolete fuzzer and can '
       'no longer be processed. Please close the issue if it is no longer '
       'actionable.') % testcase.key.id()
-  issue.add_label(data_types.ISSUE_INVALID_FUZZER_LABEL)
-  issue.save(send_email=True)
+  issue.labels.add(data_types.ISSUE_INVALID_FUZZER_LABEL)
+  issue.save(new_comment=issue_comment, notify=True)
 
   logs.log('Closed issue %d for invalid testcase %d.' % (issue.id,
                                                          testcase.key.id()))
@@ -717,7 +718,7 @@ def _send_email_to_uploader(testcase_id, to_email, content):
 def _update_issue_when_uploaded_testcase_is_processed(
     testcase, issue, description, upload_metadata):
   """Add issue comment when uploaded testcase is processed."""
-  issue.comment = description
+  issue_comment = description
 
   # Update the summary in the following cases:
   # 1. Upload metadata indicates that we need to do so.
@@ -734,7 +735,7 @@ def _update_issue_when_uploaded_testcase_is_processed(
   if testcase.project_name == 'chromium':
     data_handler.update_issue_impact_labels(testcase, issue)
 
-  issue.save()
+  issue.save(new_comment=issue_comment)
 
 
 def notify_uploader_when_testcase_is_processed(testcase, issue):
@@ -789,12 +790,11 @@ def update_os_labels(testcase, issue):
       platforms=platforms)
   for platform in platforms:
     os_label = 'OS-%s' % platform
-    if not issue.has_comment_with_label(os_label):
-      issue.add_label(os_label)
+    if not issue_tracker_utils.was_label_added(issue, os_label):
+      issue.labels.add(os_label)
 
-  if issue.dirty:
-    issue.save(send_email=False)
-    logs.log('Updated labels of issue %d.' % issue.id, labels=issue.labels)
+  issue.save(notify=False)
+  logs.log('Updated labels of issue %d.' % issue.id, labels=issue.labels)
 
 
 def update_fuzz_blocker_label(testcase, issue,
@@ -812,7 +812,8 @@ def update_fuzz_blocker_label(testcase, issue,
     # Not a top crasher, bail out.
     return
 
-  if issue.has_comment_with_label(data_types.ISSUE_FUZZ_BLOCKER_LABEL):
+  if issue_tracker_utils.was_label_added(issue,
+                                         data_types.ISSUE_FUZZ_BLOCKER_LABEL):
     # Issue was already marked a top crasher, bail out.
     return
 
@@ -835,19 +836,18 @@ def update_fuzz_blocker_label(testcase, issue,
     update_message += INTERNAL_INCORRECT_COMMENT
     update_message += (
         ' and remove the %s label.' % data_types.ISSUE_RELEASEBLOCK_BETA_LABEL)
-    issue.add_label(data_types.ISSUE_RELEASEBLOCK_BETA_LABEL)
+    issue.labels.add(data_types.ISSUE_RELEASEBLOCK_BETA_LABEL)
 
     # Update with the next beta for trunk, and remove existing milestone label.
     beta_milestone_label = (
         'M-%d' % build_info.get_release_milestone('head', testcase.platform))
-    if not issue.has_label(beta_milestone_label):
-      issue.remove_label_by_prefix('M-')
-      issue.add_label(beta_milestone_label)
+    if beta_milestone_label not in issue.labels:
+      issue.labels.remove_by_prefix('M-')
+      issue.labels.add(beta_milestone_label)
 
   logs.log(update_message)
-  issue.add_label(data_types.ISSUE_FUZZ_BLOCKER_LABEL)
-  issue.comment = update_message
-  issue.save(send_email=True)
+  issue.labels.add(data_types.ISSUE_FUZZ_BLOCKER_LABEL)
+  issue.save(new_comment=update_message, notify=True)
 
 
 def update_component_labels(testcase, issue):
@@ -876,20 +876,20 @@ def update_component_labels(testcase, issue):
   # Don't run on issues we've already applied automatic components to in case
   # labels are removed manually. This may cause issues in the event that we
   # rerun a test case, but it seems like a reasonable tradeoff to avoid spam.
-  if issue.has_comment_with_label(
-      data_types.ISSUE_PREDATOR_AUTO_COMPONENTS_LABEL):
+  if issue_tracker_utils.was_label_added(
+      issue, data_types.ISSUE_PREDATOR_AUTO_COMPONENTS_LABEL):
     return
 
   for filtered_component in filtered_components:
-    issue.add_component(filtered_component)
+    issue.components.add(filtered_component)
 
-  issue.add_label(data_types.ISSUE_PREDATOR_AUTO_COMPONENTS_LABEL)
-  issue.comment = (
+  issue.labels.add(data_types.ISSUE_PREDATOR_AUTO_COMPONENTS_LABEL)
+  issue_comment = (
       'Automatically applying components based on crash stacktrace and '
       'information from OWNERS files.\n\n'
       'If this is incorrect, please apply the %s label.' %
       data_types.ISSUE_PREDATOR_WRONG_COMPONENTS_LABEL)
-  issue.save(send_email=True)
+  issue.save(new_comment=issue_comment, notify=True)
 
 
 def update_issue_ccs_from_owners_file(testcase, issue):
@@ -900,7 +900,8 @@ def update_issue_ccs_from_owners_file(testcase, issue):
 
   # If we've assigned the ccs before, it likely means we were incorrect.
   # Don't try again for this particular issue.
-  if issue.has_comment_with_label(data_types.ISSUE_CLUSTERFUZZ_AUTO_CC_LABEL):
+  if issue_tracker_utils.was_label_added(
+      issue, data_types.ISSUE_CLUSTERFUZZ_AUTO_CC_LABEL):
     return
 
   if testcase.get_metadata('has_issue_ccs_from_owners_file'):
@@ -915,18 +916,18 @@ def update_issue_ccs_from_owners_file(testcase, issue):
     return
 
   ccs_added = False
-  comments = issue.get_comments()
+  actions = list(issue.actions)
   for cc in random.sample(ccs_list, min(AUTO_CC_LIMIT, len(ccs_list))):
-    if issue.has_cc(cc):
+    if cc in issue.ccs:
       continue
 
     # If cc was previously manually removed from the cc list, we assume that
     # they were incorrectly added. Don't try to add them again.
-    cc_was_removed = any(('-%s' % cc) in comment.cc for comment in comments)
+    cc_was_removed = any(cc in action.ccs.removed for action in actions)
     if cc_was_removed:
       continue
 
-    issue.add_cc(cc)
+    issue.ccs.add(cc)
     ccs_added = True
 
   if not ccs_added:
@@ -936,15 +937,16 @@ def update_issue_ccs_from_owners_file(testcase, issue):
     testcase.set_metadata('has_issue_ccs_from_owners_file', True)
     return
 
-  issue.comment = (
+  issue_comment = (
       'Automatically adding ccs based on OWNERS file / target commit history.')
   if utils.is_oss_fuzz():
-    issue.comment += OSS_FUZZ_INCORRECT_COMMENT
+    issue_comment += OSS_FUZZ_INCORRECT_COMMENT
   else:
-    issue.comment += INTERNAL_INCORRECT_COMMENT
-  issue.comment += '.'
-  issue.add_label(data_types.ISSUE_CLUSTERFUZZ_AUTO_CC_LABEL)
-  issue.save(send_email=True)
+    issue_comment += INTERNAL_INCORRECT_COMMENT
+  issue_comment += '.'
+
+  issue.labels.add(data_types.ISSUE_CLUSTERFUZZ_AUTO_CC_LABEL)
+  issue.save(new_comment=issue_comment, notify=True)
 
 
 def update_issue_owner_and_ccs_from_predator_results(testcase,
@@ -955,13 +957,15 @@ def update_issue_owner_and_ccs_from_predator_results(testcase,
     return
 
   # If the issue already has an owner, we don't need to update the bug.
-  if issue.owner:
+  if issue.assignee:
     return
 
   # If we've assigned an owner or cc once before, it likely means we were
   # incorrect. Don't try again for this particular issue.
-  if (issue.has_comment_with_label(data_types.ISSUE_PREDATOR_AUTO_OWNER_LABEL)
-      or issue.has_comment_with_label(data_types.ISSUE_PREDATOR_AUTO_CC_LABEL)):
+  if (issue_tracker_utils.was_label_added(
+      issue, data_types.ISSUE_PREDATOR_AUTO_OWNER_LABEL) or
+      issue_tracker_utils.was_label_added(
+          issue, data_types.ISSUE_PREDATOR_AUTO_CC_LABEL)):
     return
 
   # If there are more than 3 suspected CLs, we can't be confident in the
@@ -988,15 +992,15 @@ def update_issue_owner_and_ccs_from_predator_results(testcase,
 
     # If this owner has already been assigned before but has since been removed,
     # don't assign it to them again.
-    for comment in issue.get_comments():
-      if comment.owner == suspected_cls[0]['author']:
+    for action in issue.actions:
+      if action.assignee == suspected_cls[0]['author']:
         return
 
     # We have high confidence for the single-CL case, so we assign the owner.
-    issue.add_label(data_types.ISSUE_PREDATOR_AUTO_OWNER_LABEL)
-    issue.owner = suspected_cl['author']
+    issue.labels.add(data_types.ISSUE_PREDATOR_AUTO_OWNER_LABEL)
+    issue.assignee = suspected_cl['author']
     issue.status = 'Assigned'
-    issue.comment = (
+    issue_comment = (
         'Automatically assigning owner based on suspected regression '
         'changelist %s (%s).\n\n'
         'If this is incorrect, please let us know why and apply the %s '
@@ -1009,7 +1013,7 @@ def update_issue_owner_and_ccs_from_predator_results(testcase,
     if testcase.get_metadata('has_issue_ccs_from_predator_results'):
       return
 
-    comment_to_add = (
+    issue_comment = (
         'Automatically adding ccs based on suspected regression changelists:'
         '\n\n')
     ccs_added = False
@@ -1019,23 +1023,23 @@ def update_issue_owner_and_ccs_from_predator_results(testcase,
       # we're ccing the author. This might, for example, catch the attention of
       # someone who has already been cced.
       author = suspected_cl['author']
-      comment_to_add += '%s by %s - %s\n\n' % (suspected_cl['description'],
-                                               author, suspected_cl['url'])
-      if issue.has_cc(author):
+      issue_comment += '%s by %s - %s\n\n' % (suspected_cl['description'],
+                                              author, suspected_cl['url'])
+      if author in issue.ccs:
         continue
 
       # If an author has previously been manually removed from the cc list,
       # we assume they were incorrectly added. Don't try to add them again.
       author_was_removed = False
-      for comment in issue.get_comments():
-        if '-%s' % author in comment.cc:
+      for action in issue.actions:
+        if author in action.ccs.removed:
           author_was_removed = True
           break
 
       if author_was_removed:
         continue
 
-      issue.add_cc(author)
+      issue.ccs.add(author)
       ccs_added = True
 
     if not ccs_added:
@@ -1045,17 +1049,16 @@ def update_issue_owner_and_ccs_from_predator_results(testcase,
       testcase.set_metadata('has_issue_ccs_from_owners_file', True)
       return
 
-    issue.add_label(data_types.ISSUE_PREDATOR_AUTO_CC_LABEL)
-    comment_to_add += (
+    issue.labels.add(data_types.ISSUE_PREDATOR_AUTO_CC_LABEL)
+    issue_comment += (
         'If this is incorrect, please let us know why and apply the %s label.' %
         data_types.ISSUE_PREDATOR_WRONG_CL_LABEL)
-    issue.comment = comment_to_add
 
   try:
-    issue.save(send_email=True)
+    issue.save(new_comment=issue_comment, notify=True)
   except HttpError:
     # If we see such an error when we aren't setting an owner, it's unexpected.
-    if only_allow_ccs or not issue.owner:
+    if only_allow_ccs or not issue.assignee:
       logs.log_error(
           'Unable to update issue for test case %d.' % testcase.key.id())
       return

--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -718,8 +718,6 @@ def _send_email_to_uploader(testcase_id, to_email, content):
 def _update_issue_when_uploaded_testcase_is_processed(
     testcase, issue, description, upload_metadata):
   """Add issue comment when uploaded testcase is processed."""
-  issue_comment = description
-
   # Update the summary in the following cases:
   # 1. Upload metadata indicates that we need to do so.
   # 2. We have a valid crash state.
@@ -735,7 +733,7 @@ def _update_issue_when_uploaded_testcase_is_processed(
   if testcase.project_name == 'chromium':
     data_handler.update_issue_impact_labels(testcase, issue)
 
-  issue.save(new_comment=issue_comment)
+  issue.save(new_comment=description)
 
 
 def notify_uploader_when_testcase_is_processed(testcase, issue):

--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -386,7 +386,7 @@ def mark_issue_as_closed_if_testcase_is_fixed(testcase, issue):
 
   # If the issue is closed in a status other than Fixed, like Duplicate, WontFix
   # or Archived, we shouldn't change it. Bail out.
-  if not issue.open and issue.status != 'Fixed':
+  if not issue.is_open and issue.status != 'Fixed':
     return
 
   # Check testcase status, so as to skip unreproducible uploads.
@@ -457,7 +457,7 @@ def mark_unreproducible_testcase_as_fixed_if_issue_is_closed(testcase, issue):
     return
 
   # Make sure that there is an associated bug and it is in closed state.
-  if not issue or issue.open:
+  if not issue or issue.is_open:
     return
 
   testcase.fixed = 'NA'
@@ -493,7 +493,7 @@ def mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
     return
 
   # Make sure that there is an associated bug and it is in open state.
-  if not issue or not issue.open:
+  if not issue or not issue.is_open:
     return
 
   # Check if there are any reproducible open testcases are associated with
@@ -562,7 +562,7 @@ def mark_testcase_as_triaged_if_needed(testcase, issue):
   if issue:
     # Get latest issue object to ensure our update went through.
     issue = get_issue_for_testcase(testcase)
-    if issue.open:
+    if issue.is_open:
       return
 
   testcase.triaged = True
@@ -580,7 +580,7 @@ def mark_testcase_as_closed_if_issue_is_closed(testcase, issue):
     return
 
   # If the issue is still open, no work needs to be done. Bail out.
-  if issue.open:
+  if issue.is_open:
     return
 
   # Make sure we passed our deadline based on issue closed timestamp.
@@ -631,7 +631,7 @@ def notify_closed_issue_if_testcase_is_open(testcase, issue):
     return
 
   # If the issue is still open, no work needs to be done. Bail out.
-  if issue.open:
+  if issue.is_open:
     return
 
   # If we have already passed our deadline based on issue closed timestamp,
@@ -679,7 +679,7 @@ def notify_issue_if_testcase_is_invalid(testcase, issue):
     return
 
   # If the issue is closed, there's no work to do.
-  if not issue.open:
+  if not issue.is_open:
     return
 
   # Currently, this only happens if a test case relies on a fuzzer that has
@@ -893,7 +893,7 @@ def update_component_labels(testcase, issue):
 def update_issue_ccs_from_owners_file(testcase, issue):
   """Add cc to an issue based on owners list from owners file. This is
   currently applicable to fuzz targets only."""
-  if not issue or not issue.open:
+  if not issue or not issue.is_open:
     return
 
   # If we've assigned the ccs before, it likely means we were incorrect.
@@ -951,7 +951,7 @@ def update_issue_owner_and_ccs_from_predator_results(testcase,
                                                      issue,
                                                      only_allow_ccs=False):
   """Assign the issue to an appropriate owner if possible."""
-  if not issue or not issue.open:
+  if not issue or not issue.is_open:
     return
 
   # If the issue already has an owner, we don't need to update the bug.

--- a/src/appengine/handlers/testcase_detail/update_issue.py
+++ b/src/appengine/handlers/testcase_detail/update_issue.py
@@ -29,9 +29,9 @@ class Handler(base_handler.Handler):
     """Associate (or update) an existing issue with the testcase."""
     issue_id = helpers.cast(issue_id, int,
                             'Issue ID (%s) is not a number!' % issue_id)
-    itm = helpers.get_issue_tracker_manager(testcase)
+    issue_tracker = helpers.get_issue_tracker_for_testcase(testcase)
 
-    issue = helpers.get_or_exit(lambda: itm.get_issue(issue_id),
+    issue = helpers.get_or_exit(lambda: issue_tracker.get_issue(issue_id),
                                 'Issue (id=%d) is not found!' % issue_id,
                                 'Failed to get the issue (id=%s).' % issue_id,
                                 Exception)
@@ -42,13 +42,13 @@ class Handler(base_handler.Handler):
            ' allowed. Please file a new issue instead!') % issue_id, 400)
 
     # Create issue parameters.
-    issue.comment = data_handler.get_issue_description(testcase,
+    issue_comment = data_handler.get_issue_description(testcase,
                                                        helpers.get_user_email())
     issue_summary = data_handler.get_issue_summary(testcase)
 
     # NULL states leads to unhelpful summaries, so do not update in that case.
     if needs_summary_update and testcase.crash_state != 'NULL':
-      issue.summary = issue_summary
+      issue.title = issue_summary
 
     # Add label on memory tool used.
     issue_filer.add_memory_tool_label_if_needed(issue, testcase)
@@ -58,7 +58,7 @@ class Handler(base_handler.Handler):
 
     # Don't enforce security severity label on an existing issue.
 
-    itm.save(issue)
+    issue.save(new_comment=issue_comment)
 
     testcase.bug_information = str(issue_id)
     testcase.put()

--- a/src/appengine/handlers/testcase_detail/update_issue.py
+++ b/src/appengine/handlers/testcase_detail/update_issue.py
@@ -36,7 +36,7 @@ class Handler(base_handler.Handler):
                                 'Failed to get the issue (id=%s).' % issue_id,
                                 Exception)
 
-    if not issue.open:
+    if not issue.is_open:
       raise helpers.EarlyExitException(
           ('The issue (%d) is already closed and further updates are not'
            ' allowed. Please file a new issue instead!') % issue_id, 400)

--- a/src/appengine/libs/issue_filer.py
+++ b/src/appengine/libs/issue_filer.py
@@ -58,7 +58,7 @@ def add_memory_tool_label_if_needed(issue, testcase):
   stacktrace = data_handler.get_stacktrace(testcase)
   memory_tool_labels = label_utils.get_memory_tool_labels(stacktrace)
   for label in memory_tool_labels:
-    issue.labels.append(label)
+    issue.labels.add(label)
 
 
 def add_security_severity_label_if_needed(issue, testcase,
@@ -77,7 +77,7 @@ def add_security_severity_label_if_needed(issue, testcase,
     security_severity = data_types.SecuritySeverity.HIGH
 
   security_severity_label = label_utils.severity_to_label(security_severity)
-  issue.labels.append(security_severity_label)
+  issue.labels.add(security_severity_label)
 
 
 def add_view_restrictions_if_needed(issue, testcase):
@@ -91,7 +91,7 @@ def add_view_restrictions_if_needed(issue, testcase):
 
   job_type_lowercase = testcase.job_type.lower()
   if 'android' in job_type_lowercase or 'flash' in job_type_lowercase:
-    issue.labels.append(RESTRICT_TO_GOOGLERS_LABEL)
+    issue.labels.add(RESTRICT_TO_GOOGLERS_LABEL)
 
 
 def reported_label():
@@ -112,16 +112,16 @@ def file_issue(testcase,
 
   # Labels applied by default across all issue trackers.
   issue.status = 'New'
-  issue.labels.append('ClusterFuzz')
+  issue.labels.add('ClusterFuzz')
 
   # Add label on memory tool used.
   add_memory_tool_label_if_needed(issue, testcase)
 
   # Add reproducibility flag label.
   if testcase.one_time_crasher_flag:
-    issue.labels.append('Unreproducible')
+    issue.labels.add('Unreproducible')
   else:
-    issue.labels.append('Reproducible')
+    issue.labels.add('Reproducible')
 
   # Add security severity flag label.
   add_security_severity_label_if_needed(issue, testcase, security_severity)
@@ -143,62 +143,62 @@ def file_issue(testcase,
     if environment.is_chromeos_job(testcase.job_type):
       # ChromeOS fuzzers run on Linux platform, so use correct OS-Chrome for
       # tracking.
-      issue.labels.append('OS-Chrome')
+      issue.labels.add('OS-Chrome')
     elif testcase.platform_id:
       os_label = 'OS-%s' % ((testcase.platform_id.split(':')[0]).capitalize())
-      issue.labels.append(os_label)
+      issue.labels.add(os_label)
 
     # Add view restrictions for internal job types.
     add_view_restrictions_if_needed(issue, testcase)
 
     if testcase.security_flag:
       # Apply labels specific to security bugs.
-      issue.labels.append('Restrict-View-SecurityTeam')
-      issue.labels.append('Type-Bug-Security')
+      issue.labels.add('Restrict-View-SecurityTeam')
+      issue.labels.add('Type-Bug-Security')
 
       # Add reward labels if this is from an external fuzzer contribution.
       fuzzer = data_types.Fuzzer.query(
           data_types.Fuzzer.name == testcase.fuzzer_name).get()
       if fuzzer and fuzzer.external_contribution:
-        issue.labels.append('reward-topanel')
-        issue.labels.append('External-Fuzzer-Contribution')
+        issue.labels.add('reward-topanel')
+        issue.labels.add('External-Fuzzer-Contribution')
 
       data_handler.update_issue_impact_labels(testcase, issue)
     else:
       # Apply labels for functional (non-security) bugs.
       if utils.sub_string_exists_in(NON_CRASH_TYPES, testcase.crash_type):
         # Non-crashing test cases shouldn't be assigned Pri-1.
-        issue.labels.append('Pri-2')
-        issue.labels.append('Type-Bug')
+        issue.labels.add('Pri-2')
+        issue.labels.add('Type-Bug')
       else:
         # Default functional bug labels.
-        issue.labels.append('Pri-1')
-        issue.labels.append('Stability-Crash')
-        issue.labels.append('Type-Bug')
+        issue.labels.add('Pri-1')
+        issue.labels.add('Stability-Crash')
+        issue.labels.add('Type-Bug')
 
   # OSS-Fuzz specific labels.
   elif issue_tracker.project == 'oss-fuzz':
     if testcase.security_flag:
       # Security bug labels.
-      issue.labels.append('Type-Bug-Security')
+      issue.labels.add('Type-Bug-Security')
     else:
       # Functional bug labels.
-      issue.labels.append('Type-Bug')
+      issue.labels.add('Type-Bug')
 
     if should_restrict_issue:
-      issue.labels.append('Restrict-View-Commit')
+      issue.labels.add('Restrict-View-Commit')
 
   # Add additional labels from the job definition and fuzzer.
   additional_labels = data_handler.get_additional_values_for_variable(
       'AUTOMATIC_LABELS', testcase.job_type, testcase.fuzzer_name)
   for label in additional_labels:
-    issue.labels.append(label)
+    issue.labels.add(label)
 
   # Add additional components from the job definition and fuzzer.
   automatic_components = data_handler.get_additional_values_for_variable(
       'AUTOMATIC_COMPONENTS', testcase.job_type, testcase.fuzzer_name)
   for component in automatic_components:
-    issue.components.append(component)
+    issue.components.add(component)
 
   # Add additional ccs from the job definition and fuzzer.
   ccs = data_handler.get_additional_values_for_variable(
@@ -224,7 +224,7 @@ def file_issue(testcase,
 
   if issue_tracker.project == 'oss-fuzz' and ccs:
     # Add a reported label for deadline tracking.
-    issue.labels.append(reported_label())
+    issue.labels.add(reported_label())
 
     if should_restrict_issue:
       issue.body += '\n\n' + DEADLINE_NOTE
@@ -233,7 +233,7 @@ def file_issue(testcase,
     issue.body += '\n\n' + QUESTIONS_NOTE
 
   for cc in ccs:
-    issue.ccs.append(cc)
+    issue.ccs.add(cc)
 
   # Add additional labels from testcase metadata.
   metadata_labels = utils.parse_delimited(
@@ -242,7 +242,7 @@ def file_issue(testcase,
       strip=True,
       remove_empty=True)
   for label in metadata_labels:
-    issue.labels.append(label)
+    issue.labels.add(label)
 
   issue.reporter = user_email
   issue.save()

--- a/src/python/issue_management/issue_tracker.py
+++ b/src/python/issue_management/issue_tracker.py
@@ -235,4 +235,5 @@ class IssueTracker(object):
 
   def get_original_issue(self, issue_id):
     """Retrieve the original issue object traversing the list of duplicates."""
+    # TODO(ochang): Use implementation from monorail for all issue trackers.
     raise NotImplementedError

--- a/src/python/issue_management/issue_tracker.py
+++ b/src/python/issue_management/issue_tracker.py
@@ -26,11 +26,14 @@ class LabelStore(object):
     self._removed = {}
 
     for item in seq:
-      self.add(item)
+      self._backing[item.lower()] = item
 
   def __iter__(self):
     for value in itervalues(self._backing):
       yield value
+
+  def __contains__(self, item):
+    return item.lower() in self._backing
 
   @property
   def added(self):

--- a/src/python/issue_management/issue_tracker.py
+++ b/src/python/issue_management/issue_tracker.py
@@ -48,8 +48,9 @@ class LabelStore(object):
     key = label.lower()
     if key in self._removed:
       del self._removed[key]
+    else:
+      self._added[key] = label
 
-    self._added[key] = label
     self._backing[key] = label
 
   def remove(self, label):
@@ -60,8 +61,9 @@ class LabelStore(object):
 
     if key in self._added:
       del self._added[key]
+    else:
+      self._removed[key] = label
 
-    self._removed[key] = label
     del self._backing[key]
 
   def reset(self):
@@ -112,7 +114,7 @@ class Issue(object):
     raise NotImplementedError
 
   @property
-  def open(self):
+  def is_open(self):
     """Whether the issue is open."""
     raise NotImplementedError
 

--- a/src/python/issue_management/issue_tracker.py
+++ b/src/python/issue_management/issue_tracker.py
@@ -13,6 +13,64 @@
 """Issue tracker interface."""
 
 from builtins import object
+from future.utils import itervalues
+
+
+class LabelStore(object):
+  """Label storage which tracks changes. Case insensitive, but preserves
+  case."""
+
+  def __init__(self, seq=()):
+    self._backing = {}
+    self._added = {}
+    self._removed = {}
+
+    for item in seq:
+      self.add(item)
+
+  def __iter__(self):
+    for value in itervalues(self._backing):
+      yield value
+
+  @property
+  def added(self):
+    return itervalues(self._added)
+
+  @property
+  def removed(self):
+    return itervalues(self._removed)
+
+  def add(self, label):
+    """Add a new label."""
+    key = label.lower()
+    if key in self._removed:
+      del self._removed[key]
+
+    self._added[key] = label
+    self._backing[key] = label
+
+  def remove(self, label):
+    """Remove a label."""
+    key = label.lower()
+    if key not in self._backing:
+      return
+
+    if key in self._added:
+      del self._added[key]
+
+    self._removed[key] = label
+    del self._backing[key]
+
+  def reset(self):
+    """Reset tracking."""
+    self._added.clear()
+    self._removed.clear()
+
+  def remove_by_prefix(self, prefix):
+    """Remove labels with a given prefix."""
+    for item in list(self):
+      if item.lower().startswith(prefix.lower()):
+        self.remove(item)
 
 
 class Issue(object):
@@ -48,6 +106,11 @@ class Issue(object):
 
   @merged_into.setter
   def merged_into(self, new_merged_into):
+    raise NotImplementedError
+
+  @property
+  def open(self):
+    """Whether the issue is open."""
     raise NotImplementedError
 
   @property
@@ -97,7 +160,7 @@ class Issue(object):
     """Get the issue actions."""
     raise NotImplementedError
 
-  def save(self, notify=True):
+  def save(self, new_comment=None, notify=True):
     """Save the issue."""
     raise NotImplementedError
 
@@ -167,4 +230,9 @@ class IssueTracker(object):
     raise NotImplementedError
 
   def get_issue(self, issue_id):
+    """Get the issue with the given ID."""
+    raise NotImplementedError
+
+  def get_original_issue(self, issue_id):
+    """Retrieve the original issue object traversing the list of duplicates."""
     raise NotImplementedError

--- a/src/python/issue_management/issue_tracker_utils.py
+++ b/src/python/issue_management/issue_tracker_utils.py
@@ -160,3 +160,13 @@ def get_similar_issues(testcase,
       issue_ids.append(issue_id)
 
   return issue_objects
+
+
+def was_label_added(issue, label):
+  """Check if a label was ever added to an issue."""
+  for action in issue.actions:
+    for added in action.labels.added:
+      if label.lower() == added.lower():
+        return True
+
+  return False

--- a/src/python/issue_management/monorail/__init__.py
+++ b/src/python/issue_management/monorail/__init__.py
@@ -217,7 +217,7 @@ class IssueTracker(issue_tracker.IssueTracker):
 
   def get_original_issue(self, issue_id):
     """Retrieve the original issue object traversing the list of duplicates."""
-    return self._itm.get_original_issue(int(issue_id))
+    return Issue(self._itm.get_original_issue(int(issue_id)))
 
 
 def _to_change_list(monorail_list):

--- a/src/python/issue_management/monorail/__init__.py
+++ b/src/python/issue_management/monorail/__init__.py
@@ -18,6 +18,7 @@ standard_library.install_aliases()
 from builtins import object
 
 from issue_management import issue_tracker
+from issue_management.monorail.issue import ChangeList as ChangeList
 from issue_management.monorail.issue import Issue as MonorailIssue
 
 
@@ -26,6 +27,14 @@ class Issue(issue_tracker.Issue):
 
   def __init__(self, monorail_issue):
     self._monorail_issue = monorail_issue
+
+    # These mirror the underlying MonorailIssue data structures, to make it more
+    # opaque to the client about how issue updates are done. For instance, when
+    # a `label` is removed, what actually happens is `-label` is added. This
+    # should not be visible to the client.
+    self._ccs = issue_tracker.LabelStore(self._monorail_issue.cc)
+    self._components = issue_tracker.LabelStore(self._monorail_issue.components)
+    self._labels = issue_tracker.LabelStore(self._monorail_issue.labels)
 
   @property
   def id(self):
@@ -60,6 +69,11 @@ class Issue(issue_tracker.Issue):
     self._monorail_issue.merged_into = new_merged_into
 
   @property
+  def open(self):
+    """Whether the issue is open."""
+    return self._monorail_issue.open
+
+  @property
   def status(self):
     """The issue status."""
     return self._monorail_issue.status
@@ -89,25 +103,46 @@ class Issue(issue_tracker.Issue):
   @property
   def ccs(self):
     """The issue CC list."""
-    return self._monorail_issue.cc
+    return self._ccs
 
   @property
   def labels(self):
     """The issue labels list."""
-    return self._monorail_issue.labels
+    return self._labels
 
   @property
   def components(self):
     """The issue component list."""
-    return self._monorail_issue.components
+    return self._components
 
   @property
   def actions(self):
     """Get the issue actions."""
     return (Action(comment) for comment in self._monorail_issue.get_comments())
 
-  def save(self, notify=True):
+  def save(self, new_comment=None, notify=True):
     """Save the issue."""
+
+    # Apply actual label changes to the underlying MonorailIssue.
+    for added in self._components.added:
+      self._monorail_issue.add_component(added)
+    for removed in self._components.removed:
+      self._monorail_issue.remove_component(removed)
+    self._components.reset()
+
+    for added in self._ccs.added:
+      self._monorail_issue.add_cc(added)
+    for removed in self._ccs.removed:
+      self._monorail_issue.remove_cc(removed)
+    self._ccs.reset()
+
+    for added in self._labels.added:
+      self._monorail_issue.add_label(added)
+    for removed in self._labels.removed:
+      self._monorail_issue.remove_label(removed)
+    self._labels.reset()
+
+    self._monorail_issue.comment = new_comment
     self._monorail_issue.save(send_email=notify)
 
 
@@ -174,11 +209,15 @@ class IssueTracker(issue_tracker.IssueTracker):
     return Issue(monorail_issue)
 
   def get_issue(self, issue_id):
-    monorail_issue = self._itm.get_issue(issue_id)
+    monorail_issue = self._itm.get_issue(int(issue_id))
     if not monorail_issue:
       return None
 
     return Issue(monorail_issue)
+
+  def get_original_issue(self, issue_id):
+    """Retrieve the original issue object traversing the list of duplicates."""
+    return self._itm.get_original_issue(int(issue_id))
 
 
 def _to_change_list(monorail_list):

--- a/src/python/issue_management/monorail/__init__.py
+++ b/src/python/issue_management/monorail/__init__.py
@@ -69,7 +69,7 @@ class Issue(issue_tracker.Issue):
     self._monorail_issue.merged_into = new_merged_into
 
   @property
-  def open(self):
+  def is_open(self):
     """Whether the issue is open."""
     return self._monorail_issue.open
 

--- a/src/python/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/python/tests/appengine/handlers/cron/cleanup_test.py
@@ -276,7 +276,7 @@ class CleanupTest(unittest.TestCase):
     similar_testcase.open = False
     similar_testcase.put()
 
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.status = 'Fixed'
 
     cleanup.mark_issue_as_closed_if_testcase_is_fixed(
@@ -294,7 +294,7 @@ class CleanupTest(unittest.TestCase):
     testcase.put()
 
     self.issue.status = 'Assigned'
-    self.issue.comments += [
+    self.issue._monorail_issue.comments += [
         test_utils.create_generic_issue_comment(
             labels=[data_types.ISSUE_VERIFIED_LABEL])
     ]
@@ -313,7 +313,7 @@ class CleanupTest(unittest.TestCase):
     testcase.put()
 
     self.issue.status = 'Assigned'
-    self.issue.comments += [
+    self.issue._monorail_issue.comments += [
         test_utils.create_generic_issue_comment(
             labels=[data_types.ISSUE_MISTRIAGED_LABEL])
     ]
@@ -366,7 +366,7 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = True
+    self.issue._monorail_issue.open = True
     cleanup.mark_testcase_as_closed_if_issue_is_closed(
         testcase=testcase, issue=self.issue)
     self.assertTrue(testcase.open)
@@ -376,10 +376,10 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.closed = test_utils.CURRENT_TIME - datetime.timedelta(
         days=data_types.CLOSE_TESTCASE_WITH_CLOSED_BUG_DEADLINE + 1)
-    self.issue.comments += [
+    self.issue._monorail_issue.comments += [
         test_utils.create_generic_issue_comment(
             labels=[data_types.ISSUE_IGNORE_LABEL])
     ]
@@ -393,7 +393,7 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.closed = test_utils.CURRENT_TIME - datetime.timedelta(
         days=data_types.CLOSE_TESTCASE_WITH_CLOSED_BUG_DEADLINE)
     cleanup.mark_testcase_as_closed_if_issue_is_closed(
@@ -406,7 +406,7 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.closed = test_utils.CURRENT_TIME - datetime.timedelta(
         days=data_types.CLOSE_TESTCASE_WITH_CLOSED_BUG_DEADLINE + 1)
     cleanup.mark_testcase_as_closed_if_issue_is_closed(
@@ -456,7 +456,7 @@ class CleanupTest(unittest.TestCase):
   def test_mark_unreproducible_testcase_as_fixed_if_issue_is_closed_3(self):
     """Ensure that a reproducible testcase with associated issue in closed state
     is not marked as Fixed."""
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.one_time_crasher_flag = False
@@ -468,7 +468,7 @@ class CleanupTest(unittest.TestCase):
   def test_mark_unreproducible_testcase_as_fixed_if_issue_is_closed_4(self):
     """Ensure that an unreproducible testcase with associated issue in open
     state is marked as Fixed."""
-    self.issue.open = True
+    self.issue._monorail_issue.open = True
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.one_time_crasher_flag = True
@@ -480,7 +480,7 @@ class CleanupTest(unittest.TestCase):
   def test_mark_unreproducible_testcase_as_fixed_if_issue_is_closed_5(self):
     """Ensure that an unreproducible testcase with associated issue in closed
     state is marked as Fixed."""
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.one_time_crasher_flag = True
@@ -517,7 +517,7 @@ class CleanupTest(unittest.TestCase):
       self):
     """Ensure that an unreproducible testcase with a closed issue is not
     closed."""
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.one_time_crasher_flag = True
@@ -565,7 +565,7 @@ class CleanupTest(unittest.TestCase):
     seen in crash stats, but with mistriaged issue label is not closed."""
     self.issue = test_utils.create_generic_issue()
     self.mock.get_crash_occurrence_platforms.return_value = []
-    self.issue.comments += [
+    self.issue._monorail_issue.comments += [
         test_utils.create_generic_issue_comment(
             labels=[data_types.ISSUE_MISTRIAGED_LABEL])
     ]
@@ -592,7 +592,7 @@ class CleanupTest(unittest.TestCase):
     cleanup.mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
         testcase=testcase, issue=self.issue)
     self.assertTrue(testcase.open)
-    self.assertTrue(self.issue.open)
+    self.assertEqual('Assigned', self.issue.status)
 
   def test_mark_unreproducible_testcase_and_issue_as_closed_after_deadline_8(
       self):
@@ -609,7 +609,7 @@ class CleanupTest(unittest.TestCase):
     cleanup.mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
         testcase=testcase, issue=self.issue)
     self.assertTrue(testcase.open)
-    self.assertTrue(self.issue.open)
+    self.assertEqual('Assigned', self.issue.status)
 
   def test_mark_unreproducible_testcase_and_issue_as_closed_after_deadline_9(
       self):
@@ -624,7 +624,7 @@ class CleanupTest(unittest.TestCase):
     cleanup.mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
         testcase=testcase, issue=self.issue)
     self.assertFalse(testcase.open)
-    self.assertFalse(self.issue.open)
+    self.assertEqual('WontFix', self.issue.status)
 
   def test_mark_unreproducible_testcase_and_issue_as_closed_after_deadline_10(
       self):
@@ -640,7 +640,7 @@ class CleanupTest(unittest.TestCase):
     cleanup.mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
         testcase=testcase, issue=self.issue)
     self.assertTrue(testcase.open)
-    self.assertTrue(self.issue.open)
+    self.assertEqual('Assigned', self.issue.status)
 
   def test_mark_unreproducible_testcase_and_issue_as_closed_after_deadline_11(
       self):
@@ -657,7 +657,7 @@ class CleanupTest(unittest.TestCase):
     cleanup.mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
         testcase=testcase, issue=self.issue)
     self.assertTrue(testcase.open)
-    self.assertTrue(self.issue.open)
+    self.assertEqual('Assigned', self.issue.status)
 
   def test_mark_unreproducible_testcase_and_issue_as_closed_after_deadline_12(
       self):
@@ -676,7 +676,7 @@ class CleanupTest(unittest.TestCase):
     cleanup.mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
         testcase=testcase, issue=self.issue)
     self.assertFalse(testcase.open)
-    self.assertFalse(self.issue.open)
+    self.assertEqual('WontFix', self.issue.status)
 
   def test_notify_closed_issue_if_testcase_is_open_1(self):
     """Test that we don't do anything if testcase is already closed."""
@@ -694,7 +694,7 @@ class CleanupTest(unittest.TestCase):
     testcase.bug_information = str(self.issue.id)
     testcase.status = 'Unreproducible'
     testcase.put()
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.closed = test_utils.CURRENT_TIME - datetime.timedelta(
         days=data_types.NOTIFY_CLOSED_BUG_WITH_OPEN_TESTCASE_DEADLINE + 1)
     cleanup.notify_closed_issue_if_testcase_is_open(
@@ -724,7 +724,7 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = True
+    self.issue._monorail_issue.open = True
     cleanup.notify_closed_issue_if_testcase_is_open(
         testcase=testcase, issue=self.issue)
     self.assertNotIn(data_types.ISSUE_NEEDS_FEEDBACK_LABEL, self.issue.labels)
@@ -735,7 +735,7 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.closed = test_utils.CURRENT_TIME - datetime.timedelta(
         days=data_types.NOTIFY_CLOSED_BUG_WITH_OPEN_TESTCASE_DEADLINE)
     cleanup.notify_closed_issue_if_testcase_is_open(
@@ -748,10 +748,10 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.closed = test_utils.CURRENT_TIME - datetime.timedelta(
         days=data_types.NOTIFY_CLOSED_BUG_WITH_OPEN_TESTCASE_DEADLINE + 1)
-    self.issue.comments += [
+    self.issue._monorail_issue.comments += [
         test_utils.create_generic_issue_comment(
             labels=[data_types.ISSUE_IGNORE_LABEL])
     ]
@@ -765,10 +765,10 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.closed = test_utils.CURRENT_TIME - datetime.timedelta(
         days=data_types.NOTIFY_CLOSED_BUG_WITH_OPEN_TESTCASE_DEADLINE + 1)
-    self.issue.comments += [
+    self.issue._monorail_issue.comments += [
         test_utils.create_generic_issue_comment(
             labels=[data_types.ISSUE_NEEDS_FEEDBACK_LABEL])
     ]
@@ -782,7 +782,7 @@ class CleanupTest(unittest.TestCase):
     testcase = test_utils.create_generic_testcase()
     testcase.bug_information = str(self.issue.id)
     testcase.put()
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     self.issue.closed = test_utils.CURRENT_TIME - datetime.timedelta(
         days=data_types.NOTIFY_CLOSED_BUG_WITH_OPEN_TESTCASE_DEADLINE + 1)
     cleanup.notify_closed_issue_if_testcase_is_open(
@@ -837,7 +837,7 @@ class UpdateOsLabelsTest(unittest.TestCase):
     self.mock.get.return_value = (1, rows)
 
     issue = test_utils.create_generic_issue()
-    issue.labels = []
+    issue._monorail_issue.labels = []
     cleanup.update_os_labels(testcase, issue)
     self.assertEqual({'OS-Windows', 'OS-Linux', 'OS-Mac', 'OS-Android'},
                      set(issue.labels))
@@ -881,10 +881,11 @@ class UpdateOsLabelsTest(unittest.TestCase):
     self.mock.get.return_value = (1, rows)
 
     issue = test_utils.create_generic_issue()
+    issue._monorail_issue.labels = []
     comment = test_utils.create_generic_issue_comment(
         labels=['OS-Mac', 'OS-Android'])
-    issue.comments.append(comment)
-    issue.labels = ['OS-Windows']
+    issue._monorail_issue.comments.append(comment)
+    issue.labels.add('OS-Windows')
 
     cleanup.update_os_labels(testcase, issue)
     self.assertEqual({'OS-Windows', 'OS-Linux'}, set(issue.labels))
@@ -1030,7 +1031,7 @@ class UpdateTopCrashLabelsTest(unittest.TestCase):
     self.assertNotIn(data_types.ISSUE_RELEASEBLOCK_BETA_LABEL,
                      self.issue.labels)
     self.assertNotIn('M-63', self.issue.labels)
-    self.assertEqual('', self.issue.comment)
+    self.assertEqual('', self.issue._monorail_issue.comment)
 
   def test_top_crashes_no_match(self):
     """Test no label is added if there are no matching top crashes."""
@@ -1050,7 +1051,7 @@ class UpdateTopCrashLabelsTest(unittest.TestCase):
     self.assertNotIn(data_types.ISSUE_RELEASEBLOCK_BETA_LABEL,
                      self.issue.labels)
     self.assertNotIn('M-63', self.issue.labels)
-    self.assertEqual('', self.issue.comment)
+    self.assertEqual('', self.issue._monorail_issue.comment)
 
   def test_top_crashes_with_testcase_closed(self):
     """Test label is not added if testcase is closed."""
@@ -1073,7 +1074,7 @@ class UpdateTopCrashLabelsTest(unittest.TestCase):
     self.assertNotIn(data_types.ISSUE_RELEASEBLOCK_BETA_LABEL,
                      self.issue.labels)
     self.assertNotIn('M-63', self.issue.labels)
-    self.assertEqual('', self.issue.comment)
+    self.assertEqual('', self.issue._monorail_issue.comment)
 
   def test_top_crashes_match_single_platform(self):
     """Test label is added if there is a matching top crash."""
@@ -1087,18 +1088,21 @@ class UpdateTopCrashLabelsTest(unittest.TestCase):
             }]
         }
     }
+    self.issue.labels.add('M-62')
     cleanup.update_fuzz_blocker_label(self.testcase, self.issue,
                                       top_crashes_by_project_and_platform_map)
     self.assertIn(data_types.ISSUE_FUZZ_BLOCKER_LABEL, self.issue.labels)
     self.assertIn(data_types.ISSUE_RELEASEBLOCK_BETA_LABEL, self.issue.labels)
     self.assertIn('M-63', self.issue.labels)
+    self.assertNotIn('M-62', self.issue.labels)
     self.assertEqual(
         'This crash occurs very frequently on linux platform and is likely '
         'preventing the fuzzer fuzzer1 from making much progress. '
         'Fixing this will allow more bugs to be found.'
         '\n\nMarking this bug as a blocker for next Beta release.'
         '\n\nIf this is incorrect, please add ClusterFuzz-Wrong label and '
-        'remove the ReleaseBlock-Beta label.', self.issue.comment)
+        'remove the ReleaseBlock-Beta label.',
+        self.issue._monorail_issue.comment)
 
   def test_top_crashes_match_single_platform_oss_fuzz(self):
     """Test label is added if there is a matching top crash for external
@@ -1126,7 +1130,8 @@ class UpdateTopCrashLabelsTest(unittest.TestCase):
         'preventing the fuzzer fuzz_target1 from making much progress. '
         'Fixing this will allow more bugs to be found.'
         '\n\nIf this is incorrect, please file a bug on '
-        'https://github.com/google/oss-fuzz/issues/new', self.issue.comment)
+        'https://github.com/google/oss-fuzz/issues/new',
+        self.issue._monorail_issue.comment)
 
   def test_top_crashes_match_multiple_platforms(self):
     """Test label is added if there is a matching top crash."""
@@ -1163,7 +1168,8 @@ class UpdateTopCrashLabelsTest(unittest.TestCase):
         'progress. Fixing this will allow more bugs to be found.'
         '\n\nMarking this bug as a blocker for next Beta release.'
         '\n\nIf this is incorrect, please add ClusterFuzz-Wrong label and '
-        'remove the ReleaseBlock-Beta label.', self.issue.comment)
+        'remove the ReleaseBlock-Beta label.',
+        self.issue._monorail_issue.comment)
 
   def test_top_crashes_match_and_label_removed(self):
     """Test label is not added if it was added before and removed."""
@@ -1178,7 +1184,7 @@ class UpdateTopCrashLabelsTest(unittest.TestCase):
         }
     }
 
-    self.issue.comments += [
+    self.issue._monorail_issue.comments += [
         test_utils.create_generic_issue_comment(
             labels=[data_types.ISSUE_FUZZ_BLOCKER_LABEL])
     ]
@@ -1188,7 +1194,7 @@ class UpdateTopCrashLabelsTest(unittest.TestCase):
     self.assertNotIn(data_types.ISSUE_RELEASEBLOCK_BETA_LABEL,
                      self.issue.labels)
     self.assertNotIn('M-63', self.issue.labels)
-    self.assertEqual('', self.issue.comment)
+    self.assertEqual('', self.issue._monorail_issue.comment)
 
 
 @test_utils.with_cloud_emulators('datastore')
@@ -1220,7 +1226,7 @@ class UpdateComponentsTest(unittest.TestCase):
 
     comment = test_utils.create_generic_issue_comment(
         labels=['Test-Predator-Auto-Components'])
-    self.issue.comments.append(comment)
+    self.issue._monorail_issue.comments.append(comment)
 
     cleanup.update_component_labels(self.testcase, self.issue)
     self.assertNotIn('A', self.issue.components)
@@ -1230,7 +1236,7 @@ class UpdateComponentsTest(unittest.TestCase):
   def test_no_label_added_for_no_components(self):
     """Ensure that we don't add label when there is no component in result."""
     self.testcase.set_metadata('predator_result', {})
-    self.issue.components = ['A']
+    self.issue.components.add('A')
     cleanup.update_component_labels(self.testcase, self.issue)
     self.assertIn('A', self.issue.components)
     self.assertNotIn('Test-Predator-Auto-Components', self.issue.labels)
@@ -1241,7 +1247,9 @@ class UpdateComponentsTest(unittest.TestCase):
         'predator_result', {'result': {
             'suspected_components': ['A', 'B>C']
         }})
-    self.issue.components = ['A', 'B>C', 'D']
+    self.issue.components.add('A')
+    self.issue.components.add('B>C')
+    self.issue.components.add('D')
     cleanup.update_component_labels(self.testcase, self.issue)
     self.assertIn('A', self.issue.components)
     self.assertIn('B>C', self.issue.components)
@@ -1255,7 +1263,8 @@ class UpdateComponentsTest(unittest.TestCase):
                                {'result': {
                                    'suspected_components': ['A']
                                }})
-    self.issue.components = ['A>B', 'D']
+    self.issue.components.add('A>B')
+    self.issue.components.add('D')
     cleanup.update_component_labels(self.testcase, self.issue)
     self.assertNotIn('A', self.issue.components)
     self.assertIn('A>B', self.issue.components)
@@ -1269,7 +1278,8 @@ class UpdateComponentsTest(unittest.TestCase):
                                {'result': {
                                    'suspected_components': ['A', 'E']
                                }})
-    self.issue.components = ['A>B', 'D']
+    self.issue.components.add('A>B')
+    self.issue.components.add('D')
     cleanup.update_component_labels(self.testcase, self.issue)
     self.assertNotIn('A', self.issue.components)
     self.assertIn('A>B', self.issue.components)
@@ -1284,7 +1294,8 @@ class UpdateComponentsTest(unittest.TestCase):
                                {'result': {
                                    'suspected_components': ['A']
                                }})
-    self.issue.components = ['AA>B', 'D']
+    self.issue.components.add('AA>B')
+    self.issue.components.add('D')
     cleanup.update_component_labels(self.testcase, self.issue)
     self.assertIn('A', self.issue.components)
     self.assertIn('AA>B', self.issue.components)
@@ -1306,8 +1317,8 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     self.testcase = test_utils.create_generic_testcase()
 
     # We'll generally want to assume we have an unassigned issue.
-    self.issue.owner = ''
-    self.issue.cc = []
+    self.issue.assignee = ''
+    self.issue._monorail_issue.cc = []
     self.issue.status = 'Untriaged'
 
     self.testcase.set_metadata('issue_owners',
@@ -1317,28 +1328,28 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
   def test_skipped_issue_closed(self):
     """Test that we don't add ccs to closed issues."""
     self.issue.status = 'Fixed'
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     cleanup.update_issue_ccs_from_owners_file(self.testcase, self.issue)
-    self.assertEqual('', self.issue.comment)
-    self.assertEqual([], self.issue.cc)
+    self.assertEqual('', self.issue._monorail_issue.comment)
+    self.assertItemsEqual([], self.issue.ccs)
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_skipped_issue_updated_once(self):
     """Test that we don't add ccs if we added ccs once already."""
     comment = test_utils.create_generic_issue_comment(
         labels=['ClusterFuzz-Auto-CC'])
-    self.assertEqual('', self.issue.comment)
-    self.issue.comments.append(comment)
+    self.assertEqual('', self.issue._monorail_issue.comment)
+    self.issue._monorail_issue.comments.append(comment)
     cleanup.update_issue_ccs_from_owners_file(self.testcase, self.issue)
-    self.assertEqual([], self.issue.cc)
+    self.assertItemsEqual([], self.issue.ccs)
 
   def test_skipped_no_testcase_metadata(self):
     """Test that we don't add ccs if there are no issue_owners key in testcase
     metadata."""
     self.testcase.delete_metadata('issue_owners')
     cleanup.update_issue_ccs_from_owners_file(self.testcase, self.issue)
-    self.assertEqual('', self.issue.comment)
-    self.assertEqual([], self.issue.cc)
+    self.assertEqual('', self.issue._monorail_issue.comment)
+    self.assertItemsEqual([], self.issue.ccs)
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_skipped_empty_testcase_metadata(self):
@@ -1346,8 +1357,8 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     metadata."""
     self.testcase.set_metadata('issue_owners', '')
     cleanup.update_issue_ccs_from_owners_file(self.testcase, self.issue)
-    self.assertEqual('', self.issue.comment)
-    self.assertEqual([], self.issue.cc)
+    self.assertEqual('', self.issue._monorail_issue.comment)
+    self.assertItemsEqual([], self.issue.ccs)
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_skipped_ccs_already_added_and_metadata_set(self):
@@ -1355,31 +1366,32 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     has_issue_ccs_from_owners_file attribute."""
     self.testcase.set_metadata('has_issue_ccs_from_owners_file', True)
     cleanup.update_issue_ccs_from_owners_file(self.testcase, self.issue)
-    self.assertEqual('', self.issue.comment)
-    self.assertEqual([], self.issue.cc)
+    self.assertEqual('', self.issue._monorail_issue.comment)
+    self.assertItemsEqual([], self.issue.ccs)
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_skipped_ccs_alread_added_and_metadata_set(self):
     """Test that we don't add ccs if ccs are added already."""
-    self.issue.cc = ['dev1@example1.com', 'dev2@example2.com']
+    self.issue.ccs.add('dev1@example1.com')
+    self.issue.ccs.add('dev2@example2.com')
     cleanup.update_issue_ccs_from_owners_file(self.testcase, self.issue)
     self.assertEqual(
         True, self.testcase.get_metadata('has_issue_ccs_from_owners_file'))
-    self.assertEqual('', self.issue.comment)
-    self.assertEqual(['dev1@example1.com', 'dev2@example2.com'],
-                     sorted(self.issue.cc))
+    self.assertEqual('', self.issue._monorail_issue.comment)
+    self.assertItemsEqual(['dev1@example1.com', 'dev2@example2.com'],
+                          sorted(self.issue.ccs))
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_add_ccs_with_some_initial_ones(self):
     """Test that we only add new ccs if some are added already."""
-    self.issue.cc = ['dev1@example1.com']
+    self.issue._monorail_issue.cc = ['dev1@example1.com']
     cleanup.update_issue_ccs_from_owners_file(self.testcase, self.issue)
     self.assertEqual(
         'Automatically adding ccs based on OWNERS file / target commit history.'
         '\n\nIf this is incorrect, please add ClusterFuzz-Wrong label.',
-        self.issue.comment)
-    self.assertEqual(['dev1@example1.com', 'dev2@example2.com'],
-                     sorted(self.issue.cc))
+        self.issue._monorail_issue.comment)
+    self.assertItemsEqual(['dev1@example1.com', 'dev2@example2.com'],
+                          sorted(self.issue.ccs))
     self.assertIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_add_ccs_without_any_initial_ones(self):
@@ -1390,9 +1402,9 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
         'Automatically adding ccs based on OWNERS file / target commit history.'
         '\n\nIf this is incorrect, '
         'please file a bug on https://github.com/google/oss-fuzz/issues/new.',
-        self.issue.comment)
-    self.assertEqual(['dev1@example1.com', 'dev2@example2.com'],
-                     sorted(self.issue.cc))
+        self.issue._monorail_issue.comment)
+    self.assertItemsEqual(['dev1@example1.com', 'dev2@example2.com'],
+                          sorted(self.issue.ccs))
     self.assertIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_only_add_five_random_ccs(self):
@@ -1406,9 +1418,9 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     self.assertEqual(
         'Automatically adding ccs based on OWNERS file / target commit history.'
         '\n\nIf this is incorrect, please add ClusterFuzz-Wrong label.',
-        self.issue.comment)
+        self.issue._monorail_issue.comment)
 
-    self.assertEqual(issue_owners[-5:], self.issue.cc)
+    self.assertItemsEqual(issue_owners[-5:], self.issue.ccs)
     self.assertIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
 
@@ -1421,7 +1433,7 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
     self.testcase = test_utils.create_generic_testcase()
 
     # We'll generally want to assume we have an unassigned issue.
-    self.issue.owner = ''
+    self.issue.assignee = ''
     self.issue.status = 'Untriaged'
 
     # Set the metadata to a generic result that would lead to an update,
@@ -1441,7 +1453,7 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
     """Ensure that we set the owner when appropriate."""
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertEqual(self.issue.owner, 'a@example.com')
+    self.assertEqual(self.issue.assignee, 'a@example.com')
     self.assertEqual(self.issue.status, 'Assigned')
     self.assertIn('Test-Predator-Auto-Owner', self.issue.labels)
 
@@ -1449,30 +1461,30 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
     """Ensure that we cc single authors if assignment is disabled."""
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue, only_allow_ccs=True)
-    self.assertEqual(self.issue.owner, '')
+    self.assertEqual(self.issue.assignee, '')
     self.assertEqual(self.issue.status, 'Untriaged')
-    self.assertIn('a@example.com', self.issue.cc)
+    self.assertIn('a@example.com', self.issue.ccs)
     self.assertIn('Test-Predator-Auto-CC', self.issue.labels)
 
   def test_closed_not_updated(self):
     """Ensure that we don't set owners for closed issues."""
     self.issue.status = 'Fixed'
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertEqual(self.issue.owner, '')
+    self.assertEqual(self.issue.assignee, '')
     self.assertEqual(self.issue.status, 'Fixed')
     self.assertNotIn('Test-Predator-Auto-Owner', self.issue.labels)
 
   def test_owner_not_reassigned(self):
     """Ensure that we don't overwrite already assigned owners."""
     self.issue.status = 'Assigned'
-    self.issue.owner = 'b@example.com'
+    self.issue.assignee = 'b@example.com'
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertEqual(self.issue.owner, 'b@example.com')
+    self.assertEqual(self.issue.assignee, 'b@example.com')
     self.assertEqual(self.issue.status, 'Assigned')
     self.assertNotIn('Test-Predator-Auto-Owner', self.issue.labels)
 
@@ -1480,11 +1492,11 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
     """Ensure that we don't try to update the same issue twice."""
     comment = test_utils.create_generic_issue_comment(
         labels=['Test-Predator-Auto-Owner'])
-    self.issue.comments.append(comment)
+    self.issue._monorail_issue.comments.append(comment)
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertEqual(self.issue.owner, '')
+    self.assertEqual(self.issue.assignee, '')
     self.assertEqual(self.issue.status, 'Untriaged')
     self.assertNotIn('Test-Predator-Auto-Owner', self.issue.labels)
 
@@ -1492,11 +1504,11 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
     """Ensure that we don't assign to someone who was already the owner."""
     comment = test_utils.create_generic_issue_comment()
     comment.owner = 'a@example.com'
-    self.issue.comments.append(comment)
+    self.issue._monorail_issue.comments.append(comment)
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertEqual(self.issue.owner, '')
+    self.assertEqual(self.issue.assignee, '')
     self.assertEqual(self.issue.status, 'Untriaged')
     self.assertNotIn('Test-Predator-Auto-Owner', self.issue.labels)
 
@@ -1509,7 +1521,7 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertEqual(self.issue.owner, '')
+    self.assertEqual(self.issue.assignee, '')
     self.assertEqual(self.issue.status, 'Untriaged')
     self.assertNotIn('Test-Predator-Auto-Owner', self.issue.labels)
 
@@ -1535,12 +1547,12 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertEqual(self.issue.owner, '')
+    self.assertEqual(self.issue.assignee, '')
     self.assertEqual(self.issue.status, 'Untriaged')
     self.assertNotIn('Test-Predator-Auto-Owner', self.issue.labels)
     self.assertIn('Test-Predator-Auto-CC', self.issue.labels)
-    self.assertIn('a@example.com', self.issue.cc)
-    self.assertIn('b@example.com', self.issue.cc)
+    self.assertIn('a@example.com', self.issue.ccs)
+    self.assertIn('b@example.com', self.issue.ccs)
 
   def test_skipped_if_previously_cced_and_metadata_set(self):
     """Ensure that we don't re-cc authors who were cced in the past and have
@@ -1566,15 +1578,15 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue, only_allow_ccs=True)
-    self.assertNotIn('a@example.com', self.issue.cc)
-    self.assertNotIn('b@example.com', self.issue.cc)
+    self.assertNotIn('a@example.com', self.issue.ccs)
+    self.assertNotIn('b@example.com', self.issue.ccs)
     self.assertNotIn('Test-Predator-Auto-CC', self.issue.labels)
 
   def test_skipped_if_previously_cced_and_metadata_not_set(self):
     """Ensure that we don't re-cc authors who were cced in the past."""
     comment = test_utils.create_generic_issue_comment()
     comment.cc = ['-a@example.com']
-    self.issue.comments.append(comment)
+    self.issue._monorail_issue.comments.append(comment)
 
     self.testcase.set_metadata(
         'predator_result', {
@@ -1596,8 +1608,8 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertNotIn('a@example.com', self.issue.cc)
-    self.assertIn('b@example.com', self.issue.cc)
+    self.assertNotIn('a@example.com', self.issue.ccs)
+    self.assertIn('b@example.com', self.issue.ccs)
     self.assertIn('Test-Predator-Auto-CC', self.issue.labels)
 
   def test_skipped_if_malformed_cl(self):
@@ -1611,7 +1623,7 @@ class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
 
     cleanup.update_issue_owner_and_ccs_from_predator_results(
         self.testcase, self.issue)
-    self.assertEqual(self.issue.owner, '')
+    self.assertEqual(self.issue.assignee, '')
     self.assertEqual(self.issue.status, 'Untriaged')
     self.assertNotIn('Test-Predator-Auto-Owner', self.issue.labels)
 
@@ -1638,33 +1650,34 @@ class NotifyIssueIfTestcaseIsInvalidTest(unittest.TestCase):
   def test_skipped_if_closed_issue(self):
     """Ensure that we ignore issues that are already closed."""
     self.issue.status = 'Fixed'
-    self.issue.open = False
+    self.issue._monorail_issue.open = False
     cleanup.notify_issue_if_testcase_is_invalid(self.testcase, self.issue)
-    self.assertEqual(self.issue.comment, '')
+    self.assertEqual(self.issue._monorail_issue.comment, '')
 
   def test_skipped_if_unmarked_issue(self):
     """Ensure that we ignore issues that have valid fuzzers."""
     cleanup.notify_issue_if_testcase_is_invalid(self.testcase, self.issue)
-    self.assertEqual(self.issue.comment, '')
+    self.assertEqual(self.issue._monorail_issue.comment, '')
 
   def test_notified_if_fuzzer_was_deleted(self):
     """Ensure that we comment on issues that have invalid fuzzers."""
     self.testcase.set_metadata('fuzzer_was_deleted', True)
     cleanup.notify_issue_if_testcase_is_invalid(self.testcase, self.issue)
-    self.assertIn('is associated with an obsolete fuzzer', self.issue.comment)
+    self.assertIn('is associated with an obsolete fuzzer',
+                  self.issue._monorail_issue.comment)
     self.assertIn(data_types.ISSUE_INVALID_FUZZER_LABEL, self.issue.labels)
 
   def test_not_notified_if_fuzzer_was_deleted_and_notified(self):
     """Ensure that we don't comment again on issues that have invalid fuzzers
     and we have commented once."""
     self.testcase.set_metadata('fuzzer_was_deleted', True)
-    self.issue.comments += [
+    self.issue._monorail_issue.comments += [
         test_utils.create_generic_issue_comment(
             labels=[data_types.ISSUE_INVALID_FUZZER_LABEL])
     ]
     cleanup.notify_issue_if_testcase_is_invalid(self.testcase, self.issue)
     self.assertNotIn('is associated with an obsolete fuzzer',
-                     self.issue.comment)
+                     self.issue._monorail_issue.comment)
 
 
 @test_utils.with_cloud_emulators('datastore')

--- a/src/python/tests/appengine/handlers/testcase_detail/update_issue_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/update_issue_test.py
@@ -19,6 +19,7 @@ import webtest
 
 from datastore import data_types
 from handlers.testcase_detail import update_issue
+from issue_management import monorail
 from issue_management.monorail import issue
 from issue_management.monorail import issue_tracker_manager
 from libs import access
@@ -39,7 +40,7 @@ class HandlerTest(unittest.TestCase):
         'datastore.data_handler.get_issue_summary',
         'datastore.data_handler.get_stacktrace',
         'datastore.data_handler.update_group_bug',
-        'issue_management.issue_tracker_utils.get_issue_tracker_manager',
+        'libs.helpers.get_issue_tracker_for_testcase',
         'libs.auth.get_current_user',
         'handlers.testcase_detail.show.get_testcase_detail',
         'libs.access.get_access',
@@ -74,7 +75,8 @@ class HandlerTest(unittest.TestCase):
     """Issue is not found."""
     itm = mock.Mock(spec_set=issue_tracker_manager.IssueTrackerManager)
 
-    self.mock.get_issue_tracker_manager.return_value = itm
+    self.mock.get_issue_tracker_for_testcase.return_value = (
+        monorail.IssueTracker(itm))
     itm.get_issue.return_value = None
 
     resp = self.app.post_json(
@@ -96,7 +98,8 @@ class HandlerTest(unittest.TestCase):
     bug = issue.Issue()
     bug.open = False
 
-    self.mock.get_issue_tracker_manager.return_value = itm
+    self.mock.get_issue_tracker_for_testcase.return_value = (
+        monorail.IssueTracker(itm))
     itm.get_issue.return_value = bug
 
     resp = self.app.post_json(
@@ -119,7 +122,8 @@ class HandlerTest(unittest.TestCase):
     itm = mock.Mock(project_name='chromium')
     itm.get_issue.return_value = bug
 
-    self.mock.get_issue_tracker_manager.return_value = itm
+    self.mock.get_issue_tracker_for_testcase.return_value = (
+        monorail.IssueTracker(itm))
     self.mock.get_issue_description.return_value = 'description'
     self.mock.get_issue_summary.return_value = 'summary'
     self.mock.get_stacktrace.return_value = 'stacktrace'

--- a/src/python/tests/appengine/libs/issue_filer_test.py
+++ b/src/python/tests/appengine/libs/issue_filer_test.py
@@ -194,7 +194,7 @@ class IssueFilerTests(unittest.TestCase):
     """Tests issue filing with additional labels."""
     issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
     issue_filer.file_issue(self.testcase5, issue_tracker)
-    self.assertListEqual([
+    self.assertItemsEqual([
         'ClusterFuzz',
         'Reproducible',
         'Pri-1',
@@ -208,7 +208,7 @@ class IssueFilerTests(unittest.TestCase):
     """Tests issue filing with invalid metadata."""
     issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
     issue_filer.file_issue(self.testcase6, issue_tracker)
-    self.assertListEqual(
+    self.assertItemsEqual(
         ['ClusterFuzz', 'Reproducible', 'Pri-1', 'Stability-Crash', 'Type-Bug'],
         issue_tracker._itm.last_issue.labels)
 

--- a/src/python/tests/core/issue_management/issue_tracker_test.py
+++ b/src/python/tests/core/issue_management/issue_tracker_test.py
@@ -84,3 +84,10 @@ class LabelStoreTest(unittest.TestCase):
     store = LabelStore(['p-0', 'P-1', 'Q-2'])
     store.remove_by_prefix('p-')
     self.assertItemsEqual(['Q-2'], store)
+
+  def test_in(self):
+    """Test in operator."""
+    store = LabelStore(['laBel1', 'label2', 'Label3'])
+    self.assertTrue('label1' in store)
+    self.assertTrue('laBel2' in store)
+    self.assertTrue('labeL3' in store)

--- a/src/python/tests/core/issue_management/issue_tracker_test.py
+++ b/src/python/tests/core/issue_management/issue_tracker_test.py
@@ -91,3 +91,4 @@ class LabelStoreTest(unittest.TestCase):
     self.assertTrue('label1' in store)
     self.assertTrue('laBel2' in store)
     self.assertTrue('labeL3' in store)
+    self.assertFalse('label' in store)

--- a/src/python/tests/core/issue_management/issue_tracker_test.py
+++ b/src/python/tests/core/issue_management/issue_tracker_test.py
@@ -17,6 +17,7 @@ import unittest
 
 from issue_management.issue_tracker import LabelStore
 
+
 class LabelStoreTest(unittest.TestCase):
   """LabelStore tests."""
 

--- a/src/python/tests/core/issue_management/issue_tracker_test.py
+++ b/src/python/tests/core/issue_management/issue_tracker_test.py
@@ -69,6 +69,25 @@ class LabelStoreTest(unittest.TestCase):
     self.assertItemsEqual([], store.added)
     self.assertItemsEqual(['Label1', 'Label2'], store.removed)
 
+  def test_add_and_remove(self):
+    """Test both adding and removing."""
+    store = LabelStore(['laBel1', 'label2', 'Label3'])
+    store.remove('Label1')
+    self.assertItemsEqual(['label2', 'Label3'], store)
+    self.assertItemsEqual([], store.added)
+    self.assertItemsEqual(['Label1'], store.removed)
+
+    store.add('label1')
+    self.assertItemsEqual(['label1', 'label2', 'Label3'], store)
+    self.assertItemsEqual([], store.added)
+    self.assertItemsEqual([], store.removed)
+
+    store.remove('Label1')
+    store.add('label4')
+    self.assertItemsEqual(['label2', 'Label3', 'label4'], store)
+    self.assertItemsEqual(['label4'], store.added)
+    self.assertItemsEqual(['Label1'], store.removed)
+
   def test_reset(self):
     """Test reset."""
     store = LabelStore(['laBel1', 'label2', 'Label3'])

--- a/src/python/tests/core/issue_management/issue_tracker_test.py
+++ b/src/python/tests/core/issue_management/issue_tracker_test.py
@@ -1,0 +1,86 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the issue_tracker module."""
+
+import unittest
+
+from issue_management.issue_tracker import LabelStore
+
+class LabelStoreTest(unittest.TestCase):
+  """LabelStore tests."""
+
+  def test_init_and_iter(self):
+    """Test initializing and iterating LabelStore."""
+    store = LabelStore(['label1', 'label2'])
+    self.assertItemsEqual([], store.added)
+    self.assertItemsEqual([], store.removed)
+    self.assertItemsEqual(['label1', 'label2'], list(store))
+
+  def test_add(self):
+    """Test adding items."""
+    store = LabelStore()
+    store.add('laBel1')
+    self.assertItemsEqual(['laBel1'], store)
+    self.assertItemsEqual(['laBel1'], store.added)
+    self.assertItemsEqual([], store.removed)
+
+    store.add('label2')
+    self.assertItemsEqual(['laBel1', 'label2'], store)
+    self.assertItemsEqual(['laBel1', 'label2'], store.added)
+    self.assertItemsEqual([], store.removed)
+
+    store.add('labEl2')
+    self.assertItemsEqual(['laBel1', 'labEl2'], store)
+    self.assertItemsEqual(['laBel1', 'labEl2'], store.added)
+    self.assertItemsEqual([], store.removed)
+
+  def test_remove(self):
+    """Test removing items."""
+    store = LabelStore(['laBel1', 'label2', 'Label3'])
+    store.remove('Label1')
+    self.assertItemsEqual(['label2', 'Label3'], store)
+    self.assertItemsEqual([], store.added)
+    self.assertItemsEqual(['Label1'], store.removed)
+
+    store.remove('Label2')
+    self.assertItemsEqual(['Label3'], store)
+    self.assertItemsEqual([], store.added)
+    self.assertItemsEqual(['Label1', 'Label2'], store.removed)
+
+    store.remove('LaBel2')
+    self.assertItemsEqual(['Label3'], store)
+    self.assertItemsEqual([], store.added)
+    self.assertItemsEqual(['Label1', 'Label2'], store.removed)
+
+    store.remove('Label4')
+    self.assertItemsEqual(['Label3'], store)
+    self.assertItemsEqual([], store.added)
+    self.assertItemsEqual(['Label1', 'Label2'], store.removed)
+
+  def test_reset(self):
+    """Test reset."""
+    store = LabelStore(['laBel1', 'label2', 'Label3'])
+    store.add('label4')
+    store.add('label5')
+    store.remove('label1')
+
+    store.reset()
+    self.assertItemsEqual([], store.added)
+    self.assertItemsEqual([], store.removed)
+
+  def test_remove_by_prefix(self):
+    """Test remove_by_prefix."""
+    store = LabelStore(['p-0', 'P-1', 'Q-2'])
+    store.remove_by_prefix('p-')
+    self.assertItemsEqual(['Q-2'], store)

--- a/src/python/tests/test_libs/test_utils.py
+++ b/src/python/tests/test_libs/test_utils.py
@@ -33,6 +33,7 @@ from config import local_config
 from datastore import data_types
 from datastore import ndb
 from google_cloud_utils import pubsub
+from issue_management import monorail
 from issue_management.monorail.comment import Comment
 from issue_management.monorail.issue import Issue
 from system import environment
@@ -76,11 +77,11 @@ def create_generic_testcase(created_days_ago=28):
 def create_generic_issue(created_days_ago=28):
   """Returns a simple issue object for use in tests."""
   issue = Issue()
-  issue.cc = ['cc@chromium.org']
+  issue.cc = []
   issue.comment = ''
   issue.comments = []
-  issue.components = ['Test>Component']
-  issue.labels = ['TestLabel', 'Pri-1', 'OS-Windows']
+  issue.components = []
+  issue.labels = []
   issue.open = True
   issue.owner = 'owner@chromium.org'
   issue.status = 'Assigned'
@@ -90,7 +91,7 @@ def create_generic_issue(created_days_ago=28):
   # Test issue was created 1 week before the current (mocked) time.
   issue.created = CURRENT_TIME - datetime.timedelta(days=created_days_ago)
 
-  return issue
+  return monorail.Issue(issue)
 
 
 def create_generic_issue_comment(comment_body='Comment.',


### PR DESCRIPTION
This required some changes to the interface, namely:

- Add a `LabelStore` class to encapsulate logic for adding/removing
 labels in a case insensitive way.
- Add a `new_comment` argument to save().
- Add a readonly `open` property to Issue interface.
- Add a `get_original_issue()` method to the IssueTracker interface.