### PR TITLE
More preparation for testing refactored engine fuzzing.

### DIFF
--- a/src/python/bot/fuzzers/engine.py
+++ b/src/python/bot/fuzzers/engine.py
@@ -157,13 +157,12 @@ class Engine(object):
     raise NotImplementedError
 
 
-def register_engine(impl):
+def register(name, engine_class):
   """Register a fuzzing engine."""
-  if impl.name in _ENGINES:
-    raise ValueError(
-        'Engine {name} is already registered'.format(name=impl.name))
+  if name in _ENGINES:
+    raise ValueError('Engine {name} is already registered'.format(name=name))
 
-  _ENGINES[impl.name] = impl
+  _ENGINES[name] = engine_class
 
 
 def get(name):

--- a/src/python/bot/fuzzers/init.py
+++ b/src/python/bot/fuzzers/init.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fuzzing engine initialization."""
+
+from bot.fuzzers import engine
+from bot.fuzzers.libFuzzer import engine as libFuzzer_engine
+
+
+def run():
+  """Initialise builtin fuzzing engines."""
+  engine.register('libFuzzer_test', libFuzzer_engine.LibFuzzerEngine)

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -59,7 +59,7 @@ class LibFuzzerEngine(engine.Engine):
 
   @property
   def name(self):
-    return 'libFuzzer'
+    return 'libFuzzer_test'
 
   def prepare(self, corpus_dir, target_path, _):
     """Prepare for a fuzzing session, by generating options. Returns a

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -44,6 +44,7 @@ from base import errors
 from base import tasks
 from base import untrusted
 from base import utils
+from bot.fuzzers import init as fuzzers_init
 from bot.tasks import commands
 from bot.tasks import update_task
 from datastore import data_handler
@@ -132,6 +133,8 @@ def main():
 
   if not profiler.start_if_needed('python_profiler_bot'):
     sys.exit(-1)
+
+  fuzzers_init.run()
 
   if environment.is_trusted_host(ensure_connected=False):
     from bot.untrusted_runner import host

--- a/src/python/bot/tasks/analyze_task.py
+++ b/src/python/bot/tasks/analyze_task.py
@@ -331,7 +331,7 @@ def execute_task(testcase_id, job_type):
 
   # Test for reproducibility.
   one_time_crasher_flag = not testcase_manager.test_for_reproducibility(
-      testcase.fuzzer_name, testcase_file_path, state.crash_state,
+      testcase.overridden_fuzzer_name, testcase_file_path, state.crash_state,
       security_flag, test_timeout, http_flag, gestures)
   testcase.one_time_crasher_flag = one_time_crasher_flag
 

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -144,7 +144,7 @@ class Crash(object):
         http_flag=needs_http)
 
   @classmethod
-  def from_engine_crash(cls, target_name, crash):
+  def from_engine_crash(cls, crash):
     """Create a Crash from a engine.Crash."""
     return Crash(
         file_path=crash.input_path,
@@ -153,8 +153,7 @@ class Crash(object):
         resource_list=[],
         gestures=[],
         unsymbolized_crash_stacktrace=crash.stacktrace,
-        # We store the target name as the first argument.
-        arguments=[target_name] + crash.reproduce_args,
+        arguments=' '.join(crash.reproduce_args),
         application_command_line='')  # TODO(ochang): Write actual command line.
 
   def __init__(self,
@@ -278,8 +277,12 @@ class CrashGroup(object):
       assert crashes[0].security_flag == c.security_flag
 
     self.crashes = crashes
+    fully_qualified_fuzzer_name = context.fuzzer_name
+    if context.fuzz_target:
+      fully_qualified_fuzzer_name = context.fuzz_target.fully_qualified_name()
+
     self.main_crash, self.one_time_crasher_flag = find_main_crash(
-        crashes, context.fuzzer_name, context.test_timeout)
+        crashes, fully_qualified_fuzzer_name, context.test_timeout)
 
     self.newly_created_testcase = None
 
@@ -1418,6 +1421,9 @@ class FuzzingSession(object):
     fuzz_target_name = environment.get_value('FUZZ_TARGET')
     self.fuzz_target = record_fuzz_target(engine_impl.name, fuzz_target_name,
                                           self.job_type)
+    environment.set_value('FUZZER_NAME',
+                          self.fuzz_target.fully_qualified_name())
+
     # Synchronize corpus files with GCS
     sync_corpus_directory = builtin.get_corpus_directory(
         self.testcase_directory, self.fuzz_target.project_qualified_name())
@@ -1449,9 +1455,7 @@ class FuzzingSession(object):
     crashes = result.crashes
     if crashes:
       crashes = [
-          Crash.from_engine_crash(fuzz_target_name, crash)
-          for crash in result.crashes
-          if crash
+          Crash.from_engine_crash(crash) for crash in result.crashes if crash
       ]
 
     return crashes, fuzzer_metadata
