### PR TITLE
Upgrade go bazel rules to fix compatiblity issue with upgraded bazel.

### DIFF
--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -1,8 +1,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.3/rules_go-0.18.3.tar.gz"],
-    sha256 = "86ae934bd4c43b99893fc64be9d9fc684b81461581df7ea8fc291c816f5ee8c5",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+    ],
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 http_archive(
     name = "bazel_gazelle",


### PR DESCRIPTION
Fixes

```
| ERROR: /usr/local/google/home/ochang/.cache/bazel/_bazel_ochang/8a0c843db3aa401cba35225a01dec302/external/io_bazel_rules_go/BUILD.bazel:62:1: in go_context_data rule @io_bazel_rules_go//:go_context_data:
| Traceback (most recent call last):
| 	File "/usr/local/google/home/ochang/.cache/bazel/_bazel_ochang/8a0c843db3aa401cba35225a01dec302/external/io_bazel_rules_go/BUILD.bazel", line 62
| 		go_context_data(name = 'go_context_data')
| 	File "/usr/local/google/home/ochang/.cache/bazel/_bazel_ochang/8a0c843db3aa401cba35225a01dec302/external/io_bazel_rules_go/go/private/context.bzl", line 396, in _go_context_data_impl
| 		cc_common.configure_features(cc_toolchain = cc_toolchain, reque..., ...)
| Incompatible flag --incompatible_require_ctx_in_configure_features has been flipped, and the mandatory parameter 'ctx' of cc_common.configure_features is missing. Please add 'ctx' as a named parameter. See https://github.com/bazelbuild/bazel/issues/7793 for details.
```