### PR TITLE
Add appengine.libs.request_cache.

### DIFF
--- a/src/appengine/handlers/cron/grouper.py
+++ b/src/appengine/handlers/cron/grouper.py
@@ -130,7 +130,7 @@ def group_testcases():
             cached_issue_map[project_name][issue_id])
       else:
         issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(
-            testcase, use_cache=True)
+            testcase)
         if not issue_tracker:
           continue
 

--- a/src/appengine/handlers/cron/oss_fuzz_apply_ccs.py
+++ b/src/appengine/handlers/cron/oss_fuzz_apply_ccs.py
@@ -51,7 +51,7 @@ class Handler(base_handler.Handler):
 
     for testcase in get_open_testcases_with_bugs():
       issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(
-          testcase, use_cache=True)
+          testcase)
       if not issue_tracker:
         logging.error('Failed to get issue tracker manager for %s',
                       testcase.key.id())

--- a/src/appengine/handlers/cron/triage.py
+++ b/src/appengine/handlers/cron/triage.py
@@ -276,7 +276,7 @@ class Handler(base_handler.Handler):
       # If this project does not have an associated issue tracker, we cannot
       # file this crash anywhere.
       issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(
-          testcase, use_cache=True)
+          testcase)
       if not issue_tracker:
         continue
 

--- a/src/appengine/libs/issue_management/monorail/__init__.py
+++ b/src/appengine/libs/issue_management/monorail/__init__.py
@@ -24,8 +24,6 @@ from libs.issue_management.monorail.issue import Issue as MonorailIssue
 from libs.issue_management.monorail.issue_tracker_manager import (
     IssueTrackerManager)
 
