### PR TITLE
Add support for FUZZ_TARGET_BUILD_BUCKET_PATH (#663)

### DIFF
--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -783,6 +783,7 @@ def _save_coverage_information(context, result):
 
 def execute_task(fuzzer_name_and_revision, job_type):
   """Execute corpus pruning task."""
+  # TODO(ochang): Remove this once remaining jobs in queue are all processed.
   if '@' in fuzzer_name_and_revision:
     full_fuzzer_name, revision = fuzzer_name_and_revision.split('@')
     revision = revisions.convert_revision_to_integer(revision)

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -48,6 +48,7 @@ from datastore import ndb
 from datastore import ndb_utils
 from fuzzing import corpus_manager
 from fuzzing import coverage_uploader
+from fuzzing import fuzzer_selection
 from fuzzing import gesture_handler
 from fuzzing import leak_blacklist
 from fuzzing import testcase_manager
@@ -1532,11 +1533,14 @@ class FuzzingSession(object):
     # is done on trunk build (using revision=None). Otherwise, a job definition
     # can provide a revision to use via |APP_REVISION|.
     dataflow_bucket_path = environment.get_value('DATAFLOW_BUILD_BUCKET_PATH')
-    if (build_manager.setup_build(environment.get_value('APP_REVISION')) and
-        dataflow_bucket_path):
+    target_weights = fuzzer_selection.get_fuzz_target_weights()
+    if (build_manager.setup_build(
+        environment.get_value('APP_REVISION'), target_weights=target_weights)
+        and dataflow_bucket_path):
       # Some fuzzing jobs may use auxiliary builds, such as DFSan instrumented
       # builds accompanying libFuzzer builds to enable DFT-based fuzzing.
-      build_manager.setup_trunk_build([dataflow_bucket_path], 'DATAFLOW')
+      build_manager.setup_trunk_build(
+          [dataflow_bucket_path], build_prefix='DATAFLOW')
 
     # Check if we have an application path. If not, our build failed
     # to setup correctly.

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1531,12 +1531,12 @@ class FuzzingSession(object):
     # Set up a custom or regular build based on revision. By default, fuzzing
     # is done on trunk build (using revision=None). Otherwise, a job definition
     # can provide a revision to use via |APP_REVISION|.
+    dataflow_bucket_path = environment.get_value('DATAFLOW_BUILD_BUCKET_PATH')
     if (build_manager.setup_build(environment.get_value('APP_REVISION')) and
-        environment.get_value('DATAFLOW_BUILD_BUCKET_PATH')):
+        dataflow_bucket_path):
       # Some fuzzing jobs may use auxiliary builds, such as DFSan instrumented
       # builds accompanying libFuzzer builds to enable DFT-based fuzzing.
-      build_manager.setup_trunk_build(['DATAFLOW_BUILD_BUCKET_PATH'],
-                                      'DATAFLOW')
+      build_manager.setup_trunk_build([dataflow_bucket_path], 'DATAFLOW')
 
     # Check if we have an application path. If not, our build failed
     # to setup correctly.

--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -205,9 +205,9 @@ def find_fixed_range(testcase_id, job_type):
     _check_fixed_for_custom_binary(testcase, job_type, testcase_file_path)
     return
 
-  release_build_bucket_path = environment.get_value('RELEASE_BUILD_BUCKET_PATH')
+  build_bucket_path = build_manager.get_primary_bucket_path()
   revision_list = build_manager.get_revisions_list(
-      release_build_bucket_path, testcase=testcase)
+      build_bucket_path, testcase=testcase)
   if not revision_list:
     testcase = data_handler.get_testcase_by_id(testcase_id)
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,

--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -138,7 +138,7 @@ def _check_fixed_for_custom_binary(testcase, job_type, testcase_file_path):
 def _testcase_reproduces_in_revision(testcase, testcase_file_path, job_type,
                                      revision):
   """Test to see if a test case reproduces in the specified revision."""
-  build_manager.setup_regular_build(revision)
+  build_manager.setup_build(revision)
   app_path = environment.get_value('APP_PATH')
   if not app_path:
     raise errors.BuildSetupError(revision, job_type)

--- a/src/python/bot/tasks/regression_task.py
+++ b/src/python/bot/tasks/regression_task.py
@@ -236,9 +236,9 @@ def find_regression_range(testcase_id, job_type):
     tasks.add_task('regression', testcase_id, job_type)
     return
 
-  release_build_bucket_path = environment.get_value('RELEASE_BUILD_BUCKET_PATH')
+  build_bucket_path = build_manager.get_primary_bucket_path()
   revision_list = build_manager.get_revisions_list(
-      release_build_bucket_path, testcase=testcase)
+      build_bucket_path, testcase=testcase)
   if not revision_list:
     testcase = data_handler.get_testcase_by_id(testcase_id)
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,

