### PR TITLE
Fix dangling process issue in mac init.

### DIFF
--- a/src/python/bot/init_scripts/mac.py
+++ b/src/python/bot/init_scripts/mac.py
@@ -32,9 +32,11 @@ def _execute(cmd):
   """Execute command and return output as an iterator."""
   proc = subprocess.Popen(
       cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-  for line in iter(proc.stdout.readline, b''):
-    yield line
-  proc.kill()
+  try:
+    for line in iter(proc.stdout.readline, b''):
+      yield line
+  finally:
+    proc.kill()
 
 
 def get_launch_service_path():


### PR DESCRIPTION
If we break out of the iteration by returning, the `proc.kill` after the
`yield` is never run.