### PR TITLE
Minor refactoring and cleanup in the build_manager.

### DIFF
--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -1131,7 +1131,8 @@ def get_revisions_list(bucket_path, testcase=None):
   return revision_list
 
 
-def setup_trunk_build(bucket_paths_env_vars, build_prefix=None):
+def setup_trunk_build(bucket_paths_env_vars=DEFAULT_BUILD_BUCKET_PATH_ENV_VARS,
+                      build_prefix=None):
   """Sets up latest trunk build."""
   if not bucket_paths_env_vars:
     return None
@@ -1378,7 +1379,7 @@ def setup_build(revision=0):
 
   # If no revision is provided, we default to a trunk build.
   if not revision:
-    return setup_trunk_build(DEFAULT_BUILD_BUCKET_PATH_ENV_VARS)
+    return setup_trunk_build()
 
   # Setup regular build with revision.
   return setup_regular_build(revision)

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -112,8 +112,7 @@ class TrunkBuildTest(unittest.TestCase):
         ],
     )
 
-    build_manager.setup_trunk_build(
-        build_manager.DEFAULT_BUILD_BUCKET_PATH_ENV_VARS)
+    build_manager.setup_trunk_build()
     self.mock.setup_regular_build.assert_called_with(
         10, 'gs://path/file-release-([0-9]+).zip', None)
 
@@ -137,8 +136,7 @@ class TrunkBuildTest(unittest.TestCase):
         ],
     )
 
-    build_manager.setup_trunk_build(
-        build_manager.DEFAULT_BUILD_BUCKET_PATH_ENV_VARS)
+    build_manager.setup_trunk_build()
     self.mock.setup_regular_build.assert_called_with(
         2, 'gs://path/file-release-([0-9]+).zip', None)
 
@@ -162,8 +160,7 @@ class TrunkBuildTest(unittest.TestCase):
         ],
     )
 
-    build_manager.setup_trunk_build(
-        build_manager.DEFAULT_BUILD_BUCKET_PATH_ENV_VARS)
+    build_manager.setup_trunk_build()
     self.assertEqual(0, self.mock.setup_regular_build.call_count)
 
 

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -112,7 +112,8 @@ class TrunkBuildTest(unittest.TestCase):
         ],
     )
 
-    build_manager.setup_trunk_build()
+    build_manager.setup_trunk_build(
+        build_manager.DEFAULT_BUILD_BUCKET_PATH_ENV_VARS)
     self.mock.setup_regular_build.assert_called_with(
         10, 'gs://path/file-release-([0-9]+).zip', None)
 
@@ -136,7 +137,8 @@ class TrunkBuildTest(unittest.TestCase):
         ],
     )
 
-    build_manager.setup_trunk_build()
+    build_manager.setup_trunk_build(
+        build_manager.DEFAULT_BUILD_BUCKET_PATH_ENV_VARS)
     self.mock.setup_regular_build.assert_called_with(
         2, 'gs://path/file-release-([0-9]+).zip', None)
 
@@ -160,7 +162,8 @@ class TrunkBuildTest(unittest.TestCase):
         ],
     )
 
-    build_manager.setup_trunk_build()
+    build_manager.setup_trunk_build(
+        build_manager.DEFAULT_BUILD_BUCKET_PATH_ENV_VARS)
     self.assertEqual(0, self.mock.setup_regular_build.call_count)
 
 
@@ -274,10 +277,8 @@ class RegularBuildTest(fake_filesystem_unittest.TestCase):
     self._assert_env_vars()
     self.assertEqual(os.environ['APP_REVISION'], '2')
 
-    # Non-existent revisions results in trunk build.
-    trunk_build = build_manager.setup_regular_build(3)
-    self.assertIsInstance(trunk_build, build_manager.RegularBuild)
-    self.assertEqual(trunk_build.revision, 10)
+    # Non-existent revisions do not result in any builds being set up.
+    self.assertIsNone(build_manager.setup_regular_build(3))
 
   def test_delete(self):
     """Test deleting this build."""


### PR DESCRIPTION
Somewhat risky set of changes, uploaded up for discussion:

* the ICU workaround doesn't seem to be ever executed for Chrome, therefore I assume we don't really need it and can just remove. Maybe I misunderstand?
* I don't think it's a good idea to fallback to `setup_trunk_build` if `setup_regular_build` with a particular revision fails. Again, I might be missing some context / use case here.
* If the point above is fine, then we can move the default build paths env variables out of  `setup_trunk_build`.

//cc @oliverchang @inferno-chromium this is not urgent at all, PTAL when you can next week