### PR TITLE
Fix an exception with 0-size test cases in the viewer handler.

### DIFF
--- a/src/appengine/handlers/viewer.py
+++ b/src/appengine/handlers/viewer.py
@@ -54,11 +54,11 @@ class Handler(base_handler.Handler):
     # https://github.com/googleapis/google-cloud-python/issues/6572
     if blob_size:
       try:
-        content = blobs.read_key(key)
+        content = unicode(blobs.read_key(key), errors='replace')
       except Exception:
         raise helpers.EarlyExitException('Failed to read content.', 400)
     else:
-      content = ''
+      content = u''
 
     line_count = len(content.splitlines())
     size = len(content)

--- a/src/appengine/handlers/viewer.py
+++ b/src/appengine/handlers/viewer.py
@@ -54,11 +54,11 @@ class Handler(base_handler.Handler):
     # https://github.com/googleapis/google-cloud-python/issues/6572
     if blob_size:
       try:
-        content = unicode(blobs.read_key(key), errors='replace')
+        content = blobs.read_key(key)
       except Exception:
         raise helpers.EarlyExitException('Failed to read content.', 400)
     else:
-      content = u''
+      content = ''
 
     line_count = len(content.splitlines())
     size = len(content)


### PR DESCRIPTION
PTAL. We could do a more generic fix in storage.read_data but it would require us to check the size in all cases, which seems like it could hurt performance in cases where we don't expect issues. Since we already know the size in the handler this seems like the best quick fix to me, but I'm open to either option.