### PR TITLE
[fuchsia] Temporarily fix crash detection.

### DIFF
--- a/src/python/crash_analysis/crash_result.py
+++ b/src/python/crash_analysis/crash_result.py
@@ -20,6 +20,7 @@ from builtins import object
 from base import utils
 from crash_analysis import crash_analyzer
 from crash_analysis.stack_parsing import stack_analyzer
+from system import environment
 
 
 class CrashResult(object):
@@ -86,6 +87,8 @@ class CrashResult(object):
       return False
 
     state = self.get_state(symbolized=False)
+    if environment.platform() == 'FUCHSIA':
+      return True
     if not state.strip() and not ignore_state:
       return False
     return True


### PR DESCRIPTION
Pull request #563 was meant to put crash data on the dashboard; however,
some changes I made during code review changed how the "is_crash"
detection logic work, making no crashes appear on the dashboard.

Given that we fully intend to *properly* implement crash detection as
soon as we fix "getting symbolized crashes out of Fuchsia", for now,
let's just assume all Fuchsia crashes are real crashes, so we can start
stress-testing our dashboard.