### PR TITLE
[fuchsia] Update log capture scripts.

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -374,10 +374,6 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
 
   def fetch_and_process_logs_and_crash(self):
     """Fetch symbolized logs and crashes."""
-    # Fetch the symbolized log.
-    for logname in os.listdir(self.fuzzer.results_output()):
-      if logname == os.path.basename(self.fuzzer.logfile):
-        self.device.dlog(self.fuzzer.logfile)
 
     # Clusterfuzz assumes that the Libfuzzer output points to an absolute path,
     # where it can find the crash file.
@@ -414,6 +410,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     """LibFuzzerCommon.fuzz override."""
     self._test_qemu_ssh()
     self.fuzzer.start([])
+    self.fuzzer.monitor()
     self.fetch_and_process_logs_and_crash()
 
     with open(self.fuzzer.logfile) as logfile:

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1145,9 +1145,8 @@ def process_crashes(crashes, context):
     time.sleep(1)
 
   logs.log('Finished processing crashes.')
-  logs.log('New crashes: ' + str(new_crash_count) + ', known crashes: ' +
-           str(known_crash_count) + ', processed groups: ' +
-           str(processed_groups))
+  logs.log('New crashes: {}, known crashes: {}, processed groups: {}'.format(
+      new_crash_count, known_crash_count, processed_groups))
   return new_crash_count, known_crash_count, processed_groups
 
 

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1145,6 +1145,9 @@ def process_crashes(crashes, context):
     time.sleep(1)
 
   logs.log('Finished processing crashes.')
+  logs.log('New crashes: ' + str(new_crash_count) + ', known crashes: ' +
+           str(known_crash_count) + ', processed groups: ' +
+           str(processed_groups))
   return new_crash_count, known_crash_count, processed_groups
 
 
@@ -1732,6 +1735,8 @@ class FuzzingSession(object):
       # TODO(unassigned): Need to find a way to this efficiently before every
       # testcase is analyzed.
       android.device.initialize_device()
+
+    logs.log('Raw crash count: ' + str(len(crashes)))
 
     project_name = data_handler.get_project_name(self.job_type)
 

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -445,8 +445,6 @@ def run_testcase_and_return_result_in_queue(crash_queue,
     # Run testcase and check whether a crash occurred or not.
     return_code, crash_time, output = run_testcase(thread_index, file_path,
                                                    gestures, env_copy)
-    logs.log("Returning from testcase. Return code: " + str(return_code) +
-             ", crash time: " + str(crash_time))
 
     # Pull testcase directory to host to get any stats files.
     if environment.is_trusted_host():

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -445,6 +445,8 @@ def run_testcase_and_return_result_in_queue(crash_queue,
     # Run testcase and check whether a crash occurred or not.
     return_code, crash_time, output = run_testcase(thread_index, file_path,
                                                    gestures, env_copy)
+    logs.log("Returning from testcase. Return code: " + str(return_code) +
+             ", crash time: " + str(crash_time))
 
     # Pull testcase directory to host to get any stats files.
     if environment.is_trusted_host():

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -181,7 +181,7 @@ def extend_fvm(fuchsia_resources_dir, drive_path):
                                'default.zircon', 'tools', 'fvm')
   os.chmod(fvm_tool_path, 0o500)
   process = new_process.ProcessRunner(fvm_tool_path,
-                                      [drive_path, 'extend', '--length', '2G'])
+                                      [drive_path, 'extend', '--length', '3G'])
   result = process.run_and_wait()
   if result.return_code or result.timed_out:
     raise errors.FuchsiaSdkError('Failed to extend FVM: ' + result.output)

--- a/src/python/platforms/fuchsia/util/device.py
+++ b/src/python/platforms/fuchsia/util/device.py
@@ -21,7 +21,7 @@ import os
 import re
 import subprocess
 
-from host import Host
+from .host import Host
 
 
 class Device(object):

