### PR TITLE
Fix exception in corpus_pruning_task.py

### DIFF
--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -672,7 +672,7 @@ def _process_corpus_crashes(context, result):
     else:
       unit_path = crash.unit_path
 
-    with open(unit_path) as f:
+    with open(unit_path, 'rb') as f:
       key = blobs.write_blob(f)
 
     # Set the absolute_path property of the Testcase to a file in FUZZ_INPUTS


### PR DESCRIPTION
Fixes exception.

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 108: character maps to <undefined>
at decode (c:\python27\lib\encodings\cp1252.py:23)
at get_next_chunk (c:\clusterfuzz\src\third_party\google\resumable_media\_upload.py:803)
at _prepare_request (c:\clusterfuzz\src\third_party\google\resumable_media\_upload.py:530)
at transmit_next_chunk (c:\clusterfuzz\src\third_party\google\resumable_media\requests\upload.py:392)
at _do_resumable_upload (c:\clusterfuzz\src\third_party\google\cloud\storage\blob.py:938)
at _do_upload (c:\clusterfuzz\src\third_party\google\cloud\storage\blob.py:991)
at upload_from_file (c:\clusterfuzz\src\third_party\google\cloud\storage\blob.py:1081)
at copy_file_to (c:\clusterfuzz\src\python\google_cloud_utils\storage.py:229)
at copy_file_to (c:\clusterfuzz\src\python\google_cloud_utils\storage.py:741)
at _wrapper (c:\clusterfuzz\src\python\base\retry.py:89)
```