### PR TITLE
Print exceptions in run_one_test_parallel.

### DIFF
--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -135,17 +135,20 @@ def run_one_test_parallel(args):
     test_modules, suppress_output = args
     suite = unittest.loader.TestLoader().loadTestsFromNames(test_modules)
 
-    stream = io.BytesIO()
+    # We use BufferedWriter as a hack to accept both unicode and str write
+    # arguments.
+    stream = io.BufferedWriter(io.BytesIO())
 
     # Verbosity=0 since we cannot see real-time test execution order when tests
     # are executed in parallel.
     result = unittest.TextTestRunner(
         stream=stream, verbosity=0, buffer=suppress_output).run(suite)
 
-    return TestResult(stream.getvalue(),
+    stream.flush()
+    return TestResult(stream.raw.getvalue(),
                       len(result.errors), len(result.failures),
                       len(result.skipped), result.testsRun)
-  except:
+  except BaseException:
     # Print exception traceback here, as it will be lost otherwise.
     traceback.print_exc()
     raise

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -145,9 +145,9 @@ def run_one_test_parallel(args):
         stream=stream, verbosity=0, buffer=suppress_output).run(suite)
 
     stream.flush()
-    return TestResult(stream.raw.getvalue(),
-                      len(result.errors), len(result.failures),
-                      len(result.skipped), result.testsRun)
+    return TestResult(stream.raw.getvalue(), len(result.errors),
+                      len(result.failures), len(result.skipped),
+                      result.testsRun)
   except BaseException:
     # Print exception traceback here, as it will be lost otherwise.
     traceback.print_exc()


### PR DESCRIPTION
Usually, an exception happens in a unit test, which is surfaced
properly. However, if we hit an exception in the underlying test runner
code, we get an exception without a stacktrace. This catches and prints
the stack before it is lost.