### PR TITLE
Add a new test case info handler for the reproduce tool.

### DIFF
--- a/src/appengine/handlers/reproduce_tool/__init__.py
+++ b/src/appengine/handlers/reproduce_tool/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/appengine/handlers/reproduce_tool/testcase_info.py
+++ b/src/appengine/handlers/reproduce_tool/testcase_info.py
@@ -28,7 +28,7 @@ def _prepare_testcase_dict(testcase):
   # The job definition is also required for test case reproduction, so we add
   # it as an additional field.
   job = data_types.Job.query(data_types.Job.name == testcase.job_type).get()
-  testcase_dict['job_definition'] = job.get_environment()
+  testcase_dict['job_definition'] = job.get_environment_string()
 
   return testcase_dict
 

--- a/src/appengine/handlers/reproduce_tool/testcase_info.py
+++ b/src/appengine/handlers/reproduce_tool/testcase_info.py
@@ -1,0 +1,47 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Handler for serving serialized test cases for the reproduce tool."""
+
+from datastore import data_types
+from handlers import base_handler
+from libs import access
+from libs import handler
+
+
+def _prepare_testcase_dict(testcase):
+  """Prepare a dictionary containing all information needed by the tool."""
+  # By calling _to_dict directly here we prevent the need to modify this as
+  # the testcase model changes over time.
+  testcase_dict = testcase._to_dict()  # pylint: disable=protected-access
+
+  # The job definition is also required for test case reproduction, so we add
+  # it as an additional field.
+  job = data_types.Job.query(data_types.Job.name == testcase.job_type).get()
+  testcase_dict['job_definition'] = job.get_environment()
+
+  return testcase_dict
+
+
+class Handler(base_handler.Handler):
+  """Handler that returns a serialized testcase as JSON."""
+
+  @handler.post(handler.JSON, handler.JSON)
+  @handler.oauth
+  def post(self):
+    """Serve the testcase detail HTML page."""
+    testcase_id = self.request.get('testcaseId')
+    testcase = access.check_access_and_get_testcase(testcase_id)
+
+    testcase_dict = _prepare_testcase_dict(testcase)
+    self.render_json(testcase_dict)

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -60,6 +60,7 @@ from handlers.cron import schedule_corpus_pruning
 from handlers.cron import sync_admins
 from handlers.cron import triage
 from handlers.performance_report import (show as show_performance_report)
+from handlers.reproduce_tool import testcase_info
 from handlers.testcase_detail import (crash_stats as crash_stats_on_testcase)
 from handlers.testcase_detail import (show as show_testcase)
 from handlers.testcase_detail import create_issue
@@ -182,6 +183,7 @@ _ROUTES = [
     ('/parse_stacktrace', parse_stacktrace.Handler),
     ('/performance-report/(.+)/(.+)/(.+)', show_performance_report.Handler),
     ('/report-csp-failure', report_csp_failure.ReportCspFailureHandler),
+    ('/reproduce-tool/testcase-info', testcase_info.Handler),
     ('/session-login', login.SessionLoginHandler),
     ('/testcase', show_testcase.DeprecatedHandler),
     ('/testcase-detail/([0-9]+)', show_testcase.Handler),

--- a/src/python/tests/appengine/handlers/reproduce_tool/__init__.py
+++ b/src/python/tests/appengine/handlers/reproduce_tool/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/python/tests/appengine/handlers/reproduce_tool/testcase_info_test.py
+++ b/src/python/tests/appengine/handlers/reproduce_tool/testcase_info_test.py
@@ -1,0 +1,49 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the reproduce tool testcase_info handler."""
+# pylint: disable=protected-accesss
+
+import unittest
+
+from datastore import data_types
+from handlers.reproduce_tool import testcase_info
+from tests.test_libs import test_utils
+
+@test_utils.with_cloud_emulators('datastore')
+class PrepareTestcaseDictTest(unittest.TestCase):
+  """Tests for _prepare_testcase_dict."""
+
+  def setUp(self):
+    job = data_types.Job(name='test_job', environment_string='X = 1\nY = 2\n')
+    job.put()
+
+    testcase = data_types.Testcase()
+    testcase.status = 'Pending'
+    testcase.open = True
+    testcase.job_type = 'test_job'
+    testcase.put()
+
+    self.testcase = testcase
+
+  def test_expected_properties_included(self):
+    """Ensure that a few of the common test case properties are included."""
+    result = testcase_info._prepare_testcase_dict(self.testcase)
+    self.assertEquals(result['status'], 'Pending')
+    self.assertEquals(result['open'], True)
+    self.assertEquals(result['group_id'], 0)
+
+  def test_job_included(self):
+    """Ensure that the job definition has been included."""
+    result = testcase_info._prepare_testcase_dict(self.testcase)
+    self.assertEquals(result['job_definition'], {'X': '1', 'Y': '2'})

--- a/src/python/tests/appengine/handlers/reproduce_tool/testcase_info_test.py
+++ b/src/python/tests/appengine/handlers/reproduce_tool/testcase_info_test.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the reproduce tool testcase_info handler."""
-# pylint: disable=protected-accesss
+# pylint: disable=protected-access
 
 import unittest
 
 from datastore import data_types
 from handlers.reproduce_tool import testcase_info
 from tests.test_libs import test_utils
+
 
 @test_utils.with_cloud_emulators('datastore')
 class PrepareTestcaseDictTest(unittest.TestCase):

--- a/src/python/tests/appengine/handlers/reproduce_tool/testcase_info_test.py
+++ b/src/python/tests/appengine/handlers/reproduce_tool/testcase_info_test.py
@@ -47,4 +47,8 @@ class PrepareTestcaseDictTest(unittest.TestCase):
   def test_job_included(self):
     """Ensure that the job definition has been included."""
     result = testcase_info._prepare_testcase_dict(self.testcase)
-    self.assertEquals(result['job_definition'], {'X': '1', 'Y': '2'})
+    job_definition = result['job_definition']
+
+    # Order is not necessarily preserved.
+    self.assertIn('X = 1\n', job_definition)
+    self.assertIn('Y = 2\n', job_definition)


### PR DESCRIPTION
This handler includes the full serialized test case object as well as
the job definition associated with it.