### PR TITLE
Implement stats, testcase, logs uploading for engine fuzzing.

### DIFF
--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -57,9 +57,6 @@ from system import shell
 # libFuzzer's merge timeout.
 DEFAULT_MERGE_TIMEOUT = 30 * 60
 
-# Prefix for the fuzzer's full name.
-AFL_PREFIX = 'afl_'
-
 BOT_NAME = environment.get_value('BOT_NAME', '')
 
 STDERR_FILENAME = 'stderr.out'
@@ -1495,7 +1492,7 @@ def main(argv):
                            runner.fuzzer_stderr, fuzz_result.output)
 
     engine_common.dump_big_query_data(stats_getter.stats, testcase_file_path,
-                                      AFL_PREFIX, fuzzer_name, command)
+                                      command)
 
   finally:
     print(runner.fuzzer_stderr)

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -1467,11 +1467,8 @@ def main(argv):
     command = engine_common.strip_minijail_command(command,
                                                    runner.afl_fuzz_path)
   # Print info for the fuzzer logs.
-  print(('Command: {0}\n'
-         'Bot: {1}\n'
-         'Time ran: {2}\n').format(
-             engine_common.get_command_quoted(command), BOT_NAME,
-             fuzz_result.time_executed))
+  print(engine_common.get_log_header(command, BOT_NAME,
+                                     fuzz_result.time_executed))
 
   print(fuzz_result.output)
   runner.strategies.print_strategies()

--- a/src/python/bot/fuzzers/engine.py
+++ b/src/python/bot/fuzzers/engine.py
@@ -42,8 +42,9 @@ class Result(object):
   """Represents a result of a fuzzing session: a list of crashes found and the
   stats generated."""
 
-  def __init__(self, logs, crashes, stats):
+  def __init__(self, logs, command, crashes, stats):
     self.logs = logs
+    self.command = command
     self.crashes = crashes
     self.stats = stats
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -87,7 +87,7 @@ def get_testcase_run(stats, fuzzer_command):
   build_revision = fuzzer_utils.get_build_revision()
   job = environment.get_value('JOB_NAME')
   # fuzzer name is filled by fuzz_task.
