### PR TITLE
Clarify the regex for runtime.raise stack frame and fix a test.

### DIFF
--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -444,10 +444,10 @@ STACK_FRAME_IGNORE_REGEXES = [
 
     # Golang specific frames to ignore.
     r'^panic$',
-    r'^runtime.throw$',
-    r'^runtime.newstack$',
-    r'^runtime.morestack$',
-    r'^runtime.raise$',
+    r'^runtime\.newstack$',
+    r'^runtime\.morestack$',
+    r'^runtime\.raise(\s.*|$)',
+    r'^runtime\.throw$',
 ]
 
 STACK_FRAME_IGNORE_REGEXES_IF_SYMBOLIZED = [

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2441,8 +2441,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('golang_asan_panic.txt')
     expected_type = 'ASSERT'
     expected_address = ''
-    expected_state = (
-        'asn1: string not valid UTF-8\nasn1.Fuzz\nruntime.raise\n')
+    expected_state = 'asn1: string not valid UTF-8\nasn1.Fuzz\n'
 
     expected_stacktrace = data
     expected_security_flag = True


### PR DESCRIPTION
Basically the issue is that `runtime.raise` might be a stack frame as is, or a part of a more detailed frame parsed from the sanitizer stacktrace, e.g. from:

```
    #4 0x5c8a90 in runtime.raise runtime/sys_linux_amd64.s:149
```
