### PR TITLE
Add crash params to TestcaseVariant entity.

### DIFF
--- a/src/python/bot/tasks/variant_task.py
+++ b/src/python/bot/tasks/variant_task.py
@@ -17,6 +17,7 @@ from base import utils
 from bot.fuzzers import builtin_fuzzers
 from bot.tasks import setup
 from build_management import build_manager
+from crash_analysis.crash_comparer import CrashComparer
 from datastore import data_handler
 from datastore import data_types
 from fuzzing import testcase_manager
@@ -75,30 +76,40 @@ def execute_task(testcase_id, job_type):
       compare_crash=False)
 
   if result.is_crash():
-    state = result.get_symbolized_data()
+    crash_state = result.get_state()
+    crash_type = result.get_type()
     security_flag = result.is_security_issue()
-    one_time_crasher_flag = not testcase_manager.test_for_reproducibility(
-        testcase_file_path, state.crash_state, security_flag, test_timeout,
-        testcase.http_flag, testcase.gestures)
 
+    one_time_crasher_flag = not testcase_manager.test_for_reproducibility(
+        testcase_file_path, crash_state, security_flag, test_timeout,
+        testcase.http_flag, testcase.gestures)
     if one_time_crasher_flag:
       status = data_types.TestcaseVariantStatus.FLAKY
     else:
       status = data_types.TestcaseVariantStatus.REPRODUCIBLE
 
+    crash_comparer = CrashComparer(crash_state, testcase.crash_state)
+    is_similar = (
+        crash_comparer.is_similar() and security_flag == testcase.security_flag)
+
     unsymbolized_crash_stacktrace = result.get_stacktrace(symbolized=False)
+    symbolized_crash_stacktrace = result.get_stacktrace(symbolized=True)
     crash_stacktrace_output = utils.get_crash_stacktrace_output(
-        command, state.crash_stacktrace, unsymbolized_crash_stacktrace)
-    crash_stacktrace = data_handler.filter_stacktrace(crash_stacktrace_output)
+        command, symbolized_crash_stacktrace, unsymbolized_crash_stacktrace)
   else:
     status = data_types.TestcaseVariantStatus.UNREPRODUCIBLE
-    crash_stacktrace = None
+    is_similar = False
+    crash_type = None
+    crash_state = None
+    security_flag = False
+    crash_stacktrace_output = 'No crash occurred.'
 
   testcase = data_handler.get_testcase_by_id(testcase_id)
   if testcase.job_type == job_type:
     # This case happens when someone clicks 'Update last tested stacktrace using
     # trunk build' button.
-    testcase.last_tested_crash_stacktrace = crash_stacktrace
+    testcase.last_tested_crash_stacktrace = (
+        data_handler.filter_stacktrace(crash_stacktrace_output))
     testcase.set_metadata(
         'last_tested_crash_revision', revision, update_testcase=False)
   else:
@@ -106,5 +117,10 @@ def execute_task(testcase_id, job_type):
     variant = _get_testcase_variant_entity(testcase_id, job_type)
     variant.status = status
     variant.revision = revision
-    variant.crash_stacktrace = crash_stacktrace
+    variant.crash_type = crash_type
+    variant.crash_state = crash_state
+    variant.security_flag = security_flag
+    variant.is_similar = is_similar
+    # Explicitly skipping crash stacktrace for now as it make entities larger
+    # and we plan to use only crash paramaters in UI.
     variant.put()

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -1361,5 +1361,14 @@ class TestcaseVariant(Model):
   # Revision that the testcase variant was tried against.
   revision = ndb.IntegerProperty()
 
-  # Crash stacktrace.
-  crash_stacktrace = ndb.TextProperty(indexed=False)
+  # Crash type.
+  crash_type = ndb.StringProperty()
+
+  # Crash state.
+  crash_state = ndb.StringProperty()
+
+  # Bool to indicate if it is a security bug?
+  security_flag = ndb.BooleanProperty()
+
+  # Bool to indicate if crash is similar to original testcase.
+  is_similar = ndb.BooleanProperty()


### PR DESCRIPTION
Also, skip crash stacktrace as it makes the entity larger and
we only intend to show crash summary for each variant.