### PR TITLE
Initial implementation of issue tracker policy (#504).

### DIFF
--- a/configs/test/issue_trackers/config.yaml
+++ b/configs/test/issue_trackers/config.yaml
@@ -1,0 +1,71 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+test-project:
+  type: monorail
+  policies:
+    status:
+      # Status mappings.
+      assigned: Assigned
+      duplicate: Duplicate
+      wontfix: WontFix
+      fixed: Fixed
+      verified: Verified
+      new: New
+    existing:
+      # Rules to apply when updating existing issues.
+      labels:
+        - Stability-%SANITIZER%
+    all:
+      # Rules to apply to all issues.
+      status: new
+      labels:
+        - ClusterFuzz
+        - OS-%PLATFORM%
+        - Reported-%YYYY-MM-DD%
+        - Stability-%SANITIZER%
+      issue_body_footer: |-
+        This is an issue body footer.
+    security:
+      # Rules to apply to security issues only (in addition to "all").
+      labels:
+        - Type-Bug-Security
+        - Security_Severity-%SEVERITY%
+    non_security:
+      # Rules to apply to non-security issues only (in addition to "all").
+      labels:
+        - Type-Bug
+      crash_labels:
+        # Non security bugs are further divided into crash (e.g. a null deref)
+        # vs non crash bugs (e.g. timeouts).
+        - Stability-Crash
+        - Pri-1
+      non_crash_labels:
+        - Pri-2
+    labels:
+      # General label mappings.
+      verified: ClusterFuzz-Verified
+      ignore: ClusterFuzz-Ignore
+      needs_feedback: Needs-Feedback
+      invalid_fuzzer: ClusterFuzz-Invalid-Fuzzer
+      fuzz_blocker: Fuzz-Blocker
+      reproducible: Reproducible
+      unreproducible: Unreproducible
+      restrict_view: Restrict-View-Commit
+      reported_prefix: Reported-
+      security_severity_prefix: Security_Severity-
+    deadline_policy_message: |-
+      This bug is subject to a 90 day disclosure deadline. If 90 days elapse
+      without an upstream patch, then the bug report will automatically
+      become visible to the public.

--- a/configs/test/issue_trackers/config.yaml
+++ b/configs/test/issue_trackers/config.yaml
@@ -12,11 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Sample policy. These policies are applied when filing new bugs, updating
+# existing bugs, and bug cleanup in the cleanup cron.
+# Labels support substitutions (at most one):
+#   - %YYYY-MM-DD%: The date timestamp when the issue is filed.
+#   - %SANITIZER%: The sanitizers associated with the testcase.
+#   - %SEVERITY%: The security severity of the testcase.
+#   - %PLATFORM%: The platform the testcase was found on.
 test-project:
   type: monorail
   policies:
     status:
-      # Status mappings.
+      # REQUIRED: Status mappings.
       assigned: Assigned
       duplicate: Duplicate
       wontfix: WontFix
@@ -46,9 +53,9 @@ test-project:
       # Rules to apply to non-security issues only (in addition to "all").
       labels:
         - Type-Bug
+      # Non security bugs are further divided into crash (e.g. a null deref)
+      # vs non crash bugs (e.g. timeouts).
       crash_labels:
-        # Non security bugs are further divided into crash (e.g. a null deref)
-        # vs non crash bugs (e.g. timeouts).
         - Stability-Crash
         - Pri-1
       non_crash_labels:

--- a/src/appengine/handlers/cron/oss_fuzz_build_status.py
+++ b/src/appengine/handlers/cron/oss_fuzz_build_status.py
@@ -181,7 +181,7 @@ class Handler(base_handler.Handler):
 
   def _close_fixed_builds(self, build_status, build_type):
     """Close bugs for fixed builds."""
-    issue_tracker = issue_tracker_utils.get_issue_tracker('monorail')
+    issue_tracker = issue_tracker_utils.get_issue_tracker()
     if not issue_tracker:
       raise OssFuzzBuildStatusException('Failed to get issue tracker.')
 
@@ -205,7 +205,7 @@ class Handler(base_handler.Handler):
 
   def _process_failures(self, build_status, build_type):
     """Process failures."""
-    issue_tracker = issue_tracker_utils.get_issue_tracker('monorail')
+    issue_tracker = issue_tracker_utils.get_issue_tracker()
     if not issue_tracker:
       raise OssFuzzBuildStatusException('Failed to get issue tracker.')
 

--- a/src/appengine/handlers/testcase_detail/create_issue.py
+++ b/src/appengine/handlers/testcase_detail/create_issue.py
@@ -33,7 +33,7 @@ class Handler(base_handler.Handler):
           severity, int, 'Invalid value for security severity (%s).' % severity)
 
     additional_ccs = []
