### PR TITLE
Add 'quiet' flag to testcase upload.

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -517,14 +517,16 @@ class UploadHandlerCommon(object):
         bug_summary_update_flag,
         additional_metadata=testcase_metadata)
 
-    testcase = data_handler.get_testcase_by_id(testcase_id)
-    issue = issue_tracker_utils.get_issue_for_testcase(testcase)
-    if issue:
-      report_url = data_handler.TESTCASE_REPORT_URL.format(
-          domain=data_handler.get_domain(), testcase_id=testcase_id)
-      comment = ('ClusterFuzz is analyzing your testcase. '
-                 'Developers can follow the progress at %s.' % report_url)
-      issue.save(new_comment=comment)
+    if not self.request.get('quiet'):
+      testcase = data_handler.get_testcase_by_id(testcase_id)
+      issue = issue_tracker_utils.get_issue_for_testcase(testcase)
+      if issue:
+        report_url = data_handler.TESTCASE_REPORT_URL.format(
+            domain=data_handler.get_domain(), testcase_id=testcase_id)
+
+        comment = ('ClusterFuzz is analyzing your testcase. '
+                   'Developers can follow the progress at %s.' % report_url)
+        issue.save(new_comment=comment)
 
     helpers.log('Uploaded testcase %s' % testcase_id, helpers.VIEW_OPERATION)
     self.render_json({'id': '%s' % testcase_id})


### PR DESCRIPTION
When set, don't post the 'ClusterFuzz is analyzing your testcase...'
comment.

This is an API-only flag which won't be exposed to the UI.