### PR TITLE
Refactor similar issues finding (#504).

### DIFF
--- a/src/appengine/handlers/issue_redirector.py
+++ b/src/appengine/handlers/issue_redirector.py
@@ -22,7 +22,7 @@ from libs import helpers
 class Handler(base_handler.Handler):
   """Handler that redirects user to the issue URL."""
 
-  def get(self, testcase_id, issue_id):
+  def get(self, testcase_id):
     """Redirect user to the correct URL."""
     testcase = helpers.get_testcase(testcase_id)
     issue_url = helpers.get_or_exit(
@@ -30,4 +30,4 @@ class Handler(base_handler.Handler):
         'Issue tracker for testcase (id=%s) is not found.' % testcase_id,
         'Failed to get the issue tracker URL.')
 
-    self.redirect(issue_url + issue_id)
+    self.redirect(issue_url)

--- a/src/appengine/handlers/testcase_detail/show.py
+++ b/src/appengine/handlers/testcase_detail/show.py
@@ -43,9 +43,6 @@ FIND_SIMILAR_ISSUES_OPTIONS = [{
     'type': 'open',
     'label': 'Open'
 }, {
-    'type': 'new',
-    'label': 'New'
-}, {
     'type': 'all',
     'label': 'All'
 }]

--- a/src/appengine/libs/helpers.py
+++ b/src/appengine/libs/helpers.py
@@ -94,16 +94,6 @@ def get_issue_tracker_for_testcase(testcase):
   return issue_tracker
 
 
-# TODO(ochang): Deprecated. Remove this.
-def get_issue_tracker_manager(testcase):
-  """Get an IssueTrackerManager or raise EarlyExitException."""
-  itm = issue_tracker_utils.get_issue_tracker_manager(testcase)
-  if not itm:
-    raise EarlyExitException(
-        "The testcase doesn't have a corresponding issue tracker", 404)
-  return itm
-
-
 def cast(value, fn, error_message):
   """Return `fn(value)` or raise an EarlyExitException with 400."""
   try:

--- a/src/appengine/private/components/crash-stats/crash-stats.html
+++ b/src/appengine/private/components/crash-stats/crash-stats.html
@@ -325,7 +325,7 @@
                         <span slot="f" class="label" title="The crash was discovered before the selected time period.">New</span>
                       </if-else>
                       <template is="dom-repeat" items="[[getIssue(item)]]" as="issue">
-                        <a class="label issue" href="/issue/[[item.testcase.id]]/[[issue.number]]" title="[[issue.title]]">Issue [[issue.number]]</a>
+                        <a class="label issue" href="/issue/[[item.testcase.id]]" title="[[issue.title]]">Issue [[issue.number]]</a>
                       </template>
                     </span>
                     <span class="seen">

--- a/src/appengine/private/components/testcase-detail/find-similar-issues-panel.html
+++ b/src/appengine/private/components/testcase-detail/find-similar-issues-panel.html
@@ -140,8 +140,8 @@
                 <ul>
                   <template is="dom-repeat" items="[[response.items]]">
                     <li>
-                      <a href="[[response.issueUrlPrefix]][[item.id]]">[[item.id]]</a>
-                      [[item.summary]]
+                      <a href="[[item.url]]">[[item.issue.id]]</a>
+                      [[item.issue.title]]
                     </li>
                   </template>
                 </ul>

--- a/src/appengine/private/components/testcase-detail/test/find-similar-issues-panel.html
+++ b/src/appengine/private/components/testcase-detail/test/find-similar-issues-panel.html
@@ -37,16 +37,26 @@
       const emptyResponse = JSON.stringify({
         queryString: "Test test",
         queryUrl: "http://somethingsomething",
-        issueUrlPrefix: "http://something",
         items: []
       });
       const response = JSON.stringify({
         queryString: "Test test",
         queryUrl: "http://somethingsomething",
-        issueUrlPrefix: "http://something",
         items: [
-          {id: 1234, summary: "Test query"},
-          {id: 9999, summary: "Test query 2"}
+          {
+            issue: {
+              id: 1234,
+              summary: "Test query"
+            },
+            url: 'http://something/1234',
+          },
+          {
+            issue: {
+              id: 9999,
+              summary: "Test query 2"
+            },
+            url: 'http://something/9999',
+          },
         ]
       });
 

--- a/src/appengine/private/components/testcase-detail/testcase-detail.html
+++ b/src/appengine/private/components/testcase-detail/testcase-detail.html
@@ -117,7 +117,7 @@
           opened="{{removeIssueDialogOpened}}"
           title="Unassign issue">
         Please confirm that you want to unassign
-        <a href="[[info.issue_url]][[info.testcase.bug_information]]">the issue [[info.testcase.bug_information]]</a>
+        <a href="[[info.issue_url]]">the issue [[info.testcase.bug_information]]</a>
         from this testcase.
       </confirm-dialog>
     </template>
@@ -304,12 +304,12 @@
                 <td class="value">
                   <if-else condition="[[info.testcase.bug_information]]">
                     <span slot="t">
-                      <a href="[[info.issue_url]][[info.testcase.bug_information]]">[[info.testcase.bug_information]]</a>
+                      <a href="[[info.issue_url]]">[[info.testcase.bug_information]]</a>
                       <paper-icon-button icon="highlight-off" toggles hidden$="[[!info.is_admin]]" active="{{removeIssueDialogOpened}}" title="Unassign the issue from this testcase"></paper-icon-button>
                     </span>
                     <span slot="f">
                       <if-else condition="[[info.testcase.group_bug_information]]">
-                        <a slot="t" href="[[info.issue_url]][[info.testcase.group_bug_information]]">[[info.testcase.group_bug_information]]</a> (from its group)
+                        <a slot="t" href="[[info.issue_url]]">[[info.testcase.group_bug_information]]</a> (from its group)
                         <span slot="f">None</span>
                       </if-else>
                     </span>

--- a/src/appengine/private/components/testcase-list/testcase-list.html
+++ b/src/appengine/private/components/testcase-list/testcase-list.html
@@ -382,7 +382,7 @@
                   </td>
                   <td class="labels">
                     <template is="dom-if" if="[[item.issueId]]">
-                      <a class="issue label" href="/issue/[[item.id]]/[[item.issueId]]" title="Click to view the associated issue [[item.issueId]] in the issue tracker.">Issue [[item.issueId]]</a>
+                      <a class="issue label" href="/issue/[[item.id]]" title="Click to view the associated issue [[item.issueId]] in the issue tracker.">Issue [[item.issueId]]</a>
                     </template>
                     <template is="dom-if" if="[[item.showImpacts]]">
                       <if-else condition="[[item.isImpactSet]]">

--- a/src/appengine/private/components/upload-testcase/upload-testcase.html
+++ b/src/appengine/private/components/upload-testcase/upload-testcase.html
@@ -292,7 +292,7 @@
                   </td>
                   <td class="right">
                     <template is="dom-if" if="[[item.testcase.issueNumber]]">
-                      <a class="label issue" href="/issue/[[item.testcaseId]]/[[item.testcase.issueNumber]]" title="Click to view the associated issue [[item.testcase.issueNumber]] in the issue tracker.">Issue [[item.testcase.issueNumber]]</a>
+                      <a class="label issue" href="/issue/[[item.testcaseId]]" title="Click to view the associated issue [[item.testcase.issueNumber]] in the issue tracker.">Issue [[item.testcase.issueNumber]]</a>
                     </template>
                     <template is="dom-repeat" items="[[getStatus(item)]]" as="status">
                       <span class$="label [[status.className]]" title$="[[status.tooltip]]">[[status.label]]</span>

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -170,7 +170,7 @@ _ROUTES = [
     ('/fuzzer-stats', fuzzer_stats.Handler),
     ('/fuzzer-stats/.*', fuzzer_stats.Handler),
     ('/gcs-redirect', gcs_redirector.Handler),
-    ('/issue/([0-9]+)/(.+)', issue_redirector.Handler),
+    ('/issue/([0-9]+)', issue_redirector.Handler),
     ('/jobs', jobs.Handler),
     ('/jobs/delete-job', jobs.DeleteJobHandler),
     ('/login', login.Handler),

--- a/src/python/bot/tasks/commands.py
+++ b/src/python/bot/tasks/commands.py
@@ -37,7 +37,6 @@ from bot.tasks import upload_reports_task
 from bot.webserver import http_server
 from datastore import data_handler
 from datastore import data_types
-from issue_management import issue_tracker_utils
 from metrics import logs
 from system import environment
 from system import process_handler
@@ -82,9 +81,6 @@ def cleanup_task_state():
 
   # Reset memory tool environment variables.
   environment.reset_current_memory_tool_options()
-
-  # Clear issue tracker manager instances.
-  issue_tracker_utils.clear_issue_tracker_managers()
 
   # Clear exceptions.
   sys.exc_clear()

--- a/src/python/issue_management/issue_tracker.py
+++ b/src/python/issue_management/issue_tracker.py
@@ -257,3 +257,15 @@ class IssueTracker(object):
     """Retrieve the original issue object traversing the list of duplicates."""
     # TODO(ochang): Use implementation from monorail for all issue trackers.
     raise NotImplementedError
+
+  def find_issues(self, keywords=None, only_open=None):
+    """Find issues."""
+    raise NotImplementedError
+
+  def find_issues_url(self, keywords=None, only_open=None):
+    """Find issues (web URL)."""
+    raise NotImplementedError
+
+  def issue_url(self, issue_id):
+    """Return the issue URL with the given ID."""
+    raise NotImplementedError

--- a/src/python/issue_management/issue_tracker_utils.py
+++ b/src/python/issue_management/issue_tracker_utils.py
@@ -121,6 +121,9 @@ def get_similar_issues_url(issue_tracker, testcase, only_open=True):
 def get_issue_url(testcase):
   """Return issue url for a testcase."""
   issue_tracker = get_issue_tracker_for_testcase(testcase)
+  if not issue_tracker or not testcase.bug_information:
+    return None
+
   return issue_tracker.issue_url(testcase.bug_information)
 
 

--- a/src/python/issue_management/monorail/__init__.py
+++ b/src/python/issue_management/monorail/__init__.py
@@ -25,7 +25,8 @@ from issue_management.monorail.issue_tracker_manager import IssueTrackerManager
 
 # TODO(ochang): Clean up how we cache issue_tracker_managers.
 ISSUE_TRACKER_MANAGERS = {}
-ISSUE_TRACKER_URL = 'https://bugs.chromium.org/p/{project}/issues/detail?id={id}'
+ISSUE_TRACKER_URL = (
+    'https://bugs.chromium.org/p/{project}/issues/detail?id={id}')
 ISSUE_TRACKER_SEARCH_URL = (
     'https://bugs.chromium.org/p/{project}/issues/list?{params}')
 

--- a/src/python/issue_management/monorail/__init__.py
+++ b/src/python/issue_management/monorail/__init__.py
@@ -25,9 +25,9 @@ from issue_management.monorail.issue_tracker_manager import IssueTrackerManager
 
 # TODO(ochang): Clean up how we cache issue_tracker_managers.
 ISSUE_TRACKER_MANAGERS = {}
-ISSUE_TRACKER_URL = 'https://bugs.chromium.org/p/{project}/issues/detail?id='
+ISSUE_TRACKER_URL = 'https://bugs.chromium.org/p/{project}/issues/detail?id={id}'
 ISSUE_TRACKER_SEARCH_URL = (
-    'https://bugs.chromium.org/p/{project}/issues/list?')
+    'https://bugs.chromium.org/p/{project}/issues/list?{params}')
 
 
 class Issue(issue_tracker.Issue):
@@ -247,7 +247,7 @@ class IssueTracker(issue_tracker.IssueTracker):
     issues = self._itm.get_issues(search_text, can=can)
     return [Issue(issue) for issue in issues]
 
-  def find_issues_url(self, keywords=None, only_open=None):
+  def find_issues_url(self, keywords=None, only_open=False):
     """Find issues (web URL)."""
     if not keywords:
       return None
@@ -260,14 +260,15 @@ class IssueTracker(issue_tracker.IssueTracker):
 
     can_id = IssueTrackerManager.CAN_VALUE_TO_ID_MAP.get(can, '')
     return ISSUE_TRACKER_SEARCH_URL.format(
-        project=self.project) + urllib.parse.urlencode({
+        project=self.project,
+        params=urllib.parse.urlencode({
             'can_id': can_id,
             'q': search_text,
-        })
+        }))
 
   def issue_url(self, issue_id):
     """Return the issue URL with the given ID."""
