### PR TITLE
Fix strategy column names for new libFuzzer fuzzing implementation.

### DIFF
--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -25,6 +25,8 @@ import shutil
 import sys
 import time
 
+import six
+
 from base import utils
 from bot.fuzzers import options
 from bot.fuzzers import utils as fuzzer_utils
@@ -389,10 +391,19 @@ def get_issue_components(fuzz_target_path):
 
 def format_fuzzing_strategies(fuzzing_strategies):
   """Format the strategies used for logging purposes."""
-  if fuzzing_strategies:
-    return 'cf::fuzzing_strategies: %s' % (','.join(fuzzing_strategies))
+  if not fuzzing_strategies:
+    return ''
 
-  return ''
+  if isinstance(fuzzing_strategies, list):
+    # Legacy format. TODO(ochang): Remove this once it's not used.
+    value = ','.join(fuzzing_strategies)
+  else:
+    # New format.
+    assert isinstance(fuzzing_strategies, dict)
+    value = ','.join('{}:{}'.format(key, value)
+                     for key, value in six.iteritems(fuzzing_strategies))
+
+  return 'cf::fuzzing_strategies: ' + value
 
 
 def random_choice(sequence):

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -117,10 +117,12 @@ class LibFuzzerEngine(engine.Engine):
       if os.path.exists(default_dict_path):
         arguments.append(constants.DICT_FLAG + default_dict_path)
 
+    strategies = stats.process_strategies(
+        strategy_info.fuzzing_strategies, name_modifier=lambda x: x)
     return LibFuzzerOptions(
-        corpus_dir, arguments, strategy_info.fuzzing_strategies,
-        strategy_info.additional_corpus_dirs, strategy_info.extra_env,
-        strategy_info.use_dataflow_tracing, strategy_info.is_mutations_run)
+        corpus_dir, arguments, strategies, strategy_info.additional_corpus_dirs,
+        strategy_info.extra_env, strategy_info.use_dataflow_tracing,
+        strategy_info.is_mutations_run)
 
   def _artifact_prefix(self, prefix):
     """Returns the artifact prefix argument."""

--- a/src/python/bot/fuzzers/libFuzzer/stats.py
+++ b/src/python/bot/fuzzers/libFuzzer/stats.py
@@ -126,6 +126,11 @@ def parse_fuzzing_strategies(log_lines, strategies):
         strategies = match.group(1).split(',')
         break
 
+  return process_strategies(strategies)
+
+
+def process_strategies(strategies, name_modifier=strategy_column_name):
+  """Process strategies, parsing any stored values."""
   stats = {}
 
   def parse_line_for_strategy_prefix(line, strategy_name):
@@ -136,7 +141,7 @@ def parse_fuzzing_strategies(log_lines, strategies):
 
     try:
       strategy_value = int(line[len(strategy_prefix):])
-      stats[strategy_column_name(strategy_name)] = strategy_value
+      stats[name_modifier(strategy_name)] = strategy_value
     except (IndexError, ValueError) as e:
       logs.log_error('Failed to parse strategy "%s":\n%s\n' % (line, str(e)))
 
@@ -148,7 +153,7 @@ def parse_fuzzing_strategies(log_lines, strategies):
   # Other strategies are either ON or OFF, without arbitrary values.
   for strategy_type in strategy.LIBFUZZER_STRATEGIES_WITH_BOOLEAN_VALUE:
     if strategy_type.name in strategies:
-      stats[strategy_column_name(strategy_type.name)] = 1
+      stats[name_modifier(strategy_type.name)] = 1
 
   return stats
 

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1387,8 +1387,8 @@ class FuzzingSession(object):
     fuzz_test_timeout = environment.get_value('FUZZ_TEST_TIMEOUT')
     result = engine_impl.fuzz(target_path, options, self.testcase_directory,
                               fuzz_test_timeout)
