### PR TITLE
Revert "JSON escape login redirect URL."

### DIFF
--- a/src/appengine/private/templates/login.html
+++ b/src/appengine/private/templates/login.html
@@ -67,7 +67,7 @@
 
             xhr.onreadystatechange = function() {
               if (this.readyState == XMLHttpRequest.DONE && this.status == 200) {
-                window.location.assign(atob('{{dest|json}}'));
+                window.location.assign('{{dest}}');
               }
             }
 


### PR DESCRIPTION
Reverts google/clusterfuzz#929

Breaks redirects
Go to testcase detail page
E.g. https://clusterfuzz.com/testcase-detail/5691478277226496
Click switch account.
Login, you get redirected to
https://clusterfuzz.com/login?dest=https%3A%2F%2Fclusterfuzz.com%2Ftestcase-detail%2F5691478277226496
Then login, link breaks to
https://clusterfuzz.com/%22https://clusterfuzz.com/testcase-detail/5691478277226496%22