### PR TITLE
Add source mapping for custom GitLab servers + tests.

### DIFF
--- a/src/python/build_management/source_mapper.py
+++ b/src/python/build_management/source_mapper.py
@@ -103,7 +103,8 @@ class GitHubVCS(VCSViewer):
 
 
 class GitLabVCS(GitHubVCS):
-  VCS_URL_REGEX = re.compile(r'(https://gitlab\.com/(.*?))(\.git)?$')
+  VCS_URL_REGEX = re.compile(
+      r'(https://gitlab(\.[\w\.\-]+)?\.(com|org)/(.*?))(\.git)?$')
 
 
 class GoogleSourceVCS(VCSViewer):

--- a/src/python/tests/core/build_management/source_mapper_test.py
+++ b/src/python/tests/core/build_management/source_mapper_test.py
@@ -149,6 +149,35 @@ class NormalizeSourcePathTest(unittest.TestCase):
 class VCSViewerTest(unittest.TestCase):
   """Tests for VCSViewer."""
 
+  def test_get_vcs_viewer_for_url(self):
+    """Test that VCS recognition logic from source_mapper.py works correctly."""
+    vcs = source_mapper.get_vcs_viewer_for_url(
+        'https://anongit.freedesktop.org/git/gstreamer/gstreamer.git')
+    self.assertIsInstance(vcs, source_mapper.FreeDesktopVCS)
+
+    vcs = source_mapper.get_vcs_viewer_for_url(
+        'https://github.com/imagemagick/imagemagick.git')
+    self.assertIsInstance(vcs, source_mapper.GitHubVCS)
+
+    vcs = source_mapper.get_vcs_viewer_for_url(
+        'https://gitlab.com/libidn/libidn2.git')
+    self.assertIsInstance(vcs, source_mapper.GitLabVCS)
+
+    vcs = source_mapper.get_vcs_viewer_for_url(
+        'https://gitlab.gnome.org/GNOME/libxml2.git')
+    self.assertIsInstance(vcs, source_mapper.GitLabVCS)
+
+    vcs = source_mapper.get_vcs_viewer_for_url(
+        'https://chromium.googlesource.com/webm/libwebp.git')
+    self.assertIsInstance(vcs, source_mapper.GoogleSourceVCS)
+
+    vcs = source_mapper.get_vcs_viewer_for_url('//dir1/dir2')
+    self.assertIsInstance(vcs, source_mapper.GoogleVCS)
+
+    vcs = source_mapper.get_vcs_viewer_for_url(
+        'http://hg.code.sf.net/p/graphicsmagick/code')
+    self.assertIsInstance(vcs, source_mapper.MercurialVCS)
+
   def test_google_vcs(self):
     vcs = source_mapper.GoogleVCS('//dir1/dir2')
     self.assertEqual('https://cs.corp.google.com/dir1/dir2/?rcl=1337',


### PR DESCRIPTION
People have told me that we have some projects hosting at e.g. https://gitlab.gnome.org/GNOME/libxml2 and their stacktraces are not linkified.