-    return ISSUE_TRACKER_URL.format(project=self.project) + str(issue_id)
+    return ISSUE_TRACKER_URL.format(project=self.project, id=issue_id)
 
 
 def _to_change_list(monorail_list):

--- a/src/python/tests/appengine/handlers/issue_redirector_test.py
+++ b/src/python/tests/appengine/handlers/issue_redirector_test.py
@@ -36,10 +36,11 @@ class HandlerTest(unittest.TestCase):
   def test_succeed(self):
     """Test redirection succeeds."""
     testcase = data_types.Testcase()
+    testcase.bug_information = '456789'
     self.mock.get_testcase.return_value = testcase
-    self.mock.get_issue_url.return_value = 'http://google.com/'
+    self.mock.get_issue_url.return_value = 'http://google.com/456789'
 
-    response = self.app.get('/issue/12345/456789')
+    response = self.app.get('/issue/12345')
 
     self.assertEqual(302, response.status_int)
     self.assertEqual('http://google.com/456789', response.headers['Location'])
@@ -52,5 +53,5 @@ class HandlerTest(unittest.TestCase):
     self.mock.get_testcase.return_value = data_types.Testcase()
     self.mock.get_issue_url.return_value = ''
 
-    response = self.app.get('/issue/12345/456789', expect_errors=True)
+    response = self.app.get('/issue/12345', expect_errors=True)
     self.assertEqual(404, response.status_int)

