### PR TITLE
Move clearing of common data bundles directory to its own function.

### DIFF
--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -42,8 +42,8 @@ from system import environment
 from system import process_handler
 from system import shell
 
-LAYOUT_TEST_LAST_UPDATE_KEY = 'layout_test_last_update'
-LAYOUT_TEST_UPDATE_INTERVAL_DAYS = 1
+TESTS_LAST_UPDATE_KEY = 'tests_last_update'
+TESTS_UPDATE_INTERVAL_DAYS = 1
 
 MANIFEST_FILENAME = 'clusterfuzz-source.manifest'
 
@@ -291,10 +291,9 @@ def update_tests_if_needed():
     return
 
   last_modified_time = persistent_cache.get_value(
-      LAYOUT_TEST_LAST_UPDATE_KEY,
-      constructor=datetime.datetime.utcfromtimestamp)
+      TESTS_LAST_UPDATE_KEY, constructor=datetime.datetime.utcfromtimestamp)
   if (last_modified_time is not None and not dates.time_has_expired(
-      last_modified_time, days=LAYOUT_TEST_UPDATE_INTERVAL_DAYS)):
+      last_modified_time, days=TESTS_UPDATE_INTERVAL_DAYS)):
     return
 
   logs.log('Updating layout tests.')
@@ -317,7 +316,7 @@ def update_tests_if_needed():
 
   if not error_occured:
     persistent_cache.set_value(
-        LAYOUT_TEST_LAST_UPDATE_KEY, time.time(), persist_across_reboots=True)
+        TESTS_LAST_UPDATE_KEY, time.time(), persist_across_reboots=True)
 
   tasks.track_task_end()
 

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -84,6 +84,11 @@ def clear_crash_stacktraces_directory():
       environment.get_value('CRASH_STACKTRACES_DIR'), recreate=True)
 
 
+def clear_common_data_bundles_directory():
+  """Clear the common data bundle directory."""
+  remove_directory(environment.get_value('FUZZ_DATA'), recreate=True)
+
+
 def clear_data_bundles_directory():
   """Clears the data bundles directory."""
   remove_directory(environment.get_value('DATA_BUNDLES_DIR'), recreate=True)
@@ -99,6 +104,7 @@ def clear_data_directories():
   clear_build_directory()
   clear_build_urls_directory()
   clear_crash_stacktraces_directory()
+  clear_common_data_bundles_directory()
   clear_data_bundles_directory()
   clear_fuzzers_directories()
   clear_temp_directory()
@@ -178,7 +184,6 @@ def clear_testcase_directories():
   """Clears the testcase directories."""
   remove_directory(environment.get_value('FUZZ_INPUTS'), recreate=True)
   remove_directory(environment.get_value('FUZZ_INPUTS_DISK'), recreate=True)
-  remove_directory(environment.get_value('FUZZ_DATA'), recreate=True)
 
   if environment.platform() == 'ANDROID':
     from platforms import android

--- a/src/python/tests/core/base/persistent_cache_test.py
+++ b/src/python/tests/core/base/persistent_cache_test.py
@@ -32,12 +32,12 @@ class PersistentCacheTest(fake_filesystem_unittest.TestCase):
     persistent_cache.initialize()
 
   def test_set_get_string(self):
-    """Ensure it works with string value"""
+    """Ensure it works with string value."""
     persistent_cache.set_value('key', 'value')
     self.assertEqual(persistent_cache.get_value('key'), 'value')
 
   def test_set_get_datetime(self):
-    """Ensure it works with datetime value"""
+    """Ensure it works with datetime value."""
     epoch = datetime.datetime.utcfromtimestamp(0)
     end_time = datetime.datetime.utcfromtimestamp(10)
     diff_time = end_time - epoch
@@ -47,17 +47,17 @@ class PersistentCacheTest(fake_filesystem_unittest.TestCase):
             'key', constructor=datetime.datetime.utcfromtimestamp), end_time)
 
   def test_delete(self):
-    """Ensure it deletes key"""
+    """Ensure it deletes key."""
     persistent_cache.set_value('key', 'value')
     persistent_cache.delete_value('key')
     self.assertEqual(persistent_cache.get_value('key'), None)
 
   def test_get_nonexistence(self):
-    """Ensure it returns default_value when key doesn't exists"""
+    """Ensure it returns default_value when key doesn't exists."""
     self.assertEqual(persistent_cache.get_value('key', default_value=1), 1)
 
   def test_get_invalid(self):
-    """Ensure it returns default_value when constructor fails"""
+    """Ensure it returns default_value when constructor fails."""
     time_now = datetime.datetime.utcnow()
     persistent_cache.set_value('key', 'random')
     self.assertEqual(persistent_cache.get_value('key'), 'random')
@@ -68,9 +68,17 @@ class PersistentCacheTest(fake_filesystem_unittest.TestCase):
             constructor=datetime.datetime.utcfromtimestamp), time_now)
 
   def test_persist_across_reboots(self):
-    """Ensure persist_across_reboots works"""
+    """Ensure persist_across_reboots works."""
     persistent_cache.set_value('key', 'a')
     persistent_cache.set_value('key2', 'b', persist_across_reboots=True)
     persistent_cache.clear_values()
     self.assertEqual(persistent_cache.get_value('key'), None)
     self.assertEqual(persistent_cache.get_value('key2'), 'b')
+
+  def test_clear_all(self):
+    """Ensure clear all works."""
+    persistent_cache.set_value('key', 'a')
+    persistent_cache.set_value('key2', 'b', persist_across_reboots=True)
+    persistent_cache.clear_values(clear_all=True)
+    self.assertEqual(persistent_cache.get_value('key'), None)
+    self.assertEqual(persistent_cache.get_value('key2'), None)


### PR DESCRIPTION
clear_testcase_directories is called before start of every task in cleanup_task_state,
so it clears the downloaded web tests bundle everytime. This is
a regression from #896.
Also, add a test for persistent_cache's clear_values function
with clear_all=True. This is not related to fix, but good to have.