--- a/src/python/platforms/fuchsia/util/process.py
+++ b/src/python/platforms/fuchsia/util/process.py
@@ -1,0 +1,66 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Process runner."""
+
+from builtins import object
+
+import subprocess
+
+
+class Process(object):
+  """Represent an child process.
+
+       This class is intentionally similar to subprocess, except that it allows
+       various fields to be set before executing the process. Additionally, it
+       allows tests to overload process creation and execution in one place;
+       see MockProcess.
+    """
+
+  def __init__(self, args, **kwargs):
+    self.args = args
+    self.cwd = kwargs.get('cwd', None)
+    self.stdin = kwargs.get('stdin', None)
+    self.stdout = kwargs.get('stdout', None)
+    self.stderr = kwargs.get('stderr', None)
+
+  def popen(self):
+    """Analogous to subprocess.Popen."""
+    p = subprocess.Popen(
+        self.args, stdin=self.stdin, stdout=self.stdout, stderr=self.stderr)
+    self.__init__([])
+    return p
+
+  def call(self):
+    """Analogous to subprocess.call."""
+    p = self.popen()
+    return p.wait()
+
+  def check_call(self):
+    """Analogous to subprocess.check_call."""
+    cmd = self.args
+    rc = self.call()
+    if rc != 0:
+      raise subprocess.CalledProcessError(rc, cmd)
+    return rc
+
+  def check_output(self):
+    """Analogous to subprocess.check_output."""
+    cmd = self.args
+    self.stdout = subprocess.PIPE
+    p = self.popen()
+    out, _ = p.communicate()
+    rc = p.returncode
+    if rc != 0:
+      raise subprocess.CalledProcessError(rc, cmd)
+    return out

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -698,7 +698,7 @@ class TestLauncherFuchsia(BaseLauncherTest):
     data_types.Fuzzer(
         revision=1,
         additional_environment_string=
-        'FUCHSIA_BUILD_URL = gs://fuchsia-clusterfuzz-test-july-15-2019/*\n',
+        'FUCHSIA_BUILD_URL = gs://fuchsia-clusterfuzz-test-august-6-2019/*\n',
         builtin=True,
         differential=False,
         file_size='builtin',
@@ -731,7 +731,8 @@ class TestLauncherFuchsia(BaseLauncherTest):
     data_types.Job(
         environment_string=(
             'CUSTOM_BINARY = True\n'
-            'FUCHSIA_BUILD_URL = gs://fuchsia-clusterfuzz-test-july-15-2019/*\n'
+            'FUCHSIA_BUILD_URL = gs://fuchsia-clusterfuzz-test-august-6-2019/*'
+            '\n'
             'QUEUE_OVERRIDE=FUCHSIA\n'
             'OS_OVERRIDE=FUCHSIA'),
         name='libfuzzer_asan_test_fuzzer',
@@ -766,7 +767,7 @@ class TestLauncherFuchsia(BaseLauncherTest):
     environment.set_value('QUEUE_OVERRIDE', 'FUCHSIA')
     environment.set_value('OS_OVERRIDE', 'FUCHSIA')
     environment.set_value('FUCHSIA_BUILD_URL',
-                          'gs://fuchsia-clusterfuzz-test-july-15-2019/*')
+                          'gs://fuchsia-clusterfuzz-test-august-6-2019/*')
     self.tmp_resources_dir = tempfile.mkdtemp()
     environment.set_value('RESOURCES_DIR', self.tmp_resources_dir)
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -775,10 +775,8 @@ class TestLauncherFuchsia(BaseLauncherTest):
   def tearDown(self):
     shutil.rmtree(self.tmp_resources_dir, ignore_errors=True)
 
-  @skipIf(
-      True,
-      'Temporarily disabling the Fuchsia test until build size reduced.'
-  )
+  @skipIf(True,
+          'Temporarily disabling the Fuchsia test until build size reduced.')
   def test_fuzzer_can_boot_and_run(self):
     """Tests running a single round of fuzzing on a Fuchsia target, using
     'echo' in place of a fuzzing command."""

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -699,7 +699,7 @@ class TestLauncherFuchsia(BaseLauncherTest):
     data_types.Fuzzer(
         revision=1,
         additional_environment_string=
-        'FUCHSIA_BUILD_URL = gs://fuchsia-clusterfuzz-test-august-6-2019/*\n',
+        'FUCHSIA_BUILD_URL = gs://fuchsia-clusterfuzz-test-august-12-2019/*\n',
         builtin=True,
         differential=False,
         file_size='builtin',
@@ -732,7 +732,7 @@ class TestLauncherFuchsia(BaseLauncherTest):
     data_types.Job(
         environment_string=(
             'CUSTOM_BINARY = True\n'
-            'FUCHSIA_BUILD_URL = gs://fuchsia-clusterfuzz-test-august-6-2019/*'
+            'FUCHSIA_BUILD_URL = gs://fuchsia-clusterfuzz-test-august-12-2019/*'
             '\n'
             'QUEUE_OVERRIDE=FUCHSIA\n'
             'OS_OVERRIDE=FUCHSIA'),
@@ -768,7 +768,7 @@ class TestLauncherFuchsia(BaseLauncherTest):
     environment.set_value('QUEUE_OVERRIDE', 'FUCHSIA')
     environment.set_value('OS_OVERRIDE', 'FUCHSIA')
     environment.set_value('FUCHSIA_BUILD_URL',
-                          'gs://fuchsia-clusterfuzz-test-august-6-2019/*')
+                          'gs://fuchsia-clusterfuzz-test-august-12-2019/*')
     self.tmp_resources_dir = tempfile.mkdtemp()
     environment.set_value('RESOURCES_DIR', self.tmp_resources_dir)
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -777,7 +777,7 @@ class TestLauncherFuchsia(BaseLauncherTest):
 
   @skipIf(
       True,
-      'Temporarily disabling the Fuchsia integration test until build size reduced.'
+      'Temporarily disabling the Fuchsia test until build size reduced.'
   )
   def test_fuzzer_can_boot_and_run(self):
     """Tests running a single round of fuzzing on a Fuchsia target, using

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -35,6 +35,7 @@ from system import environment
 from system import shell
 from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils
