### PR TITLE
Don't lowercase string in String filters.

### DIFF
--- a/src/appengine/libs/filters.py
+++ b/src/appengine/libs/filters.py
@@ -66,7 +66,7 @@ def get_boolean(value):
 
 def get_string(value):
   """Get sanitized string."""
-  return value.strip().lower()
+  return value.strip()
 
 
 class Filter(object):

--- a/src/python/tests/appengine/handlers/testcase_list_test.py
+++ b/src/python/tests/appengine/handlers/testcase_list_test.py
@@ -59,7 +59,7 @@ class AddFiltersTest(unittest.TestCase):
 
   def test_both_fields(self):
     """Test filter field and keyword field."""
-    self.params['q'] = ('hello group:456 issue:123 platform:Windows'
+    self.params['q'] = ('hello group:456 issue:123 platform:windows'
                         ' stable:s.1 beta:b.2 fuzzer:2 job:3')
     self.params['fuzzer'] = 'fuzz'
     self.params['issue'] = 'yes'

--- a/src/python/tests/appengine/libs/filters_test.py
+++ b/src/python/tests/appengine/libs/filters_test.py
@@ -110,7 +110,7 @@ class StringTest(unittest.TestCase):
   def test_get(self):
     """Test get stripped string."""
     self.filter.add(self.query, {'param': ' aAa '})
-    self.query.assert_has_calls([mock.call.filter('field', 'aaa')])
+    self.query.assert_has_calls([mock.call.filter('field', 'aAa')])
 
 
 class KeywordTest(unittest.TestCase):


### PR DESCRIPTION
This fixes yet another bug from
https://github.com/google/clusterfuzz/issues/635
We shouldn't lowercase string in String filters as otherwise
queries won't work. This didnt get noticed uptil now since
we used to store fuzzer_name_indices in lowercase (before https://github.com/google/clusterfuzz/commit/7e1d45708959d7748af782fa1fc31d8880a1744f) and rest
of fields like job, project, etc were always in lowercase.
This functionality was always broken. This fixes the filters,
whereas search functionality with keywords will still allow
the case insensitive search.

After this, we will have:
1. For exact match, use {whatever field name}:{case sensitive value}, e.g. fuzzer:AbC
2. for case insensitive, just type a string in search field, e.g. abc