--- a/src/python/tests/core/issue_management/monorail/monorail_test.py
+++ b/src/python/tests/core/issue_management/monorail/monorail_test.py
@@ -254,15 +254,13 @@ class MonorailTests(unittest.TestCase):
         keywords=['one', 'two'], only_open=False)
     self.assertEqual(
         'https://bugs.chromium.org/p/name/issues/list'
-        '?can_id=1&q=%22one%22+%22two%22',
-        url)
+        '?can_id=1&q=%22one%22+%22two%22', url)
 
     url = self.issue_tracker.find_issues_url(
         keywords=['one', 'two'], only_open=True)
     self.assertEqual(
         'https://bugs.chromium.org/p/name/issues/list'
-        '?can_id=2&q=%22one%22+%22two%22',
-        url)
+        '?can_id=2&q=%22one%22+%22two%22', url)
 
   def test_issue_url(self):
     """Test issue_url."""

--- a/src/python/tests/core/issue_management/monorail/monorail_test.py
+++ b/src/python/tests/core/issue_management/monorail/monorail_test.py
@@ -14,12 +14,14 @@
 """Tests for monorail issue management."""
 
 import datetime
+import mock
 import unittest
 
 from issue_management import monorail
 from issue_management.monorail import issue_tracker_manager
 from issue_management.monorail.comment import Comment as MonorailComment
 from issue_management.monorail.issue import Issue as MonorailIssue
