### PR TITLE
Add support for dataflow builds to the OSS-Fuzz setup handler (#503).

### DIFF
--- a/src/appengine/handlers/cron/oss_fuzz_setup.py
+++ b/src/appengine/handlers/cron/oss_fuzz_setup.py
@@ -524,7 +524,7 @@ def sync_cf_job(project, info, corpus_bucket, quarantine_bucket, logs_bucket,
     if selective_unpack:
       job.environment_string += 'UNPACK_ALL_FUZZ_TARGETS_AND_FILES = False\n'
 
-    if (template.engine == 'libfuzzer' and
+    if (template.engine == 'libfuzzer' and template.architecture == 'x86_64' and
         'dataflow' in info.get('fuzzing_engines', DEFAULT_ENGINES)):
       # Dataflow binaries are built with dataflow sanitizer, but can be used as
       # an auxiliary build with libFuzzer builds (e.g. with ASan or UBSan).


### PR DESCRIPTION
This CL adds support for `dataflow` fuzzing engine in OSS-Fuzz setup handler. If `dataflow` engine is specified for a project, the handler will add `DATAFLOW_BUILD_BUCKET_PATH` env variable to libFuzzer jobs.