-    if cc_me == 'true':
+    if cc_me:
       additional_ccs.append(user_email)
 
     issue_id = issue_filer.file_issue(

--- a/src/appengine/handlers/testcase_detail/update_issue.py
+++ b/src/appengine/handlers/testcase_detail/update_issue.py
@@ -54,8 +54,8 @@ class Handler(base_handler.Handler):
     policy = issue_tracker_policy.get(issue_tracker.project)
     properties = policy.get_existing_issue_properties()
     for label in properties.labels:
-      for result in issue_filer.apply_substitutions(label, testcase,
-                                                    security_severity=None):
+      for result in issue_filer.apply_substitutions(
+          label, testcase, security_severity=None):
         issue.labels.add(result)
 
     issue.save(new_comment=issue_comment)

--- a/src/appengine/handlers/testcase_detail/update_issue.py
+++ b/src/appengine/handlers/testcase_detail/update_issue.py
@@ -54,7 +54,8 @@ class Handler(base_handler.Handler):
     policy = issue_tracker_policy.get(issue_tracker.project)
     properties = policy.get_existing_issue_properties()
     for label in properties.labels:
-      for result in issue_filer.apply_substitutions(label, testcase, None):
+      for result in issue_filer.apply_substitutions(label, testcase,
+                                                    security_severity=None):
         issue.labels.add(result)
 
     issue.save(new_comment=issue_comment)

--- a/src/appengine/handlers/testcase_detail/update_issue.py
+++ b/src/appengine/handlers/testcase_detail/update_issue.py
@@ -16,6 +16,7 @@
 from datastore import data_handler
 from handlers import base_handler
 from handlers.testcase_detail import show
+from issue_management import issue_tracker_policy
 from libs import handler
 from libs import helpers
 from libs import issue_filer
@@ -50,13 +51,11 @@ class Handler(base_handler.Handler):
     if needs_summary_update and testcase.crash_state != 'NULL':
       issue.title = issue_summary
 
-    # Add label on memory tool used.
-    issue_filer.add_memory_tool_label_if_needed(issue, testcase)
-
-    # Add view restrictions for internal job types.
-    issue_filer.add_view_restrictions_if_needed(issue, testcase)
-
-    # Don't enforce security severity label on an existing issue.
+    policy = issue_tracker_policy.get(issue_tracker.project)
+    properties = policy.get_existing_issue_properties()
+    for label in properties.labels:
+      for result in issue_filer.apply_substitutions(label, testcase, None):
+        issue.labels.add(result)
 
     issue.save(new_comment=issue_comment)
 

--- a/src/appengine/libs/issue_filer.py
+++ b/src/appengine/libs/issue_filer.py
@@ -17,6 +17,7 @@ from base import external_users
 from base import utils
 from datastore import data_handler
 from datastore import data_types
+from issue_management import issue_tracker_policy
 from issue_management import label_utils
 from system import environment
 
@@ -32,71 +33,73 @@ NON_CRASH_TYPES = [
     'Unsigned-integer-overflow',
 ]
 
-RESTRICT_TO_GOOGLERS_LABEL = 'Restrict-View-Google'
 
-DEADLINE_NOTE = (
-    'This bug is subject to a 90 day disclosure deadline. If 90 days elapse\n'
-    'without an upstream patch, then the bug report will automatically\n'
-    'become visible to the public.')
+def platform_substitution(label, testcase, _):
+  """Platform ubstitution."""
+  platform = None
+  if environment.is_chromeos_job(testcase.job_type):
+    # ChromeOS fuzzers run on Linux platform, so use correct OS-Chrome for
+    # tracking.
+    platform = 'Chrome'
+  elif testcase.platform_id:
+    platform = testcase.platform_id.split(':')[0].capitalize()
 
-FIX_NOTE = (
-    'When you fix this bug, please\n'
-    '  * mention the fix revision(s).\n'
-    '  * state whether the bug was a short-lived regression or an old bug'
-    ' in any stable releases.\n'
-    '  * add any other useful information.\n'
-    'This information can help downstream consumers.')
+  if not platform:
+    return []
 
-QUESTIONS_NOTE = (
-    'If you need to contact the OSS-Fuzz team with a question, concern, or any '
-    'other feedback, please file an issue at '
-    'https://github.com/google/oss-fuzz/issues.')
+  return [label.replace('%PLATFORM%', platform)]
 
 
-def add_memory_tool_label_if_needed(issue, testcase):
-  """Find memory tool used and add corresponding labels to the issue."""
+def current_date():
+  """Date format."""
+  return utils.utcnow().date().isoformat()
+
+
+def date_substitution(label, *_):
+  """Date ubstitution."""
+  return [label.replace('%YYYY-MM-DD%', current_date())]
+
+
+def sanitizer_substitution(label, testcase, _):
+  """Sanitizer ubstitution."""
   stacktrace = data_handler.get_stacktrace(testcase)
   memory_tool_labels = label_utils.get_memory_tool_labels(stacktrace)
-  for label in memory_tool_labels:
-    issue.labels.add(label)
+
+  return [
+      label.replace('%SANITIZER%', memory_tool)
+      for memory_tool in memory_tool_labels
+  ]
 
 
-def add_security_severity_label_if_needed(issue, testcase,
-                                          security_severity_override):
-  """Add security severity label to issue."""
-  if not testcase.security_flag:
-    return
-
+def severity_substitution(label, testcase, security_severity):
+  """Severity ubstitution."""
   # Use severity from testcase if one is not available.
   security_severity = (
       testcase.security_severity
-      if security_severity_override is None else security_severity_override)
+      if security_severity is None else security_severity)
 
   # Set to default high severity if we can't determine it automatically.
   if not data_types.SecuritySeverity.is_valid(security_severity):
     security_severity = data_types.SecuritySeverity.HIGH
 
