### PR TITLE
[stack_analyzer] Add "libfuzzer: deadly signal" to crash detection.

### DIFF
--- a/src/python/crash_analysis/crash_analyzer.py
+++ b/src/python/crash_analysis/crash_analyzer.py
@@ -272,6 +272,10 @@ def is_security_issue(crash_stacktrace, crash_type, crash_address):
   if crash_type == 'Stack-overflow':
     return False
 
+  # Fatal signals.
+  if crash_type == 'Fatal-signal':
+    return False
+
   # LeakSanitizer, finds memory leaks.
   if '-leak' in crash_type:
     return False

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -103,7 +103,8 @@ KASAN_CRASH_TYPE_ADDRESS_REGEX = re.compile(
     r'BUG: KASAN: (.*) (in|on).*(addr|address) ([a-f0-9]+)')
 KASAN_GPF_REGEX = re.compile(r'general protection fault:.*KASAN')
 LIBFUZZER_TIMEOUT_REGEX = re.compile(r'.*ERROR:\s*libFuzzer:\s*timeout')
-LIBFUZZER_DEADLY_SIGNAL_REGEX = re.compile(r'.*ERROR:\s*libFuzzer:\s*deadly signal')
+LIBFUZZER_DEADLY_SIGNAL_REGEX = re.compile(
+    r'.*ERROR:\s*libFuzzer:\s*deadly signal')
 LINUX_GDB_CRASH_TYPE_REGEX = re.compile(r'Program received signal ([a-zA-Z]+),')
 LINUX_GDB_CRASH_ADDRESS_REGEX = re.compile(r'rip[ ]+([xX0-9a-fA-F]+)')
 LSAN_DIRECT_LEAK_REGEX = re.compile(r'Direct leak of ')
@@ -1493,11 +1494,11 @@ def get_crash_data(crash_data, symbolize_flag=True):
 
       # Libfuzzer deadly signal errors.
       update_state_on_match(
-        LIBFUZZER_DEADLY_SIGNAL_REGEX,
-        line,
-        state,
-        new_type='deadly signal',
-        reset=True)
+          LIBFUZZER_DEADLY_SIGNAL_REGEX,
+          line,
+          state,
+          new_type='deadly signal',
+          reset=True)
 
     if state.fatal_error_occurred:
       error_line_match = update_state_on_match(

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -103,6 +103,7 @@ KASAN_CRASH_TYPE_ADDRESS_REGEX = re.compile(
     r'BUG: KASAN: (.*) (in|on).*(addr|address) ([a-f0-9]+)')
 KASAN_GPF_REGEX = re.compile(r'general protection fault:.*KASAN')
 LIBFUZZER_TIMEOUT_REGEX = re.compile(r'.*ERROR:\s*libFuzzer:\s*timeout')
+LIBFUZZER_DEADLY_SIGNAL_REGEX = re.compile(r'.*ERROR:\s*libFuzzer:\s*deadly signal')
 LINUX_GDB_CRASH_TYPE_REGEX = re.compile(r'Program received signal ([a-zA-Z]+),')
 LINUX_GDB_CRASH_ADDRESS_REGEX = re.compile(r'rip[ ]+([xX0-9a-fA-F]+)')
 LSAN_DIRECT_LEAK_REGEX = re.compile(r'Direct leak of ')
@@ -1489,6 +1490,14 @@ def get_crash_data(crash_data, symbolize_flag=True):
           address_from_group=1,
           address_filter=lambda s: '0x' + s,
           reset=True)
+
+      # Libfuzzer deadly signal errors.
+      update_state_on_match(
+        LIBFUZZER_DEADLY_SIGNAL_REGEX,
+        line,
+        state,
+        new_type='deadly signal',
+        reset=True)
 
     if state.fatal_error_occurred:
       error_line_match = update_state_on_match(

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -1492,12 +1492,12 @@ def get_crash_data(crash_data, symbolize_flag=True):
           address_filter=lambda s: '0x' + s,
           reset=True)
 
-      # Libfuzzer deadly signal errors.
+      # Libfuzzer fatal signal errors.
       update_state_on_match(
           LIBFUZZER_DEADLY_SIGNAL_REGEX,
           line,
           state,
-          new_type='deadly signal',
+          new_type='Fatal-signal',
           reset=True)
 
     if state.fatal_error_occurred:

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_deadly_signal.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_deadly_signal.txt
@@ -1,0 +1,14 @@
+==247664== ERROR: libFuzzer: deadly signal
+    #0 0x4f2ae7 in __sanitizer_print_stack_trace /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/asan/asan_stack.cc:38:3
+    #1 0x42f0f6 in fuzzer::Fuzzer::CrashCallback() /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:233:5
+    #2 0x42f0bf in fuzzer::Fuzzer::StaticCrashSignalCallback() /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:206:6
+    #3 0x7fa27237a39f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1239f)
+    #4 0x51a44a in LLVMFuzzerTestOneInput (/src/a.out+0x51a44a)
+    #5 0x43061c in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:515:13
+    #6 0x42fe7b in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:440:3
+    #7 0x43183d in fuzzer::Fuzzer::MutateAndTestOne() /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:648:19
+    #8 0x432235 in fuzzer::Fuzzer::Loop(std::vector<std::string, fuzzer::fuzzer_allocator<std::string> > const&) /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:775:5
+    #9 0x4270b3 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:754:6
+    #10 0x44a012 in main /home/snd-local/releases/6.0/release/final/llvm.src/projects/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
+    #11 0x7fa2719a852a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2352a)
+    #12 0x41fda9 in _start (/src/a.out+0x41fda9)

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1323,11 +1323,11 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
   def test_libfuzzer_deadly_signal(self):
     data = self._read_test_data('libfuzzer_deadly_signal.txt')
-    expected_type = 'deadly signal'
+    expected_type = 'Fatal-signal'
     expected_state = 'NULL'
     expected_address = ''
     expected_stacktrace = data
-    expected_security_flag = True
+    expected_security_flag = False
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1328,7 +1328,9 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_address = ''
     expected_stacktrace = data
     expected_security_flag = True
-    self._validate_get_crash_data(data, expected_type, expected_address, expected_state, expected_stacktrace, expected_security_flag)
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
 
   def test_windows_asan_divide_by_zero(self):
     """Test for Windows ASan divide by zero crashes."""

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1321,6 +1321,15 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_libfuzzer_deadly_signal(self):
+    data = self._read_test_data('libfuzzer_deadly_signal.txt')
+    expected_type = 'deadly signal'
+    expected_state = 'NULL'
+    expected_address = ''
+    expected_stacktrace = data
+    expected_security_flag = True
+    self._validate_get_crash_data(data, expected_type, expected_address, expected_state, expected_stacktrace, expected_security_flag)
+
   def test_windows_asan_divide_by_zero(self):
     """Test for Windows ASan divide by zero crashes."""
     data = self._read_test_data('windows_asan_divide_by_zero.txt')


### PR DESCRIPTION
This was brought up mostly by a desire to have a convenient test case
for bringing Fuchsia onto Clusterfuzz; simply throwing a __builtin_trap
is a pretty reliable way to get a libfuzzer crash.

However, Clusterfuzz doesn't currently recognize this form of crash, so
we're adding it now!