### PR TITLE
Disable Radamsa + ML RNN for LPM targets

### DIFF
--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -157,8 +157,8 @@ def get_merge_timeout(default_merge_timeout):
 def is_lpm_fuzz_target(fuzzer_path):
   """Returns True if |fuzzer_path| is a libprotobuf-mutator based fuzz
   target."""
-  with open(fuzzer_path) as fuzzer_handle:
-    return utils.search_string_in_file('TestOneProtoInput', fuzzer_handle)
+  with open(fuzzer_path) as file_handle:
+    return utils.search_string_in_file('TestOneProtoInput', file_handle)
 
 
 def get_issue_owners(fuzz_target_path):

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -152,7 +152,11 @@ def get_merge_timeout(default_merge_timeout):
   """Get the maximum amount of time that should be spent merging a corpus."""
   return get_overridable_timeout(default_merge_timeout,
                                  'MERGE_TIMEOUT_OVERRIDE')
-
+def is_lpm_fuzz_target(fuzzer_path):
+  """Returns True if |fuzzer_path| is a libprotobuf-mutator based fuzz
+  target."""
+  with open(fuzzer_path) as fuzzer_handle:
+    return utils.search_string_in_file('TestOneProtoInput', fuzzer_handle)
 
 def get_issue_owners(fuzz_target_path):
   """Return list of owner emails given a fuzz target path.

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -157,6 +157,7 @@ def get_merge_timeout(default_merge_timeout):
 def is_lpm_fuzz_target(fuzzer_path):
   """Returns True if |fuzzer_path| is a libprotobuf-mutator based fuzz
   target."""
+  # TODO(metzman): Use this function to disable running LPM targets with AFL.
   with open(fuzzer_path) as file_handle:
     return utils.search_string_in_file('TestOneProtoInput', file_handle)
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -152,11 +152,14 @@ def get_merge_timeout(default_merge_timeout):
   """Get the maximum amount of time that should be spent merging a corpus."""
   return get_overridable_timeout(default_merge_timeout,
                                  'MERGE_TIMEOUT_OVERRIDE')
+
+
 def is_lpm_fuzz_target(fuzzer_path):
   """Returns True if |fuzzer_path| is a libprotobuf-mutator based fuzz
   target."""
   with open(fuzzer_path) as fuzzer_handle:
     return utils.search_string_in_file('TestOneProtoInput', fuzzer_handle)
+
 
 def get_issue_owners(fuzz_target_path):
   """Return list of owner emails given a fuzz target path.

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -99,12 +99,13 @@ class Generator(object):
   ML_RNN = 2
 
 
-def _select_generator(strategy_pool):
+def _select_generator(strategy_pool, fuzzer_path):
   """Pick a generator to generate new testcases before fuzzing or return
   Generator.NONE if no generator selected."""
   # We can't use radamsa binary on Windows. Disable ML for now until we know it
-  # works.
-  if IS_WIN:
+  # works on Win.
+  # These generators don't produce testcases that LPM fuzzers can use.
+  if IS_WIN or engine_common.is_lpm_fuzz_target(fuzzer_path):
     return Generator.NONE
   elif strategy_pool.do_strategy(strategy.CORPUS_MUTATION_ML_RNN_STRATEGY):
     return Generator.ML_RNN
@@ -777,7 +778,7 @@ def main(argv):
   fuzzing_strategies = []
 
   # Select a generator to use for existing testcase mutations.
-  generator = _select_generator(strategy_pool)
+  generator = _select_generator(strategy_pool, fuzzer_path)
   is_mutations_run = generator != Generator.NONE
 
   # Timeout for fuzzer run.

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -2168,5 +2168,20 @@ class MoveMergeableUnitsTest(fake_fs_unittest.TestCase):
         os.path.exists(os.path.join(self.CORPUS_DIRECTORY, filename)))
 
 
+class SelectGeneratorTest(unittest.TestCase):
+  FUZZER_PATH = '/fake/fuzzer_path'
+
+  def setUp(self):
+    self.pool = strategy_selection.generate_strategy_pool()
+    test_helpers.patch(self, ['bot.fuzzers.engine_common.is_lpm_fuzzer',
+                              'bot.fuzzers.libFuzzer.StrategyPool.do_strategy'])
+    self.mock.do_strategy.return_value = True
+    self.mock.is_lpm_fuzz_target.return_value = True
+
+  def test_lpm_fuzz_target(self):
+    self.assertEqual(launcher.Generator.NONE,
+                     launcher._select_generator(self.pool, self.FUZZER_PATH))
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -2176,8 +2176,8 @@ class SelectGeneratorTest(unittest.TestCase):
   def setUp(self):
     self.pool = strategy_selection.generate_strategy_pool()
     test_helpers.patch(self, [
-        'bot.fuzzers.engine_common.is_lpm_fuzzer',
-        'bot.fuzzers.libFuzzer.StrategyPool.do_strategy'
+        'bot.fuzzers.engine_common.is_lpm_fuzz_target',
+        'bot.fuzzers.libFuzzer.strategy_selection.StrategyPool.do_strategy'
     ])
     self.mock.do_strategy.return_value = True
     self.mock.is_lpm_fuzz_target.return_value = True

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -2169,6 +2169,8 @@ class MoveMergeableUnitsTest(fake_fs_unittest.TestCase):
 
 
 class SelectGeneratorTest(unittest.TestCase):
+  """Tests for _select_generator."""
+
   FUZZER_PATH = '/fake/fuzzer_path'
 
   def setUp(self):
@@ -2182,7 +2184,7 @@ class SelectGeneratorTest(unittest.TestCase):
 
   def test_lpm_fuzz_target(self):
     self.assertEqual(launcher.Generator.NONE,
-                     launcher._select_generator(self.pool, self.FUZZER_PATH))
+                     launcher._select_generator(self.pool, self.FUZZER_PATH))  # pylint: disable=protected-access
 
 
 if __name__ == '__main__':

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -2173,8 +2173,10 @@ class SelectGeneratorTest(unittest.TestCase):
 
   def setUp(self):
     self.pool = strategy_selection.generate_strategy_pool()
-    test_helpers.patch(self, ['bot.fuzzers.engine_common.is_lpm_fuzzer',
-                              'bot.fuzzers.libFuzzer.StrategyPool.do_strategy'])
+    test_helpers.patch(self, [
+        'bot.fuzzers.engine_common.is_lpm_fuzzer',
+        'bot.fuzzers.libFuzzer.StrategyPool.do_strategy'
+    ])
     self.mock.do_strategy.return_value = True
     self.mock.is_lpm_fuzz_target.return_value = True
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -2170,7 +2170,6 @@ class MoveMergeableUnitsTest(fake_fs_unittest.TestCase):
 
 class SelectGeneratorTest(unittest.TestCase):
   """Tests for _select_generator."""
-
   FUZZER_PATH = '/fake/fuzzer_path'
 
   def setUp(self):


### PR DESCRIPTION
Radamsa and ML RNN mutate testcases in a corpus.
More often than not, this makes items in the corpus invalid protos.
Since LF/LPM isn't smart enough not to merge these back into the corpus (I think because they reveal new coverage in the parser), the corpus gets (permanently?) gunked up with tescases that LPM can't mutate as a result. This takes time away from real testcases.