### PR TITLE
Revert "Fix formatting in render-either and impact-button HTML components."

### DIFF
--- a/src/appengine/private/components/common/impact-button/impact-button.html
+++ b/src/appengine/private/components/common/impact-button/impact-button.html
@@ -33,10 +33,10 @@
       }
     </style>
     <a href$="/testcases?impact=[[lower(release)]]" on-tap="handleTap">[[release]]</a>
-    <template is="dom-repeat" items="[[getComponents(version)]]">
-      <template is="dom-if" if="[[item.prefixWithDot]]">.</template>
-      <a href$="/testcases?q=[[lower(release)]]%3A[[item.filter]]" data-filter-version$="[[item.filter]]" on-tap="handleTap">[[item.label]]</a>
-    </template>
+    <template is="dom-repeat" items="[[getComponents(version)]]"
+      ><template is="dom-if" if="[[item.prefixWithDot]]">.</template
+      ><a href$="/testcases?q=[[lower(release)]]%3A[[item.filter]]" data-filter-version$="[[item.filter]]" on-tap="handleTap">[[item.label]]</a
+    ></template>
     <template is="dom-if" if="[[likely]]">
       (likely)
     </template>

--- a/src/appengine/private/components/common/render-either/render-either.html
+++ b/src/appengine/private/components/common/render-either/render-either.html
@@ -16,10 +16,10 @@
 <link rel="import" href="../../../bower_components/polymer/polymer.html">
 
 <dom-module id="render-either">
-  <template>
-    <template is="dom-if" if="[[main]]">[[trim(main)]]</template>
-    <template is="dom-if" if="[[!main]]">[[trim(else)]]</template>
-  </template>
+  <template
+    ><template is="dom-if" if="[[main]]">[[trim(main)]]</template
+    ><template is="dom-if" if="[[!main]]">[[trim(else)]]</template
+  ></template>
   <script>
     Polymer({
       is: 'render-either',


### PR DESCRIPTION
Reverts google/clusterfuzz#689

This breaks rendering and causes spaces between anchor tags on impact button. This was done as shown by example 2 in https://css-tricks.com/fighting-the-space-between-inline-block-elements/#article-header-id-0