### PR TITLE
Fix exception with clank revision parsing.

### DIFF
--- a/src/python/build_management/revisions.py
+++ b/src/python/build_management/revisions.py
@@ -96,7 +96,8 @@ def _clank_revision_file_to_revisions_dict(content):
   clank_revision = component_revision_mappings['clank_revision']
 
   # Initialize revisions dictionary with chromium repo.
-  revisions_dict = get_component_revisions_dict(chromium_revision, None)
+  revisions_dict = get_component_revisions_dict(
+      chromium_revision, 'linux_asan_chrome_mp')  # FIXME: Remove this hardcode.
   if revisions_dict is None:
     logs.log_error(
         'Failed to get chromium component revisions.',


### PR DESCRIPTION
None job type does not work since REVISION_VARS_URL is already
overwritten by job environment on bot. So, unable to fetch default
vars url to get chromium revision. Hardcode for now.