### PR TITLE
Fix broken issue link when a group bug is used + add tests.

### DIFF
--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -154,10 +154,17 @@ def get_similar_issues_url(issue_tracker, testcase, only_open=True):
 def get_issue_url(testcase):
   """Return issue url for a testcase."""
   issue_tracker = get_issue_tracker_for_testcase(testcase)
-  if not issue_tracker or not testcase.bug_information:
+  if not issue_tracker:
     return None
 
-  return issue_tracker.issue_url(testcase.bug_information)
+  issue_id = (
+      testcase.bug_information
+      if testcase.bug_information else testcase.group_bug_information)
+  if not issue_id:
+    return None
+
+  # Use str(issue_id) as |group_bug_information| is an integer.
+  return issue_tracker.issue_url(str(issue_id))
 
 
 def was_label_added(issue, label):

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -80,17 +80,28 @@ def get_issue_tracker_policy_for_testcase(testcase):
   return issue_tracker_policy.get(issue_tracker_project_name)
 
 
+def get_issue_id(testcase):
+  """Return id of the issue associated with the testcase."""
+  issue_id = testcase.bug_information
+  if issue_id:
+    return issue_id
+      
+  issue_id = testcase.group_bug_information
+  if issue_id:
+    # Use str(issue_id) as |group_bug_information| might be an integer.
+    return str(issue_id)
+
+  return None
+
+
 def get_issue_for_testcase(testcase):
   """Return issue object associated with testcase."""
-  if not testcase.bug_information:
-    return None
-
   issue_tracker = get_issue_tracker_for_testcase(testcase)
   if not issue_tracker:
     return None
 
   try:
