### PR TITLE
Allow explicit disabling of new engine fuzzing implementation.

### DIFF
--- a/src/python/bot/fuzzers/engine.py
+++ b/src/python/bot/fuzzers/engine.py
@@ -181,8 +181,12 @@ def get(name):
 
 def do_trial():
   """Returns or not we should trial using this new implementation."""
-  if environment.get_value('USE_NEW_ENGINE_IMPL'):
+  use_new_impl = environment.get_value('USE_NEW_ENGINE_IMPL')
+  if use_new_impl:
     return True
+
+  if use_new_impl is False:  # Explicitly set to false.
+    return False
 
   if environment.get_value('TASK_NAME') == 'fuzz':
     probability = _TRIAL_PROBABILITY_FUZZ


### PR DESCRIPTION
ChromeOS currently doesn't work because of minijail.