### PR TITLE
Modify project setup templates to use standard ones.

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -99,22 +99,22 @@ class JobInfo(object):
 # The order of templates is important here. Later templates override settings in
 # the earlier ones. An engine template may override vars set for a sanitizer.
 LIBFUZZER_ASAN_JOB = JobInfo('libfuzzer_asan_', 'libfuzzer', 'address',
-                             ['asan', 'libfuzzer', 'prune'])
+                             ['engine_asan', 'libfuzzer', 'prune'])
 LIBFUZZER_MSAN_JOB = JobInfo('libfuzzer_msan_', 'libfuzzer', 'memory',
-                             ['msan', 'libfuzzer'])
+                             ['engine_msan', 'libfuzzer'])
 LIBFUZZER_UBSAN_JOB = JobInfo('libfuzzer_ubsan_', 'libfuzzer', 'undefined',
-                              ['ubsan', 'libfuzzer'])
+                              ['engine_ubsan', 'libfuzzer'])
 AFL_ASAN_JOB = JobInfo(
     'afl_asan_',
     'afl',
-    'address', ['asan', 'afl'],
+    'address', ['engine_asan', 'afl'],
     minimize_job_override=LIBFUZZER_ASAN_JOB)
 NO_ENGINE_ASAN_JOB = JobInfo('asan_', 'none', 'address', [])
 
 LIBFUZZER_ASAN_I386_JOB = JobInfo(
     'libfuzzer_asan_i386_',
     'libfuzzer',
-    'address', ['asan', 'libfuzzer'],
+    'address', ['engine_asan', 'libfuzzer'],
     architecture='i386')
 
 JOB_MAP = {

--- a/src/local/butler/scripts/setup.py
+++ b/src/local/butler/scripts/setup.py
@@ -64,12 +64,15 @@ ENGINE_UBSAN_TEMPLATE = """LSAN = False
 ADDITIONAL_UBSAN_OPTIONS = symbolize=0:allocator_release_to_os_interval_ms=500
 """
 
+PRUNE_TEMPLATE = 'CORPUS_PRUNE = True'
+
 TEMPLATES = {
     'afl': AFL_TEMPLATE,
     'engine_asan': ENGINE_ASAN_TEMPLATE,
     'engine_msan': ENGINE_MSAN_TEMPLATE,
     'engine_ubsan': ENGINE_UBSAN_TEMPLATE,
     'libfuzzer': LIBFUZZER_TEMPLATE,
+    'prune': PRUNE_TEMPLATE,
 }
 
 

--- a/src/python/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/python/tests/appengine/handlers/cron/project_setup_test.py
@@ -285,7 +285,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         data_types.Job.name == 'libfuzzer_asan_lib1').get()
     self.assertIsNotNone(job)
     self.assertEqual(job.platform, 'LIB1_LINUX')
-    self.assertItemsEqual(job.templates, ['asan', 'libfuzzer', 'prune'])
+    self.assertItemsEqual(job.templates, ['engine_asan', 'libfuzzer', 'prune'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib1/lib1-address-([0-9]+).zip\n'
@@ -304,7 +304,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         data_types.Job.name == 'libfuzzer_asan_lib2').get()
     self.assertIsNotNone(job)
     self.assertEqual(job.platform, 'LIB2_LINUX')
-    self.assertItemsEqual(job.templates, ['asan', 'libfuzzer', 'prune'])
+    self.assertItemsEqual(job.templates, ['engine_asan', 'libfuzzer', 'prune'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib2/lib2-address-([0-9]+).zip\n'
@@ -323,7 +323,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         data_types.Job.name == 'libfuzzer_asan_lib3').get()
     self.assertIsNotNone(job)
     self.assertEqual(job.platform, 'LIB3_LINUX')
-    self.assertItemsEqual(job.templates, ['asan', 'libfuzzer', 'prune'])
+    self.assertItemsEqual(job.templates, ['engine_asan', 'libfuzzer', 'prune'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib3/lib3-address-([0-9]+).zip\n'
@@ -343,7 +343,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         data_types.Job.name == 'libfuzzer_asan_i386_lib3').get()
     self.assertIsNotNone(job)
     self.assertEqual(job.platform, 'LIB3_LINUX')
-    self.assertItemsEqual(job.templates, ['asan', 'libfuzzer'])
+    self.assertItemsEqual(job.templates, ['engine_asan', 'libfuzzer'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds-i386/lib3/lib3-address-([0-9]+).zip\n'
@@ -363,7 +363,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         data_types.Job.name == 'libfuzzer_msan_lib3').get()
     self.assertIsNotNone(job)
     self.assertEqual(job.platform, 'LIB3_LINUX')
-    self.assertItemsEqual(job.templates, ['msan', 'libfuzzer'])
+    self.assertItemsEqual(job.templates, ['engine_msan', 'libfuzzer'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib3/lib3-memory-([0-9]+).zip\n'
@@ -384,7 +384,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         data_types.Job.name == 'libfuzzer_ubsan_lib3').get()
     self.assertIsNotNone(job)
     self.assertEqual(job.platform, 'LIB3_LINUX')
-    self.assertItemsEqual(job.templates, ['ubsan', 'libfuzzer'])
+    self.assertItemsEqual(job.templates, ['engine_ubsan', 'libfuzzer'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib3/lib3-undefined-([0-9]+).zip\n'
@@ -403,7 +403,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     job = data_types.Job.query(data_types.Job.name == 'afl_asan_lib1').get()
     self.assertIsNotNone(job)
     self.assertEqual(job.platform, 'LIB1_LINUX')
-    self.assertItemsEqual(job.templates, ['asan', 'afl'])
+    self.assertItemsEqual(job.templates, ['engine_asan', 'afl'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds-afl/lib1/lib1-address-([0-9]+).zip\n'
@@ -1576,7 +1576,7 @@ class GenericProjectSetupTest(unittest.TestCase):
         'gs://bucket/a-b/libfuzzer/address/%TARGET%/([0-9]+).zip\n'
         'PROJECT_NAME = //a/b\nSUMMARY_PREFIX = //a/b\nMANAGED = True\n',
         job.environment_string)
-    self.assertItemsEqual(['asan', 'libfuzzer', 'prune'], job.templates)
+    self.assertItemsEqual(['engine_asan', 'libfuzzer', 'prune'], job.templates)
 
     libfuzzer = data_types.Fuzzer.query(
         data_types.Fuzzer.name == 'libFuzzer').get()


### PR DESCRIPTION
Use template names created in `butler.py run setup`.