### PR TITLE
Fix minimize task exception.

### DIFF
--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1129,7 +1129,7 @@ def _run_libfuzzer_tool(tool_name,
   def _set_dedup_flags():
     """Allow libFuzzer to do its own crash comparison during minimization."""
     memory_tool_options = environment.get_memory_tool_options(
-        memory_tool_options_var)
+        memory_tool_options_var, default_value={})
 
     memory_tool_options['symbolize'] = 1
     memory_tool_options['dedup_token_length'] = 3
@@ -1141,7 +1141,8 @@ def _run_libfuzzer_tool(tool_name,
     """Reset memory tool options."""
     # This is needed so that when we re-run, we can symbolize ourselves
     # (ignoring inline frames).
-    environment.set_value(memory_tool_options_var, saved_memory_tool_options)
+    if saved_memory_tool_options is not None:
+      environment.set_value(memory_tool_options_var, saved_memory_tool_options)
 
   output_file_path = get_temporary_file_name(testcase_file_path)
 


### PR DESCRIPTION
Fixes OSS-Fuzz exception:

```
TypeError: 'NoneType' object does not support item assignment
at _set_dedup_flags (/mnt/scratch0/bots/oss-fuzz-linux-zone3-host-r3nt-4/clusterfuzz/src/python/bot/tasks/minimize_task.py:1135)
at _run_libfuzzer_tool (/mnt/scratch0/bots/oss-fuzz-linux-zone3-host-r3nt-4/clusterfuzz/src/python/bot/tasks/minimize_task.py:1153)
at do_libfuzzer_minimization (/mnt/scratch0/bots/oss-fuzz-linux-zone3-host-r3nt-4/clusterfuzz/src/python/bot/tasks/minimize_task.py:1304)
at execute_task (/mnt/scratch0/bots/oss-fuzz-linux-zone3-host-r3nt-4/clusterfuzz/src/python/bot/tasks/minimize_task.py:396)
at run_command (/mnt/scratch0/bots/oss-fuzz-linux-zone3-host-r3nt-4/clusterfuzz/src/python/bot/tasks/commands.py:181)
at process_command (/mnt/scratch0/bots/oss-fuzz-linux-zone3-host-r3nt-4/clusterfuzz/src/python/bot/tasks/commands.py:359)
at wrapper (/mnt/scratch0/bots/oss-fuzz-linux-zone3-host-r3nt-4/clusterfuzz/src/python/bot/tasks/commands.py:138)
at task_loop (/mnt/scratch0/bots/oss-fuzz-linux-zone3-host-r3nt-4/clusterfuzz/src/python/bot/startup/run_bot.py:97)
```