-    issue_id = testcase.bug_information
+    issue_id = get_issue_id(testcase)
     issue = issue_tracker.get_original_issue(issue_id)
   except:
     logs.log_error(
@@ -157,14 +168,11 @@ def get_issue_url(testcase):
   if not issue_tracker:
     return None
 
-  issue_id = (
-      testcase.bug_information
-      if testcase.bug_information else testcase.group_bug_information)
+  issue_id = get_issue_id(testcase)
   if not issue_id:
     return None
 
-  # Use str(issue_id) as |group_bug_information| might be an integer.
-  return issue_tracker.issue_url(str(issue_id))
+  return issue_tracker.issue_url(issue_id)
 
 
 def was_label_added(issue, label):

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -154,7 +154,8 @@ def get_similar_issues_url(issue_tracker, testcase, only_open=True):
 
 
 def get_issue_url(testcase):
-  """Return issue url for a testcase."""
+  """Return issue url for a testcase. This is used when rendering a testcase,
+  details page, therefore it accounts for |group_bug_information| as well."""
   issue_tracker = get_issue_tracker_for_testcase(testcase)
   if not issue_tracker:
     return None

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -80,28 +80,17 @@ def get_issue_tracker_policy_for_testcase(testcase):
   return issue_tracker_policy.get(issue_tracker_project_name)
 
 
-def get_issue_id(testcase):
-  """Return id of the issue associated with the testcase."""
-  issue_id = testcase.bug_information
-  if issue_id:
-    return issue_id
-      
-  issue_id = testcase.group_bug_information
-  if issue_id:
-    # Use str(issue_id) as |group_bug_information| might be an integer.
-    return str(issue_id)
-
-  return None
-
-
 def get_issue_for_testcase(testcase):
   """Return issue object associated with testcase."""
+  if not testcase.bug_information:
+    return None
+
   issue_tracker = get_issue_tracker_for_testcase(testcase)
   if not issue_tracker:
     return None
 
   try:
-    issue_id = get_issue_id(testcase)
+    issue_id = testcase.bug_information
     issue = issue_tracker.get_original_issue(issue_id)
   except:
     logs.log_error(
@@ -168,11 +157,14 @@ def get_issue_url(testcase):
   if not issue_tracker:
     return None
 
-  issue_id = get_issue_id(testcase)
+  issue_id = (
+      testcase.bug_information
+      if testcase.bug_information else testcase.group_bug_information)
   if not issue_id:
     return None
 
-  return issue_tracker.issue_url(issue_id)
+  # Use str(issue_id) as |group_bug_information| might be an integer.
+  return issue_tracker.issue_url(str(issue_id))
 
 
 def was_label_added(issue, label):

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -163,7 +163,7 @@ def get_issue_url(testcase):
   if not issue_id:
     return None
 
-  # Use str(issue_id) as |group_bug_information| is an integer.
+  # Use str(issue_id) as |group_bug_information| might be an integer.
   return issue_tracker.issue_url(str(issue_id))
 
 

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -83,6 +83,8 @@ def get_issue_tracker_policy_for_testcase(testcase):
 def get_issue_for_testcase(testcase):
   """Return issue object associated with testcase."""
   if not testcase.bug_information:
+    # Do not check |testcase.group_bug_information| as we look for an issue
+    # associated with the testcase directly, not through a group of testcases.
     return None
 
   issue_tracker = get_issue_tracker_for_testcase(testcase)

--- a/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
+++ b/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
@@ -1,0 +1,67 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the issue_tracker_utils module."""
+
+import mock
+import unittest
+
+from datastore import data_types
+from libs.issue_management import issue_tracker
+from libs.issue_management import issue_tracker_policy
+from libs.issue_management import issue_tracker_utils
+from tests.test_libs import helpers as test_helpers
+from tests.test_libs import test_utils
+
+@test_utils.with_cloud_emulators('datastore')
+class IssueTrackerUtilsUrlTest(unittest.TestCase):
+  """Issue tracker utils tests for URL handling methods."""
+
+  def setUp(self):
+    test_helpers.patch(self, [
+        'libs.issue_management.issue_tracker_utils.get_issue_tracker_for_testcase',
+        'libs.issue_management.issue_tracker.IssueTracker.issue_url',
+    ])
+    
+
+  def test_get_issue_url(self):
+    """Basic test for a case when testcase is associated with a bug."""
+    testcase = data_types.Testcase()
+    testcase.bug_information = '1337'
+
+    test_issue_tracker = issue_tracker.IssueTracker()
+    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
+
+    url = issue_tracker_utils.get_issue_url(testcase)
+    self.mock.issue_url.assert_called_with(test_issue_tracker, '1337')
+
+  def test_get_issue_url_group_bug(self):
+    """Test for a case when testcase is associated with a group bug."""
+    testcase = data_types.Testcase()
+    testcase.group_bug_information = 31337
+
+    test_issue_tracker = issue_tracker.IssueTracker()
+    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
+
+    url = issue_tracker_utils.get_issue_url(testcase)
+    self.mock.issue_url.assert_called_with(test_issue_tracker, '31337')
+
+  def test_get_issue_url_no_bug(self):
+    """Test for a case when testcase has no bugs associated with it."""
+    testcase = data_types.Testcase()
+
+    test_issue_tracker = issue_tracker.IssueTracker()
+    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
+
+    url = issue_tracker_utils.get_issue_url(testcase)
+    self.assertEqual(0, self.mock.issue_url.call_count)

--- a/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
+++ b/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
@@ -16,25 +16,49 @@
 import unittest
 
 from datastore import data_types
+from libs.issue_management import issue_tracker
 from libs.issue_management import issue_tracker_utils
+from tests.test_libs import helpers as test_helpers
 
 
-class IssueTrackerUtilsTest(unittest.TestCase):
-  """Issue tracker utils tests."""
+class IssueTrackerUtilsUrlTest(unittest.TestCase):
+  """Issue tracker utils tests for URL handling methods."""
 
-  def test_get_issue_id(self):
+  def setUp(self):
+    test_helpers.patch(self, [
+        'libs.issue_management.issue_tracker_utils.'
+        'get_issue_tracker_for_testcase',
+        'libs.issue_management.issue_tracker.IssueTracker.issue_url',
+    ])
+
+  def test_get_issue_url(self):
     """Basic test for a case when testcase is associated with a bug."""
     testcase = data_types.Testcase()
     testcase.bug_information = '1337'
-    self.assertEqual('1337', issue_tracker_utils.get_issue_id(testcase))
 
-  def test_get_issue_id_group_bug(self):
+    test_issue_tracker = issue_tracker.IssueTracker()
+    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
+
+    issue_tracker_utils.get_issue_url(testcase)
+    self.mock.issue_url.assert_called_with(test_issue_tracker, '1337')
+
+  def test_get_issue_url_group_bug(self):
     """Test for a case when testcase is associated with a group bug."""
     testcase = data_types.Testcase()
     testcase.group_bug_information = 31337
-    self.assertEqual('31337', issue_tracker_utils.get_issue_id(testcase))
 
-  def test_get_issue_id_no_bug(self):
+    test_issue_tracker = issue_tracker.IssueTracker()
+    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
+
+    issue_tracker_utils.get_issue_url(testcase)
+    self.mock.issue_url.assert_called_with(test_issue_tracker, '31337')
+
+  def test_get_issue_url_no_bug(self):
     """Test for a case when testcase has no bugs associated with it."""
     testcase = data_types.Testcase()
-    self.assertIsNone(issue_tracker_utils.get_issue_id(testcase))
+
+    test_issue_tracker = issue_tracker.IssueTracker()
+    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
+
+    issue_tracker_utils.get_issue_url(testcase)
+    self.assertEqual(0, self.mock.issue_url.call_count)

--- a/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
+++ b/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
@@ -18,12 +18,9 @@ import unittest
 
 from datastore import data_types
 from libs.issue_management import issue_tracker
-from libs.issue_management import issue_tracker_policy
 from libs.issue_management import issue_tracker_utils
 from tests.test_libs import helpers as test_helpers
-from tests.test_libs import test_utils
 
-@test_utils.with_cloud_emulators('datastore')
 class IssueTrackerUtilsUrlTest(unittest.TestCase):
   """Issue tracker utils tests for URL handling methods."""
 

--- a/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
+++ b/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
@@ -16,49 +16,25 @@
 import unittest
 
 from datastore import data_types
-from libs.issue_management import issue_tracker
 from libs.issue_management import issue_tracker_utils
-from tests.test_libs import helpers as test_helpers
 
 
-class IssueTrackerUtilsUrlTest(unittest.TestCase):
-  """Issue tracker utils tests for URL handling methods."""
+class IssueTrackerUtilsTest(unittest.TestCase):
+  """Issue tracker utils tests."""
 
-  def setUp(self):
-    test_helpers.patch(self, [
-        'libs.issue_management.issue_tracker_utils.'
-        'get_issue_tracker_for_testcase',
-        'libs.issue_management.issue_tracker.IssueTracker.issue_url',
-    ])
-
-  def test_get_issue_url(self):
+  def test_get_issue_id(self):
     """Basic test for a case when testcase is associated with a bug."""
     testcase = data_types.Testcase()
     testcase.bug_information = '1337'
+    self.assertEqual('1337', issue_tracker_utils.get_issue_id(testcase))
 
-    test_issue_tracker = issue_tracker.IssueTracker()
-    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
-
-    issue_tracker_utils.get_issue_url(testcase)
-    self.mock.issue_url.assert_called_with(test_issue_tracker, '1337')
-
-  def test_get_issue_url_group_bug(self):
+  def test_get_issue_id_group_bug(self):
     """Test for a case when testcase is associated with a group bug."""
     testcase = data_types.Testcase()
     testcase.group_bug_information = 31337
+    self.assertEqual('31337', issue_tracker_utils.get_issue_id(testcase))
 
-    test_issue_tracker = issue_tracker.IssueTracker()
-    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
-
-    issue_tracker_utils.get_issue_url(testcase)
-    self.mock.issue_url.assert_called_with(test_issue_tracker, '31337')
-
-  def test_get_issue_url_no_bug(self):
+  def test_get_issue_id_no_bug(self):
     """Test for a case when testcase has no bugs associated with it."""
     testcase = data_types.Testcase()
-
-    test_issue_tracker = issue_tracker.IssueTracker()
-    self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
-
-    issue_tracker_utils.get_issue_url(testcase)
-    self.assertEqual(0, self.mock.issue_url.call_count)
+    self.assertIsNone(issue_tracker_utils.get_issue_id(testcase))

--- a/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
+++ b/src/python/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tests for the issue_tracker_utils module."""
 
-import mock
 import unittest
 
 from datastore import data_types
@@ -21,15 +20,16 @@ from libs.issue_management import issue_tracker
 from libs.issue_management import issue_tracker_utils
 from tests.test_libs import helpers as test_helpers
 
+
 class IssueTrackerUtilsUrlTest(unittest.TestCase):
   """Issue tracker utils tests for URL handling methods."""
 
   def setUp(self):
     test_helpers.patch(self, [
-        'libs.issue_management.issue_tracker_utils.get_issue_tracker_for_testcase',
+        'libs.issue_management.issue_tracker_utils.'
+        'get_issue_tracker_for_testcase',
         'libs.issue_management.issue_tracker.IssueTracker.issue_url',
     ])
-    
 
   def test_get_issue_url(self):
     """Basic test for a case when testcase is associated with a bug."""
@@ -39,7 +39,7 @@ class IssueTrackerUtilsUrlTest(unittest.TestCase):
     test_issue_tracker = issue_tracker.IssueTracker()
     self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
 
-    url = issue_tracker_utils.get_issue_url(testcase)
+    issue_tracker_utils.get_issue_url(testcase)
     self.mock.issue_url.assert_called_with(test_issue_tracker, '1337')
 
   def test_get_issue_url_group_bug(self):
@@ -50,7 +50,7 @@ class IssueTrackerUtilsUrlTest(unittest.TestCase):
     test_issue_tracker = issue_tracker.IssueTracker()
     self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
 
-    url = issue_tracker_utils.get_issue_url(testcase)
+    issue_tracker_utils.get_issue_url(testcase)
     self.mock.issue_url.assert_called_with(test_issue_tracker, '31337')
 
   def test_get_issue_url_no_bug(self):
@@ -60,5 +60,5 @@ class IssueTrackerUtilsUrlTest(unittest.TestCase):
     test_issue_tracker = issue_tracker.IssueTracker()
     self.mock.get_issue_tracker_for_testcase.return_value = test_issue_tracker
 
-    url = issue_tracker_utils.get_issue_url(testcase)
+    issue_tracker_utils.get_issue_url(testcase)
     self.assertEqual(0, self.mock.issue_url.call_count)


### PR DESCRIPTION
Noticed on https://clusterfuzz.com/testcase-detail/5103503034417152, the issue link points to `https://clusterfuzz.com/testcase-detail/null`.