-    for strategy in options.strategies:
-      result.stats['strategy_' + strategy] = 1
+    for strategy, value in six.iteritems(options.strategies):
+      result.stats['strategy_' + strategy] = value
 
     # Format logs with header and strategy information.
     log_header = engine_common.get_log_header(result.command,

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -67,7 +67,9 @@ class PrepareTest(fake_fs_unittest.TestCase):
     test_helpers.patch(self, ['bot.fuzzers.libFuzzer.launcher.pick_strategies'])
 
     self.mock.pick_strategies.return_value = launcher.StrategyInfo(
-        fuzzing_strategies=['strategy1', 'strategy2'],
+        fuzzing_strategies=[
+            'unknown_1', 'value_profile', 'corpus_subset_20', 'fork_2'
+        ],
         arguments=['-arg1'],
         additional_corpus_dirs=['/new_corpus_dir'],
         extra_env={'extra_env': '1'},
@@ -83,7 +85,11 @@ class PrepareTest(fake_fs_unittest.TestCase):
         '-max_len=31337', '-timeout=11', '-rss_limit_mb=2048', '-arg1',
         '-dict=/path/blah.dict'
     ], options.arguments)
-    self.assertItemsEqual(['strategy1', 'strategy2'], options.strategies)
+    self.assertDictEqual({
+        'value_profile': 1,
+        'corpus_subset': 20,
+        'fork': 2
+    }, options.strategies)
     self.assertItemsEqual(['/new_corpus_dir', '/corpus_dir'],
                           options.fuzz_corpus_dirs)
     self.assertDictEqual({'extra_env': '1'}, options.extra_env)

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1344,7 +1344,7 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
     engine_impl.prepare.return_value = engine.FuzzOptions(
         '/corpus', ['arg'], {
             'strategy_1': 1,
-            'strategy_2': 2
+            'strategy_2': 50,
         })
     engine_impl.fuzz.return_value = engine.FuzzResult(
         'logs', ['cmd'], expected_crashes, {'stat': 1}, 42.0)
@@ -1364,7 +1364,7 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
         'Return code: 1\n\n'
         'Command: cmd\nBot: None\nTime ran: 42.0\n\n'
         'logs\n'
-        'cf::fuzzing_strategies: strategy_1:1,strategy_2:2', log_time)
+        'cf::fuzzing_strategies: strategy_1:1,strategy_2:50', log_time)
     self.mock.upload_testcase.assert_called_with('/input', log_time)
 
     self.assertEqual(1, len(crashes))
@@ -1383,6 +1383,6 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
         'kind': 'TestcaseRun',
         'stat': 1,
         'strategy_strategy_1': 1,
-        'strategy_strategy_2': 2,
+        'strategy_strategy_2': 50,
         'timestamp': 0.0,
     }, testcase_run.data)

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1342,7 +1342,10 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
     engine_impl = mock.Mock()
     engine_impl.name = 'libFuzzer'
     engine_impl.prepare.return_value = engine.FuzzOptions(
-        '/corpus', ['arg'], ['strategy_1', 'strategy_2'])
+        '/corpus', ['arg'], {
+            'strategy_1': 1,
+            'strategy_2': 2
+        })
     engine_impl.fuzz.return_value = engine.FuzzResult(
         'logs', ['cmd'], expected_crashes, {'stat': 1}, 42.0)
 
@@ -1361,7 +1364,7 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
         'Return code: 1\n\n'
         'Command: cmd\nBot: None\nTime ran: 42.0\n\n'
         'logs\n'
-        'cf::fuzzing_strategies: strategy_1,strategy_2', log_time)
+        'cf::fuzzing_strategies: strategy_1:1,strategy_2:2', log_time)
     self.mock.upload_testcase.assert_called_with('/input', log_time)
 
     self.assertEqual(1, len(crashes))
@@ -1380,6 +1383,6 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
         'kind': 'TestcaseRun',
         'stat': 1,
         'strategy_strategy_1': 1,
-        'strategy_strategy_2': 1,
+        'strategy_strategy_2': 2,
         'timestamp': 0.0,
     }, testcase_run.data)


### PR DESCRIPTION
Some strategies embed a numeric value in the name. This is expected to be
parsed before being set in the stats.

In a future PR, once we complete the migration, we can get rid of the
encoding + decoding steps which append the '_value' and then parses it.