### PR TITLE
Stack Analyzer: add parsing for Golang stacktraces (#265).

### DIFF
--- a/src/python/crash_analysis/crash_analyzer.py
+++ b/src/python/crash_analysis/crash_analyzer.py
@@ -91,6 +91,13 @@ UBSAN_CRASH_TYPES_SECURITY = [
     'Non-positive-vla-bound-value',
     'Object-size',
 ]
+GOLANG_CRASH_TYPES_NON_SECURITY = [
+    'index out of range',
+    'integer divide by zero',
+    'makeslice: len out of range',
+    'slice bounds out of range',
+    'stack overflow',
+]
 
 # Default page size of 4KB.
 NULL_DEREFERENCE_BOUNDARY = 0x1000
@@ -296,6 +303,9 @@ def is_security_issue(crash_stacktrace, crash_type, crash_address):
     return True
 
   if crash_type in UBSAN_CRASH_TYPES_NON_SECURITY:
+    return False
+
+  if crash_type in GOLANG_CRASH_TYPES_NON_SECURITY:
     return False
 
   # Floating point exceptions.

--- a/src/python/crash_analysis/crash_analyzer.py
+++ b/src/python/crash_analysis/crash_analyzer.py
@@ -92,11 +92,11 @@ UBSAN_CRASH_TYPES_SECURITY = [
     'Object-size',
 ]
 GOLANG_CRASH_TYPES_NON_SECURITY = [
-    'index out of range',
-    'integer divide by zero',
-    'makeslice: len out of range',
-    'slice bounds out of range',
-    'stack overflow',
+    'Index out of range',
+    'Integer divide by zero',
+    'Makeslice: len out of range',
+    'Slice bounds out of range',
+    'Stack overflow',
 ]
 
 # Default page size of 4KB.

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -426,7 +426,7 @@ STACK_FRAME_IGNORE_REGEXES = [
     r'^\<unknown\>$',
     r'^\[vdso\]$',
 
-    # Golang specific regexes to ignore.
+    # Golang specific frames to ignore.
     r'^runtime.throw$',
     r'^runtime.newstack$',
     r'^runtime.morestack$',

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -264,7 +264,7 @@ GOLANG_CRASH_TYPES_MAP = [
 ]
 
 GOLANG_STACK_FRAME_FUNCTION_REGEX = re.compile(
-    r'^([0-9a-zA-Z\.\-\_\\\/\(\)\*]+)\([0-9a-zA-Z\s,\_]*\)$')
+    r'^([0-9a-zA-Z\.\-\_\\\/\(\)\*]+)\([x0-9a-f\s,\.]*\)$')
 
 # Mappings of Android kernel error status codes to strings.
 ANDROID_KERNEL_STATUS_TO_STRING = {

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_asan_panic.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_asan_panic.txt
@@ -1,0 +1,26 @@
+panic: asn1: string not valid UTF-8
+
+goroutine 17 [running, locked to thread]:
+github.com/dvyukov/go-fuzz-corpus/asn1.Fuzz(0x602000030190, 0x6, 0x6, 0x10c00015dea0)
+    /tmp/go-fuzz-build479809458/gopath/src/github.com/dvyukov/go-fuzz-corpus/asn1/asn1.go:46 +0x825
+main.fuzzer_run(0x602000030190, 0x6, 0x6)
+    /tmp/go-fuzz-build479809458/gopath/src/github.com/dvyukov/go-fuzz-corpus/asn1/go.fuzz.main/main.go:13 +0x41
+main._cgoexpwrap_c53586c27493_fuzzer_run(0x602000030190, 0x6, 0x6)
+    _cgo_gotypes.go:45 +0x41
+==160894== ERROR: libFuzzer: deadly signal
+    #0 0x4ff8f3 in __sanitizer_print_stack_trace /src/llvm/projects/compiler-rt/lib/asan/asan_stack.cc:37
+    #1 0x6e942a in fuzzer::PrintStackTrace() /src/libfuzzer/FuzzerUtil.cpp:205:5
+    #2 0x69f7eb in fuzzer::Fuzzer::CrashCallback() /src/libfuzzer/FuzzerLoop.cpp:234:3
+    #3 0x7fa0fe5e20bf  (/lib/x86_64-linux-gnu/libpthread.so.0+0x110bf)
+    #4 0x589b13 in runtime.raise /tmp/go-fuzz-build479809458/goroot/src/runtime/sys_linux_amd64.s:145
+
+NOTE: libFuzzer has rudimentary signal handlers.
+      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
+SUMMARY: libFuzzer: deadly signal
+MS: 1 ChangeBit-; base unit: 0d33cba94bf7c5b7b042dc97b1a2d50ccb4a3e42
+0x14,0x4,0xff,0xff,0xff,0xff,
+\x14\x04\xff\xff\xff\xff
+artifact_prefix='./'; Test unit written to ./crash-7dbf1774dcb05cfa72766eb3651f869afcdbb3dd
+Base64: FAT/////
+==160894==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x7fff0e9fa000; bottom 0x10c00015c000; size: 0x6f3f0e89e000 (122316617539584)
+False positive error reports may follow

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_asan_panic.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_asan_panic.txt
@@ -1,26 +1,22 @@
 panic: asn1: string not valid UTF-8
 
 goroutine 17 [running, locked to thread]:
-github.com/dvyukov/go-fuzz-corpus/asn1.Fuzz(0x602000030190, 0x6, 0x6, 0x10c00015dea0)
-    /tmp/go-fuzz-build479809458/gopath/src/github.com/dvyukov/go-fuzz-corpus/asn1/asn1.go:46 +0x825
-main.fuzzer_run(0x602000030190, 0x6, 0x6)
-    /tmp/go-fuzz-build479809458/gopath/src/github.com/dvyukov/go-fuzz-corpus/asn1/go.fuzz.main/main.go:13 +0x41
-main._cgoexpwrap_c53586c27493_fuzzer_run(0x602000030190, 0x6, 0x6)
-    _cgo_gotypes.go:45 +0x41
-==160894== ERROR: libFuzzer: deadly signal
-    #0 0x4ff8f3 in __sanitizer_print_stack_trace /src/llvm/projects/compiler-rt/lib/asan/asan_stack.cc:37
-    #1 0x6e942a in fuzzer::PrintStackTrace() /src/libfuzzer/FuzzerUtil.cpp:205:5
-    #2 0x69f7eb in fuzzer::Fuzzer::CrashCallback() /src/libfuzzer/FuzzerLoop.cpp:234:3
-    #3 0x7fa0fe5e20bf  (/lib/x86_64-linux-gnu/libpthread.so.0+0x110bf)
-    #4 0x589b13 in runtime.raise /tmp/go-fuzz-build479809458/goroot/src/runtime/sys_linux_amd64.s:145
+github.com/dvyukov/go-fuzz-corpus/asn1.Fuzz(0x603000009100, 0x16, 0x16, 0x7ffd132f5368)
+  /src/go/packages/src/github.com/dvyukov/go-fuzz-corpus/asn1/asn1.go:46 +0x994
+main.LLVMFuzzerTestOneInput(0x603000009100, 0x16, 0x9d2410)
+  github.com/dvyukov/go-fuzz-corpus/asn1/go.fuzz.main/main.go:35 +0x66
+main._cgoexpwrap_0a73695ed89a_LLVMFuzzerTestOneInput(0x603000009100, 0x16, 0x27a5b0)
+  _cgo_gotypes.go:64 +0x37
+==42108== ERROR: libFuzzer: deadly signal
+    #0 0x49f071 in __sanitizer_print_stack_trace /src/llvm/projects/compiler-rt/lib/asan/asan_stack.cpp:86:3
+    #1 0x56236d in fuzzer::PrintStackTrace() /src/libfuzzer/FuzzerUtil.cpp:205:5
+    #2 0x511cae in fuzzer::Fuzzer::CrashCallback() /src/libfuzzer/FuzzerLoop.cpp:232:3
+    #3 0x7faa7c80b38f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1138f)
+    #4 0x5c8a90 in runtime.raise runtime/sys_linux_amd64.s:149
 
 NOTE: libFuzzer has rudimentary signal handlers.
       Combine libFuzzer with AddressSanitizer or similar for better crash reports.
 SUMMARY: libFuzzer: deadly signal
-MS: 1 ChangeBit-; base unit: 0d33cba94bf7c5b7b042dc97b1a2d50ccb4a3e42
-0x14,0x4,0xff,0xff,0xff,0xff,
-\x14\x04\xff\xff\xff\xff
-artifact_prefix='./'; Test unit written to ./crash-7dbf1774dcb05cfa72766eb3651f869afcdbb3dd
-Base64: FAT/////
-==160894==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x7fff0e9fa000; bottom 0x10c00015c000; size: 0x6f3f0e89e000 (122316617539584)
+==42108==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x7ffd132f9000; bottom 0x10c00015b000; size: 0x6f3d1319e000 (122308104151040)
 False positive error reports may follow
+For details see https://github.com/google/sanitizers/issues/189

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_fatal_error_stack_overflow.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_fatal_error_stack_overflow.txt
@@ -1,0 +1,34 @@
+runtime: goroutine stack exceeds 1000000000-byte limit
+fatal error: stack overflow
+
+runtime stack:
+runtime.throw(0x60f619, 0xe)
+/home/sdk/goroot/go/src/runtime/panic.go:619 +0x81
+runtime.newstack()
+/home/sdk/goroot/go/src/runtime/stack.go:1054 +0x71f
+runtime.morestack()
+/home/sdk/goroot/go/src/runtime/asm_amd64.s:480 +0x89
+
+goroutine 34 [running]:
+github.com/google/syzkaller/pkg/ast.(*scanner).next(0xc420158000)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/scanner.go:271 +0x218 fp=0xc446ec03a8 sp=0xc446ec03a0 pc=0x5035c8
+github.com/google/syzkaller/pkg/ast.(*scanner).scanIdent(0xc420158000, 0xc4201502ea, 0x8, 0x492488, 0x1, 0x492489, 0x0, 0x0, 0x0)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/scanner.go:253 +0x2c fp=0xc446ec03f8 sp=0xc446ec03a8 pc=0x5031ac
+github.com/google/syzkaller/pkg/ast.(*scanner).Scan(0xc420158000, 0x50269b, 0xd, 0xc4201502ea, 0xc4201502ea, 0x8, 0x492488, 0x1, 0x492489)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/scanner.go:160 +0x3ab fp=0xc446ec04c8 sp=0xc446ec03f8 pc=0x50269b
+github.com/google/syzkaller/pkg/ast.(*parser).next(0xc466ebfce0)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/parser.go:154 +0x4b fp=0xc446ec0548 sp=0xc446ec04c8 pc=0x4fecfb
+github.com/google/syzkaller/pkg/ast.(*parser).tryConsume(0xc466ebfce0, 0xd, 0xc4201502ea)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/parser.go:166 +0x48 fp=0xc446ec0560 sp=0xc446ec0548 pc=0x4fee88
+github.com/google/syzkaller/pkg/ast.(*parser).parseTypeList(0xc466ebfce0, 0x13, 0x0, 0x492487)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/parser.go:446 +0x38 fp=0xc446ec05d0 sp=0xc446ec0560 pc=0x501498
+github.com/google/syzkaller/pkg/ast.(*parser).parseType(0xc466ebfce0, 0xd)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/parser.go:440 +0xd4 fp=0xc446ec0640 sp=0xc446ec05d0 pc=0x5011b4
+github.com/google/syzkaller/pkg/ast.(*parser).parseTypeList(0xc466ebfce0, 0x13, 0x0, 0x492485)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/parser.go:447 +0x53 fp=0xc446ec06b0 sp=0xc446ec0640 pc=0x5014b3
+github.com/google/syzkaller/pkg/ast.(*parser).parseType(0xc466ebfce0, 0xd)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/parser.go:440 +0xd4 fp=0xc446ec0720 sp=0xc446ec06b0 pc=0x5011b4
+github.com/google/syzkaller/pkg/ast.(*parser).parseTypeList(0xc466ebfce0, 0x13, 0x0, 0x492483)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/parser.go:447 +0x53 fp=0xc446ec0790 sp=0xc446ec0720 pc=0x5014b3
+github.com/google/syzkaller/pkg/ast.(*parser).parseType(0xc466ebfce0, 0xd)
+/home/sdk/gopath/src/github.com/google/syzkaller/pkg/ast/parser.go:440 +0xd4 fp=0xc446ec0800 sp=0xc446ec0790 pc=0x5011b4

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_libfuzzer_panic.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_libfuzzer_panic.txt
@@ -1,0 +1,10 @@
+panic: parse //%B9%B9%B9%B9%B9%01%00%00%00%00%00%00%00%B9%B9%B9%B9%B9%B9%B9%B9%B9%B9%B9%B9%B9%B9%B9: invalid URL escape "%01"
+
+goroutine 17 [running, locked to thread]:
+github.com/dvyukov/go-fuzz-corpus/url.Fuzz(0x6030001458a0, 0x20, 0x20, 0x10c0000c8ea0)
+        /tmp/go-fuzz-build242808228/gopath/src/github.com/dvyukov/go-fuzz-corpus/url/main.go:24 +0x3d5
+main.fuzzer_run(0x6030001458a0, 0x20, 0x20)
+        /tmp/go-fuzz-build242808228/gopath/src/github.com/dvyukov/go-fuzz-corpus/url/go.fuzz.main/main.go:13 +0x41
+main._cgoexpwrap_9bd49841752b_fuzzer_run(0x6030001458a0, 0x20, 0x20)
+        _cgo_gotypes.go:45 +0x41
+==158476== ERROR: libFuzzer: deadly signal

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_custom_short_message.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_custom_short_message.txt
@@ -1,0 +1,33 @@
+panic: bad hex char
+
+goroutine 305380 [running]:
+github.com/google/syzkaller/prog.fromHexChar(0x0, 0x1)
+  prog/encoding.go:905 +0x6d
+github.com/google/syzkaller/prog.hexToByte(0xc456803100, 0xc4567f4300)
+  prog/encoding.go:885 +0x40
+github.com/google/syzkaller/prog.(*parser).deserializeData(0xc456808d20, 0xc445bad730, 0x766744, 0xc456808d20, 0xc445bad720, 0x4084f5)
+  prog/encoding.go:846 +0x86d
+github.com/google/syzkaller/prog.(*parser).parseArgString(0xc456808d20, 0x147b880, 0x2fa3da0, 0x2cea3e0, 0xe, 0x1403bc0, 0x3c0)
+  prog/encoding.go:484 +0x58
+github.com/google/syzkaller/prog.(*parser).parseArgImpl(0xc456808d20, 0x147b880, 0x2fa3da0, 0x7faaddab8a30, 0x0, 0x0, 0xc42060b180)
+  prog/encoding.go:335 +0x79
+github.com/google/syzkaller/prog.(*parser).parseArg(0xc456808d20, 0x147b880, 0x2fa3da0, 0x0, 0x0, 0xc445bad9a0, 0x47942a)
+  prog/encoding.go:307 +0x6f
+github.com/google/syzkaller/prog.(*parser).parseArgAddr(0xc456808d20, 0x147bce0, 0x19f1260, 0x8, 0x8, 0xc42000c220, 0x7faadee331c8)
+  prog/encoding.go:461 +0x3e7
+github.com/google/syzkaller/prog.(*parser).parseArgImpl(0xc456808d20, 0x147bce0, 0x19f1260, 0x0, 0xc42000c220, 0x1, 0xc445bad9e8)
+  prog/encoding.go:333 +0x24e
+github.com/google/syzkaller/prog.(*parser).parseArg(0xc456808d20, 0x147bce0, 0x19f1260, 0x0, 0x1, 0xc42000c220, 0x0)
+  prog/encoding.go:307 +0x6f
+github.com/google/syzkaller/prog.(*parser).parseProg(0xc456808d20, 0xc4b73f4500, 0x27c, 0x280)
+  prog/encoding.go:261 +0x6d3
+github.com/google/syzkaller/prog.(*Target).Deserialize(0xc4201aab60, 0xc4b73f4500, 0x27c, 0x280, 0x1, 0xc4b73f4500, 0x0, 0x280)
+  prog/encoding.go:192 +0x75
+github.com/google/syzkaller/prog.(*Target).ParseLog(0xc4201aab60, 0xc45628eb23, 0x120038, 0x1f74dd, 0xc4201aab60, 0x0, 0x0)
+  prog/parse.go:58 +0x27c
+github.com/google/syzkaller/pkg/repro.Run(0xc45628eb23, 0x120038, 0x1f74dd, 0xc42026ab40, 0x13fc300, 0xc42012c840, 0xc420274be0, 0xc47cf63c00, 0x4, 0x4, ...)
+  pkg/repro/repro.go:69 +0xf7
+main.(*Manager).vmLoop.func2(0xc47a2748e0, 0xc421736160, 0xc47cf63c00, 0x4, 0x4, 0xc420944a80)
+  syz-manager/manager.go:346 +0xac
+created by main.(*Manager).vmLoop
+  syz-manager/manager.go:345 +0xa45

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_index_out_of_range.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_index_out_of_range.txt
@@ -1,0 +1,20 @@
+panic: runtime error: index out of range
+goroutine 108 [running]:
+net/http.(*conn).serve.func1(0xc420115a40)
+  /home/philipp/Documents/syzkaller/go/src/net/http/server.go:1726 +0xd0
+panic(0xc30720, 0x144ca60)
+  /home/philipp/Documents/syzkaller/go/src/runtime/panic.go:502 +0x229
+main.(*Manager).httpPrio(0xc4201dab60, 0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /home/philipp/Documents/syzkaller/gopath/src/github.com/google/syzkaller/syz-manager/html.go:298 +0x5f4
+main.(*Manager).(main.httpPrio)-fm(0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /home/philipp/Documents/syzkaller/gopath/src/github.com/google/syzkaller/syz-manager/html.go:37 +0x48
+net/http.HandlerFunc.ServeHTTP(0xc420272400, 0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /home/philipp/Documents/syzkaller/go/src/net/http/server.go:1947 +0x44
+net/http.(*ServeMux).ServeHTTP(0x2e82ba0, 0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /home/philipp/Documents/syzkaller/go/src/net/http/server.go:2337 +0x130
+net/http.serverHandler.ServeHTTP(0xc4203ac000, 0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /home/philipp/Documents/syzkaller/go/src/net/http/server.go:2694 +0xbc
+net/http.(*conn).serve(0xc420115a40, 0xf2e540, 0xc420134800)
+  /home/philipp/Documents/syzkaller/go/src/net/http/server.go:1830 +0x651
+created by net/http.(*Server).Serve
+  /home/philipp/Documents/syzkaller/go/src/net/http/server.go:2795 +0x27b

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_integer_divide_by_zero.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_integer_divide_by_zero.txt
@@ -1,0 +1,8 @@
+panic: runtime error: integer divide by zero
+
+goroutine 40 [running]:
+github.com/d2r2/go-bsbmp.(*SensorBMP180).ReadPressureMult10Pa(0x2502020, 0x2500080, 0x3, 0x4087becc, 0xc0000000, 0x4087becc)
+  /home/pi/go/src/github.com/d2r2/go-bsbmp/bmp180.go:340 +0xfa4
+github.com/d2r2/go-bsbmp.(*BMP).ReadAltitude(0x2500090, 0x3, 0x4087becc, 0x1, 0x4b2038)
+  /home/pi/go/src/github.com/d2r2/go-bsbmp/bmp.go:213 +0x38
+main.main.func3(0x2500090)

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_invalid_memory_address.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_invalid_memory_address.txt
@@ -1,0 +1,24 @@
+2017/07/22 10:43:12 loop: instance 0 finished, crash=true
+2017/07/22 10:43:12 vm-0: crash: UBSAN: Undefined behaviour in net/ipv4/tcp_ipv4.c:1631:25
+2017/07/22 10:43:13 loop: add pending repro for 'UBSAN: Undefined behaviour in net/ipv4/tcp_ipv4.c:1631:25'
+2017/07/22 10:43:13 loop: add to repro queue 'UBSAN: Undefined behaviour in net/ipv4/tcp_ipv4.c:1631:25'
+2017/07/22 10:43:13 loop: phase=3 shutdown=false instances=1/1 [0] repro: pending=0 reproducing=1 queued=1
+2017/07/22 10:43:13 loop: starting repro of 'UBSAN: Undefined behaviour in net/ipv4/tcp_ipv4.c:1631:25' on instances [0]
+2017/07/22 10:43:14 reproducing crash 'UBSAN: Undefined behaviour in net/ipv4/tcp_ipv4.c:1631:25': 855 programs, 1 VMs
+2017/07/22 10:43:14 reproducing crash 'UBSAN: Undefined behaviour in net/ipv4/tcp_ipv4.c:1631:25': suspecting 0 programs
+2017/07/22 10:43:14 reproducing crash 'UBSAN: Undefined behaviour in net/ipv4/tcp_ipv4.c:1631:25': no program crashed
+2017/07/22 10:43:14 reproducing crash 'UBSAN: Undefined behaviour in net/ipv4/tcp_ipv4.c:1631:25': **minimizing guilty program
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xac5680]**
+
+goroutine 173193 [running]:
+github.com/google/syzkaller/pkg/repro.(*context).reproMinimizeProg(0xc423875950, 0x0, 0x0, 0x400, 0x0)
+  /home/user/gopath/src/github.com/google/syzkaller/pkg/repro/repro.go:218 +0xd0
+github.com/google/syzkaller/pkg/repro.(*context).repro(0xc423875950, 0xc427362000, 0x357, 0x400, 0x578, 0xc4206ddb70, 0xc420418000, 0x39)
+  /home/user/gopath/src/github.com/google/syzkaller/pkg/repro/repro.go:385 +0xa2
+github.com/google/syzkaller/pkg/repro.Run(0xc4279a8000, 0x3bcd09, 0x6f0000, 0xc420418000, 0xc420434420, 0xc42071dfc8, 0x1, 0x1, 0x2, 0x2, ...)
+  /home/user/gopath/src/github.com/google/syzkaller/pkg/repro/repro.go:130 +0x518
+main.(*Manager).vmLoop.func2(0xc4213dc3c0, 0xc420025a20, 0xc42071dfc8, 0x1, 0x1, 0xc420ebfc80)
+  /home/user/gopath/src/github.com/google/syzkaller/syz-manager/manager.go:380 +0x96
+created by main.(*Manager).vmLoop
+  /home/user/gopath/src/github.com/google/syzkaller/syz-manager/manager.go:382 +0xaa9

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_makeslice_len_out_of_range.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_makeslice_len_out_of_range.txt
@@ -1,0 +1,19 @@
+panic: runtime error: makeslice: len out of range
+
+goroutine 1 [running]:
+panic(0x85d9e0, 0xc849858ed0)
+    /usr/lib/go/src/runtime/panic.go:464 +0x3e6
+cmd/compile/internal/gc.newliveness(0xc82082ee10, 0xc82b6e4240, 0xc8505aa000, 0x35a64, 0x3a000, 0xc8497de000, 0xd398, 0xf000, 0x4130239190186200)
+    /usr/lib/go/src/cmd/compile/internal/gc/plive.go:687 +0x161
+cmd/compile/internal/gc.liveness(0xc82082ee10, 0xc82b6e4240, 0xc82d2c3e80, 0xc82d2c3f00)
+    /usr/lib/go/src/cmd/compile/internal/gc/plive.go:1782 +0x2cf
+cmd/compile/internal/gc.compile(0xc82082ee10)
+    /usr/lib/go/src/cmd/compile/internal/gc/pgen.go:541 +0xdf2
+cmd/compile/internal/gc.funccompile(0xc82082ee10)
+    /usr/lib/go/src/cmd/compile/internal/gc/dcl.go:1450 +0x1c0
+cmd/compile/internal/gc.Main()
+    /usr/lib/go/src/cmd/compile/internal/gc/lex.go:476 +0x2205
+cmd/compile/internal/amd64.Main()
+    /usr/lib/go/src/cmd/compile/internal/amd64/galign.go:127 +0x58d
+main.main()
+    /usr/lib/go/src/cmd/compile/main.go:33 +0x395

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_slice_bounds_out_of_range.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_slice_bounds_out_of_range.txt
@@ -1,0 +1,11 @@
+panic: runtime error: slice bounds out of range
+
+goroutine 1 [running]:
+binee/pefile.(*PeFile).readImports(0xc0000e4000)
+  /bineedev/go/src/binee/pefile/pefile.go:640 +0xbbe
+binee/pefile.LoadPeFile(0x7ffebeb925c7, 0x20, 0x0, 0x0, 0x0)
+  /bineedev/go/src/binee/pefile/pefile.go:325 +0x1f07
+binee/windows.New(0x7ffebeb925c7, 0x20, 0x4, 0x4, 0xc000058610, 0x1, 0x1, 0x0, 0x0, 0x0, ...)
+  /bineedev/go/src/binee/windows/winemulator.go:283 +0x20b1
+main.main()
+  /bineedev/go/src/binee/main.go:176 +0x604

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_with_type_assertions_in_frames.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_with_type_assertions_in_frames.txt
@@ -1,0 +1,31 @@
+root@syztest:/SYZCALLER/gopath/src/github.com/google/syzkaller# ./bin/syz-manager -config=test.cfg
+//about 20h+//
+2018/09/18 15:35:31 VMs 18, executed 529729, cover 775463, crashes 324, repro 0
+2018/09/18 15:35:38 vm-0: crash: no output from test machine
+panic: index > windowEnd
+goroutine 962087 [running]:
+compress/flate.(*compressor).deflate(0xc459c18000)
+  /SYZCALLER/go/src/compress/flate/deflate.go:397 +0xb7d
+compress/flate.(*compressor).syncFlush(0xc459c18000, 0x0, 0x0)
+  /SYZCALLER/go/src/compress/flate/deflate.go:565 +0x5c
+compress/flate.(*Writer).Flush(0xc459c18000, 0xc468646fef, 0x13160)
+  /SYZCALLER/go/src/compress/flate/deflate.go:724 +0x2d
+github.com/google/syzkaller/pkg/rpctype.(*flateConn).Write(0xc420ad9380, 0xc468646fef, 0x13160, 0x2f011, 0xc424c82d80, 0xc422387228, 0xc420722be0)
+  /SYZCALLER/gopath/src/github.com/google/syzkaller/pkg/rpctype/rpc.go:139 +0x7c
+bufio.(*Writer).Write(0xc422efbb00, 0xc468646fef, 0x1414a, 0x2f011, 0x42abf6, 0xebbea0, 0xc420722c80)
+  /SYZCALLER/go/src/bufio/bufio.go:599 +0x14f
+encoding/gob.(*Encoder).writeMessage(0xc4202121e0, 0x1391760, 0xc422efbb00, 0xc420212218)
+  /SYZCALLER/go/src/encoding/gob/encoder.go:81 +0x18a
+encoding/gob.(*Encoder).EncodeValue(0xc4202121e0, 0xbe18e0, 0xc4579bc780, 0x16, 0x0, 0x0)
+  /SYZCALLER/go/src/encoding/gob/encoder.go:252 +0x478
+encoding/gob.(*Encoder).Encode(0xc4202121e0, 0xbe18e0, 0xc4579bc780, 0x0, 0x0)
+  /SYZCALLER/go/src/encoding/gob/encoder.go:175 +0x61
+net/rpc.(*gobServerCodec).WriteResponse(0xc420ad9470, 0xc4210aa6f0, 0xbe18e0, 0xc4579bc780, 0x4c4e64, 0xbe18e0)
+  /SYZCALLER/go/src/net/rpc/server.go:418 +0x17f
+net/rpc.(*Server).sendResponse(0xc420132500, 0xc42fead8e8, 0xc42bf736a0, 0xbe18e0, 0xc4579bc780, 0x13ad3e0, 0xc420ad9470, 0x0, 0x0)
+  /SYZCALLER/go/src/net/rpc/server.go:360 +0xff
+net/rpc.(*service).call(0xc4201403c0, 0xc420132500, 0xc42fead8e8, 0xc42013c580, 0xc42bf736a0, 0xbe18a0, 0xc440306050, 0x16, 0xbe18e0, 0xc4579bc780, ...)
+  /SYZCALLER/go/src/net/rpc/server.go:388 +0x218
+created by net/rpc.(*Server).ServeCodec
+  /SYZCALLER/go/src/net/rpc/server.go:475 +0x36b
+root@syztest:/SYZCALLER/gopath/src/github.com/google/syzkaller#

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_sigsegv_panic.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_sigsegv_panic.txt
@@ -1,0 +1,10 @@
+root@943ca8071e8b:/out# ./fuzzer-bzip2 
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5da137]
+
+goroutine 1 [running]:
+math.glob..func1(0x5da117)
+  /src/go/src/math/exp_asm.go:11 +0x7
+math.init.ializers()
+  /src/go/src/math/exp_asm.go:11 +0x3f
+Aborted

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2530,7 +2530,8 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_type = 'Invalid memory address'
     expected_address = ''
     expected_state = ('repro.(*context).reproMinimizeProg\n'
-                      'repro.(*context).repro\n')
+                      'repro.(*context).repro\n'
+                      'repro.Run\n')
 
     expected_stacktrace = data
     expected_security_flag = True
@@ -2560,7 +2561,8 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_type = 'Slice bounds out of range'
     expected_address = ''
     expected_state = ('pefile.(*PeFile).readImports\n'
-                      'pefile.LoadPeFile\n')
+                      'pefile.LoadPeFile\n'
+                      'windows.New\n')
 
     expected_stacktrace = data
     expected_security_flag = False

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2439,7 +2439,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
   def test_golang_asan_panic(self):
     """Test golang stacktrace with panic and ASan."""
     data = self._read_test_data('golang_asan_panic.txt')
-    expected_type = 'asn1: string not valid UTF-8'
+    expected_type = 'ASSERT'
     expected_address = ''
     expected_state = (
         'asn1: string not valid UTF-8\nasn1.Fuzz\nruntime.raise\n')
@@ -2453,8 +2453,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
   def test_golang_sigsegv_panic(self):
     """Test golang stacktrace with panic and SIGSEGV."""
     data = self._read_test_data('golang_sigsegv_panic.txt')
-    expected_type = (
-        'runtime error: invalid memory address or nil pointer dereference')
+    expected_type = 'invalid memory address'
     expected_address = ''
     expected_state = (
         'runtime error: invalid memory address or nil pointer dereference\n'
@@ -2470,8 +2469,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
   def test_golang_libfuzzer_panic(self):
     """Test golang stacktrace with panic and libFuzzer's deadly signal."""
     data = self._read_test_data('golang_libfuzzer_panic.txt')
-    expected_type = ('parse //%B9%B9%B9%B9%B9%01%00%00%00%0<...>%B9%B9%B9%B9: '
-                     'invalid URL escape "%01"')
+    expected_type = 'ASSERT'
     expected_address = ''
     expected_state = (
         'parse //%B9%B9%B9%B9%B9%01%00%00%00%00%00%00%00%B9%B9%B9%B9%B9%B9%B9%B'
@@ -2479,6 +2477,132 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
     expected_stacktrace = data
     expected_security_flag = True
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_panic_with_type_assertions_in_frames(self):
+    """Test golang stacktrace with panic with type assertions in stack frames.
+    """
+    data = self._read_test_data(
+        'golang_panic_with_type_assertions_in_frames.txt')
+    expected_type = 'ASSERT'
+    expected_address = ''
+    expected_state = ('index > windowEnd\n'
+                      'flate.(*compressor).deflate\n'
+                      'flate.(*compressor).syncFlush\n')
+
+    expected_stacktrace = data
+    expected_security_flag = True
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_fatal_error_stack_overflow(self):
+    """Test golang stacktrace with fatal error caused by stack overflow."""
+    data = self._read_test_data('golang_fatal_error_stack_overflow.txt')
+    expected_type = 'stack overflow'
+    expected_address = ''
+    expected_state = ('ast.(*scanner).next\n'
+                      'ast.(*scanner).scanIdent\n'
+                      'ast.(*scanner).Scan\n')
+
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_panic_custom_short_message(self):
+    """Test golang stacktrace with panic and custom short message."""
+    data = self._read_test_data('golang_panic_custom_short_message.txt')
+    expected_type = 'ASSERT'
+    expected_address = ''
+    expected_state = 'bad hex char\nprog.fromHexChar\nprog.hexToByte\n'
+
+    expected_stacktrace = data
+    expected_security_flag = True
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_panic_runtime_error_invalid_memory_address(self):
+    """Test golang stacktrace with panic caused by invalid memory address."""
+    data = self._read_test_data(
+        'golang_panic_runtime_error_invalid_memory_address.txt')
+    expected_type = 'invalid memory address'
+    expected_address = ''
+    expected_state = (
+        'runtime error: invalid memory address or nil pointer dereference\n'
+        'repro.(*context).reproMinimizeProg\n'
+        'repro.(*context).repro\n')
+
+    expected_stacktrace = data
+    expected_security_flag = True
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_panic_runtime_error_index_out_of_range(self):
+    """Test golang stacktrace with panic caused by index out of range."""
+    data = self._read_test_data(
+        'golang_panic_runtime_error_index_out_of_range.txt')
+    expected_type = 'index out of range'
+    expected_address = ''
+    expected_state = ('runtime error: index out of range\n'
+                      'http.(*conn).serve.func1\n'
+                      'panic\n')
+
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_panic_runtime_error_slice_bounds_out_of_range(self):
+    """Test golang stacktrace with panic caused by slice bounds out of range."""
+    data = self._read_test_data(
+        'golang_panic_runtime_error_slice_bounds_out_of_range.txt')
+    expected_type = 'slice bounds out of range'
+    expected_address = ''
+    expected_state = ('runtime error: slice bounds out of range\n'
+                      'pefile.(*PeFile).readImports\n'
+                      'pefile.LoadPeFile\n')
+
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_panic_runtime_error_integer_divide_by_zero(self):
+    """Test golang stacktrace with panic caused by integer divide by zero."""
+    data = self._read_test_data(
+        'golang_panic_runtime_error_integer_divide_by_zero.txt')
+    expected_type = 'integer divide by zero'
+    expected_address = ''
+    expected_state = ('runtime error: integer divide by zero\n'
+                      'go-bsbmp.(*SensorBMP180).ReadPressureMult10Pa\n'
+                      'go-bsbmp.(*BMP).ReadAltitude\n')
+
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_panic_runtime_error_makeslice_len_out_of_range(self):
+    """Test golang stacktrace with panic caused by makeslice len out of range.
+    """
+    data = self._read_test_data(
+        'golang_panic_runtime_error_makeslice_len_out_of_range.txt')
+    expected_type = 'makeslice: len out of range'
+    expected_address = ''
+    expected_state = (
+        'runtime error: makeslice: len out of range\npanic\ngc.newliveness\n')
+
+    expected_stacktrace = data
+    expected_security_flag = False
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2435,3 +2435,50 @@ class StackAnalyzerTestcase(unittest.TestCase):
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
+
+  def test_golang_asan_panic(self):
+    """Test golang stacktrace with panic and ASan."""
+    data = self._read_test_data('golang_asan_panic.txt')
+    expected_type = 'asn1: string not valid UTF-8'
+    expected_address = ''
+    expected_state = (
+        'asn1: string not valid UTF-8\nasn1.Fuzz\nruntime.raise\n')
+
+    expected_stacktrace = data
+    expected_security_flag = True
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_sigsegv_panic(self):
+    """Test golang stacktrace with panic and SIGSEGV."""
+    data = self._read_test_data('golang_sigsegv_panic.txt')
+    expected_type = (
+        'runtime error: invalid memory address or nil pointer dereference')
+    expected_address = ''
+    expected_state = (
+        'runtime error: invalid memory address or nil pointer dereference\n'
+        'math.glob..func1\n'
+        'math.init.ializers\n')
+
+    expected_stacktrace = data
+    expected_security_flag = True
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_golang_libfuzzer_panic(self):
+    """Test golang stacktrace with panic and libFuzzer's deadly signal."""
+    data = self._read_test_data('golang_libfuzzer_panic.txt')
+    expected_type = ('parse //%B9%B9%B9%B9%B9%01%00%00%00%0<...>%B9%B9%B9%B9: '
+                     'invalid URL escape "%01"')
+    expected_address = ''
+    expected_state = (
+        'parse //%B9%B9%B9%B9%B9%01%00%00%00%00%00%00%00%B9%B9%B9%B9%B9%B9%B9%B'
+        '9%B9%B9%B9\nurl.Fuzz\n')
+
+    expected_stacktrace = data
+    expected_security_flag = True
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2453,12 +2453,9 @@ class StackAnalyzerTestcase(unittest.TestCase):
   def test_golang_sigsegv_panic(self):
     """Test golang stacktrace with panic and SIGSEGV."""
     data = self._read_test_data('golang_sigsegv_panic.txt')
-    expected_type = 'invalid memory address'
+    expected_type = 'Invalid memory address'
     expected_address = ''
-    expected_state = (
-        'runtime error: invalid memory address or nil pointer dereference\n'
-        'math.glob..func1\n'
-        'math.init.ializers\n')
+    expected_state = 'math.glob..func1\nmath.init.ializers\n'
 
     expected_stacktrace = data
     expected_security_flag = True
@@ -2501,7 +2498,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
   def test_golang_fatal_error_stack_overflow(self):
     """Test golang stacktrace with fatal error caused by stack overflow."""
     data = self._read_test_data('golang_fatal_error_stack_overflow.txt')
-    expected_type = 'stack overflow'
+    expected_type = 'Stack overflow'
     expected_address = ''
     expected_state = ('ast.(*scanner).next\n'
                       'ast.(*scanner).scanIdent\n'
@@ -2530,12 +2527,10 @@ class StackAnalyzerTestcase(unittest.TestCase):
     """Test golang stacktrace with panic caused by invalid memory address."""
     data = self._read_test_data(
         'golang_panic_runtime_error_invalid_memory_address.txt')
-    expected_type = 'invalid memory address'
+    expected_type = 'Invalid memory address'
     expected_address = ''
-    expected_state = (
-        'runtime error: invalid memory address or nil pointer dereference\n'
-        'repro.(*context).reproMinimizeProg\n'
-        'repro.(*context).repro\n')
+    expected_state = ('repro.(*context).reproMinimizeProg\n'
+                      'repro.(*context).repro\n')
 
     expected_stacktrace = data
     expected_security_flag = True
@@ -2547,12 +2542,11 @@ class StackAnalyzerTestcase(unittest.TestCase):
     """Test golang stacktrace with panic caused by index out of range."""
     data = self._read_test_data(
         'golang_panic_runtime_error_index_out_of_range.txt')
-    expected_type = 'index out of range'
+    expected_type = 'Index out of range'
     expected_address = ''
-    expected_state = ('runtime error: index out of range\n'
-                      'http.(*conn).serve.func1\n'
-                      'panic\n')
-
+    expected_state = ('http.(*conn).serve.func1\n'
+                      'http.HandlerFunc.ServeHTTP\n'
+                      'http.(*ServeMux).ServeHTTP\n')
     expected_stacktrace = data
     expected_security_flag = False
     self._validate_get_crash_data(data, expected_type, expected_address,
@@ -2563,10 +2557,9 @@ class StackAnalyzerTestcase(unittest.TestCase):
     """Test golang stacktrace with panic caused by slice bounds out of range."""
     data = self._read_test_data(
         'golang_panic_runtime_error_slice_bounds_out_of_range.txt')
-    expected_type = 'slice bounds out of range'
+    expected_type = 'Slice bounds out of range'
     expected_address = ''
-    expected_state = ('runtime error: slice bounds out of range\n'
-                      'pefile.(*PeFile).readImports\n'
+    expected_state = ('pefile.(*PeFile).readImports\n'
                       'pefile.LoadPeFile\n')
 
     expected_stacktrace = data
@@ -2579,10 +2572,9 @@ class StackAnalyzerTestcase(unittest.TestCase):
     """Test golang stacktrace with panic caused by integer divide by zero."""
     data = self._read_test_data(
         'golang_panic_runtime_error_integer_divide_by_zero.txt')
-    expected_type = 'integer divide by zero'
+    expected_type = 'Integer divide by zero'
     expected_address = ''
-    expected_state = ('runtime error: integer divide by zero\n'
-                      'go-bsbmp.(*SensorBMP180).ReadPressureMult10Pa\n'
+    expected_state = ('go-bsbmp.(*SensorBMP180).ReadPressureMult10Pa\n'
                       'go-bsbmp.(*BMP).ReadAltitude\n')
 
     expected_stacktrace = data
@@ -2596,10 +2588,9 @@ class StackAnalyzerTestcase(unittest.TestCase):
     """
     data = self._read_test_data(
         'golang_panic_runtime_error_makeslice_len_out_of_range.txt')
-    expected_type = 'makeslice: len out of range'
+    expected_type = 'Makeslice: len out of range'
     expected_address = ''
-    expected_state = (
-        'runtime error: makeslice: len out of range\npanic\ngc.newliveness\n')
+    expected_state = ('gc.newliveness\ngc.liveness\ngc.compile\n')
 
     expected_stacktrace = data
     expected_security_flag = False


### PR DESCRIPTION
This should unblock https://github.com/google/oss-fuzz/pull/2188.

The security flag distinction can be improved, but at this point it's hard to judge how. Looks like the same panic (i.e. assert) may come from a non-security issue (e.g. a standard package errors out on something) as well as from an assertion added by the fuzzer author intentionally, which may be a legit security issue then.

I propose to mark all of these as security for now (just being cautious) and iterate / improve based on the feedback from the users later on.

Also, stacktraces are pretty inconvenient in a sense that function names and file names are located on different lines. This implementation does not parse file names, it only handles function names.