-  testcase_run = fuzzer_stats.TestcaseRun('', job, build_revision,
+  testcase_run = fuzzer_stats.TestcaseRun(None, job, build_revision,
                                           current_timestamp())
 
   testcase_run['command'] = fuzzer_command

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -56,6 +56,9 @@ OWNERS_FILE_EXTENSION = '.owners'
 # Extension for per-fuzz target labels to be added to issue tracker.
 LABELS_FILE_EXTENSION = '.labels'
 
+# Header format for logs.
+LOG_HEADER_FORMAT = ('Command: {command}\n' 'Bot: {bot}\n' 'Time ran: {time}\n')
+
 
 def current_timestamp():
   """Returns the current timestamp. Needed for mocking."""
@@ -400,3 +403,9 @@ def unpack_seed_corpus_if_needed(fuzz_target_path,
 
   logs.log('Unarchiving seed corpus %s took %s seconds.' %
            (seed_corpus_archive_path, time.time() - start_time))
+
+
+def get_log_header(command, bot_name, time_executed):
+  """Get the log header."""
+  return LOG_HEADER_FORMAT.format(
+      command=get_command_quoted(command), bot=bot_name, time=time_executed)

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -79,16 +79,22 @@ def decide_with_probability(probability):
   return random.SystemRandom().random() < probability
 
 
-def dump_big_query_data(stats, testcase_file_path, fuzzer_name_prefix,
-                        fuzzer_name, fuzzer_command):
-  """Dump BigQuery stats."""
+def get_testcase_run(stats, fuzzer_command):
+  """Get testcase run for stats."""
   build_revision = fuzzer_utils.get_build_revision()
   job = environment.get_value('JOB_NAME')
-  testcase_run = fuzzer_stats.TestcaseRun(fuzzer_name_prefix + fuzzer_name, job,
-                                          build_revision, current_timestamp())
+  # fuzzer name is filled by fuzz_task.
+  testcase_run = fuzzer_stats.TestcaseRun('', job, build_revision,
+                                          current_timestamp())
 
   testcase_run['command'] = fuzzer_command
   testcase_run.update(stats)
+  return testcase_run
+
+
+def dump_big_query_data(stats, testcase_file_path, fuzzer_command):
+  """Dump BigQuery stats."""
+  testcase_run = get_testcase_run(stats, fuzzer_command)
   fuzzer_stats.TestcaseRun.write_to_disk(testcase_run, testcase_file_path)
 
 

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -258,7 +258,7 @@ class LibFuzzerEngine(engine.Engine):
     # TODO(ochang): Custom crash state.
     # TODO(ochang): Recommended dictionary.
 
-    return engine.Result(fuzz_logs, crashes, parsed_stats)
+    return engine.Result(fuzz_logs, fuzz_result.command, crashes, parsed_stats)
 
   def reproduce(self, target_path, input_path, arguments, max_time):
     """Reproduce a crash given an input.
@@ -306,7 +306,7 @@ class LibFuzzerEngine(engine.Engine):
       raise MergeError('Merging new testcases failed')
 
     # TODO(ochang): Get crashes found during merge.
-    return engine.Result(merge_result.output, [], {})
+    return engine.Result(merge_result.output, merge_result.command, [], {})
 
   def minimize_testcase(self, target_path, arguments, input_path, output_path,
                         max_time):

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -941,14 +941,13 @@ def main(argv):
     shutil.move(crash_testcase_file_path, testcase_file_path)
 
   # Print the command output.
-  log_header_format = ('Command: %s\n' 'Bot: %s\n' 'Time ran: %f\n')
   bot_name = environment.get_value('BOT_NAME', '')
   command = fuzz_result.command
   if use_minijail:
     # Remove minijail prefix.
     command = engine_common.strip_minijail_command(command, fuzzer_path)
-  print(log_header_format % (engine_common.get_command_quoted(command),
-                             bot_name, fuzz_result.time_executed))
+  print(engine_common.get_log_header(command, bot_name,
+                                     fuzz_result.time_executed))
 
   # Parse stats information based on libFuzzer output.
   parsed_stats = parse_log_stats(log_lines)

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -1050,8 +1050,7 @@ def main(argv):
   parsed_stats.update(stat_overrides)
 
   # Dump stats data for further uploading to BigQuery.
-  engine_common.dump_big_query_data(parsed_stats, testcase_file_path,
-                                    LIBFUZZER_PREFIX, fuzzer_name, command)
+  engine_common.dump_big_query_data(parsed_stats, testcase_file_path, command)
 
   # Add custom crash state based on fuzzer name (if needed).
   add_custom_crash_state_if_needed(fuzzer_name, log_lines, parsed_stats)

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -497,8 +497,8 @@ def add_additional_testcase_run_data(testcase_run, fully_qualified_fuzzer_name,
   testcase_run['build_revision'] = revision
 
 
-def get_and_upload_testcase_run_stats(fuzzer_name, fully_qualified_fuzzer_name,
-                                      job_type, revision, testcase_file_paths):
+def read_and_upload_testcase_run_stats(fuzzer_name, fully_qualified_fuzzer_name,
+                                       job_type, revision, testcase_file_paths):
   """Upload per-testcase stats."""
   if fuzzer_name not in builtin_fuzzers.BUILTIN_FUZZERS:
     # Testcase run stats are only applicable to builtin fuzzers (libFuzzer,AFL).
@@ -1375,7 +1375,7 @@ class FuzzingSession(object):
 
     # Format logs with header and strategy information.
     log_header = engine_common.get_log_header(result.command,
-                                              environemnt.get_value('BOT_NAME'),
+                                              environment.get_value('BOT_NAME'),
                                               result.crash_time)
 
     formatted_strategies = engine_common.format_fuzzing_strategies(
@@ -1725,9 +1725,9 @@ class FuzzingSession(object):
             thread_wait_timeout=THREAD_WAIT_TIMEOUT,
             data_directory=self.data_directory))
 
-    get_and_upload_testcase_run_stats(self.fuzzer_name,
-                                      self.fully_qualified_fuzzer_name,
-                                      self.job_type, testcase_file_paths)
+    read_and_upload_testcase_run_stats(
+        self.fuzzer_name, self.fully_qualified_fuzzer_name, self.job_type,
+        crash_revision, testcase_file_paths)
     upload_job_run_stats(self.fully_qualified_fuzzer_name, self.job_type,
                          crash_revision, time.time(),
                          new_crash_count, known_crash_count,

--- a/src/python/fuzzing/testcase_manager.py
+++ b/src/python/fuzzing/testcase_manager.py
@@ -443,6 +443,12 @@ def run_testcase_and_return_result_in_queue(crash_queue,
     # Analyze the crash.
     crash_output = _get_crash_output(output)
     crash_result = CrashResult(return_code, crash_time, crash_output)
+
+    # To provide consistency between stats and logs, we use timestamp taken
+    # from stats when uploading logs and testcase.
+    if upload_output:
+      log_time = _get_testcase_time(file_path)
+
     if crash_result.is_crash():
       # Initialize resource list with the testcase path.
       resource_list = [file_path]
@@ -468,16 +474,11 @@ def run_testcase_and_return_result_in_queue(crash_queue,
       # Don't upload uninteresting testcases (no crash) or if there is no log to
       # correlate it with (not upload_output).
       if upload_output:
-        log_time = _get_testcase_time(file_path)
         upload_testcase(file_path, log_time)
 
     if upload_output:
       # Include full output for uploaded logs (crash output, merge output, etc).
       crash_result_full = CrashResult(return_code, crash_time, output)
-
-      # To provide consistency between stats and logs, we use timestamp taken
-      # from stats.
-      log_time = _get_testcase_time(file_path)
       log = prepare_log_for_upload(crash_result_full.get_stacktrace(),
                                    return_code)
       upload_log(log, log_time)

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -360,7 +360,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               'expected_duration':
                   2650,
               'fuzzer':
-                 None,
+                  None,
               'fuzzing_time_percent':
                   0.0,
               'job':

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -360,7 +360,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               'expected_duration':
                   2650,
               'fuzzer':
-                  u'',
+                 None,
               'fuzzing_time_percent':
                   0.0,
               'job':
@@ -563,7 +563,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               'expected_duration':
                   2650,
               'fuzzer':
-                  u'',
+                  None,
               'fuzzing_time_percent':
                   0.0,
               'job':
@@ -1282,7 +1282,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               'expected_duration':
                   2650,
               'fuzzer':
-                  u'',
+                  None,
               'fuzzing_time_percent':
                   0.0,
               'job':
@@ -1944,7 +1944,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               u'expected_duration':
                   2650,
               'fuzzer':
-                  u'',
+                  None,
               u'fuzzing_time_percent':
                   0.0,
               'job':
@@ -2271,7 +2271,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               u'expected_duration':
                   2650,
               'fuzzer':
-                  u'',
+                  None,
               u'fuzzing_time_percent':
                   0.0,
               'job':

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -360,7 +360,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               'expected_duration':
                   2650,
               'fuzzer':
-                  u'libfuzzer_fake_fuzzer',
+                  u'',
               'fuzzing_time_percent':
                   0.0,
               'job':
@@ -563,7 +563,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               'expected_duration':
                   2650,
               'fuzzer':
-                  u'libfuzzer_fake_fuzzer',
+                  u'',
               'fuzzing_time_percent':
                   0.0,
               'job':
@@ -1282,7 +1282,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               'expected_duration':
                   2650,
               'fuzzer':
-                  u'libfuzzer_fake_fuzzer',
+                  u'',
               'fuzzing_time_percent':
                   0.0,
               'job':
@@ -1944,7 +1944,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               u'expected_duration':
                   2650,
               'fuzzer':
-                  u'libfuzzer_fake_fuzzer',
+                  u'',
               u'fuzzing_time_percent':
                   0.0,
               'job':
@@ -2271,7 +2271,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
               u'expected_duration':
                   2650,
               'fuzzer':
-                  u'libfuzzer_fake_fuzzer',
+                  u'',
               u'fuzzing_time_percent':
                   0.0,
               'job':

--- a/src/python/tests/core/fuzzing/testcase_manager_test.py
+++ b/src/python/tests/core/fuzzing/testcase_manager_test.py
@@ -106,7 +106,11 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
 
     crash_result = CrashResult(
         return_code=1, crash_time=5, output='fake output')
-    testcase_manager.upload_testcase_output(crash_result, self.testcase_path)
+
+    log = testcase_manager.prepare_log_for_upload(crash_result.get_stacktrace(),
+                                                  crash_result.return_code)
+    log_time = testcase_manager._get_testcase_time(self.testcase_path)
+    testcase_manager.upload_log(log, log_time)
 
     # Date and time below is derived from 1472846341 timestamp value.
     self.mock.write_data.assert_called_once_with(
@@ -126,7 +130,10 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
         '"fuzzer": "fuzzer", "build_revision": 123}\n')
 
     crash_result = CrashResult(return_code=None, crash_time=None, output=None)
-    testcase_manager.upload_testcase_output(crash_result, self.testcase_path)
+    log = testcase_manager.prepare_log_for_upload(crash_result.get_stacktrace(),
+                                                  crash_result.return_code)
+    log_time = testcase_manager._get_testcase_time(self.testcase_path)
+    testcase_manager.upload_log(log, log_time)
     self.mock.write_data.assert_called_once_with(
         'Component revisions (build r123):\n'
         'Component: REVISION\nComponent2: REVISION2\n\n'
@@ -148,7 +155,10 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
 
     crash_result = CrashResult(
         return_code=1, crash_time=5, output='fake output')
-    testcase_manager.upload_testcase_output(crash_result, self.testcase_path)
+    log = testcase_manager.prepare_log_for_upload(crash_result.get_stacktrace(),
+                                                  crash_result.return_code)
+    log_time = testcase_manager._get_testcase_time(self.testcase_path)
+    testcase_manager.upload_log(log, log_time)
 
     # Date and time below is derived from 1472846341 timestamp value.
     self.mock.write_data.assert_called_once_with(

--- a/src/python/tests/core/fuzzing/testcase_manager_test.py
+++ b/src/python/tests/core/fuzzing/testcase_manager_test.py
@@ -56,6 +56,7 @@ class CreateTestcaseListFileTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(expected_files_list, actual_files_list)
 
 
+# pylint: disable=protected-access
 class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
   """Tests for logs uploading."""
 

--- a/src/python/tests/core/metrics/fuzzer_stats_test.py
+++ b/src/python/tests/core/metrics/fuzzer_stats_test.py
@@ -40,7 +40,6 @@ class FuzzerStatsTest(unittest.TestCase):
   """Fuzzer stats tests."""
 
   def setUp(self):
-    helpers.patch_environ(self)
     data_types.Fuzzer(name='parent').put()
 
     data_types.FuzzTarget(engine='parent', binary='child').put()
@@ -53,8 +52,6 @@ class FuzzerStatsTest(unittest.TestCase):
     helpers.patch(self, [
         'google_cloud_utils.storage.write_data',
     ])
-
-    os.environ['APP_REVISION'] = '123'
 
   def test_upload_testcase_run(self):
     """Tests uploading of TestcaseRun."""
@@ -234,7 +231,7 @@ class FuzzerStatsTest(unittest.TestCase):
 
     mock_read_from_disk_new.return_value = testcase_run
     fuzz_task.get_and_upload_testcase_run_stats(
-        'libFuzzer', 'libFuzzer_fuzzer1', 'job', ['fake_path'])
+        'libFuzzer', 'libFuzzer_fuzzer1', 'job', 123, ['fake_path'])
 
     self.assertEqual(1, self.mock.write_data.call_count)
 
@@ -253,7 +250,7 @@ class FuzzerStatsTest(unittest.TestCase):
 
     mock_read_from_disk_new.return_value = testcase_run
     fuzz_task.get_and_upload_testcase_run_stats(
-        'blackbox_fuzzer', 'blackbox_fuzzer', 'job', ['fake_path'])
+        'blackbox_fuzzer', 'blackbox_fuzzer', 'job', 123, ['fake_path'])
 
     self.assertEqual(0, self.mock.write_data.call_count)
 

--- a/src/python/tests/core/metrics/fuzzer_stats_test.py
+++ b/src/python/tests/core/metrics/fuzzer_stats_test.py
@@ -16,6 +16,7 @@
 import datetime
 import json
 import mock
+import os
 import re
 import unittest
 
@@ -39,6 +40,7 @@ class FuzzerStatsTest(unittest.TestCase):
   """Fuzzer stats tests."""
 
   def setUp(self):
+    helpers.patch_environ(self)
     data_types.Fuzzer(name='parent').put()
 
     data_types.FuzzTarget(engine='parent', binary='child').put()
@@ -51,6 +53,8 @@ class FuzzerStatsTest(unittest.TestCase):
     helpers.patch(self, [
         'google_cloud_utils.storage.write_data',
     ])
+
+    os.environ['APP_REVISION'] = '123'
 
   def test_upload_testcase_run(self):
     """Tests uploading of TestcaseRun."""
@@ -223,14 +227,14 @@ class FuzzerStatsTest(unittest.TestCase):
   @mock.patch('metrics.fuzzer_stats.TestcaseRun.read_from_disk')
   def test_fuzz_task_upload_testcase_run_stats_builtin_fuzzer(
       self, mock_read_from_disk_new):
-    """Tests that fuzz_task.upload_testcase_run_stats uploads stats."""
+    """Tests that fuzz_task.get_and_upload_testcase_run_stats uploads stats."""
     testcase_run = fuzzer_stats.TestcaseRun('placeholder', 'placeholder', 0,
                                             1472846341.017923)
     testcase_run['stat'] = 9001
 
     mock_read_from_disk_new.return_value = testcase_run
-    fuzz_task.upload_testcase_run_stats('libFuzzer', 'libFuzzer_fuzzer1', 'job',
-                                        123, ['fake_path'])
+    fuzz_task.get_and_upload_testcase_run_stats(
+        'libFuzzer', 'libFuzzer_fuzzer1', 'job', ['fake_path'])
 
     self.assertEqual(1, self.mock.write_data.call_count)
 
@@ -242,14 +246,14 @@ class FuzzerStatsTest(unittest.TestCase):
   @mock.patch('metrics.fuzzer_stats.TestcaseRun.read_from_disk')
   def test_fuzz_task_upload_testcase_run_stats_blackbox_fuzzer(
       self, mock_read_from_disk_new):
-    """Tests that fuzz_task.upload_testcase_run_stats uploads stats."""
+    """Tests that fuzz_task.get_and_upload_testcase_run_stats uploads stats."""
     testcase_run = fuzzer_stats.TestcaseRun('placeholder', 'placeholder', 0,
                                             1472846341.017923)
     testcase_run['stat'] = 9001
 
     mock_read_from_disk_new.return_value = testcase_run
-    fuzz_task.upload_testcase_run_stats('blackbox_fuzzer', 'blackbox_fuzzer',
-                                        'job', 123, ['fake_path'])
+    fuzz_task.get_and_upload_testcase_run_stats(
+        'blackbox_fuzzer', 'blackbox_fuzzer', 'job', ['fake_path'])
 
     self.assertEqual(0, self.mock.write_data.call_count)
 

--- a/src/python/tests/core/metrics/fuzzer_stats_test.py
+++ b/src/python/tests/core/metrics/fuzzer_stats_test.py
@@ -16,7 +16,6 @@
 import datetime
 import json
 import mock
-import os
 import re
 import unittest
 
@@ -224,13 +223,13 @@ class FuzzerStatsTest(unittest.TestCase):
   @mock.patch('metrics.fuzzer_stats.TestcaseRun.read_from_disk')
   def test_fuzz_task_upload_testcase_run_stats_builtin_fuzzer(
       self, mock_read_from_disk_new):
-    """Tests that fuzz_task.get_and_upload_testcase_run_stats uploads stats."""
+    """Tests that fuzz_task.read_and_upload_testcase_run_stats uploads stats."""
     testcase_run = fuzzer_stats.TestcaseRun('placeholder', 'placeholder', 0,
                                             1472846341.017923)
     testcase_run['stat'] = 9001
 
     mock_read_from_disk_new.return_value = testcase_run
-    fuzz_task.get_and_upload_testcase_run_stats(
+    fuzz_task.read_and_upload_testcase_run_stats(
         'libFuzzer', 'libFuzzer_fuzzer1', 'job', 123, ['fake_path'])
 
     self.assertEqual(1, self.mock.write_data.call_count)
@@ -243,13 +242,13 @@ class FuzzerStatsTest(unittest.TestCase):
   @mock.patch('metrics.fuzzer_stats.TestcaseRun.read_from_disk')
   def test_fuzz_task_upload_testcase_run_stats_blackbox_fuzzer(
       self, mock_read_from_disk_new):
-    """Tests that fuzz_task.get_and_upload_testcase_run_stats uploads stats."""
+    """Tests that fuzz_task.read_and_upload_testcase_run_stats uploads stats."""
     testcase_run = fuzzer_stats.TestcaseRun('placeholder', 'placeholder', 0,
                                             1472846341.017923)
     testcase_run['stat'] = 9001
 
     mock_read_from_disk_new.return_value = testcase_run
-    fuzz_task.get_and_upload_testcase_run_stats(
+    fuzz_task.read_and_upload_testcase_run_stats(
         'blackbox_fuzzer', 'blackbox_fuzzer', 'job', 123, ['fake_path'])
 
     self.assertEqual(0, self.mock.write_data.call_count)


### PR DESCRIPTION
- Put log header logic into engine_common.get_log_header() function for getting log headers.
- Remove fuzzer name setting in dump_big_query_data. It sets an incorrect name anyway, and is later overwritten in fuzz_task.
- Refactor testcase_manager log/testcase uploading to make it easier to reduce its functionality.