### PR TITLE
Disable corpus subset when DFT is used, also extend strategy_pool API (#503).

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
+++ b/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
@@ -40,11 +40,6 @@ class StrategyPool(object):
     """Add a strategy into our existing strategy pool."""
     self.strategy_names.add(strategy_tuple.name)
 
-  def remove_strategy(self, strategy_tuple):
-    """Remove a strategy from our existing strategy pool."""
-    if strategy_tuple.name in self.strategy_names:
-      self.strategy_names.remove(strategy_tuple.name)
-
   def do_strategy(self, strategy_tuple):
     """Boolean value representing whether or not a strategy is in our strategy
     pool."""

--- a/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
+++ b/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
@@ -40,10 +40,10 @@ class StrategyPool(object):
     """Add a strategy into our existing strategy pool."""
     self.strategy_names.add(strategy_tuple.name)
 
-  def remove_strategy(self, strategy_name):
+  def remove_strategy(self, strategy_tuple):
     """Remove a strategy from our existing strategy pool."""
-    if strategy_name in self.strategy_names:
-      self.strategy_names.remove(strategy_name)
+    if strategy_tuple.name in self.strategy_names:
+      self.strategy_names.remove(strategy_tuple.name)
 
   def do_strategy(self, strategy_tuple):
     """Boolean value representing whether or not a strategy is in our strategy

--- a/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
+++ b/src/python/bot/fuzzers/libFuzzer/strategy_selection.py
@@ -40,6 +40,11 @@ class StrategyPool(object):
     """Add a strategy into our existing strategy pool."""
     self.strategy_names.add(strategy_tuple.name)
 
+  def remove_strategy(self, strategy_name):
+    """Remove a strategy from our existing strategy pool."""
+    if strategy_name in self.strategy_names:
+      self.strategy_names.remove(strategy_name)
+
   def do_strategy(self, strategy_tuple):
     """Boolean value representing whether or not a strategy is in our strategy
     pool."""


### PR DESCRIPTION
A bit speculative change, but feels intuitive that DFT is less useful when used with corpus subset.

Will be good to deploy it soon as it'll be midnight by UTC in ~1.5 hours and we can look at the daily stats to evaluate the impact of this change.