### PR TITLE
Remove unneeded build dir init in engine_test.py

### DIFF
--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -34,7 +34,6 @@ class PrepareTest(fake_fs_unittest.TestCase):
     test_helpers.patch_environ(self)
     test_utils.set_up_pyfakefs(self)
 
-    self.fs.CreateDirectory('/build')
     self.fs.CreateDirectory('/inputs')
     self.fs.CreateFile('/path/target')
     self.fs.CreateFile(


### PR DESCRIPTION
This also fixes a pyfakefs conflict with a local mount point.