### PR TITLE
Disable weighted strategy selection to resume fuzzing on OSS-Fuzz.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -778,7 +778,7 @@ def main(argv):
   # fuzzing strategies is the list of strategies that are enabled. (e.g. if
   # mutator is selected in the pool, but not available for a given target, it
   # would not be added to fuzzing strategies.)
-  strategy_pool = strategy_selection.generate_weighted_strategy_pool()
+  strategy_pool = strategy_selection.generate_default_strategy_pool()
   fuzzing_strategies = []
 
   # Select a generator to use for existing testcase mutations.

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -778,7 +778,7 @@ def main(argv):
   # fuzzing strategies is the list of strategies that are enabled. (e.g. if
   # mutator is selected in the pool, but not available for a given target, it
   # would not be added to fuzzing strategies.)
-  strategy_pool = strategy_selection.generate_default_strategy_pool()
+  strategy_pool = strategy_selection.generate_weighted_strategy_pool()
   fuzzing_strategies = []
 
   # Select a generator to use for existing testcase mutations.

--- a/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
+++ b/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
@@ -100,13 +100,15 @@ def generate_default_strategy_pool():
 def generate_weighted_strategy_pool():
   """Generate a strategy pool based on probability
   distribution from multi armed bandit experimentation."""
+  if not environment.get_value('USE_BANDIT_STRATEGY_SELECTION'):
+    return generate_default_strategy_pool()
+
   query = data_types.FuzzStrategyProbability.query()
   distribution = list(ndb_utils.get_all_from_query(query))
 
   # If we are not able to query properly, draw randomly according to
   # probability parameters.
-  if (not distribution or
-      not environment.get_value('USE_BANDIT_STRATEGY_SELECTION')):
+  if not distribution:
     return generate_default_strategy_pool()
 
   strategy_selection = utils.random_weighted_choice(distribution, 'probability')

--- a/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
+++ b/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
@@ -84,9 +84,12 @@ def generate_default_strategy_pool():
     pool.add_strategy(strategy.CORPUS_SUBSET_STRATEGY)
 
   for value in [
+      strategy.DATAFLOW_TRACING_STRATEGY,
+      strategy.FORK_STRATEGY,
+      strategy.MUTATOR_PLUGIN_STRATEGY,
+      strategy.RECOMMENDED_DICTIONARY_STRATEGY,
       strategy.RANDOM_MAX_LENGTH_STRATEGY,
-      strategy.RECOMMENDED_DICTIONARY_STRATEGY, strategy.VALUE_PROFILE_STRATEGY,
-      strategy.FORK_STRATEGY, strategy.MUTATOR_PLUGIN_STRATEGY
+      strategy.VALUE_PROFILE_STRATEGY,
   ]:
     if do_strategy(value):
       pool.add_strategy(value)

--- a/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
+++ b/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
@@ -87,8 +87,8 @@ def generate_default_strategy_pool():
       strategy.DATAFLOW_TRACING_STRATEGY,
       strategy.FORK_STRATEGY,
       strategy.MUTATOR_PLUGIN_STRATEGY,
-      strategy.RECOMMENDED_DICTIONARY_STRATEGY,
       strategy.RANDOM_MAX_LENGTH_STRATEGY,
+      strategy.RECOMMENDED_DICTIONARY_STRATEGY,
       strategy.VALUE_PROFILE_STRATEGY,
   ]:
     if do_strategy(value):


### PR DESCRIPTION
@mbarbella-chromium @mukundv-chrome I'll TBR this as soon as I can, because fuzzing on OSS-Fuzz with libFuzzer is completely broken right now:

```

Traceback (most recent call last):
  File "/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/libFuzzer/launcher.py", line 1044, in <module>
    main(sys.argv)
  File "/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/libFuzzer/launcher.py", line 781, in main
    strategy_pool = strategy_selection.generate_weighted_strategy_pool()
  File "/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/libFuzzer/strategy_selection.py", line 101, in generate_weighted_strategy_pool
    distribution = list(ndb_utils.get_all_from_query(query))
  File "/mnt/scratch0/clusterfuzz/src/python/datastore/ndb_utils.py", line 42, in get_all_from_query
    for result in query.iter(**kwargs):
  File "/mnt/scratch0/clusterfuzz/src/python/datastore/ndb_patcher.py", line 109, in next
    entity = next(self._iterator)
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/page_iterator.py", line 204, in _items_iter
    for page in self._page_iter(increment=False):
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/page_iterator.py", line 235, in _page_iter
    page = self._next_page()
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/cloud/datastore/query.py", line 517, in _next_page
    query=query_pb,
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/cloud/datastore_v1/gapic/datastore_client.py", line 294, in run_query
    request, retry=retry, timeout=timeout, metadata=metadata)
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/gapic_v1/method.py", line 143, in __call__
    return wrapped_func(*args, **kwargs)
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/retry.py", line 273, in retry_wrapped_func
    on_error=on_error,
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/retry.py", line 182, in retry_target
    return target()
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/timeout.py", line 214, in func_with_timeout
    return func(*args, **kwargs)
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/grpc_helpers.py", line 59, in error_remapped_callable
    six.raise_from(exceptions.from_grpc_error(exc), exc)
  File "/mnt/scratch0/clusterfuzz/src/third_party/six.py", line 737, in raise_from
    raise value
google.api_core.exceptions.PermissionDenied: 403 Missing or insufficient permissions.
```