### PR TITLE
Change writeDisposition from WRITE_TRUNCATE to WRITE_APPEND for BigQuery stats import.

### DIFF
--- a/src/appengine/handlers/cron/load_bigquery_stats.py
+++ b/src/appengine/handlers/cron/load_bigquery_stats.py
@@ -149,7 +149,7 @@ class Handler(base_handler.Handler):
                   'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
                   'sourceFormat': 'NEWLINE_DELIMITED_JSON',
                   'sourceUris': ['gs:/' + gcs_path + '*.json'],
-                  'writeDisposition': 'WRITE_TRUNCATE',
+                  'writeDisposition': 'WRITE_APPEND',
               },
           },
       }

--- a/src/python/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/python/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -109,7 +109,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                             },
                             'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION'],
                             'writeDisposition':
-                                'WRITE_TRUNCATE',
+                                'WRITE_APPEND',
                             'sourceUris': [
                                 'gs://test-bigquery-bucket/fuzzer/JobRun/date/'
                                 '20160907/*.json'

--- a/src/python/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/python/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -134,7 +134,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                             },
                             'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION'],
                             'writeDisposition':
-                                'WRITE_TRUNCATE',
+                                'WRITE_APPEND',
                             'sourceUris': [
                                 'gs://test-bigquery-bucket/fuzzer/TestcaseRun/'
                                 'date/20160907/*.json'


### PR DESCRIPTION
Otherwise stats importing may fail when there is a JSON file that doesn't have some of the known fields (e.g. `slowest_unit_time_sec`) and appears to be the last in the GCS listing.