### PR TITLE
Account for testcase minimized flags when picking variant task argument.

### DIFF
--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -95,7 +95,7 @@ def _copy_testcase_to_device_and_setup_environment(testcase,
 
 
 def _get_application_arguments(testcase, task_name):
-  """Get application arguments to use for setting up testcase. Use minimized
+  """Get application arguments to use for setting up |testcase|. Use minimized
    arguments if available. For variant task, where we run a testcase against
    another job type, use both minimized arguments and application arguments
    from job."""
@@ -111,13 +111,15 @@ def _get_application_arguments(testcase, task_name):
   job_args_list = shlex.split(job_args)
   testcase_args_list = shlex.split(testcase_args)
   testcase_args_filtered_list = [
-      s for s in testcase_args_list if s not in job_args_list
+      arg for arg in testcase_args_list if arg not in job_args_list
   ]
 
   app_args = ' '.join(testcase_args_filtered_list)
   if job_args:
-    app_args += ' ' + job_args
-  return app_args.strip()
+    if app_args:
+      app_args += ' '
+    app_args += job_args
+  return app_args
 
 
 def prepare_environment_for_testcase(testcase):

--- a/src/python/tests/core/bot/tasks/setup_test.py
+++ b/src/python/tests/core/bot/tasks/setup_test.py
@@ -81,7 +81,7 @@ class GetApplicationArgumentsTest(unittest.TestCase):
     self.assertEqual(
         '--arg2', setup._get_application_arguments(self.testcase, 'minimize'))
 
-  def test_minimized_arguments_for_variant_task_1(self):
+  def test_no_unique_minimized_arguments_for_variant_task(self):
     """Test that only APP_ARGS is returned if minimized arguments have no
     unique arguments, for variant task."""
     self.testcase.minimized_arguments = '--arg2'
@@ -91,7 +91,7 @@ class GetApplicationArgumentsTest(unittest.TestCase):
     self.assertEqual('--arg1 --arg2 --arg3="--flag1 --flag2"',
                      setup._get_application_arguments(self.testcase, 'variant'))
 
-  def test_minimized_arguments_for_variant_task_2(self):
+  def test_some_duplicate_minimized_arguments_for_variant_task(self):
     """Test that both minimized arguments and APP_ARGS are returned with
     duplicate args stripped from minimized arguments for variant task."""
     self.testcase.minimized_arguments = '--arg3="--flag1 --flag2" --arg4'
@@ -101,7 +101,7 @@ class GetApplicationArgumentsTest(unittest.TestCase):
     self.assertEqual('--arg4 --arg1 --arg2 --arg3="--flag1 --flag2"',
                      setup._get_application_arguments(self.testcase, 'variant'))
 
-  def test_minimized_arguments_for_variant_task_3(self):
+  def test_unique_minimized_arguments_for_variant_task(self):
     """Test that both minimized arguments and APP_ARGS are returned when they
     don't have common args for variant task."""
     self.testcase.minimized_arguments = '--arg5'
@@ -111,7 +111,7 @@ class GetApplicationArgumentsTest(unittest.TestCase):
     self.assertEqual('--arg5 --arg1 --arg2 --arg3="--flag1 --flag2"',
                      setup._get_application_arguments(self.testcase, 'variant'))
 
-  def test_minimized_arguments_for_variant_task_4(self):
+  def test_no_job_app_args_for_variant_task(self):
     """Test that only minimized arguments is returned when APP_ARGS is not set
     in job definition."""
     self.testcase.minimized_arguments = '--arg5'

--- a/src/python/tests/core/local/butler/reproduce_test.py
+++ b/src/python/tests/core/local/butler/reproduce_test.py
@@ -37,6 +37,9 @@ def _fake_get_testcase(*_):
       'fuzzer_name': 'fuzzer',
       'job_definition': 'APP_NAME = echo\nAPP_ARGS = -n\n',
       'platform': environment.platform().lower(),
+      'minimized_arguments': '',
+      'window_argument': '',
+      'timeout_multiplier': 1.0,
   }
 
   return reproduce.SerializedTestcase(testcase_map)


### PR DESCRIPTION
Add unique arguments from testcase minimized arguments that don't
exist in APP_ARGS. Fixes #746 and also fixes the regression that
cause engine fuzzer testcase to stop working.