### PR TITLE
Fix exception in issue_filer

### DIFF
--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -189,8 +189,8 @@ def update_issue_impact_labels(testcase, issue):
 def apply_substitutions(label, testcase, security_severity=None):
   """Apply label substitutions."""
   if label is None:
-    # If the label is not configured, then skip subsitutions.
-    return [None]
+    # If the label is not configured, then nothing to subsitute.
+    return []
 
   label_substitutions = (
       ('%PLATFORM%', platform_substitution),

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -187,7 +187,11 @@ def update_issue_impact_labels(testcase, issue):
 
 
 def apply_substitutions(label, testcase, security_severity=None):
-  """Apply label substituions."""
+  """Apply label substitutions."""
+  if label is None:
+    # If the label is not configured, then skip subsitutions.
+    return [None]
+
   label_substitutions = (
       ('%PLATFORM%', platform_substitution),
       ('%YYYY-MM-DD%', date_substitution),


### PR DESCRIPTION
This fixes exception on triage cron on internal instance.

```
argument of type 'NoneType' is not iterable (/base/data/home/apps/s~cluster-fuzz/cron-service:20190619t080320.419009350000290661/handlers/base_handler.py:211)
Traceback (most recent call last):
  File "/base/alloc/tmpfs/dynamic_runtimes/python27g/500e2bb923862643/python27/python27_lib/versions/third_party/webapp2-2.3/webapp2.py", line 545, in dispatch
    return method(*args, **kwargs)
  File "/base/data/home/apps/s~cluster-fuzz/cron-service:20190619t080320.419009350000290661/libs/handler.py", line 95, in wrapper
    return func(self)
  File "/base/data/home/apps/s~cluster-fuzz/cron-service:20190619t080320.419009350000290661/handlers/cron/triage.py", line 289, in get
    issue_filer.file_issue(testcase, issue_tracker)
  File "/base/data/home/apps/s~cluster-fuzz/cron-service:20190619t080320.419009350000290661/libs/issue_management/issue_filer.py", line 322, in file_issue
    for result in apply_substitutions(label, testcase, security_severity):
  File "/base/data/home/apps/s~cluster-fuzz/cron-service:20190619t080320.419009350000290661/libs/issue_management/issue_filer.py", line 199, in apply_substitutions
    if marker in label:
TypeError: argument of type 'NoneType' is not iterable
```