### PR TITLE
For testcase variant, pick the associated engine fuzzer for that job.

### DIFF
--- a/src/python/bot/fuzzers/builtin_fuzzers.py
+++ b/src/python/bot/fuzzers/builtin_fuzzers.py
@@ -35,3 +35,12 @@ def get(fuzzer_name):
     return None
 
   return BUILTIN_FUZZERS[fuzzer_name]
+
+
+def get_fuzzer_for_job(job_name):
+  """Return a fuzzer override for engine jobs."""
+  for fuzzer_name in BUILTIN_FUZZERS:
+    if fuzzer_name.lower() in job_name.lower():
+      return fuzzer_name
+
+  return None

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -350,9 +350,11 @@ def execute_task(testcase_id, job_type):
   # Update comments to reflect bot information.
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
-  # Setup testcase and its dependencies.
+  # Setup testcase and its dependencies. Also, allow setting up a different
+  # fuzzer.
+  minimize_fuzzer_override = environment.get_value('MINIMIZE_FUZZER_OVERRIDE')
   file_list, input_directory, testcase_file_path = setup.setup_testcase(
-      testcase)
+      testcase, fuzzer_override=minimize_fuzzer_override)
   if not file_list:
     return
 

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -119,10 +119,10 @@ def prepare_environment_for_testcase(testcase):
     environment.set_value('FUZZ_TARGET', fuzz_target)
 
 
-def setup_testcase(testcase):
+def setup_testcase(testcase, fuzzer_override=None):
   """Sets up the testcase and needed dependencies like fuzzer,
   data bundle, etc."""
-  fuzzer_name = testcase.fuzzer_name
+  fuzzer_name = fuzzer_override or testcase.fuzzer_name
   job_type = testcase.job_type
   task_name = environment.get_value('TASK_NAME')
   testcase_fail_wait = environment.get_value('FAIL_WAIT')
@@ -134,11 +134,6 @@ def setup_testcase(testcase):
   # Adjust the test timeout value if this is coming from an user uploaded
   # testcase.
   _set_timeout_value_from_user_upload(testcase_id)
-
-  if task_name == 'minimize':
-    # Allow minimizing with a different fuzzer set up.
-    minimize_fuzzer_override = environment.get_value('MINIMIZE_FUZZER_OVERRIDE')
-    fuzzer_name = minimize_fuzzer_override or fuzzer_name
 
   # Update the fuzzer if necessary in order to get the updated data bundle.
   if fuzzer_name:

--- a/src/python/bot/tasks/variant_task.py
+++ b/src/python/bot/tasks/variant_task.py
@@ -14,6 +14,7 @@
 """Variant task for analyzing testcase variants with a different job."""
 
 from base import utils
+from bot.fuzzers import builtin_fuzzers
 from bot.tasks import setup
 from build_management import build_manager
 from datastore import data_handler
@@ -34,12 +35,23 @@ def _get_testcase_variant_entity(testcase_id, job_type):
   return variant
 
 
+def _get_fuzzer_override(job_name):
+  """Return a fuzzer override for engine jobs."""
+  for fuzzer_name in builtin_fuzzers.BUILTIN_FUZZERS:
+    if fuzzer_name.lower() in job_name.lower():
+      return fuzzer_name
+
+  return None
+
+
 def execute_task(testcase_id, job_type):
   """Run a test case with a different job type to see if they reproduce."""
   testcase = data_handler.get_testcase_by_id(testcase_id)
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase)
+  fuzzer_override = _get_fuzzer_override(job_type)
+  file_list, _, testcase_file_path = setup.setup_testcase(
+      testcase, fuzzer_override=fuzzer_override)
   if not file_list:
     return
 

--- a/src/python/bot/tasks/variant_task.py
+++ b/src/python/bot/tasks/variant_task.py
@@ -35,21 +35,12 @@ def _get_testcase_variant_entity(testcase_id, job_type):
   return variant
 
 
-def _get_fuzzer_override(job_name):
-  """Return a fuzzer override for engine jobs."""
-  for fuzzer_name in builtin_fuzzers.BUILTIN_FUZZERS:
-    if fuzzer_name.lower() in job_name.lower():
-      return fuzzer_name
-
-  return None
-
-
 def execute_task(testcase_id, job_type):
   """Run a test case with a different job type to see if they reproduce."""
   testcase = data_handler.get_testcase_by_id(testcase_id)
 
   # Setup testcase and its dependencies.
-  fuzzer_override = _get_fuzzer_override(job_type)
+  fuzzer_override = builtin_fuzzers.get_fuzzer_for_job(job_type)
   file_list, _, testcase_file_path = setup.setup_testcase(
       testcase, fuzzer_override=fuzzer_override)
   if not file_list:


### PR DESCRIPTION
When we run a libFuzzer testcase with an afl job, it needs to
setup afl libfuzzer.