### PR TITLE
Fix exception, env.*SAN_OPTIONS is a dict from minimize task.

### DIFF
--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -51,7 +51,6 @@ GOMA_DIR_LINE_REGEX = re.compile(r'^\s*goma_dir\s*=')
 HEARTBEAT_LAST_UPDATE_KEY = 'heartbeat_update'
 INPUT_DIR = 'inputs'
 MEMCACHE_TTL_IN_SECONDS = 15 * 60
-SYMBOLIZE_FLAG_REGEX = re.compile('[:]?symbolize=(0|1|true|false)')
 
 NUM_TESTCASE_QUALITY_BITS = 3
 MAX_TESTCASE_QUALITY = 2**NUM_TESTCASE_QUALITY_BITS - 1
@@ -341,12 +340,13 @@ def get_memory_tool_options_string(testcase):
   result = ''
   for options_name, options_value in sorted(six.iteritems(env)):
     # Strip symbolize flag, use default symbolize=1.
-    options_value = SYMBOLIZE_FLAG_REGEX.sub('', options_value)
+    options_value.pop('symbolize', None)
     if not options_value:
       continue
 
-    result += '{options_name}="{options_value}" '.format(
-        options_name=options_name, options_value=quote(options_value))
+    options_string = environment.join_memory_tool_options(options_value)
+    result += '{options_name}="{options_string}" '.format(
+        options_name=options_name, options_string=quote(options_string))
 
   return result
 

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -61,11 +61,11 @@ def _eval_value(value_string):
     return value_string
 
 
-def _join_memory_tool_options(options):
+def join_memory_tool_options(options):
   """Joins a dict holding memory tool options into a string that can be set in
   the environment."""
-  return ':'.join(
-      '%s=%s' % (key, str(value)) for key, value in six.iteritems(options))
+  return ':'.join('%s=%s' % (key, str(value))
+                  for key, value in sorted(six.iteritems(options)))
 
 
 def _maybe_convert_to_int(value):
@@ -151,7 +151,7 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
 
   # Test for leaks if this is an LSan-enabled job type.
   if get_value('LSAN') and leaks:
-    lsan_options = _join_memory_tool_options(get_lsan_options())
+    lsan_options = join_memory_tool_options(get_lsan_options())
     set_value('LSAN_OPTIONS', lsan_options)
     asan_options['detect_leaks'] = 1
   else:
@@ -190,7 +190,7 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
   # Check if UBSAN is enabled as well for this ASAN build.
   # If yes, set UBSAN_OPTIONS and enable suppressions.
   if get_value('UBSAN'):
-    ubsan_options = _join_memory_tool_options(get_ubsan_options())
+    ubsan_options = join_memory_tool_options(get_ubsan_options())
     set_value('UBSAN_OPTIONS', ubsan_options)
 
   return asan_options
@@ -697,7 +697,7 @@ def set_common_environment_variables():
 
 def set_memory_tool_options(env_var, options_dict):
   """Set current memory tool options."""
-  set_value(env_var, _join_memory_tool_options(options_dict))
+  set_value(env_var, join_memory_tool_options(options_dict))
 
 
 def set_environment_parameters_from_file(file_path):
@@ -768,7 +768,7 @@ def reset_current_memory_tool_options(redzone_size=0,
       })
 
   # Join the options.
-  joined_tool_options = _join_memory_tool_options(tool_options)
+  joined_tool_options = join_memory_tool_options(tool_options)
   tool_options_variable_name = '%s_OPTIONS' % tool_name
   set_value(tool_options_variable_name, joined_tool_options)
 

--- a/src/python/tests/core/bot/fuzzers/builtin_test.py
+++ b/src/python/tests/core/bot/fuzzers/builtin_test.py
@@ -146,7 +146,7 @@ class EngineFuzzerTest(BaseEngineFuzzerTest):
     fuzzer = TestEngineFuzzer()
     fuzzer.run('/input', '/output', 1)
 
-    self.assertEqual('fake_option2=1:fake_option1=1',
+    self.assertEqual('fake_option1=1:fake_option2=1',
                      environment.get_value('ASAN_OPTIONS'))
     self.assertEqual(None, environment.get_value('MSAN_OPTIONS'))
 

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -660,9 +660,18 @@ class GetFormattedReproductionHelpTest(unittest.TestCase):
 
     testcase.set_metadata(
         'env', {
-            'ASAN_OPTIONS': 'handle_abort=1:symbolize=0:redzone=512',
-            'UBSAN_OPTIONS': 'halt_on_error=1:symbolize=0',
-            'OTHER_OPTIONS': 'symbolize=1'
+            'ASAN_OPTIONS': {
+                'handle_abort': 1,
+                'symbolize': 0,
+                'redzone': 512,
+            },
+            'UBSAN_OPTIONS': {
+                'halt_on_error': 1,
+                'symbolize': 0,
+            },
+            'OTHER_OPTIONS': {
+                'symbolize': 1
+            }
         })
 
     self.assertEquals(


### PR DESCRIPTION
Fixes exception, also part of https://github.com/google/clusterfuzz/issues/353
```
TypeError: expected string or buffer
at get_memory_tool_options_string (/base/data/home/apps/s~google.com:cluster-fuzz/20190829t084526.420663467542689250/python/datastore/data_handler.py:344)
at get_formatted_reproduction_help (/base/data/home/apps/s~google.com:cluster-fuzz/20190829t084526.420663467542689250/python/datastore/data_handler.py:376)
at get_testcase_detail (/base/data/home/apps/s~google.com:cluster-fuzz/20190829t084526.420663467542689250/handlers/testcase_detail/show.py:389)
at get_testcase_detail_by_id (/base/data/home/apps/s~google.com:cluster-fuzz/20190829t084526.420663467542689250/handlers/testcase_detail/show.py:327)
```