-  security_severity_label = label_utils.severity_to_label(security_severity)
-  issue.labels.add(security_severity_label)
+  security_severity_string = label_utils.severity_to_string(security_severity)
+  return [label.replace('%SEVERITY%', security_severity_string)]
 
 
-def add_view_restrictions_if_needed(issue, testcase):
-  """Add additional view restrictions for android and flash bugs."""
-  if testcase.project_name != 'chromium':
-    return
+def apply_substitutions(label, testcase, security_severity):
+  """Apply label substituions."""
+  label_substitutions = (
+      ('%PLATFORM%', platform_substitution),
+      ('%YYYY-MM-DD%', date_substitution),
+      ('%SANITIZER%', sanitizer_substitution),
+      ('%SEVERITY%', severity_substitution),
+  )
 
-  # If the label is already there, no work to do.
-  if RESTRICT_TO_GOOGLERS_LABEL in issue.labels:
-    return
+  for marker, handler in label_substitutions:
+    if marker in label:
+      return handler(label, testcase, security_severity)
 
-  job_type_lowercase = testcase.job_type.lower()
-  if 'android' in job_type_lowercase or 'flash' in job_type_lowercase:
-    issue.labels.add(RESTRICT_TO_GOOGLERS_LABEL)
-
-
-def reported_label():
-  """Return a Reported-YYYY-MM-DD label."""
-  return 'Reported-' + utils.utcnow().date().isoformat()
+  return [label]
 
 
 def file_issue(testcase,
@@ -110,83 +113,24 @@ def file_issue(testcase,
   issue.body = data_handler.get_issue_description(
       testcase, reporter=user_email, show_reporter=True)
 
-  # Labels applied by default across all issue trackers.
-  issue.status = 'New'
-  issue.labels.add('ClusterFuzz')
-
-  # Add label on memory tool used.
-  add_memory_tool_label_if_needed(issue, testcase)
+  policy = issue_tracker_policy.get(issue_tracker.project)
 
   # Add reproducibility flag label.
   if testcase.one_time_crasher_flag:
-    issue.labels.add('Unreproducible')
+    issue.labels.add(policy.label('unreproducible'))
   else:
-    issue.labels.add('Reproducible')
-
-  # Add security severity flag label.
-  add_security_severity_label_if_needed(issue, testcase, security_severity)
-
-  # Get view restriction rules for the job.
-  issue_restrictions = data_handler.get_value_from_job_definition(
-      testcase.job_type, 'ISSUE_VIEW_RESTRICTIONS', 'security')
-  should_restrict_issue = (
-      issue_restrictions == 'all' or
-      (issue_restrictions == 'security' and testcase.security_flag))
+    issue.labels.add(policy.label('reproducible'))
 
   # Chromium-specific labels.
-  if issue_tracker.project == 'chromium':
-    # A different status system is used on the chromium tracker. Since we
-    # have already reproduced the crash, we skip the Unconfirmed status.
-    issue.status = 'Untriaged'
+  if issue_tracker.project and issue_tracker.project == 'chromium':
+    # Add reward labels if this is from an external fuzzer contribution.
+    fuzzer = data_types.Fuzzer.query(
+        data_types.Fuzzer.name == testcase.fuzzer_name).get()
+    if fuzzer and fuzzer.external_contribution:
+      issue.labels.add('reward-topanel')
+      issue.labels.add('External-Fuzzer-Contribution')
 
-    # Add OS label.
-    if environment.is_chromeos_job(testcase.job_type):
-      # ChromeOS fuzzers run on Linux platform, so use correct OS-Chrome for
-      # tracking.
-      issue.labels.add('OS-Chrome')
-    elif testcase.platform_id:
-      os_label = 'OS-%s' % ((testcase.platform_id.split(':')[0]).capitalize())
-      issue.labels.add(os_label)
-
-    # Add view restrictions for internal job types.
-    add_view_restrictions_if_needed(issue, testcase)
-
-    if testcase.security_flag:
-      # Apply labels specific to security bugs.
-      issue.labels.add('Restrict-View-SecurityTeam')
-      issue.labels.add('Type-Bug-Security')
-
-      # Add reward labels if this is from an external fuzzer contribution.
-      fuzzer = data_types.Fuzzer.query(
-          data_types.Fuzzer.name == testcase.fuzzer_name).get()
-      if fuzzer and fuzzer.external_contribution:
-        issue.labels.add('reward-topanel')
-        issue.labels.add('External-Fuzzer-Contribution')
-
-      data_handler.update_issue_impact_labels(testcase, issue)
-    else:
-      # Apply labels for functional (non-security) bugs.
-      if utils.sub_string_exists_in(NON_CRASH_TYPES, testcase.crash_type):
-        # Non-crashing test cases shouldn't be assigned Pri-1.
-        issue.labels.add('Pri-2')
-        issue.labels.add('Type-Bug')
-      else:
-        # Default functional bug labels.
-        issue.labels.add('Pri-1')
-        issue.labels.add('Stability-Crash')
-        issue.labels.add('Type-Bug')
-
-  # OSS-Fuzz specific labels.
-  elif issue_tracker.project == 'oss-fuzz':
-    if testcase.security_flag:
-      # Security bug labels.
-      issue.labels.add('Type-Bug-Security')
-    else:
-      # Functional bug labels.
-      issue.labels.add('Type-Bug')
-
-    if should_restrict_issue:
-      issue.labels.add('Restrict-View-Commit')
+    data_handler.update_issue_impact_labels(testcase, issue)
 
   # Add additional labels from the job definition and fuzzer.
   additional_labels = data_handler.get_additional_values_for_variable(
@@ -199,6 +143,14 @@ def file_issue(testcase,
       'AUTOMATIC_COMPONENTS', testcase.job_type, testcase.fuzzer_name)
   for component in automatic_components:
     issue.components.add(component)
+
+  is_crash = not utils.sub_string_exists_in(NON_CRASH_TYPES,
+                                            testcase.crash_type)
+  properties = policy.get_new_issue_properties(
+      is_security=testcase.security_flag, is_crash=is_crash)
+
+  # Labels applied by default across all issue trackers.
+  issue.status = properties.status
 
   # Add additional ccs from the job definition and fuzzer.
   ccs = data_handler.get_additional_values_for_variable(
@@ -222,15 +174,29 @@ def file_issue(testcase,
   if testcase.uploader_email and testcase.uploader_email not in ccs:
     ccs.append(testcase.uploader_email)
 
-  if issue_tracker.project == 'oss-fuzz' and ccs:
-    # Add a reported label for deadline tracking.
-    issue.labels.add(reported_label())
+  ccs.extend(properties.ccs)
 
-    if should_restrict_issue:
-      issue.body += '\n\n' + DEADLINE_NOTE
+  # Get view restriction rules for the job.
+  issue_restrictions = data_handler.get_value_from_job_definition(
+      testcase.job_type, 'ISSUE_VIEW_RESTRICTIONS', 'security')
+  should_restrict_issue = (
+      issue_restrictions == 'all' or
+      (issue_restrictions == 'security' and testcase.security_flag))
 
-    issue.body += '\n\n' + FIX_NOTE
-    issue.body += '\n\n' + QUESTIONS_NOTE
+  if should_restrict_issue:
+    issue.labels.add(policy.label('restrict_view'))
+
+  for label in properties.labels:
+    for result in apply_substitutions(label, testcase, security_severity):
+      if result.startswith(policy.label('reported_prefix')) and not ccs:
+        # Do not add reported label when there are no CCs.
+        continue
+
+      issue.labels.add(result)
+
+  issue.body += properties.issue_body_footer
+  if should_restrict_issue and ccs and policy.deadline_policy_message:
+    issue.body += '\n\n' + policy.deadline_policy_message
 
   for cc in ccs:
     issue.ccs.add(cc)
@@ -252,5 +218,4 @@ def file_issue(testcase,
   testcase.put()
 
   data_handler.update_group_bug(testcase.group_id)
-
   return issue.id

--- a/src/appengine/libs/issue_filer.py
+++ b/src/appengine/libs/issue_filer.py
@@ -75,7 +75,7 @@ def severity_substitution(label, testcase, security_severity):
   """Severity substitution."""
   # Use severity from testcase if one is not available.
   if security_severity is None:
-    security_severity =  testcase.security_severity
+    security_severity = testcase.security_severity
 
   # Set to default high severity if we can't determine it automatically.
   if not data_types.SecuritySeverity.is_valid(security_severity):

--- a/src/appengine/libs/issue_filer.py
+++ b/src/appengine/libs/issue_filer.py
@@ -149,7 +149,6 @@ def file_issue(testcase,
   properties = policy.get_new_issue_properties(
       is_security=testcase.security_flag, is_crash=is_crash)
 
-  # Labels applied by default across all issue trackers.
   issue.status = properties.status
 
   # Add additional ccs from the job definition and fuzzer.

--- a/src/python/config/local_config.py
+++ b/src/python/config/local_config.py
@@ -30,6 +30,7 @@ SEPARATOR = '.'
 GAE_AUTH_PATH = 'gae.auth'
 GAE_CONFIG_PATH = 'gae.config'
 GCE_CLUSTERS_PATH = 'gce.clusters'
+ISSUE_TRACKERS_PATH = 'issue_trackers.config'
 MONITORING_REGIONS_PATH = 'monitoring.regions'
 PROJECT_PATH = 'project'
 
@@ -229,3 +230,10 @@ class MonitoringRegionsConfig(Config):
 
   def __init__(self):
     super(MonitoringRegionsConfig, self).__init__(MONITORING_REGIONS_PATH)
+
+
+class IssueTrackerConfig(Config):
+  """Issue tracker config."""
+
+  def __init__(self):
+    super(IssueTrackerConfig, self).__init__(ISSUE_TRACKERS_PATH)

--- a/src/python/issue_management/issue_tracker_policy.py
+++ b/src/python/issue_management/issue_tracker_policy.py
@@ -1,0 +1,129 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Issue tracker policy."""
+
+from builtins import object
+from collections import namedtuple
+
+from config import local_config
+
+Status = namedtuple('Status',
+                    ['assigned', 'duplicate', 'wontfix', 'fixed', 'verified'])
+
+EXPECTED_STATUSES = [
+    'assigned',
+    'duplicate',
+    'wontfix',
+    'fixed',
+    'verified',
+    'new',
+]
+
+
+class ConfigurationError(Exception):
+  """Base configuration error class."""
+
+
+class NewIssuePolicy(object):
+  """New issue policy."""
+
+  def __init__(self):
+    self.status = ''
+    self.ccs = []
+    self.labels = []
+    self.issue_body_footer = ''
+
+
+class IssueTrackerPolicy(object):
+  """Represents an issue tracker policy."""
+
+  def __init__(self, data):
+    self._data = data
+    if 'status' not in self._data:
+      raise ConfigurationError('Status not set in policies.')
+
+    for status in EXPECTED_STATUSES:
+      if status not in self._data['status']:
+        raise ConfigurationError(
+            'Expected status {} is not set.'.format(status))
+
+  def status(self, status_type):
+    """Get the actual status string for the given type."""
+    return self._data['status'][status_type]
+
+  def label(self, label_type):
+    """Get the actual label string for the given type."""
+    return self._data['labels'].get(label_type)
+
+  @property
+  def deadline_policy_message(self):
+    """Get the deadline policy message, if if exists."""
+    return self._data.get('deadline_policy_message')
+
+  def get_new_issue_properties(self, is_security, is_crash):
+    """Get the properties to apply to a new issue."""
+    policy = NewIssuePolicy()
+
+    if 'all' in self._data:
+      apply_new_issue_properties(policy, self._data['all'], is_crash)
+
+    if is_security:
+      if 'security' in self._data:
+        apply_new_issue_properties(policy, self._data['security'], is_crash)
+    else:
+      if 'security' in self._data:
+        apply_new_issue_properties(policy, self._data['non_security'], is_crash)
+
+    return policy
+
+  def get_existing_issue_properties(self):
+    """Get the properties to apply to a new issue."""
+    policy = NewIssuePolicy()
+
+    if 'existing' in self._data:
+      apply_new_issue_properties(policy, self._data['existing'], False)
+
+    return policy
+
+
+def apply_new_issue_properties(policy, data, is_crash):
+  """Apply issue policies."""
+  policy.status = data.get('status')
+
+  if 'ccs' in data:
+    policy.labels.extend(data['ccs'])
+
+  if 'labels' in data:
+    policy.labels.extend(data['labels'])
+
+  if is_crash:
+    if 'crash_labels' in data:
+      policy.labels.extend(data['crash_labels'])
+  else:
+    if 'non_crash_labels' in data:
+      policy.labels.extend(data['non_crash_labels'])
+
+
+def get(project_name):
+  """Get policy."""
+  issue_tracker_config = local_config.IssueTrackerConfig()
+  project_config = issue_tracker_config.get(project_name)
+  if not project_config:
+    raise ConfigurationError(
+        'Issue tracker for {} does not exist'.format(project_name))
+
+  if not 'policies' in project_config:
+    raise ConfigurationError(
+        'Policies for {} do not exist'.format(project_name))
+
+  return IssueTrackerPolicy(project_config['policies'])

--- a/src/python/issue_management/issue_tracker_policy.py
+++ b/src/python/issue_management/issue_tracker_policy.py
@@ -82,7 +82,7 @@ class IssueTrackerPolicy(object):
         self._apply_new_issue_properties(policy, self._data['security'],
                                          is_crash)
     else:
-      if 'security' in self._data:
+      if 'non_security' in self._data:
         self._apply_new_issue_properties(policy, self._data['non_security'],
                                          is_crash)
 

--- a/src/python/issue_management/issue_tracker_policy.py
+++ b/src/python/issue_management/issue_tracker_policy.py
@@ -75,16 +75,36 @@ class IssueTrackerPolicy(object):
     policy = NewIssuePolicy()
 
     if 'all' in self._data:
-      apply_new_issue_properties(policy, self._data['all'], is_crash)
+      self._apply_new_issue_properties(policy, self._data['all'], is_crash)
 
     if is_security:
       if 'security' in self._data:
-        apply_new_issue_properties(policy, self._data['security'], is_crash)
+        self._apply_new_issue_properties(policy, self._data['security'],
+                                         is_crash)
     else:
       if 'security' in self._data:
-        apply_new_issue_properties(policy, self._data['non_security'], is_crash)
+        self._apply_new_issue_properties(policy, self._data['non_security'],
+                                         is_crash)
 
     return policy
+
+  def _apply_new_issue_properties(self, policy, issue_type, is_crash):
+    """Apply issue policies."""
+    if 'status' in issue_type:
+      policy.status = self._data['status'][issue_type['status']]
+
+    if 'ccs' in issue_type:
+      policy.labels.extend(issue_type['ccs'])
+
+    if 'labels' in issue_type:
+      policy.labels.extend(issue_type['labels'])
+
+    if is_crash:
+      if 'crash_labels' in issue_type:
+        policy.labels.extend(issue_type['crash_labels'])
+    else:
+      if 'non_crash_labels' in issue_type:
+        policy.labels.extend(issue_type['non_crash_labels'])
 
   def get_existing_issue_properties(self):
     """Get the properties to apply to a new issue."""
@@ -94,24 +114,6 @@ class IssueTrackerPolicy(object):
       apply_new_issue_properties(policy, self._data['existing'], False)
 
     return policy
-
-
-def apply_new_issue_properties(policy, data, is_crash):
-  """Apply issue policies."""
-  policy.status = data.get('status')
-
-  if 'ccs' in data:
-    policy.labels.extend(data['ccs'])
-
-  if 'labels' in data:
-    policy.labels.extend(data['labels'])
-
-  if is_crash:
-    if 'crash_labels' in data:
-      policy.labels.extend(data['crash_labels'])
-  else:
-    if 'non_crash_labels' in data:
-      policy.labels.extend(data['non_crash_labels'])
 
 
 def get(project_name):

--- a/src/python/issue_management/issue_tracker_policy.py
+++ b/src/python/issue_management/issue_tracker_policy.py
@@ -111,7 +111,7 @@ class IssueTrackerPolicy(object):
     policy = NewIssuePolicy()
 
     if 'existing' in self._data:
-      apply_new_issue_properties(policy, self._data['existing'], False)
+      self._apply_new_issue_properties(policy, self._data['existing'], False)
 
     return policy
 

--- a/src/python/issue_management/label_utils.py
+++ b/src/python/issue_management/label_utils.py
@@ -20,31 +20,31 @@ from datastore import data_types
 MEMORY_TOOLS_LABELS = [
     {
         'token': 'AddressSanitizer',
-        'label': 'Stability-Memory-AddressSanitizer'
+        'label': 'Memory-AddressSanitizer'
     },
     {
         'token': 'LeakSanitizer',
-        'label': 'Stability-Memory-LeakSanitizer'
+        'label': 'Memory-LeakSanitizer'
     },
     {
         'token': 'MemorySanitizer',
-        'label': 'Stability-Memory-MemorySanitizer'
+        'label': 'Memory-MemorySanitizer'
     },
     {
         'token': 'ThreadSanitizer',
-        'label': 'Stability-ThreadSanitizer'
+        'label': 'ThreadSanitizer'
     },
     {
         'token': 'UndefinedBehaviorSanitizer',
-        'label': 'Stability-UndefinedBehaviorSanitizer'
+        'label': 'UndefinedBehaviorSanitizer'
     },
     {
         'token': 'afl',
-        'label': 'Stability-AFL'
+        'label': 'AFL'
     },
     {
         'token': 'libfuzzer',
-        'label': 'Stability-LibFuzzer'
+        'label': 'LibFuzzer'
     },
 ]
 MISSING_VALUE_STRING = '---'

--- a/src/python/tests/appengine/handlers/testcase_detail/create_issue_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/create_issue_test.py
@@ -56,7 +56,7 @@ class HandlerTest(unittest.TestCase):
         '/', {
             'testcaseId': self.testcase.key.id(),
             'severity': 3,
-            'ccMe': 'true',
+            'ccMe': True,
             'csrf_token': form.generate_csrf_token(),
         })
 
@@ -85,7 +85,7 @@ class HandlerTest(unittest.TestCase):
         '/', {
             'testcaseId': self.testcase.key.id(),
             'severity': 3,
-            'ccMe': 'true',
+            'ccMe': True,
             'csrf_token': form.generate_csrf_token(),
         },
         expect_errors=True)
@@ -100,7 +100,7 @@ class HandlerTest(unittest.TestCase):
         '/', {
             'testcaseId': self.testcase.key.id() + 1,
             'severity': 3,
-            'ccMe': 'true',
+            'ccMe': True,
             'csrf_token': form.generate_csrf_token(),
         },
         expect_errors=True)
@@ -116,7 +116,7 @@ class HandlerTest(unittest.TestCase):
         '/', {
             'testcaseId': self.testcase.key.id(),
             'severity': 'a',
-            'ccMe': 'true',
+            'ccMe': True,
             'csrf_token': form.generate_csrf_token(),
         },
         expect_errors=True)
@@ -132,7 +132,7 @@ class HandlerTest(unittest.TestCase):
         '/', {
             'testcaseId': self.testcase.key.id(),
             'severity': 3,
-            'ccMe': 'true',
+            'ccMe': True,
             'csrf_token': form.generate_csrf_token(),
         },
         expect_errors=True)

--- a/src/python/tests/appengine/handlers/testcase_detail/update_issue_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/update_issue_test.py
@@ -19,6 +19,7 @@ import webtest
 
 from datastore import data_types
 from handlers.testcase_detail import update_issue
+from issue_management import issue_tracker_policy
 from issue_management import monorail
 from issue_management.monorail import issue
 from issue_management.monorail import issue_tracker_manager
@@ -26,6 +27,20 @@ from libs import access
 from libs import form
 from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils
+
+CHROMIUM_POLICY = issue_tracker_policy.IssueTrackerPolicy({
+    'status': {
+        'assigned': 'Assigned',
+        'duplicate': 'Duplicate',
+        'fixed': 'Fixed',
+        'new': 'Untriaged',
+        'verified': 'Verified',
+        'wontfix': 'WontFix'
+    },
+    'existing': {
+        'labels': ['Stability-%SANITIZER%']
+    },
+})
 
 
 @test_utils.with_cloud_emulators('datastore')
@@ -35,7 +50,6 @@ class HandlerTest(unittest.TestCase):
   def setUp(self):
     test_helpers.patch(self, [
         'issue_management.label_utils.get_memory_tool_labels',
-        'libs.issue_filer.add_view_restrictions_if_needed',
         'datastore.data_handler.get_issue_description',
         'datastore.data_handler.get_issue_summary',
         'datastore.data_handler.get_stacktrace',
@@ -44,10 +58,12 @@ class HandlerTest(unittest.TestCase):
         'libs.auth.get_current_user',
         'handlers.testcase_detail.show.get_testcase_detail',
         'libs.access.get_access',
+        'issue_management.issue_tracker_policy.get',
     ])
     self.mock.get_access.return_value = access.UserAccess.Allowed
     self.mock.get_testcase_detail.return_value = {'testcase': 'yes'}
     self.mock.get_current_user().email = 'test@test.com'
+    self.mock.get.return_value = CHROMIUM_POLICY
 
     self.app = webtest.TestApp(
         webapp2.WSGIApplication([('/', update_issue.Handler)]))
@@ -127,7 +143,7 @@ class HandlerTest(unittest.TestCase):
     self.mock.get_issue_description.return_value = 'description'
     self.mock.get_issue_summary.return_value = 'summary'
     self.mock.get_stacktrace.return_value = 'stacktrace'
-    self.mock.get_memory_tool_labels.return_value = ['label']
+    self.mock.get_memory_tool_labels.return_value = ['tool']
 
     resp = self.app.post_json(
         '/', {
@@ -143,5 +159,5 @@ class HandlerTest(unittest.TestCase):
 
     self.assertEqual('description', bug.comment)
     self.assertEqual('summary', bug.summary)
-    self.assertListEqual(['label'], bug.labels)
+    self.assertListEqual(['Stability-tool'], bug.labels)
     self.assertEqual('2', self.testcase.key.get().bug_information)

--- a/src/python/tests/appengine/libs/issue_filer_test.py
+++ b/src/python/tests/appengine/libs/issue_filer_test.py
@@ -468,3 +468,20 @@ class IssueFilerTests(unittest.TestCase):
     self.testcase1.put()
     issue_filer.file_issue(self.testcase1, issue_tracker)
     self.assertIn('Reproducible', issue_tracker._itm.last_issue.labels)
+
+  def test_crash_labels(self):
+    """Test crash label setting."""
+    self.mock.get.return_value = CHROMIUM_POLICY
+    issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
+
+    self.testcase1.crash_type = 'UNKNOWN'
+    self.testcase1.put()
+    issue_filer.file_issue(self.testcase1, issue_tracker)
+    self.assertIn('Pri-1', issue_tracker._itm.last_issue.labels)
+    self.assertIn('Stability-Crash', issue_tracker._itm.last_issue.labels)
+
+    self.testcase1.crash_type = 'Undefined-shift'
+    self.testcase1.put()
+    issue_filer.file_issue(self.testcase1, issue_tracker)
+    self.assertIn('Pri-2', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Stability-Crash', issue_tracker._itm.last_issue.labels)

--- a/src/python/tests/core/issue_management/label_utils_test.py
+++ b/src/python/tests/core/issue_management/label_utils_test.py
@@ -32,7 +32,7 @@ class LabelUtilsTest(unittest.TestCase):
 
   def test_memory_tools_labels_asan(self):
     """Run memory tools detection with test data."""
-    expected_labels = ['Stability-Memory-AddressSanitizer']
+    expected_labels = ['Memory-AddressSanitizer']
     data = self._read_test_data('memory_tools_asan.txt')
     actual_labels = label_utils.get_memory_tool_labels(data)
 
@@ -40,7 +40,7 @@ class LabelUtilsTest(unittest.TestCase):
 
   def test_memory_tools_labels_asan_afl(self):
     """Run memory tools detection with test data."""
-    expected_labels = ['Stability-Memory-AddressSanitizer', 'Stability-AFL']
+    expected_labels = ['Memory-AddressSanitizer', 'AFL']
     data = self._read_test_data('memory_tools_asan_afl.txt')
     actual_labels = label_utils.get_memory_tool_labels(data)
 
@@ -48,9 +48,7 @@ class LabelUtilsTest(unittest.TestCase):
 
   def test_memory_tools_labels_asan_libfuzzer(self):
     """Run memory tools detection with test data."""
-    expected_labels = [
-        'Stability-Memory-AddressSanitizer', 'Stability-LibFuzzer'
-    ]
+    expected_labels = ['Memory-AddressSanitizer', 'LibFuzzer']
     data = self._read_test_data('memory_tools_asan_libfuzzer.txt')
     actual_labels = label_utils.get_memory_tool_labels(data)
 
@@ -58,9 +56,7 @@ class LabelUtilsTest(unittest.TestCase):
 
   def test_memory_tools_labels_asan_lsan(self):
     """Run memory tools detection with test data."""
-    expected_labels = [
-        'Stability-Memory-AddressSanitizer', 'Stability-Memory-LeakSanitizer'
-    ]
+    expected_labels = ['Memory-AddressSanitizer', 'Memory-LeakSanitizer']
     data = self._read_test_data('memory_tools_asan_lsan.txt')
     actual_labels = label_utils.get_memory_tool_labels(data)
 
@@ -68,7 +64,7 @@ class LabelUtilsTest(unittest.TestCase):
 
   def test_memory_tools_labels_msan(self):
     """Run memory tools detection with test data."""
-    expected_labels = ['Stability-Memory-MemorySanitizer']
+    expected_labels = ['Memory-MemorySanitizer']
     data = self._read_test_data('memory_tools_msan.txt')
     actual_labels = label_utils.get_memory_tool_labels(data)
 
@@ -76,9 +72,7 @@ class LabelUtilsTest(unittest.TestCase):
 
   def test_memory_tools_labels_msan_libfuzzer(self):
     """Run memory tools detection with test data."""
-    expected_labels = [
-        'Stability-Memory-MemorySanitizer', 'Stability-LibFuzzer'
-    ]
+    expected_labels = ['Memory-MemorySanitizer', 'LibFuzzer']
     data = self._read_test_data('memory_tools_msan_libfuzzer.txt')
     actual_labels = label_utils.get_memory_tool_labels(data)
 
@@ -86,7 +80,7 @@ class LabelUtilsTest(unittest.TestCase):
 
   def test_memory_tools_labels_tsan(self):
     """Run memory tools detection with test data."""
-    expected_labels = ['Stability-ThreadSanitizer']
+    expected_labels = ['ThreadSanitizer']
     data = self._read_test_data('memory_tools_tsan.txt')
     actual_labels = label_utils.get_memory_tool_labels(data)
 
@@ -94,7 +88,7 @@ class LabelUtilsTest(unittest.TestCase):
 
   def test_memory_tools_ubsan(self):
     """Run memory tools detection with test data."""
-    expected_labels = ['Stability-UndefinedBehaviorSanitizer']
+    expected_labels = ['UndefinedBehaviorSanitizer']
     data = self._read_test_data('memory_tools_ubsan.txt')
     actual_labels = label_utils.get_memory_tool_labels(data)
 


### PR DESCRIPTION
This is an initial implementation of issue tracker policy.

This changes issue filing and issue update to read a config from
CONFIG_DIR/issue_trackers/config.yaml. Policies are keyed by project name.

Policy labels support substitutions in the form of %SUBSTITUTION%.
e.g. Stability-%SANITIZER% or Reported-%YYYY-MM-DD%.

See configs/test/issue_trackers for a sample config.

Future CLs will modify cleanup and other places which add or remove labels.