### PR TITLE
Fix issue with ubsan crashes turning unreproducible.

### DIFF
--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1263,8 +1263,7 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
       reproduced = False
       for _ in range(MINIMIZE_SANITIZER_OPTIONS_RETRIES):
         crash_result = _run_libfuzzer_testcase(testcase, testcase_file_path)
-        if (crash_result and \
-            crash_result.is_crash() and \
+        if (crash_result.is_crash() and \
             crash_result.is_security_issue() ==
             initial_crash_result.is_security_issue() and
             crash_result.get_type() == initial_crash_result.get_type() and

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1264,6 +1264,7 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
       for _ in range(MINIMIZE_SANITIZER_OPTIONS_RETRIES):
         crash_result = _run_libfuzzer_testcase(testcase, testcase_file_path)
         if (crash_result and \
+            crash_result.is_crash() and \
             crash_result.is_security_issue() ==
             initial_crash_result.is_security_issue() and
             crash_result.get_type() == initial_crash_result.get_type() and

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -26,6 +26,7 @@ from base import utils
 from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from build_management import revisions
+from crash_analysis import crash_analyzer
 from crash_analysis.crash_comparer import CrashComparer
 from crash_analysis.crash_result import CrashResult
 from datastore import data_handler
@@ -575,6 +576,10 @@ class TestcaseRunner(object):
       output = log_header + '\n' + result.output
 
     process_handler.terminate_stale_application_instances()
+
+    if not return_code and (crash_analyzer.is_memory_tool_crash(output) or
+                            crash_analyzer.is_check_failure_crash(output)):
+      return_code = 1
 
     crash_result = CrashResult(return_code, crash_time, output)
     if not crash_result.is_crash():

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -515,8 +515,9 @@ def engine_reproduce(engine_impl, target_name, testcase_path, arguments,
                                  timeout)
 
   # This matches the check in process_handler.run_process.
-  if not result.return_code and (crash_analyzer.is_memory_tool_crash(
-      result.output) or crash_analyzer.is_check_failure_crash(result.output)):
+  if not result.return_code and \
+      (crash_analyzer.is_memory_tool_crash(result.output) or
+       crash_analyzer.is_check_failure_crash(result.output)):
     result.return_code = 1
 
   return result


### PR DESCRIPTION
- Add missing is_crash() in minimize options. This makes sure
  that it is not minimizing any option that changes return code to
  zero.
- Explicit fix return code when a memory tool output or check failure
  output is found. This check was in process_handler.run_process, but
  not in engine.reproduce branch.