### PR TITLE
Reset page when using testcase filters on list page.

### DIFF
--- a/src/appengine/private/components/testcase-list/testcase-list.html
+++ b/src/appengine/private/components/testcase-list/testcase-list.html
@@ -476,9 +476,7 @@
       }
 
       searchButtonTapped(ev) {
-        this.params.page = '';
-        this.set('result.page', 1);
-        this.search();
+        this.resetPageAndSearch();
       }
 
       paramsModified(ev) {
@@ -502,6 +500,12 @@
 
         this.$.paginatedList.updateQuery();
         this.$.ajax.generateRequest();
+      }
+
+      resetPageAndSearch() {
+        this.params.page = '';
+        this.set('result.page', 1);
+        this.search();
       }
 
       handleRequest() {
@@ -581,30 +585,30 @@
 
       filterProject(ev) {
         this.set('params.project', ev.target.dataset.project);
-        this.search();
+        this.resetPageAndSearch();
       }
 
       filterPlatform(ev) {
         this.set(
             'params.q',
             `${(this.params.q || '')} platform:${ev.target.dataset.platform}`.trim());
-        this.search();
+        this.resetPageAndSearch();
       }
 
       filterReproducible(ev) {
         this.set('params.reproducible', ev.target.dataset.reproducible);
-        this.search();
+        this.resetPageAndSearch();
       }
 
       filterSecurity(ev) {
         this.set('params.security', ev.target.dataset.security);
-        this.search();
+        this.resetPageAndSearch();
       }
 
       filterImpact(ev) {
         this.set('params.impact', ev.target.dataset.impact);
         this.set('params.q', this.clearStableBetaFilter(this.params.q));
-        this.search();
+        this.resetPageAndSearch();
       }
 
       clearStableBetaFilter(q) {
@@ -628,7 +632,7 @@
         }
 
         this.set('params.q', q);
-        this.search();
+        this.resetPageAndSearch();
       }
     }
 


### PR DESCRIPTION
This matches the dropdown filters which also reset page.
Fixes
https://bugs.chromium.org/p/chromium/issues/detail?id=928355