+from testtools import skipIf
 
 TEST_PATH = os.path.abspath(os.path.dirname(__file__))
 TEMP_DIRECTORY = os.path.join(TEST_PATH, 'temp')
@@ -685,10 +686,6 @@ class TestLauncherMinijail(BaseLauncherTest):
 
 @test_utils.integration
 @test_utils.with_cloud_emulators('datastore')
-@skipIf(
-    True,
-    'Temporarily disabling the Fuchsia integration test until build size reduced.'
-)
 class TestLauncherFuchsia(BaseLauncherTest):
   """libFuzzer launcher tests (Fuchsia)."""
 
@@ -777,7 +774,10 @@ class TestLauncherFuchsia(BaseLauncherTest):
 
   def tearDown(self):
     shutil.rmtree(self.tmp_resources_dir, ignore_errors=True)
-
+  @skipIf(
+    True,
+    'Temporarily disabling the Fuchsia integration test until build size reduced.'
+  )
   def test_fuzzer_can_boot_and_run(self):
     """Tests running a single round of fuzzing on a Fuchsia target, using
     'echo' in place of a fuzzing command."""

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -774,9 +774,10 @@ class TestLauncherFuchsia(BaseLauncherTest):
 
   def tearDown(self):
     shutil.rmtree(self.tmp_resources_dir, ignore_errors=True)
+
   @skipIf(
-    True,
-    'Temporarily disabling the Fuchsia integration test until build size reduced.'
+      True,
+      'Temporarily disabling the Fuchsia integration test until build size reduced.'
   )
   def test_fuzzer_can_boot_and_run(self):
     """Tests running a single round of fuzzing on a Fuchsia target, using

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -685,6 +685,10 @@ class TestLauncherMinijail(BaseLauncherTest):
 
 @test_utils.integration
 @test_utils.with_cloud_emulators('datastore')
+@skipIf(
+    True,
+    'Temporarily disabling the Fuchsia integration test until build size reduced.'
+)
 class TestLauncherFuchsia(BaseLauncherTest):
   """libFuzzer launcher tests (Fuchsia)."""
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -35,7 +35,6 @@ from system import environment
 from system import shell
 from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils
-from testtools import skipIf
 
 TEST_PATH = os.path.abspath(os.path.dirname(__file__))
 TEMP_DIRECTORY = os.path.join(TEST_PATH, 'temp')
@@ -775,8 +774,9 @@ class TestLauncherFuchsia(BaseLauncherTest):
   def tearDown(self):
     shutil.rmtree(self.tmp_resources_dir, ignore_errors=True)
 
-  @skipIf(True,
-          'Temporarily disabling the Fuchsia test until build size reduced.')
+  @unittest.skipIf(
+      not environment.get_value('FUCHSIA_TESTS'),
+      'Temporarily disabling the Fuchsia test until build size reduced.')
   def test_fuzzer_can_boot_and_run(self):
     """Tests running a single round of fuzzing on a Fuchsia target, using
     'echo' in place of a fuzzing command."""

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -187,7 +187,7 @@ class FuchsiaBuildTest(fake_filesystem_unittest.TestCase):
     """Tests setting up a build."""
     environment.set_value('RESOURCES_DIR', self.tmp_resources_dir)
     environment.set_value('FUCHSIA_BUILD_URL',
-                          'gs://fuchsia-clusterfuzz-test-july-15-2019/*')
+                          'gs://fuchsia-clusterfuzz-test-august-6-2019/*')
     build = build_manager.setup_fuchsia_build()
     self.assertIsInstance(build, build_manager.FuchsiaBuild)
     self._assert_env_vars()

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -170,6 +170,9 @@ class TrunkBuildTest(unittest.TestCase):
     self.assertEqual(0, self.mock.setup_regular_build.call_count)
 
 
+@unittest.skipIf(
+    not environment.get_value('FUCHSIA_TESTS'),
+    'Temporarily disabling the Fuchsia test until build size reduced.')
 class FuchsiaBuildTest(fake_filesystem_unittest.TestCase):
   """Tests for Fuchsia build setup."""
 


### PR DESCRIPTION
Fuchsia's previous log capture scripts weren't properly grabbing all the
symbolized output, and furthermore, that symbolized output wasn't in a
format that was compatible with the regexes Clusterfuzz uses to detect
crashes.

This updates the scripts in src/python/platforms/fuchsia/util to handle
symbolized log capture properly.

Additionally, I added some logging on the Clusterfuzz side to make
diagnosing these issues easier in the future; lmk if they work okay for
you.