### PR TITLE
Fix access lib to use overridden fuzzer name if available.

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -62,7 +62,7 @@ def attach_testcases(rows):
           'isSecurity': testcase.security_flag,
           'issueNumber': testcase.bug_information,
           'job': testcase.job_type,
-          'fuzzerName': testcase.overridden_fuzzer_name or testcase.fuzzer_name
+          'fuzzerName': testcase.actual_fuzzer_name()
       }
     row['testcase'] = testcase
 

--- a/src/appengine/libs/access.py
+++ b/src/appengine/libs/access.py
@@ -112,7 +112,7 @@ def can_user_access_testcase(testcase):
       testcase.security_flag and not config.relax_security_bug_restrictions)
 
   if has_access(
-      fuzzer_name=testcase.fuzzer_name,
+      fuzzer_name=testcase.actual_fuzzer_name(),
       job_type=testcase.job_type,
       need_privileged_access=need_privileged_access):
     return True

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -295,7 +295,7 @@ def get_issue_description(testcase,
   domain = get_domain()
   testcase_id = testcase.key.id()
 
-  fuzzer_name = testcase.overridden_fuzzer_name or testcase.fuzzer_name
+  fuzzer_name = testcase.actual_fuzzer_name()
   download_url = TESTCASE_DOWNLOAD_URL.format(
       domain=domain, testcase_id=testcase_id)
   report_url = TESTCASE_REPORT_URL.format(

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -637,6 +637,10 @@ class Testcase(Model):
     if update_testcase:
       self.put()
 
+  def actual_fuzzer_name(self):
+    """Actual fuzzer name, uses one from overridden attribute if available."""
+    return self.overridden_fuzzer_name or self.fuzzer_name
+
 
 class TestcaseGroup(Model):
   """Group for a set of testcases."""


### PR DESCRIPTION
Fixes one part of https://github.com/google/clusterfuzz/issues/635