+from tests.test_libs import helpers
 
 
 class IssueTrackerManager(issue_tracker_manager.IssueTrackerManager):
@@ -43,10 +45,15 @@ class IssueTrackerManager(issue_tracker_manager.IssueTrackerManager):
     self.last_issue = issue
 
 
-class IssueFilerTests(unittest.TestCase):
-  """Tests for the issue filer."""
+class MonorailTests(unittest.TestCase):
+  """Tests for the monorail issue tracker."""
 
   def setUp(self):
+    helpers.patch(self, [
+        'issue_management.monorail.issue_tracker_manager.'
+        'IssueTrackerManager.get_issues',
+    ])
+
     mock_issue = MonorailIssue()
     mock_issue.id = 1337
     mock_issue.summary = 'summary'
@@ -210,5 +217,55 @@ class IssueFilerTests(unittest.TestCase):
                           self.itm.last_issue.components)
 
   def test_get_original_issue(self):
+    """Test get_original_issue."""
     issue = self.issue_tracker.get_original_issue(1338)
     self.assertEqual(1337, issue.id)
+
+  def test_find_issues(self):
+    """Test find_issues."""
+    issue0 = MonorailIssue()
+    issue0.id = 1
+
+    issue1 = MonorailIssue()
+    issue1.id = 2
+    self.mock.get_issues.return_value = [
+        issue0,
+        issue1,
+    ]
+    issues = self.issue_tracker.find_issues(
+        keywords=['one', 'two'], only_open=True)
+    self.assertItemsEqual([1, 2], [issue.id for issue in issues])
+
+    self.mock.get_issues.assert_has_calls([
+        mock.call(mock.ANY, '"one" "two"', can='open'),
+    ])
+
+    issues = self.issue_tracker.find_issues(
+        keywords=['one', 'two'], only_open=False)
+    self.assertItemsEqual([1, 2], [issue.id for issue in issues])
+
+    self.mock.get_issues.assert_has_calls([
+        mock.call(mock.ANY, '"one" "two"', can='all'),
+    ])
+
+  def test_find_issues_url(self):
+    """Test find_issues_url."""
+    url = self.issue_tracker.find_issues_url(
+        keywords=['one', 'two'], only_open=False)
+    self.assertEqual(
+        'https://bugs.chromium.org/p/name/issues/list'
+        '?can_id=1&q=%22one%22+%22two%22',
+        url)
+
+    url = self.issue_tracker.find_issues_url(
+        keywords=['one', 'two'], only_open=True)
+    self.assertEqual(
+        'https://bugs.chromium.org/p/name/issues/list'
+        '?can_id=2&q=%22one%22+%22two%22',
+        url)
+
+  def test_issue_url(self):
+    """Test issue_url."""
+    issue_url = self.issue_tracker.issue_url(1337)
+    self.assertEqual('https://bugs.chromium.org/p/name/issues/detail?id=1337',
+                     issue_url)

