### PR TITLE
Fix issue with missing issue mapping for filed testcases.

### DIFF
--- a/src/appengine/handlers/cron/triage.py
+++ b/src/appengine/handlers/cron/triage.py
@@ -251,6 +251,10 @@ class Handler(base_handler.Handler):
       if testcase.job_type in excluded_jobs:
         continue
 
+      # Skip if we are running progression task at this time.
+      if testcase.get_metadata('progression_pending'):
+        continue
+
       # If the testcase has a bug filed already, no triage is needed.
       if is_bug_filed(testcase):
         continue


### PR DESCRIPTION
This should fix
https://github.com/google/oss-fuzz/issues/2574
We could run into cases when progression task updates
testcase comments after a certain time (calculating
build urls list, etc), assuming that triage cron
can't run during that time. This is a wrong assumption
and caused filed testcase to lose their issue mapping.
Re-fetch testcase to minimize race and avoid the issue
altogether by not allowing triage cron to file testcase
when progression task is running.
Also, remove an unneeded optimization where same build
is not retried for progression. In most build systems,
we will have new builds per day.