### PR TITLE
LibFuzzerEngine: Pass artifact_prefix as argument to LibFuzzerRunner.

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -594,7 +594,6 @@ class MinijailLibFuzzerRunner(engine_common.MinijailEngineFuzzerRunner,
     if artifact_prefix:
       artifact_prefix = self._get_chroot_directory(artifact_prefix)
 
-    # Set artifact prefix to '/' in minijail.
     return LibFuzzerCommon.fuzz(
         self,
         corpus_directories,

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -202,9 +202,12 @@ class FuzzTest(fake_fs_unittest.TestCase):
     self.mock.fuzz.assert_called_with(
         mock.ANY, ['/fuzz-inputs/temp-9001/new', '/corpus'],
         additional_args=[
-            '-arg=1', '-timeout=123', '-dict=blah.dict', '-max_len=9001',
-            '-artifact_prefix=/fake/'
+            '-arg=1',
+            '-timeout=123',
+            '-dict=blah.dict',
+            '-max_len=9001',
         ],
+        artifact_prefix='/fake',
         extra_env={},
         fuzz_timeout=1470.0)
 
@@ -214,6 +217,7 @@ class FuzzTest(fake_fs_unittest.TestCase):
             '/corpus'
         ],
         additional_args=['-arg=1', '-timeout=123'],
+        artifact_prefix=None,
         merge_timeout=1800.0,
         tmp_dir='/fuzz-inputs/temp-9001/merge-workdir')
 


### PR DESCRIPTION
Instead of constructing our own argument. LibFuzzerRunner will
transparently bind things for minijail to work.