### PR TITLE
Fix exception with filing an issue with empty crash type and state.

### DIFF
--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -254,12 +254,11 @@ def get_issue_summary(testcase):
   else:
     issue_summary += 'Unknown error'
 
-  crash_state_lines = testcase.crash_state.splitlines()
-  if testcase.crash_state == 'NULL' or not crash_state_lines:
+  if testcase.crash_state == 'NULL' or not testcase.crash_state:
     # Special case for empty stacktrace.
     issue_summary += ' with empty stacktrace'
   else:
-    issue_summary += ' in ' + crash_state_lines[0]
+    issue_summary += ' in ' + testcase.crash_state.splitlines()[0]
 
   return issue_summary
 

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -251,12 +251,15 @@ def get_issue_summary(testcase):
     filtered_crash_type = re.sub(r'UNKNOWN( READ| WRITE)?', 'Crash',
                                  testcase.crash_type.splitlines()[0])
     issue_summary += filtered_crash_type
+  else:
+    issue_summary += 'Unknown error'
 
-  if testcase.crash_state == 'NULL':
+  crash_state_lines = testcase.crash_state.splitlines()
+  if testcase.crash_state == 'NULL' or not crash_state_lines:
     # Special case for empty stacktrace.
     issue_summary += ' with empty stacktrace'
   else:
-    issue_summary += ' in ' + testcase.crash_state.splitlines()[0]
+    issue_summary += ' in ' + crash_state_lines[0]
 
   return issue_summary
 

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -111,6 +111,13 @@ class DataHandlerTest(unittest.TestCase):
         crash_address='0x1337',
         crash_state='NULL')
 
+    self.testcase_empty = data_types.Testcase(
+        job_type='linux_asan_chrome',
+        fuzzer_name='libfuzzer_binary_name',
+        crash_type='',
+        crash_address='',
+        crash_state='')
+
     self.testcase_bad_cast = data_types.Testcase(
         job_type='linux_asan_chrome',
         fuzzer_name='libfuzzer_binary_name',
@@ -145,9 +152,10 @@ class DataHandlerTest(unittest.TestCase):
 
     entities_to_put = [
         self.testcase, self.testcase_assert, self.testcase_null,
-        self.testcase_bad_cast, self.testcase_bad_cast_without_crash_function,
-        self.job, self.job2, self.local_data_bundle, self.cloud_data_bundle,
-        self.fuzzer1, self.fuzzer2, self.fuzzer3
+        self.testcase_empty, self.testcase_bad_cast,
+        self.testcase_bad_cast_without_crash_function, self.job, self.job2,
+        self.local_data_bundle, self.cloud_data_bundle, self.fuzzer1,
+        self.fuzzer2, self.fuzzer3
     ]
     for entity in entities_to_put:
       entity.put()
@@ -340,6 +348,11 @@ class DataHandlerTest(unittest.TestCase):
     """Test get_issue_summary for null crash state."""
     summary = data_handler.get_issue_summary(self.testcase_null)
     self.assertEqual(summary, 'project: Crash with empty stacktrace')
+
+  def test_get_issue_summary_empty(self):
+    """Test get_issue_summary for empty crash state and empty crash type."""
+    summary = data_handler.get_issue_summary(self.testcase_empty)
+    self.assertEqual(summary, 'project: Unknown error with empty stacktrace')
 
   def test_get_issue_summary_bad_cast(self):
     """Test get_issue_summary for bad cast."""


### PR DESCRIPTION
We can get an empty crash state when the crash type is empty.