### PR TITLE
More changes for generic project setup (#647).

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -876,8 +876,9 @@ class Handler(base_handler.Handler):
       logs.log_error('Failed to get AFL Fuzzer entity.')
       return
 
-    bucket_config = local_config.ProjectConfig().sub_config(
-        'project_setup.build_buckets')
+    project_setup_config = local_config.ProjectConfig().sub_config(
+        'project_setup')
+    bucket_config = project_setup_config.sub_config('build_buckets')
 
     if not bucket_config:
       raise ProjectSetupError('Project setup buckets not specified.')
@@ -885,7 +886,8 @@ class Handler(base_handler.Handler):
     config = ProjectSetup(
         BUILD_BUCKET_PATH_TEMPLATE,
         REVISION_URL,
-        segregate_projects=True,
+        segregate_projects=project_setup_config.get('segregate_projects',
+                                                    False),
         engine_build_buckets={
             'libfuzzer': bucket_config.get('libfuzzer'),
             'libfuzzer-i386': bucket_config.get('libfuzzer_i386'),
@@ -897,7 +899,7 @@ class Handler(base_handler.Handler):
             'libfuzzer': libfuzzer,
             'afl': afl,
         },
-        add_info_labels=True)
+        add_info_labels=project_setup_config.get('add_info_labels'))
 
     projects = get_projects()
     config.set_up(projects)

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -80,7 +80,7 @@ MIN_ELAPSED_TIME_SINCE_REPORT = 3
 NAME_CHECK_REGEX = re.compile(r'^[a-zA-Z0-9_-]+$')
 
 # Regex to match special chars in project name.
-FUZZ_TARGET_SPECIAL_CHARS_REGEX = re.compile('[^a-zA-Z0-9_-]')
+SPECIAL_CHARS_REGEX = re.compile('[^a-zA-Z0-9_-]')
 
 # List of supported platforms.
 PLATFORMS = [
@@ -1075,16 +1075,17 @@ def fuzz_target_fully_qualified_name(engine, project, binary):
   return engine + '_' + fuzz_target_project_qualified_name(project, binary)
 
 
+def normalized_name(name):
+  """Return normalized name with special chars like slash, colon, etc normalized
+  to hyphen(-). This is important as otherwise these chars break local and cloud
+  storage paths."""
+  return SPECIAL_CHARS_REGEX.sub('-', name).strip('-')
+
+
 def fuzz_target_project_qualified_name(project, binary):
   """Get a fuzz target's project qualified name."""
 
-  def _normalized(name):
-    """Return normalized project name with special chars like slash, colon, etc
-    normalized to hyphen(-). This is important as otherwise these chars break
-    local and cloud storage paths."""
-    return FUZZ_TARGET_SPECIAL_CHARS_REGEX.sub('-', name).strip('-')
-
-  binary = _normalized(binary)
+  binary = normalized_name(binary)
   if not project:
     return binary
 
@@ -1092,7 +1093,7 @@ def fuzz_target_project_qualified_name(project, binary):
     # Don't prefix with project name if it's the default project.
     return binary
 
-  normalized_project_prefix = _normalized(project) + '_'
+  normalized_project_prefix = normalized_name(project) + '_'
   if binary.startswith(normalized_project_prefix):
     return binary
 

--- a/src/python/tests/test_libs/mock_config.py
+++ b/src/python/tests/test_libs/mock_config.py
@@ -1,0 +1,39 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Mock config."""
+from __future__ import absolute_import
+
+from builtins import object
+
+
+class MockConfig(object):
+  """Mock config."""
+
+  def __init__(self, data):
+    self._data = data
+
+  def get(self, key_name='', default=None):
+    """Get key value using a key name."""
+    parts = key_name.split(':')
+    value = self._data
+    for part in parts:
+      if part not in value:
+        return default
+
+      value = value[part]
+
+    return value
+
+  def sub_config(self, path):
+    return MockConfig(self.get(path))


### PR DESCRIPTION
- Support reading a projects.json file as a source for project setup.
- Make build type configurable.
- Support custom build path template from project info via 'build_path' key.
- Make srcmap setup optional.
- Add MockConfig to make it easier to mock out local config for testing.