### PR TITLE
Convert one more issue.add_label to issue.labels.add (#504).

### DIFF
--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -725,7 +725,7 @@ def _update_issue_when_uploaded_testcase_is_processed(
   # 3. Crash state != 'NULL' which is unhelpful for title.
   if (upload_metadata.bug_summary_update_flag and testcase.crash_state and
       testcase.crash_state != 'NULL'):
-    issue.summary = data_handler.get_issue_summary(testcase)
+    issue.title = data_handler.get_issue_summary(testcase)
 
   # Add severity labels for all project types.
   data_handler.update_issue_severity_labels(testcase, issue)

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -1055,10 +1055,11 @@ def update_issue_impact_labels(testcase, issue):
     return
 
   if existing_impact != data_types.SecurityImpact.MISSING:
-    issue.remove_label('Security_Impact-' +
-                       label_utils.impact_to_string(existing_impact))
+    issue.labels.remove('Security_Impact-' +
+                        label_utils.impact_to_string(existing_impact))
 
-  issue.add_label('Security_Impact-' + label_utils.impact_to_string(new_impact))
+  issue.labels.add('Security_Impact-' +
+                   label_utils.impact_to_string(new_impact))
 
 
 def update_issue_severity_labels(testcase, issue):


### PR DESCRIPTION
This is called by issue_filer and cleanup, which were both converted to use the new interface.

Also fix another use of issue.summary.