### PR TITLE
Corpus backup task: silently skip outdated fuzz targets (#907).

### DIFF
--- a/src/appengine/handlers/cron/corpus_backup.py
+++ b/src/appengine/handlers/cron/corpus_backup.py
@@ -99,5 +99,9 @@ class MakePublicHandler(base_handler.Handler):
           target_jobs)
 
       for target in fuzz_targets:
+        if not target:
+          # This is expected if any fuzzer/job combinations become outdated.
+          continue
+
         _make_corpus_backup_public(target, corpus_fuzzer_name_override,
                                    corpus_backup_bucket_name)

--- a/src/python/datastore/fuzz_target_utils.py
+++ b/src/python/datastore/fuzz_target_utils.py
@@ -27,7 +27,7 @@ def get_fuzz_targets_for_target_jobs(target_jobs):
   fuzz_targets = ndb.get_multi(target_keys)
 
   for fuzz_target, target_job in zip(fuzz_targets, target_jobs):
-    # ndb.get_multi returns None for non-existent keys, log missing FuzzTargets.
+    # ndb.get_multi returns None for a non-existent key, log missing FuzzTarget.
     if not fuzz_target:
       logs.log_error('FuzzTarget entity for %s does not exist.' %
                      target_job.fuzz_target_name)

--- a/src/python/datastore/fuzz_target_utils.py
+++ b/src/python/datastore/fuzz_target_utils.py
@@ -27,7 +27,7 @@ def get_fuzz_targets_for_target_jobs(target_jobs):
   fuzz_targets = ndb.get_multi(target_keys)
 
   for fuzz_target, target_job in zip(fuzz_targets, target_jobs):
-    # ndb.get_multi returns None for a non-existent key, log missing FuzzTarget.
+    # ndb.get_multi returns None for non-existent keys, log missing FuzzTargets.
     if not fuzz_target:
       logs.log_error('FuzzTarget entity for %s does not exist.' %
                      target_job.fuzz_target_name)

--- a/src/python/datastore/fuzz_target_utils.py
+++ b/src/python/datastore/fuzz_target_utils.py
@@ -16,7 +16,6 @@
 from datastore import data_types
 from datastore import ndb
 from datastore import ndb_utils
-from metrics import logs
 
 
 def get_fuzz_targets_for_target_jobs(target_jobs):
@@ -24,15 +23,7 @@ def get_fuzz_targets_for_target_jobs(target_jobs):
   target_keys = [
       ndb.Key(data_types.FuzzTarget, t.fuzz_target_name) for t in target_jobs
   ]
-  fuzz_targets = ndb.get_multi(target_keys)
-
-  for fuzz_target, target_job in zip(fuzz_targets, target_jobs):
-    # ndb.get_multi returns None for a non-existent key, log missing FuzzTarget.
-    if not fuzz_target:
-      logs.log_error('FuzzTarget entity for %s does not exist.' %
-                     target_job.fuzz_target_name)
-
-  return fuzz_targets
+  return ndb.get_multi(target_keys)
 
 
 def get_fuzz_target_jobs(fuzz_target_name=None,


### PR DESCRIPTION
I think we can make it a warning, but I'd prefer to figure out why the issue is happening in the first place. Maybe there is some other issue which we can fix and avoid these confusing failures across multiple cron tasks. This should help us to track down the root cause.