### PR TITLE
Pass schema as part of bigquery load call

### DIFF
--- a/src/appengine/handlers/cron/load_bigquery_stats.py
+++ b/src/appengine/handlers/cron/load_bigquery_stats.py
@@ -96,27 +96,6 @@ class Handler(base_handler.Handler):
         projectId=project_id, datasetId=dataset_id, body=table_body)
     return self._execute_insert_request(table_insert)
 
-  def _update_schema_if_needed(self, bigquery, dataset_id, table_id, schema):
-    """Update the table's schema if needed."""
-    if not schema:
-      return
-
-    project_id = utils.get_application_id()
-    table = bigquery.tables().get(
-        datasetId=dataset_id, tableId=table_id, projectId=project_id).execute()
-
-    if 'schema' in table and table['schema'] == schema:
-      return
-
-    body = {
-        'schema': schema,
-    }
-
-    logs.log('Updating schema for %s:%s' % (dataset_id, table_id))
-    bigquery.tables().patch(
-        datasetId=dataset_id, tableId=table_id, projectId=project_id,
-        body=body).execute()
-
   def _load_data(self, bigquery, fuzzer):
     """Load yesterday's stats into BigQuery."""
     project_id = utils.get_application_id()
@@ -140,21 +119,24 @@ class Handler(base_handler.Handler):
       else:
         schema = kind.SCHEMA
 
-      self._update_schema_if_needed(bigquery, dataset_id, table_id, schema)
-
       gcs_path = fuzzer_stats.get_gcs_stats_path(kind_name, fuzzer, timestamp)
+      load = {
+          'destinationTable': {
+              'projectId': project_id,
+              'tableId': table_id + '$' + date_string,
+              'datasetId': dataset_id,
+          },
+          'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
+          'sourceFormat': 'NEWLINE_DELIMITED_JSON',
+          'sourceUris': ['gs:/' + gcs_path + '*.json'],
+          'writeDisposition': 'WRITE_TRUNCATE',
+      }
+      if schema is not None:
+        load['schema'] = schema
+
       job_body = {
           'configuration': {
-              'load': {
-                  'destinationTable': {
-                      'projectId': project_id,
-                      'tableId': table_id + '$' + date_string,
-                      'datasetId': dataset_id,
-                  },
-                  'sourceFormat': 'NEWLINE_DELIMITED_JSON',
-                  'sourceUris': ['gs:/' + gcs_path + '*.json'],
-                  'writeDisposition': 'WRITE_TRUNCATE',
-              },
+              'load': load,
           },
       }
 
@@ -168,7 +150,7 @@ class Handler(base_handler.Handler):
       # See https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query.
       logs.log('Response from BigQuery: %s' % response)
 
-  @handler.check_cron()
+  #@handler.check_cron()
   def get(self):
     """Load bigquery stats from GCS."""
     if not big_query.get_bucket():

--- a/src/appengine/handlers/cron/load_bigquery_stats.py
+++ b/src/appengine/handlers/cron/load_bigquery_stats.py
@@ -150,7 +150,7 @@ class Handler(base_handler.Handler):
       # See https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query.
       logs.log('Response from BigQuery: %s' % response)
 
-  #@handler.check_cron()
+  @handler.check_cron()
   def get(self):
     """Load bigquery stats from GCS."""
     if not big_query.get_bucket():

--- a/src/python/metrics/fuzzer_stats_schema.py
+++ b/src/python/metrics/fuzzer_stats_schema.py
@@ -161,10 +161,6 @@ _AFL_SCHEMA = [{
     'mode': 'NULLABLE',
     'name': 'leak_count',
     'type': 'INTEGER'
-}, {
-    'mode': 'NULLABLE',
-    'name': 'seconds_executed',
-    'type': 'INTEGER'
 }]
 
 _LIBFUZZER_SCHEMA = [{

--- a/src/python/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/python/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -105,6 +105,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                                 'tableId': 'JobRun$20160907',
                                 'datasetId': 'fuzzer_stats'
                             },
+                            'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
                             'writeDisposition':
                                 'WRITE_TRUNCATE',
                             'sourceUris': [
@@ -113,6 +114,69 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                             ],
                             'sourceFormat':
                                 'NEWLINE_DELIMITED_JSON',
+                            'schema': {
+                                'fields': [{
+                                    'type': 'INTEGER',
+                                    'name': 'testcases_executed',
+                                    'mode': 'NULLABLE'
+                                }, {
+                                    'type': 'INTEGER',
+                                    'name': 'build_revision',
+                                    'mode': 'NULLABLE'
+                                }, {
+                                    'type': 'INTEGER',
+                                    'name': 'new_crashes',
+                                    'mode': 'NULLABLE'
+                                }, {
+                                    'type': 'STRING',
+                                    'name': 'job',
+                                    'mode': 'NULLABLE'
+                                }, {
+                                    'type': 'FLOAT',
+                                    'name': 'timestamp',
+                                    'mode': 'NULLABLE'
+                                }, {
+                                    'fields': [{
+                                        'type': 'STRING',
+                                        'name': 'crash_type',
+                                        'mode': 'NULLABLE'
+                                    }, {
+                                        'type': 'BOOLEAN',
+                                        'name': 'is_new',
+                                        'mode': 'NULLABLE'
+                                    }, {
+                                        'type': 'STRING',
+                                        'name': 'crash_state',
+                                        'mode': 'NULLABLE'
+                                    }, {
+                                        'type': 'BOOLEAN',
+                                        'name': 'security_flag',
+                                        'mode': 'NULLABLE'
+                                    }, {
+                                        'type': 'INTEGER',
+                                        'name': 'count',
+                                        'mode': 'NULLABLE'
+                                    }],
+                                    'type':
+                                        'RECORD',
+                                    'name':
+                                        'crashes',
+                                    'mode':
+                                        'REPEATED'
+                                }, {
+                                    'type': 'INTEGER',
+                                    'name': 'known_crashes',
+                                    'mode': 'NULLABLE'
+                                }, {
+                                    'type': 'STRING',
+                                    'name': 'fuzzer',
+                                    'mode': 'NULLABLE'
+                                }, {
+                                    'type': 'STRING',
+                                    'name': 'kind',
+                                    'mode': 'NULLABLE'
+                                }]
+                            },
                         }
                     }
                 },
@@ -127,6 +191,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                                 'tableId': 'TestcaseRun$20160907',
                                 'datasetId': 'fuzzer_stats'
                             },
+                            'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
                             'writeDisposition':
                                 'WRITE_TRUNCATE',
                             'sourceUris': [


### PR DESCRIPTION
This allows for changing field types, which the original schema update call does not and fails with e.g. "Provided Schema does not match Table cluster-fuzz:afl_stats.TestcaseRun. Field seconds_executed has changed type from FLOAT to INTEGER". Also, allows removing of old unused types.