### PR TITLE
Be smart about prefix to fix bug in radamsa use where filenames get too long.

### DIFF
--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -140,7 +140,7 @@ def generate_new_testcase_mutations(corpus_directory,
 
 FILENAME_LENGTH_LIMIT = 255
 
-RADAMSA_FILENAME_REGEX = 'radamsa-\d+-(.*)'
+RADAMSA_FILENAME_REGEX = r'radamsa-\d+-(.*)'
 
 
 def get_radamsa_output_filename(initial_filename, i):

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -137,6 +137,21 @@ def generate_new_testcase_mutations(corpus_directory,
   return False
 
 
+RADAMSA_FILENAME_REGEX = 'radamsa-\d+-(.*)'
+
+
+def get_radamsa_output_filename(initial_filename, i):
+  """Get the name of a file mutated by radamsa."""
+  # Don't add the radamsa prefix to a file that already has it to avoid hitting
+  # filename/path length limits.
+  match = re.search(initial_filename, RADAMSA_FILENAME_REGEX, re.DOTALL)
+  if match:
+    base_filename = match.group(0)
+  else:
+    base_filename = initial_filename
+  return 'radamsa-%05d-%s' % (i + 1, base_filename)
+
+
 def generate_new_testcase_mutations_using_radamsa(
     corpus_directory, new_testcase_mutations_directory, generation_timeout):
   """Generate new testcase mutations based on Radamsa."""
@@ -163,7 +178,7 @@ def generate_new_testcase_mutations_using_radamsa(
     original_file_path = random_choice(filtered_files_list)
     original_filename = os.path.basename(original_file_path)
     output_path = os.path.join(new_testcase_mutations_directory,
-                               'radamsa-%08d-%s' % (i + 1, original_filename))
+                               get_radamsa_output_filename(i, original_filename))
 
     result = radamsa_runner.run_and_wait(
         ['-o', output_path, original_file_path], timeout=RADAMSA_TIMEOUT)

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -154,6 +154,8 @@ def get_radamsa_output_filename(initial_filename, i):
   else:
     base_filename = initial_filename
   prefix = 'radamsa-%05d-' % (i + 1)
+  # FIXME: AFL will still break if the filename is 255. AFL needs to rename
+  # every file to a sensible length.
   return prefix + base_filename[:FILENAME_LENGTH_LIMIT - len(prefix)]
 
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -138,6 +138,7 @@ def generate_new_testcase_mutations(corpus_directory,
   return False
 
 
+# Filename length limit on ext4.
 FILENAME_LENGTH_LIMIT = 255
 
 RADAMSA_FILENAME_REGEX = r'radamsa-\d+-(.*)'
@@ -152,8 +153,8 @@ def get_radamsa_output_filename(initial_filename, i):
     base_filename = match.group(1)
   else:
     base_filename = initial_filename
-  prefix = 'radamsa-%05d' % (i + 1)
-  return '%s-%s' % (prefix, base_filename[:FILENAME_LENGTH_LIMIT - len(prefix)])
+  prefix = 'radamsa-%05d-' % (i + 1)
+  return prefix + base_filename[:FILENAME_LENGTH_LIMIT - len(prefix)]
 
 
 def generate_new_testcase_mutations_using_radamsa(

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -155,7 +155,8 @@ def get_radamsa_output_filename(initial_filename, i):
     base_filename = initial_filename
   prefix = 'radamsa-%05d-' % (i + 1)
   # FIXME: AFL will still break if the filename is near 255 chars since it
-  # naively appends. AFL needs to rename every file to a sensible length.
+  # naively appends. AFL needs to rename every file to a sensible length (not
+  # just those created by radamsa).
   return prefix + base_filename[:FILENAME_LENGTH_LIMIT - len(prefix)]
 
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -154,8 +154,8 @@ def get_radamsa_output_filename(initial_filename, i):
   else:
     base_filename = initial_filename
   prefix = 'radamsa-%05d-' % (i + 1)
-  # FIXME: AFL will still break if the filename is 255. AFL needs to rename
-  # every file to a sensible length.
+  # FIXME: AFL will still break if the filename is near 255 chars since it
+  # naively appends. AFL needs to rename every file to a sensible length.
   return prefix + base_filename[:FILENAME_LENGTH_LIMIT - len(prefix)]
 
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -141,14 +141,14 @@ def generate_new_testcase_mutations(corpus_directory,
 # Filename length limit on ext4.
 FILENAME_LENGTH_LIMIT = 255
 
-RADAMSA_FILENAME_REGEX = r'radamsa-\d+-(.*)'
+RADAMSA_FILENAME_REGEX = re.compile(r'radamsa-\d+-(.*)', re.DOTALL)
 
 
 def get_radamsa_output_filename(initial_filename, i):
   """Get the name of a file mutated by radamsa."""
   # Don't add the radamsa prefix to a file that already has it to avoid hitting
   # filename/path length limits.
-  match = re.search(RADAMSA_FILENAME_REGEX, initial_filename, re.DOTALL)
+  match = RADAMSA_FILENAME_REGEX.search(initial_filename)
   if match:
     base_filename = match.group(1)
   else:

--- a/src/python/tests/core/bot/fuzzers/engine_common_test.py
+++ b/src/python/tests/core/bot/fuzzers/engine_common_test.py
@@ -459,3 +459,19 @@ class UnpackSeedCorpusIfNeededTest(fake_filesystem_unittest.TestCase):
     self._write_seed_corpus(self.seed_corpus_subdirs_contents, '.zip')
     self._unpack_seed_corpus_if_needed()
     self._assert_elements_equal(expected_dir_contents, self._list_corpus_dir())
+
+
+class GetRadamsaOutputFilenameTest(unittest.TestCase):
+
+  def test_get_output_filename(self):
+    output_filename = engine_common.get_radamsa_output_filename('file', 0)
+    self.assertEqual('radamsa-00001-file', output_filename)
+
+  def test_no_double_prefix(self):
+    output_filename = engine_common.get_radamsa_output_filename(
+        'radamsa-00002-file', 0)
+    self.assertEqual('radamsa-00001-file', output_filename)
+
+  def test_length_limit(self):
+    output_filename = engine_common.get_radamsa_output_filename(500 * 'a', 0)
+    self.assertLessThan(len(output_filename), 255)

--- a/src/python/tests/core/bot/fuzzers/engine_common_test.py
+++ b/src/python/tests/core/bot/fuzzers/engine_common_test.py
@@ -474,5 +474,7 @@ class GetRadamsaOutputFilenameTest(unittest.TestCase):
     self.assertEqual('radamsa-00001-file', output_filename)
 
   def test_length_limit(self):
-    output_filename = engine_common.get_radamsa_output_filename(500 * 'a', 0)
-    self.assertLessThan(len(output_filename), 255)
+    linux_filename_length_limit = 255
+    output_filename = engine_common.get_radamsa_output_filename(
+        linux_filename_length_limit * 2 * 'a', 0)
+    self.assertLessEqual(len(output_filename), linux_filename_length_limit)

--- a/src/python/tests/core/bot/fuzzers/engine_common_test.py
+++ b/src/python/tests/core/bot/fuzzers/engine_common_test.py
@@ -462,6 +462,7 @@ class UnpackSeedCorpusIfNeededTest(fake_filesystem_unittest.TestCase):
 
 
 class GetRadamsaOutputFilenameTest(unittest.TestCase):
+  """get_radamsa_output_filename tests."""
 
   def test_get_output_filename(self):
     output_filename = engine_common.get_radamsa_output_filename('file', 0)

--- a/src/python/tests/core/bot/fuzzers/engine_common_test.py
+++ b/src/python/tests/core/bot/fuzzers/engine_common_test.py
@@ -464,17 +464,22 @@ class UnpackSeedCorpusIfNeededTest(fake_filesystem_unittest.TestCase):
 class GetRadamsaOutputFilenameTest(unittest.TestCase):
   """get_radamsa_output_filename tests."""
 
-  def test_get_output_filename(self):
+  def test_get_radamsa_output_filename(self):
+    """Test get_radamsa_output_filename works as expected."""
     output_filename = engine_common.get_radamsa_output_filename('file', 0)
     self.assertEqual('radamsa-00001-file', output_filename)
 
   def test_no_double_prefix(self):
+    """Test get_radamsa_output_filename strips an existing prefix before adding
+    a new one."""
     output_filename = engine_common.get_radamsa_output_filename(
         'radamsa-00002-file', 0)
     self.assertEqual('radamsa-00001-file', output_filename)
 
-  def test_length_limit(self):
-    linux_filename_length_limit = 255
+  def test_filename_length_limit(self):
+    """Test get_radamsa_output_filename does not return filenames that are too
+    long."""
+    filename_length_limit = 255
     output_filename = engine_common.get_radamsa_output_filename(
-        linux_filename_length_limit * 2 * 'a', 0)
-    self.assertLessEqual(len(output_filename), linux_filename_length_limit)
+        filename_length_limit * 2 * 'a', 0)
+    self.assertLessEqual(len(output_filename), filename_length_limit)


### PR DESCRIPTION
Started seeing some errors like this:
```
[1;92m[+] [0mLooks like we're not running on a tty, so I'll be a bit less verbose.[0m
[1;92m[+] [0mYou have 1 CPU core and 1 runnable tasks (utilization: 100%).[0m
[1;94m[*] [0mChecking core_pattern...[0m
[1;94m[*] [0mSetting up output directories...[0m
[1;92m[+] [0mOutput directory exists but deemed OK to reuse.[0m
[1;94m[*] [0mDeleting old session data...[0m
[1;92m[+] [0mOutput dir cleanup successful.[0m
[1;94m[*] [0mScanning '/eigen_solver_fuzzer'...[0m
[1;92m[+] [0mNo auto-generated dictionary tokens to reuse.[0m
[1;94m[*] [0mCreating hard links for all input files...[0m
)B[?25h[0m[1;91m
[-]  SYSTEM ERROR : [1;97mUnable to create '/afl_output_dir/queue/id:002872,orig:radamsa-00000002-radamsa-00001589-radamsa-00000143-radamsa-00001428-radamsa-00000523-radamsa-00000491-radamsa-00000257-radamsa-00000709-radamsa-00000189-radamsa-00001659-radamsa-00000923-radamsa-00000288-3249393e2d1d5716045509d54cbbb8daae122201'[1;91m
    Stop location : [0mlink_or_copy(), afl-fuzz.c:2923
[1;91m       OS message : [0mFile name too long
"
 ```

We should probably be more careful about lengths elsewhere.
Here especially so because the (entirely optional) prefix was appended in a loop.