### PR TITLE
Fix upload exception.

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -507,6 +507,7 @@ class UploadHandlerCommon(object):
         bug_summary_update_flag,
         additional_metadata=testcase_metadata)
 
+    testcase = data_handler.get_testcase_by_id(testcase_id)
     issue = issue_tracker_utils.get_issue_for_testcase(testcase)
     if issue:
       report_url = data_handler.TESTCASE_REPORT_URL.format(


### PR DESCRIPTION
Fixes
```
UnboundLocalError: local variable 'testcase' referenced before assignment
at do_post (/base/data/home/apps/s~cluster-fuzz/20190619t080320.419009338764634083/handlers/upload_testcase.py:510)
at post (/base/data/home/apps/s~cluster-fuzz/20190619t080320.419009338764634083/handlers/upload_testcase.py:536)
at wrapper (/base/data/home/apps/s~cluster-fuzz/20190619t080320.419009338764634083/libs/handler.py:421)
at wrapper (/base/data/home/apps/s~cluster-fuzz/20190619t080320.419009338764634083/libs/handler.py:366)
at dispatch (/base/alloc/tmpfs/dynamic_runtimes/python27g/6a5167f0cae8960d/python27/python27_lib/versions/third_party/webapp2-2.3/webapp2.py:545)
```