-# TODO(ochang): Clean up how we cache issue_tracker_managers.
-ISSUE_TRACKER_MANAGERS = {}
 ISSUE_TRACKER_URL = (
     'https://bugs.chromium.org/p/{project}/issues/detail?id={id}')
 ISSUE_TRACKER_SEARCH_URL = (
@@ -293,18 +291,13 @@ def _to_change_list(monorail_list):
   return change_list
 
 
-def _get_issue_tracker_manager_for_project(project_name, use_cache=False):
+def _get_issue_tracker_manager_for_project(project_name):
   """Return monorail issue tracker manager for the given project."""
   # If there is no issue tracker set, bail out.
   if not project_name or project_name == 'disabled':
     return None
 
-  if use_cache and project_name in ISSUE_TRACKER_MANAGERS:
-    return ISSUE_TRACKER_MANAGERS[project_name]
-
-  issue_tracker_manager = IssueTrackerManager(project_name=project_name)
-  ISSUE_TRACKER_MANAGERS[project_name] = issue_tracker_manager
-  return issue_tracker_manager
+  return IssueTrackerManager(project_name=project_name)
 
 
 def _get_search_text(keywords):
@@ -316,10 +309,9 @@ def _get_search_text(keywords):
   return search_text
 
 
-def get_issue_tracker(project_name, use_cache=False):
+def get_issue_tracker(project_name):
   """Get the issue tracker for the project name."""
-  itm = _get_issue_tracker_manager_for_project(
-      project_name, use_cache=use_cache)
+  itm = _get_issue_tracker_manager_for_project(project_name)
   if itm is None:
     return None
 

--- a/src/appengine/libs/request_cache.py
+++ b/src/appengine/libs/request_cache.py
@@ -1,0 +1,58 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Request specific caching.."""
+
+import collections
+
+import webapp2
+
+from base import memoize
+from metrics import logs
+
+
+class _FifoRequestCache(memoize.FifoInMemory):
+  """In memory caching engine scoped to a request."""
+
+  def __init__(self, cache_key, capacity):
+    super(_FifoRequestCache, self).__init__(capacity)
+    self._cache_key = str(cache_key)
+
+  @property
+  def cache(self):
+    """Get the cache backing."""
+    request = webapp2.get_request()
+    if not request:
+      # Not a request (e.g. in a unit test). Should not happen in production.
+      logs.log_error('No request found for cache.')
+      return None
+
+    key = '__cache:' + self._cache_key
+
+    backing = getattr(request, key, None)
+    if backing is None:
+      backing = collections.OrderedDict()
+      setattr(request, key, backing)
+
+    return backing
+
+
+def wrap(capacity):
+  """Wraps a function to use the per request cache."""
+
+  def decorator(func):
+    """Decorator function."""
+    engine = _FifoRequestCache(id(func), capacity)
+    return memoize.wrap(engine)(func)
+
+  return decorator

--- a/src/python/base/memoize.py
+++ b/src/python/base/memoize.py
@@ -39,11 +39,22 @@ class FifoInMemory(object):
 
   def __init__(self, capacity):
     self.capacity = capacity
-    self.cache = collections.OrderedDict()
     self.lock = threading.Lock()
+    self._cache = None
+
+  @property
+  def cache(self):
+    """Get the cache backing. None may be returned."""
+    if self._cache is None:
+      self._cache = collections.OrderedDict()
+
+    return self._cache
 
   def put(self, key, value):
     """Put (key, value) into cache."""
+    if self.cache is None:
+      return
+
     # Lock to avoid race condition in popitem.
     self.lock.acquire()
 
@@ -56,6 +67,9 @@ class FifoInMemory(object):
 
   def get(self, key):
     """Get the value from cache."""
+    if self.cache is None:
+      return None
+
     return self.cache.get(key)
 
   def get_key(self, func, args, kwargs):

--- a/src/python/tests/appengine/libs/request_cache_test.py
+++ b/src/python/tests/appengine/libs/request_cache_test.py
@@ -1,0 +1,106 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""request_cache tests."""
+
+from builtins import object
+import unittest
+
+from libs import request_cache
+from tests.test_libs import helpers as test_helpers
+
+
+class CacheClass(object):
+  """Test cache class."""
+
+  def __init__(self):
+    self.called = []
+
+  @request_cache.wrap(3)
+  def foo(self, a):
+    self.called.append((a,))
+    return a + 1
+
+
+class CacheClass2(object):
+  """Test cache class."""
+
+  def __init__(self):
+    self.called = []
+
+  @request_cache.wrap(3)
+  def foo(self, a):
+    self.called.append((a,))
+    return a + 2
+
+
+class CacheTest(unittest.TestCase):
+  """Cache tests."""
+
+  def setUp(self):
+    test_helpers.patch(self, [
+        'webapp2.get_request',
+    ])
+
+    self.mock.get_request.return_value = object()
+
+  def test_basic(self):
+    """Basic tests."""
+    c = CacheClass()
+    self.assertEqual(2, c.foo(1))
+    self.assertEqual(2, c.foo(1))
+    self.assertEqual(3, c.foo(2))
+
+    self.assertListEqual([
+        (1,),
+        (2,),
+    ], c.called)
+
+  def test_no_request(self):
+    """Test no request available."""
+    self.mock.get_request.return_value = None
+    c = CacheClass()
+    self.assertEqual(2, c.foo(1))
+    self.assertEqual(2, c.foo(1))
+
+    self.assertListEqual([
+        (1,),
+        (1,),
+    ], c.called)
+
+  def test_name_clash(self):
+    """Test name clash."""
+    c1 = CacheClass()
+    c2 = CacheClass2()
+    self.assertEqual(2, c1.foo(1))
+    self.assertEqual(3, c2.foo(1))
+
+    self.assertListEqual([
+        (1,),
+    ], c1.called)
+
+    self.assertListEqual([
+        (1,),
+    ], c2.called)
+
+  def test_scoped_to_request(self):
+    """Test that the cache is scoped to requests."""
+    c = CacheClass()
+    self.assertEqual(2, c.foo(1))
+    self.mock.get_request.return_value = object()
+    self.assertEqual(2, c.foo(1))
+
+    self.assertListEqual([
+        (1,),
+        (1,),
+    ], c.called)

--- a/src/python/tests/appengine/libs/request_cache_test.py
+++ b/src/python/tests/appengine/libs/request_cache_test.py
@@ -72,10 +72,12 @@ class CacheTest(unittest.TestCase):
     c = CacheClass()
     self.assertEqual(2, c.foo(1))
     self.assertEqual(2, c.foo(1))
+    self.assertEqual(3, c.foo(2))
 
     self.assertListEqual([
         (1,),
         (1,),
+        (2,),
     ], c.called)
 
   def test_name_clash(self):


### PR DESCRIPTION
This is a cache that's scoped to a request. Use this to replace the
issue tracker cache.