--- a/src/python/tests/core/issue_management/monorail/monorail_test.py
+++ b/src/python/tests/core/issue_management/monorail/monorail_test.py
@@ -89,7 +89,7 @@ class MonorailTests(unittest.TestCase):
     mock_issue_merged = MonorailIssue()
     mock_issue_merged.id = 1338
     mock_issue_merged.merged_into = 1337
-    mock_issue_merged.merged_into_project = 'name'
+    mock_issue_merged.merged_into_project = 'project'
     mock_issue_merged.closed = datetime.datetime(2019, 1, 1)
 
     mock_issues = {
@@ -97,7 +97,7 @@ class MonorailTests(unittest.TestCase):
         1338: mock_issue_merged,
     }
 
-    self.itm = IssueTrackerManager('name', mock_issues)
+    self.itm = IssueTrackerManager('project', mock_issues)
     self.issue_tracker = monorail.IssueTracker(self.itm)
 
   def test_get_issue(self):
@@ -253,17 +253,17 @@ class MonorailTests(unittest.TestCase):
     url = self.issue_tracker.find_issues_url(
         keywords=['one', 'two'], only_open=False)
     self.assertEqual(
-        'https://bugs.chromium.org/p/name/issues/list'
+        'https://bugs.chromium.org/p/project/issues/list'
         '?can_id=1&q=%22one%22+%22two%22', url)
 
     url = self.issue_tracker.find_issues_url(
         keywords=['one', 'two'], only_open=True)
     self.assertEqual(
-        'https://bugs.chromium.org/p/name/issues/list'
+        'https://bugs.chromium.org/p/project/issues/list'
         '?can_id=2&q=%22one%22+%22two%22', url)
 
   def test_issue_url(self):
     """Test issue_url."""
     issue_url = self.issue_tracker.issue_url(1337)
-    self.assertEqual('https://bugs.chromium.org/p/name/issues/detail?id=1337',
-                     issue_url)
+    self.assertEqual(
+        'https://bugs.chromium.org/p/project/issues/detail?id=1337', issue_url)


### PR DESCRIPTION
This is the last remaining conversion (apart from tests).

Add find_issues, find_issues_url and issue_url to IssueTracker
interface.

find_issues and find_issues_url take in search keywords and whether or
not to query for open issues only or all issues.

Move issue tracker manager functions to issue_management/monorail.

Modify issue_redirector to only take testcase ID.

Remove distinction between finding "New" and "Open" issues. It complicates
the interface and seems unnecessary.