### PR TITLE
Always reset memory tool options when preparing the environment.

### DIFF
--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -126,9 +126,6 @@ def _get_application_arguments(testcase, task_name):
 def _setup_memory_tools_environment(testcase):
   """Set up environment for various memory tools used."""
   env = testcase.get_metadata('env')
-  if not env:
-    environment.reset_current_memory_tool_options(redzone_size=testcase.redzone)
-    return
 
   for options_name, options_value in six.iteritems(env):
     if not options_value:
@@ -139,6 +136,7 @@ def _setup_memory_tools_environment(testcase):
 
 def prepare_environment_for_testcase(testcase):
   """Set various environment variables based on the test case."""
+  environment.reset_current_memory_tool_options(redzone_size=testcase.redzone)
   _setup_memory_tools_environment(testcase)
 
   # Setup environment variable for windows size and location properties.

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -126,6 +126,8 @@ def _get_application_arguments(testcase, task_name):
 def _setup_memory_tools_environment(testcase):
   """Set up environment for various memory tools used."""
   env = testcase.get_metadata('env')
+  if not env:
+    return
 
   for options_name, options_value in six.iteritems(env):
     if not options_value:


### PR DESCRIPTION
This partially reverts #921. I suspect that this is why we have marked some testcases as Unreproducible this morning (see the chat for more context).