### PR TITLE
Don't match testcase platform id if running variant task.

### DIFF
--- a/src/python/bot/tasks/commands.py
+++ b/src/python/bot/tasks/commands.py
@@ -273,7 +273,7 @@ def process_command(task):
       # This can happen when you have different type of devices (e.g
       # android) on the same platform group. In this case, we just recreate
       # the task.
-      if (testcase_platform_id and
+      if (task_name != 'variant' and testcase_platform_id and
           not utils.fields_match(testcase_platform_id, current_platform_id)):
         logs.log(
             'Testcase %d platform (%s) does not match with ours (%s), exiting' %


### PR DESCRIPTION
Variant task runs a testcase against a different platform as well.
So, ignore this check.

Part of https://github.com/google/clusterfuzz/issues/565