### PR TITLE
Call an init function from config modules.

### DIFF
--- a/src/appengine/appengine_config.py
+++ b/src/appengine/appengine_config.py
@@ -48,6 +48,13 @@ else:
   if os.path.exists(config_modules_path):
     sys.path.insert(0, config_modules_path)
 
+try:
+  # Run any module initialization code.
+  import module_init
+  module_init.appengine()
+except ImportError:
+  pass
+
 # Adding the protobuf module to the google module. Otherwise, we couldn't
 # import google.protobuf because google.appengine already took the name.
 import google

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -29,6 +29,9 @@ _ISSUE_TRACKER_CONSTRUCTORS = {
 
 def register_issue_tracker(tracker_type, constructor):
   """Register an issue tracker implementation."""
+  if tracker_type in _ISSUE_TRACKER_CONSTRUCTORS:
+    raise ValueError(
+        'Tracker type {type} is already registered.'.format(type=tracker_type))
   _ISSUE_TRACKER_CONSTRUCTORS[tracker_type] = constructor
 
 
@@ -53,7 +56,7 @@ def get_issue_tracker(project_name=None):
 
   constructor = _ISSUE_TRACKER_CONSTRUCTORS.get(issue_project_config['type'])
   if not constructor:
-    raise ValueError('Invalid issue tracker type ' +
+    raise ValueError('Invalid issue tracker type: ' +
                      issue_project_config['type'])
 
   return constructor(project_name)


### PR DESCRIPTION
Modules can define a "module_init" module containing a "appengine"
function which is called on App Engine startup.

Also expose a way to register issue tracker implementations.