### PR TITLE
Move flakiness label update to appengine cleanup cron.

### DIFF
--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -57,14 +57,6 @@ def mark_unreproducible_if_flaky(testcase, potentially_flaky):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                        'Testcase appears to be flaky')
 
-  issue = data_handler.get_issue_for_testcase(testcase)
-  if issue and issue.has_label('Reproducible'):
-    issue.remove_label('Reproducible')
-    issue.add_label('Unreproducible')
-    issue.comment = ('ClusterFuzz testcase %d appears to be flaky, '
-                     'updating reproducibility label.' % testcase.key.id())
-    issue.save()
-
   # For unreproducible testcases, it is still beneficial to get second stack
   # information from stack task and component information from blame task.
   create_blame_task_if_needed(testcase)

--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -57,6 +57,9 @@ def mark_unreproducible_if_flaky(testcase, potentially_flaky):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                        'Testcase appears to be flaky')
 
+  # Issue update to flip reproducibility label is done in App Engine cleanup
+  # cron. This avoids calling the issue tracker apis from GCE.
+
   # For unreproducible testcases, it is still beneficial to get second stack
   # information from stack task and component information from blame task.
   create_blame_task_if_needed(testcase)

--- a/src/python/issue_management/issue_tracker_utils.py
+++ b/src/python/issue_management/issue_tracker_utils.py
@@ -17,6 +17,7 @@ from datastore import data_types
 from datastore import ndb_utils
 from issue_management import monorail
 from issue_management.monorail.issue_tracker_manager import IssueTrackerManager
+from metrics import logs
 
 ISSUE_TRACKER_MANAGERS = {}
 ISSUE_TRACKER_URL = 'https://bugs.chromium.org/p/{project}/issues/detail?id='
@@ -61,6 +62,26 @@ def get_issue_tracker_for_testcase(testcase, use_cache=False):
 
   return get_issue_tracker(
       'monorail', issue_tracker_project_name, use_cache=use_cache)
+
+
+def get_issue_for_testcase(testcase):
+  """Return issue object associated with testcase."""
+  if not testcase.bug_information:
+    return None
+
+  issue_tracker = get_issue_tracker_for_testcase(testcase, use_cache=True)
+  if not issue_tracker:
+    return None
+
+  try:
+    issue_id = testcase.bug_information
+    issue = issue_tracker.get_original_issue(issue_id)
+  except:
+    logs.log_error(
+        'Error occurred when fetching issue %s.' % testcase.bug_information)
+    return None
+
+  return issue
 
 
 # TODO(ochang): Move this to monorail/. See comment on

--- a/src/python/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/python/tests/appengine/handlers/cron/cleanup_test.py
@@ -1437,8 +1437,6 @@ class UpdateIssueLabelsForFlakyTestcaseTest(unittest.TestCase):
   """Tests for update_issue_labels_for_flaky_testcase."""
 
   def setUp(self):
-    helpers.patch_environ(self)
-
     self.issue = test_utils.create_generic_issue()
     self.testcase = test_utils.create_generic_testcase()
 

--- a/src/python/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/python/tests/appengine/handlers/cron/cleanup_test.py
@@ -1433,6 +1433,50 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
 
 
 @test_utils.with_cloud_emulators('datastore')
+class UpdateIssueLabelsForFlakyTestcaseTest(unittest.TestCase):
+  """Tests for update_issue_labels_for_flaky_testcase."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+
+    self.issue = test_utils.create_generic_issue()
+    self.testcase = test_utils.create_generic_testcase()
+
+  def test_mark_unreproducible_if_reproducible_change(self):
+    """Test that we change label on issue if the testcase is now flaky."""
+    self.issue.labels.add('Reproducible')
+    self.testcase.one_time_crasher_flag = True
+    cleanup.update_issue_labels_for_flaky_testcase(self.testcase, self.issue)
+
+    self.assertNotIn('Reproducible', self.issue.labels)
+    self.assertIn('Unreproducible', self.issue.labels)
+    self.assertEqual(
+        'ClusterFuzz testcase 1 appears to be flaky, '
+        'updating reproducibility label.', self.issue._monorail_issue.comment)
+
+  def test_skip_if_unreproducible(self):
+    """Test that we don't change labels if the testcase is unreproducible and
+    issue is already marked unreproducible."""
+    self.issue.labels.add('Unreproducible')
+    self.testcase.one_time_crasher_flag = True
+    cleanup.update_issue_labels_for_flaky_testcase(self.testcase, self.issue)
+
+    self.assertNotIn('Reproducible', self.issue.labels)
+    self.assertIn('Unreproducible', self.issue.labels)
+    self.assertEqual('', self.issue._monorail_issue.comment)
+
+  def test_skip_if_reproducible(self):
+    """Test that we don't change labels if the testcase is reproducible."""
+    self.issue.labels.add('Reproducible')
+    self.testcase.one_time_crasher_flag = False
+    cleanup.update_issue_labels_for_flaky_testcase(self.testcase, self.issue)
+
+    self.assertIn('Reproducible', self.issue.labels)
+    self.assertNotIn('Unreproducible', self.issue.labels)
+    self.assertEqual('', self.issue._monorail_issue.comment)
+
+
+@test_utils.with_cloud_emulators('datastore')
 class UpdateIssueOwnerAndCCsFromPredatorResultsTest(unittest.TestCase):
   """Tests for update_issue_owner_and_ccs_from_predator_results."""
 


### PR DESCRIPTION
Also, convert user uploaded testcase issue update code to
use apis using new_comment. This fix is part of
https://github.com/google/clusterfuzz/issues/541