### PR TITLE
Don't catch all exceptions in timeout wrapper.

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -730,7 +730,7 @@ def timeout(duration):
       try:
         async_result = THREAD_POOL.apply_async(func, args=args, kwds=kwargs)
         return async_result.get(timeout=duration)
-      except Exception:
+      except multiprocessing.TimeoutError:
         # Sleep for some minutes in order to wait for flushing metrics.
         time.sleep(120)
 


### PR DESCRIPTION
timeout wrapper was catching OSError, which is incorrect.
This caused a SystemExit in store_file_in_cache, when we
should be just retrying as part of retry.wrap in
storage.copy_file_from