### PR TITLE
Add a temporary use_minijail override to libfuzzer.get_runner.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -205,7 +205,8 @@ class LibFuzzerEngine(engine.Engine):
       A FuzzResult object.
     """
     profiler.start_if_needed('libfuzzer_fuzz')
-    runner = libfuzzer.get_runner(target_path)
+    # TODO(ochang): Figure out solution for ChromeOS.
+    runner = libfuzzer.get_runner(target_path, use_minijail=False)
     launcher.set_sanitizer_options(target_path)
 
     artifact_prefix = self._artifact_prefix(os.path.abspath(reproducers_dir))

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -597,9 +597,11 @@ class MinijailLibFuzzerRunner(engine_common.MinijailEngineFuzzerRunner,
       return result
 
 
-def get_runner(fuzzer_path, temp_dir=None):
+def get_runner(fuzzer_path, temp_dir=None, use_minijail=None):
   """Get a libfuzzer runner."""
-  use_minijail = environment.get_value('USE_MINIJAIL')
+  if use_minijail is None:
+    use_minijail = environment.get_value('USE_MINIJAIL')
+
   build_dir = environment.get_value('BUILD_DIR')
   dataflow_build_dir = environment.get_value('DATAFLOW_BUILD_DIR')
 


### PR DESCRIPTION
The new engine implementation does not support minijail.