### PR TITLE
Move crash arguments initialization into fuzz_task.Crash constructor …

### DIFF
--- a/src/python/fuzzing/testcase_manager.py
+++ b/src/python/fuzzing/testcase_manager.py
@@ -507,6 +507,7 @@ def test_for_crash_with_retries(testcase,
 
   for round_number in range(1, crash_retries + 1):
     run_timeout = warmup_timeout if round_number == 1 else test_timeout
+    # TODO(ochang): Set up engine for greybox testcases.
     return_code, crash_time, output = process_handler.run_process(
         command,
         timeout=run_timeout,


### PR DESCRIPTION
…(#483).

This is to make things work for both engine.Crash, where the arguments
come from the Crash object and testcase_manager.Crash testcases, where
the arguments come from the flags-* file.