--- a/src/python/bot/tasks/regression_task.py
+++ b/src/python/bot/tasks/regression_task.py
@@ -101,7 +101,7 @@ def _testcase_reproduces_in_revision(testcase,
     data_handler.update_testcase_comment(testcase, data_types.TaskState.WIP,
                                          log_message)
 
-  build_manager.setup_regular_build(revision)
+  build_manager.setup_build(revision)
   app_path = environment.get_value('APP_PATH')
   if not app_path:
     raise errors.BuildSetupError(revision, job_type)

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -1149,7 +1149,9 @@ def get_revisions_list(bucket_path, testcase=None):
 
 
 def _get_targets_list(bucket_path):
-  """Get the target list for a given bucket path."""
+  """Get the target list for a given fuzz target bucket path. This is done by
+  reading the targets.list file, which contains a list of the currently active
+  fuzz targets."""
   targets_list_path = os.path.join(
       os.path.dirname(os.path.dirname(bucket_path)), TARGETS_LIST_FILENAME)
   data = storage.read_data(targets_list_path)
@@ -1163,7 +1165,7 @@ def _setup_split_targets_build(bucket_path, target_weights, revision=None):
   """Set up targets build."""
   targets_list = _get_targets_list(bucket_path)
   if not targets_list:
-    raise BuildManagerException('No targets found')
+    raise BuildManagerException('No targets found in targets.list.')
 
   fuzz_target = _set_random_fuzz_target_for_fuzzing_if_needed(
       targets_list, target_weights)

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -400,11 +400,6 @@ def _set_random_fuzz_target_for_fuzzing_if_needed(fuzz_targets, target_weights):
   if not environment.is_engine_fuzzer_job():
     return None
 
-  # TODO(ochang): Untie this dependency on knowledge of the current task.
-  task_name = environment.get_value('TASK_NAME')
-  if task_name != 'fuzz':
-    return None
-
   fuzz_targets = list(fuzz_targets)
   if not fuzz_targets:
     logs.log_error('No fuzz targets found. Unable to pick random one.')

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -1108,7 +1108,9 @@ def get_primary_bucket_path():
 
     return fuzz_target_build_bucket_path.replace('%TARGET%', fuzz_target)
 
-  raise BuildManagerException('No primary bucket path defined.')
+  raise BuildManagerException(
+      'RELEASE_BUILD_BUCKET_PATH or FUZZ_TARGET_BUILD_BUCKET_PATH '
+      'needs to be defined.')
 
 
 def get_revisions_list(bucket_path, testcase=None):

--- a/src/python/build_management/revisions.py
+++ b/src/python/build_management/revisions.py
@@ -703,7 +703,7 @@ def write_revision_to_revision_file(revision_file, revision):
 
 def revision_pattern_from_build_bucket_path(bucket_path):
   """Get the revision pattern from a build bucket path."""
-  return '.*' + os.path.basename(bucket_path)
+  return '.*?' + os.path.basename(bucket_path)
 
 
 @memoize.wrap(memoize.FifoOnDisk(DISK_CACHE_SIZE))

--- a/src/python/fuzzing/fuzzer_selection.py
+++ b/src/python/fuzzing/fuzzer_selection.py
@@ -104,12 +104,6 @@ def select_fuzz_target(targets, target_weights):
 
 def get_fuzz_target_weights():
   """Get a list of fuzz target weights based on the current fuzzer."""
-  # No work to do if this isn't fuzz task. Weights are only required if a
-  # fuzzer has not yet been selected.
-  task_name = environment.get_value('TASK_NAME')
-  if task_name != 'fuzz':
-    return None
-
   job_type = environment.get_value('JOB_NAME')
 
   target_jobs = list(fuzz_target_utils.get_fuzz_target_jobs(job=job_type))

--- a/src/python/tests/appengine/handlers/schedule_corpus_pruning_test.py
+++ b/src/python/tests/appengine/handlers/schedule_corpus_pruning_test.py
@@ -28,11 +28,6 @@ class ScheduleCorpusPruningTest(unittest.TestCase):
   def setUp(self):
     helpers.patch_environ(self)
 
-    helpers.patch(self, [
-        'build_management.build_manager.get_revisions_list',
-    ])
-    self.mock.get_revisions_list.return_value = [1337, 31337]
-
     # Two fuzz targets with two jobs enabled, one with and one without pruning.
     data_types.FuzzTarget(
         engine='libFuzzer', binary='test_fuzzer_1', project='project_1').put()
@@ -104,9 +99,9 @@ class ScheduleCorpusPruningTest(unittest.TestCase):
   def test_schedule_corpus_pruning(self):
     """Test schedule_corpus_pruning.Handler.."""
     tasks = schedule_corpus_pruning.get_tasks_to_schedule()
-    tasks_expected = [('libFuzzer_test_fuzzer_1@31337',
+    tasks_expected = [('libFuzzer_test_fuzzer_1',
                        'continuous_fuzzing_job_with_pruning', 'jobs-linux'),
-                      ('libFuzzer_test_fuzzer_2@31337',
+                      ('libFuzzer_test_fuzzer_2',
                        'continuous_fuzzing_job_with_pruning', 'jobs-linux'),
                       ('libFuzzer_test_fuzzer_a',
                        'custom_binary_job_with_pruning', 'jobs-linux'),

--- a/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -316,7 +316,7 @@ class UntrustedRunnerIntegrationTest(
                           os.path.join(os.environ['ROOT_DIR'], launcher_dir))
 
     self._setup_env(job_type='libfuzzer_asan_job')
-    build = build_manager.setup_build()
+    build = build_manager.setup_build(target_weights={})
     self.assertIsNotNone(build)
 
     worker_root_dir = os.environ['WORKER_ROOT_DIR']

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -1019,7 +1019,6 @@ class AuxiliaryRegularBuildTest(fake_filesystem_unittest.TestCase):
 
   def test_delete(self):
     """Test deleting this build."""
-    os.environ['FUZZ_TARGET'] = 'fuzz_target'
     os.environ['DATAFLOW_BUILD_BUCKET_PATH'] = (
         'gs://path/file-dataflow-([0-9]+).zip')
 
@@ -1182,6 +1181,7 @@ class AuxiliaryRegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
   def test_delete(self):
     """Test deleting this build."""
+    os.environ['FUZZ_TARGET'] = 'fuzz_target'
     os.environ['DATAFLOW_BUILD_BUCKET_PATH'] = (
         'gs://path/file-dataflow-([0-9]+).zip')
 

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -454,6 +454,7 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
   def test_delete(self):
     """Test deleting this build."""
+    os.environ['FUZZ_TARGET'] = 'fuzz_target'
     os.environ['RELEASE_BUILD_BUCKET_PATH'] = (
         'gs://path/file-release-([0-9]+).zip')
 
@@ -1018,6 +1019,7 @@ class AuxiliaryRegularBuildTest(fake_filesystem_unittest.TestCase):
 
   def test_delete(self):
     """Test deleting this build."""
+    os.environ['FUZZ_TARGET'] = 'fuzz_target'
     os.environ['DATAFLOW_BUILD_BUCKET_PATH'] = (
         'gs://path/file-dataflow-([0-9]+).zip')
 

--- a/src/python/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/python/tests/core/fuzzing/fuzzer_selection_test.py
@@ -287,15 +287,6 @@ class GetFuzzTargetWeightsTest(unittest.TestCase):
         weight=3.0,
     ).put()
 
-  def test_bailout_for_bad_task(self):
-    """Ensure that we bail out and return None if called for non-fuzz tasks."""
-    os.environ['TASK_NAME'] = 'minimize'
-    os.environ['JOB_NAME'] = 'some_job'
-
-    result = fuzzer_selection.get_fuzz_target_weights()
-
-    self.assertIsNone(result)
-
   def test_empty_if_no_children(self):
     """Ensure that we function properly if a fuzzer has no children."""
     os.environ['TASK_NAME'] = 'fuzz'


### PR DESCRIPTION
not ready for review.

- Add support for using `FUZZ_TARGET_BUILD_BUCKET_PATH`, which is of the format:
`gs://bucket/subdir/%TARGET%/([0-9]+).zip`. 
  - When this is specified, build_manager will pick a fuzz target first (if it hasn't been picked already), and substitute`'%TARGET%` with the actual target name. This is the only new behaviour, as the resulting bucket path can then be passed to RegularBuild to continue regular setup.

- Also add `build_manager.get_primary_bucket_path`, so that regression/progression can list builds properly.

- Replace calls to `setup_regular_build` with `setup_build`.

- Also remove revision fixing in schedule_corpus_pruning_tasks. This was needed back when
we were merging sancovs, and is no longer needed.

- Move fuzzer_selection.get_fuzz_target_weights() out of build_manager and into fuzz_task. This removes an undesired dependency where `get_fuzz_target_weights` checks what the current task is, and makes it easier to prevent calling it multiple times unnecessarily.

- Make `revision_pattern_from_build_bucket_path` less greedy to support zip filenames of the format `([0-9]+).zip`