### PR TITLE
Use common get_original_issue implementation for all issue trackers (#504).

### DIFF
--- a/src/appengine/libs/issue_management/monorail/__init__.py
+++ b/src/appengine/libs/issue_management/monorail/__init__.py
@@ -75,11 +75,11 @@ class Issue(issue_tracker.Issue):
   @property
   def merged_into(self):
     """The issue that this is merged into."""
-    return self._monorail_issue.merged_into
+    if self._monorail_issue.merged_into_project != self.issue_tracker.project:
+      # Don't consider duplicates in a different issue project.
+      return None
 
-  @merged_into.setter
-  def merged_into(self, new_merged_into):
-    self._monorail_issue.merged_into = new_merged_into
+    return self._monorail_issue.merged_into
 
   @property
   def is_open(self):
@@ -233,10 +233,6 @@ class IssueTracker(issue_tracker.IssueTracker):
       return None
 
     return Issue(monorail_issue)
-
-  def get_original_issue(self, issue_id):
-    """Retrieve the original issue object traversing the list of duplicates."""
-    return Issue(self._itm.get_original_issue(int(issue_id)))
 
   def find_issues(self, keywords=None, only_open=False):
     """Find issues."""

--- a/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
+++ b/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
@@ -48,9 +48,11 @@ class IssueTrackerManager(object):
     self.issues = {}
     self.next_id = 1
 
-  def get_original_issue(self, issue_id):
+  def get_issue(self, issue_id):
     """Get original issue."""
-    return self.issues[issue_id]
+    issue = self.issues[issue_id]
+    issue.itm = self
+    return issue
 
   def save(self, issue, *args, **kwargs):  # pylint: disable=unused-argument
     """Save an issue."""

--- a/src/python/tests/appengine/libs/issue_management/monorail/monorail_test.py
+++ b/src/python/tests/appengine/libs/issue_management/monorail/monorail_test.py
@@ -92,9 +92,15 @@ class MonorailTests(unittest.TestCase):
     mock_issue_merged.merged_into_project = 'project'
     mock_issue_merged.closed = datetime.datetime(2019, 1, 1)
 
+    mock_issue_merged_another_project = MonorailIssue()
+    mock_issue_merged_another_project.id = 1339
+    mock_issue_merged_another_project.merged_into = 1
+    mock_issue_merged_another_project.merged_into_project = 'different-project'
+
     mock_issues = {
         1337: mock_issue,
         1338: mock_issue_merged,
+        1339: mock_issue_merged_another_project,
     }
 
     self.itm = IssueTrackerManager('project', mock_issues)
@@ -267,3 +273,8 @@ class MonorailTests(unittest.TestCase):
     issue_url = self.issue_tracker.issue_url(1337)
     self.assertEqual(
         'https://bugs.chromium.org/p/project/issues/detail?id=1337', issue_url)
+
+  def test_merged_into_different_project(self):
+    """Test merged_into for a different issue tracker project."""
+    issue = self.issue_tracker.get_issue(1339)
+    self.assertIsNone(issue.merged_into)


### PR DESCRIPTION
Also, remove the merged_into setter, since it's not used by anything.