### PR TITLE
Allow non-string additional vars in project setup.

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -816,9 +816,10 @@ class ProjectSetup(object):
         engine_sanitizer_vars = engine_vars.get(template.memory_tool, {})
         additional_vars.update(engine_sanitizer_vars)
 
-        for key, value in six.iteritems(additional_vars):
+        for key, value in sorted(six.iteritems(additional_vars)):
           job.environment_string += ('{} = {}\n'.format(
-              key, value.encode('unicode-escape')))
+              key,
+              str(value).encode('unicode-escape')))
 
       job.put()
 

--- a/src/python/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/python/tests/appengine/handlers/cron/project_setup_test.py
@@ -1590,7 +1590,9 @@ class GenericProjectSetupTest(unittest.TestCase):
             },
             'additional_vars': {
                 'all': {
-                    'ADDITIONAL_VAR': 'VAL',
+                    'STRING_VAR': 'VAL',
+                    'BOOL_VAR': True,
+                    'INT_VAR': 0,
                 },
                 'libfuzzer': {
                     'address': {
@@ -1614,7 +1616,9 @@ class GenericProjectSetupTest(unittest.TestCase):
         'gs://bucket/a-b/libfuzzer/address/%TARGET%/([0-9]+).zip\n'
         'PROJECT_NAME = //a/b\nSUMMARY_PREFIX = //a/b\nMANAGED = True\n'
         'ASAN_VAR = VAL\n'
-        'ADDITIONAL_VAR = VAL\n', job.environment_string)
+        'BOOL_VAR = True\n'
+        'INT_VAR = 0\n'
+        'STRING_VAR = VAL\n', job.environment_string)
     self.assertItemsEqual(['engine_asan', 'libfuzzer', 'prune'], job.templates)
 
     libfuzzer = data_types.Fuzzer.query(


### PR DESCRIPTION
This is needed to set UBSan to true for builds that have both
ASan and UBSan combined.