@@ -1673,8 +1677,8 @@ class FuzzingSession(object):
 
     # Check if we have an application path. If not, our build failed
     # to setup correctly.
-    app_path = environment.get_value('APP_PATH')
-    if not app_path:
+    if (environment.get_value('APP_NAME') and
+        not environment.get_value('APP_PATH')):
       _track_fuzzer_run_result(self.fuzzer_name, 0, 0,
                                FuzzErrorCode.BUILD_SETUP_FAILED)
       return

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -277,9 +277,10 @@ class CrashGroup(object):
       assert crashes[0].security_flag == c.security_flag
 
     self.crashes = crashes
-    fully_qualified_fuzzer_name = context.fuzzer_name
     if context.fuzz_target:
       fully_qualified_fuzzer_name = context.fuzz_target.fully_qualified_name()
+    else:
+      fully_qualified_fuzzer_name = context.fuzzer_name
 
     self.main_crash, self.one_time_crasher_flag = find_main_crash(
         crashes, fully_qualified_fuzzer_name, context.test_timeout)

--- a/src/python/bot/tasks/variant_task.py
+++ b/src/python/bot/tasks/variant_task.py
@@ -81,8 +81,8 @@ def execute_task(testcase_id, job_type):
 
     gestures = testcase.gestures if use_gestures else None
     one_time_crasher_flag = not testcase_manager.test_for_reproducibility(
-        testcase.fuzzer_name, testcase_file_path, crash_state, security_flag,
-        test_timeout, testcase.http_flag, gestures)
+        testcase.overriden_fuzzer_name, testcase_file_path, crash_state,
+        security_flag, test_timeout, testcase.http_flag, gestures)
     if one_time_crasher_flag:
       status = data_types.TestcaseVariantStatus.FLAKY
     else:

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -530,7 +530,7 @@ class TestcaseRunner(object):
       self._target_path = engine_common.find_fuzzer_path(
           build_dir, fuzz_target.binary)
       if not self._target_path:
