### PR TITLE
Reproduce tool fixes.

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -266,11 +266,14 @@ def main():
   parser_reproduce = subparsers.add_parser(
       'reproduce', help='Reproduce a crash or error from a test case.')
   parser_reproduce.add_argument(
-      '--testcase', required=True, help='Testcase URL.')
+      '-t', '--testcase', required=True, help='Testcase URL.')
   parser_reproduce.add_argument(
+      '-b',
       '--build-dir',
       required=True,
       help='Build directory containing the target app and dependencies.')
+  parser_reproduce.add_argument(
+      '-i', '--iterations', help='Number of times to attempt reproduction.')
 
   args = parser.parse_args()
 

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -38,7 +38,6 @@ import unittest
 from local.butler import appengine
 from local.butler import common
 from src.python.config import local_config
-from src.python.metrics import logs
 
 APPENGINE_TEST_DIRECTORY = os.path.join('src', 'python', 'tests', 'appengine')
 CORE_TEST_DIRECTORY = os.path.join('src', 'python', 'tests', 'core')
@@ -300,7 +299,8 @@ def execute(args):
   os.environ['DATASTORE_USE_PROJECT_ID_AS_APP_ID'] = 'true'
 
   if args.verbose:
-    logs.configure_for_tests()
+    # Force logging to console for this process and child processes.
+    os.environ['LOG_TO_CONSOLE'] = 'True'
   else:
     # Disable logging.
     logging.disable(logging.CRITICAL)

--- a/src/local/butler/reproduce_tool/config.py
+++ b/src/local/butler/reproduce_tool/config.py
@@ -35,7 +35,6 @@ class ReproduceToolConfiguration(object):
         path=REPRODUCE_TOOL_CONFIG_HANDLER).geturl()
     response, content = http_utils.request(config_url, body={})
     if response.status != 200:
-      assert False, (response, content)
       raise errors.ReproduceToolUnrecoverableError('Failed to access server.')
 
     self._config = json_utils.loads(content)

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -1397,11 +1397,6 @@ def main(argv):
   build_directory = environment.get_value('BUILD_DIR')
   fuzzer_path = engine_common.find_fuzzer_path(build_directory, target_name)
   if not fuzzer_path:
-    # This is an expected case when doing regression testing with old builds
-    # that do not have that fuzz target. It can also happen when a host sends a
-    # message to an untrusted worker that just restarted and lost information on
-    # build directory.
-    logs.log_warn('Could not find fuzz target %s.' % target_name)
     return
 
   # Install signal handler.

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -124,6 +124,10 @@ def find_fuzzer_path(build_directory, fuzzer_name):
           filename == fuzzer_filename):
         return os.path.join(root, filename)
 
+  # This is an expected case when doing regression testing with old builds
+  # that do not have that fuzz target. It can also happen when a host sends a
+  # message to an untrusted worker that just restarted and lost information on
+  # build directory.
   logs.log_warn('Fuzzer: %s not found in build_directory: %s.' %
                 (fuzzer_name, build_directory))
   return None

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -782,11 +782,6 @@ def main(argv):
   build_directory = environment.get_value('BUILD_DIR')
   fuzzer_path = engine_common.find_fuzzer_path(build_directory, target_name)
   if not fuzzer_path:
-    # This is an expected case when doing regression testing with old builds
-    # that do not have that fuzz target. It can also happen when a host sends a
-    # message to an untrusted worker that just restarted and lost information on
-    # build directory.
-    logs.log_warn('Could not find fuzz target %s.' % target_name)
     return
 
   # Install signal handler.

--- a/src/python/tests/test_libs/untrusted_runner_helpers.py
+++ b/src/python/tests/test_libs/untrusted_runner_helpers.py
@@ -28,7 +28,6 @@ from bot.untrusted_runner import untrusted
 from datastore import data_types
 from datastore import ndb
 from datastore import ndb_patcher
-from metrics import logs
 from system import environment
 from system import shell
 from tests.test_libs import helpers as test_helpers
@@ -114,8 +113,6 @@ class UntrustedRunnerIntegrationTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    logs.configure_for_tests()
-
     os.environ['HOST_INSTANCE_NAME'] = 'host'
     os.environ['HOST_INSTANCE_NUM'] = '0'
     os.environ['BOT_NAME'] = 'host-0'


### PR DESCRIPTION
* Don't set APP_PATH as it incorrectly sets it to
  {build_dir}/launcher.py for engine fuzzers and causes
  reproduction to fail due to non-existent. Instead let
  build_manager.set_environment_vars set it correctly.
* Make logging work in tests since log initialization from
  py_unittest does not pass to child processes, unless the
  child explicitly calls configure. So, instead pass a env
  var LOG_TO_CONSOLE and initialize logger automatically in
  child process when this env var is set.
  See https://github.com/google/clusterfuzz/issues/485
* Add some useful log statements to make execution flow clear.
* Add iterations option to control number of reproduction
  iterations (instead of default 10).
* Fix order of status message and output. Print status message
  after output so that people can see result without scrolling.
* Remove the unneeded warn in afl,libfuzzer/launcher.py. This
  is already logged by engine_common.find_fuzzer_path.
* Do not run Xvfb, blackbox for engine based jobs. This shaves
  off 10 sec of run-time.
* Improve reproduce test to use an actual binary and build dir.
* Add shorter versions of command line options.