-        raise TargetNotFoundError('Failed to find target ' + target_name)
+        raise TargetNotFoundError('Failed to find target ' + fuzz_target.binary)
     else:
       self._is_black_box = True
       self._command = get_command_line_for_application(

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -516,7 +516,7 @@ class TestcaseRunner(object):
     if fuzz_target:
       engine_impl = engine.get(fuzz_target.engine)
       if not engine_impl:
-        raise RuntimeError(engine_impl)
+        raise RuntimeError('Could not find engine ' + engine_impl.name)
 
       self._is_black_box = False
       self._engine_impl = engine_impl

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -512,8 +512,12 @@ class TestcaseRunner(object):
     self._gestures = gestures
     self._needs_http = needs_http
 
-    engine_impl = engine.get(fuzzer_name)
-    if engine_impl:
+    fuzz_target = data_handler.get_fuzz_target(fuzzer_name)
+    if fuzz_target:
+      engine_impl = engine.get(fuzz_target.engine)
+      if not engine_impl:
+        raise RuntimeError(engine_impl)
+
       self._is_black_box = False
       self._engine_impl = engine_impl
 
@@ -521,10 +525,10 @@ class TestcaseRunner(object):
       additional_command_line_flags = get_additional_command_line_flags(
           testcase_path)
       self._arguments = additional_command_line_flags.split()
-      target_name = self._arguments.pop(0)
 
       build_dir = environment.get_value('BUILD_DIR')
-      self._target_path = engine_common.find_fuzzer_path(build_dir, target_name)
+      self._target_path = engine_common.find_fuzzer_path(
+          build_dir, fuzz_target.binary)
       if not self._target_path:
         raise TargetNotFoundError('Failed to find target ' + target_name)
     else:
@@ -676,8 +680,8 @@ def test_for_crash_with_retries(testcase,
   crash stacktrace, etc."""
   gestures = testcase.gestures if use_gestures else None
   try:
-    runner = TestcaseRunner(testcase.fuzzer_name, testcase_path, test_timeout,
-                            gestures, http_flag)
+    runner = TestcaseRunner(testcase.overridden_fuzzer_name, testcase_path,
+                            test_timeout, gestures, http_flag)
   except TargetNotFoundError:
     # If a target isn't found, treat it as not crashing.
     return CrashResult(return_code=0, crash_time=0, output='')

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -911,8 +911,12 @@ class ProductionBuild(Build):
 class CustomBuild(Build):
   """Custom binary."""
 
-  def __init__(self, base_build_dir, custom_binary_key, custom_binary_filename,
-               custom_binary_revision, target_weights):
+  def __init__(self,
+               base_build_dir,
+               custom_binary_key,
+               custom_binary_filename,
+               custom_binary_revision,
+               target_weights=None):
     super(CustomBuild, self).__init__(base_build_dir, custom_binary_revision)
     self.custom_binary_key = custom_binary_key
     self.custom_binary_filename = custom_binary_filename
@@ -1316,7 +1320,7 @@ def setup_symbolized_builds(revision):
   return None
 
 
-def setup_custom_binary(target_weights):
+def setup_custom_binary(target_weights=None):
   """Set up the custom binary for a particular job."""
   # Check if this build is dependent on any other custom job. If yes,
   # then fake out our job name for setting up the build.

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -912,11 +912,12 @@ class CustomBuild(Build):
   """Custom binary."""
 
   def __init__(self, base_build_dir, custom_binary_key, custom_binary_filename,
-               custom_binary_revision):
+               custom_binary_revision, target_weights):
     super(CustomBuild, self).__init__(base_build_dir, custom_binary_revision)
     self.custom_binary_key = custom_binary_key
     self.custom_binary_filename = custom_binary_filename
     self._build_dir = os.path.join(self.base_build_dir, 'custom')
+    self.target_weights = target_weights
 
   @property
   def build_dir(self):
@@ -953,6 +954,8 @@ class CustomBuild(Build):
       # Remove the archive.
       shell.remove_file(build_local_archive)
 
+    _set_random_fuzz_target_for_fuzzing_if_needed(
+        _get_fuzz_targets_from_dir(self.build_dir), self.target_weights)
     return True
 
   def setup(self):
@@ -975,6 +978,9 @@ class CustomBuild(Build):
       logs.log('Retrieved custom binary build r%d.' % self.revision)
     else:
       logs.log('Build already exists.')
+
+      _set_random_fuzz_target_for_fuzzing_if_needed(
+          _get_fuzz_targets_from_dir(self.build_dir), self.target_weights)
 
     self._setup_application_path(build_update=build_update)
     self._post_setup_success(update_revision=build_update)
@@ -1310,7 +1316,7 @@ def setup_symbolized_builds(revision):
   return None
 
 
-def setup_custom_binary():
+def setup_custom_binary(target_weights):
   """Set up the custom binary for a particular job."""
   # Check if this build is dependent on any other custom job. If yes,
   # then fake out our job name for setting up the build.
@@ -1331,8 +1337,12 @@ def setup_custom_binary():
     return False
 
   base_build_dir = _base_build_dir('')
-  build = CustomBuild(base_build_dir, job.custom_binary_key,
-                      job.custom_binary_filename, job.custom_binary_revision)
+  build = CustomBuild(
+      base_build_dir,
+      job.custom_binary_key,
+      job.custom_binary_filename,
+      job.custom_binary_revision,
+      target_weights=target_weights)
 
   # Revert back the actual job name.
   if share_build_job_type:
@@ -1404,7 +1414,7 @@ def setup_build(revision=0, target_weights=None):
   # For custom binaries we always use the latest version. Revision is ignored.
   custom_binary = environment.get_value('CUSTOM_BINARY')
   if custom_binary:
-    return setup_custom_binary()
+    return setup_custom_binary(target_weights=target_weights)
 
   # In this case, we assume the build is already installed on the system.
   system_binary = environment.get_value('SYSTEM_BINARY_DIR')

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -443,7 +443,8 @@ class CrashGroupTest(unittest.TestCase):
 
     self.mock.get_project_name.return_value = 'some_project'
     self.crashes = [self._make_crash('g1'), self._make_crash('g2')]
-    self.context = mock.MagicMock(test_timeout=99, fuzzer_name='test')
+    self.context = mock.MagicMock(
+        test_timeout=99, fuzzer_name='test', fuzz_target=None)
     self.reproducible_testcase = self._make_testcase(
         project_name='some_project',
         bug_information='',
@@ -1368,7 +1369,7 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(1, crashes[0].return_code)
     self.assertEqual('stack', crashes[0].unsymbolized_crash_stacktrace)
     self.assertEqual(1.0, crashes[0].crash_time)
-    self.assertListEqual(['test_target', 'args'], crashes[0].arguments)
+    self.assertEqual('args', crashes[0].arguments)
     upload_args = self.mock.upload_stats.call_args[0][0]
     testcase_run = upload_args[0]
     self.assertDictEqual({

--- a/src/python/tests/core/local/butler/reproduce_test.py
+++ b/src/python/tests/core/local/butler/reproduce_test.py
@@ -36,6 +36,7 @@ def _fake_get_testcase(*_):
       'additional_metadata': '{}',
       'fuzzer_name': 'fuzzer',
       'job_definition': 'APP_NAME = echo\nAPP_ARGS = -n\n',
+      'overridden_fuzzer_name': 'fuzzer',
       'platform': environment.platform().lower(),
   }
 


### PR DESCRIPTION
- Remove target name from stored arguments. We can just use the Testcase
  overridden_fuzzer_name attribute.
- Register 'libFuzzer_test' engine during startup in run_bot.
- Allow APP_PATH to not be set if APP_NAME isn't specifiedl.
- Support fuzz targets in custom builds.
- Various other fixes.