### PR TITLE
[fuchsia] Enables reproducible crashes for Fuchsia testcases.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -620,8 +620,7 @@ def main(argv):
   set_sanitizer_options(fuzzer_path)
 
   # If we don't have a corpus, then that means this is not a fuzzing run.
-  # TODO(flowerhack): Implement this to properly load past testcases.
-  if not corpus_directory and environment.platform() != 'FUCHSIA':
+  if not corpus_directory:
     load_testcase_if_exists(runner, testcase_file_path, fuzzer_name,
                             use_minijail, arguments)
     return

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -443,6 +443,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     """LibFuzzerCommon.fuzz override."""
     self._test_qemu_ssh()
 
+    #TODO(flowerhack): Pass libfuzzer args (additional_args) here
     return_code = self.fuzzer.start([])
     self.fuzzer.monitor(return_code)
     self.fetch_and_process_logs_and_crash()
@@ -468,6 +469,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     testcase_path_name = os.path.basename(os.path.normpath(testcase_path))
     self.device.store(testcase_path, self.fuzzer.data_path())
 
+    # TODO(flowerhack): Pass libfuzzer args (additional_args) here
     return_code = self.fuzzer.start(['repro', 'data/' + testcase_path_name])
     self.fuzzer.monitor(return_code)
     self.fetch_and_process_logs_and_crash()
@@ -481,6 +483,14 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     fuzzer_process_result.time_executed = 0
     fuzzer_process_result.command = self.fuzzer.last_fuzz_cmd
     return fuzzer_process_result
+
+  def minimize_crash(self,
+                     testcase_path,
+                     output_path,
+                     timeout,
+                     artifact_prefix=None,
+                     additional_args=None):
+    return new_process.ProcessResult()
 
   def ssh_command(self, *args):
     return ['ssh'] + self.ssh_root + list(args)

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -443,8 +443,8 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     """LibFuzzerCommon.fuzz override."""
     self._test_qemu_ssh()
 
-    ret = self.fuzzer.start([])
-    self.fuzzer.monitor(ret)
+    return_code = self.fuzzer.start([])
+    self.fuzzer.monitor(return_code)
     self.fetch_and_process_logs_and_crash()
 
     with open(self.fuzzer.logfile) as logfile:
@@ -468,8 +468,8 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     testcase_path_name = os.path.basename(os.path.normpath(testcase_path))
     self.device.store(testcase_path, self.fuzzer.data_path())
 
-    ret = self.fuzzer.start(['repro', 'data/' + testcase_path_name])
-    self.fuzzer.monitor(ret)
+    return_code = self.fuzzer.start(['repro', 'data/' + testcase_path_name])
+    self.fuzzer.monitor(return_code)
     self.fetch_and_process_logs_and_crash()
 
     with open(self.fuzzer.logfile) as logfile:

--- a/src/python/platforms/fuchsia/util/device.py
+++ b/src/python/platforms/fuchsia/util/device.py
@@ -138,9 +138,9 @@ class Device(object):
     if quiet:
       if logfile:
         with open(logfile, 'w') as f:
-          self._ssh(cmdline, stdout=f).call()
+          return self._ssh(cmdline, stdout=f).call()
       else:
-        self._ssh(cmdline, stdout=Host.DEVNULL).call()
+        return self._ssh(cmdline, stdout=Host.DEVNULL).call()
     else:
       if logfile:
         p1 = self._ssh(cmdline, stdout=subprocess.PIPE).popen()
@@ -233,7 +233,7 @@ class Device(object):
         pid = int(parts[1])
     return pid
 
-  def process_logs(self, logfile, guess_pid=False):
+  def process_logs(self, logfile, guess_pid=False, retcode=0):
     """Constructs a symbolized fuzzer log from a device.
 
         Merges the provided fuzzer log with the symbolized system log for the
@@ -253,17 +253,24 @@ class Device(object):
     mutation_pattern = re.compile(r'^MS: [0-9]*')
     artifacts = []
     artifact_pattern = re.compile(r'Test unit written to data/(\S*)')
+    repro_pattern = re.compile(r'Running: .*')
+    line_of_actual_crash = None
     with open(logfile) as log:
       with open(logfile + '.tmp', 'w') as tmp:
         for line in log:
           # Check for a line that tells us the process ID
           match = pid_pattern.search(line)
           if match:
+            line_with_crash_message = line
             pid = int(match.group(1))
 
-          # Check for a unit being dumped, i.e. a finding.
+          # Check for one of two things:
+          # 1) a unit being dumped (e.g. a finding from a regular fuzz run)
+          # 2) a nonzero return code plus a "Running: [foo]" message (which
+          # indicates this is a *reproducer* run that has successfully crashed)
+          repro_match = repro_pattern.search(line)
           match = mutation_pattern.search(line)
-          if match:
+          if match or (repro_match and retcode > 0):
             if pid <= 0 and guess_pid:
               pid = self._guess_pid()
             if pid > 0:
@@ -282,7 +289,18 @@ class Device(object):
 
           # Echo the line
           tmp.write(line)
-    os.rename(logfile + '.tmp', logfile)
+
+    # Clusterfuzz's stack analyzer expects the
+    # `==[num]== ERROR: [SanitizerName]: [failure type]` line
+    # to occur *before* the stacktrace, so make a new tempfile
+    # where we insert that line at the top.
+    with open(logfile + '.tmp', 'r+') as tmp:
+      with open(logfile + '.tmp2', 'w') as tmp2:
+        tmp2.write(line_with_crash_message)
+        for line in tmp:
+          tmp2.write(line)
+    os.remove(logfile + '.tmp')
+    os.rename(logfile + '.tmp2', logfile)
     return artifacts
 
   def _scp(self, srcs, dst):

--- a/src/python/platforms/fuchsia/util/device.py
+++ b/src/python/platforms/fuchsia/util/device.py
@@ -19,6 +19,7 @@ from builtins import range
 import glob
 import os
 import re
+import shutil
 import subprocess
 
 from .host import Host
@@ -300,8 +301,7 @@ class Device(object):
     with open(logfile + '.tmp', 'r') as tmp:
       with open(logfile + '.final', 'w') as final:
         final.write(line_with_crash_message)
-        for line in tmp:
-          final.write(line)
+        shutil.copyfileobj(tmp, final)
     os.remove(logfile + '.tmp')
     os.rename(logfile + '.final', logfile)
     return artifacts

--- a/src/python/platforms/fuchsia/util/device.py
+++ b/src/python/platforms/fuchsia/util/device.py
@@ -140,15 +140,13 @@ class Device(object):
       if logfile:
         with open(logfile, 'w') as f:
           return self._ssh(cmdline, stdout=f).call()
-      else:
-        return self._ssh(cmdline, stdout=Host.DEVNULL).call()
+      return self._ssh(cmdline, stdout=Host.DEVNULL).call()
     else:
       if logfile:
         p1 = self._ssh(cmdline, stdout=subprocess.PIPE).popen()
         p2 = self.host.create_process(['tee', logfile], stdin=p1.stdout)
-        p2.check_call()
-      else:
-        self._ssh(cmdline, stdout=None).call()
+        return p2.check_call()
+      return self._ssh(cmdline, stdout=None).call()
 
   def getpids(self):
     """Maps names to process IDs for running fuzzers.
@@ -255,7 +253,7 @@ class Device(object):
     artifacts = []
     artifact_pattern = re.compile(r'Test unit written to data/(\S*)')
     repro_pattern = re.compile(r'Running: .*')
-    line_of_actual_crash = None
+    line_with_crash_message = None
     with open(logfile) as log:
       with open(logfile + '.tmp', 'w') as tmp:
         for line in log:

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -219,9 +219,8 @@ class Fuzzer(object):
     # make the rest of the plumbing look the same.
     if self._foreground:
       return self.run(fuzzer_args, logfile=self.results_output('fuzz-0.log'))
-    else:
-      self.device.rm(self.data_path('fuzz-*.log'))
-      self.run(fuzzer_args)
+    self.device.rm(self.data_path('fuzz-*.log'))
+    return self.run(fuzzer_args)
 
   def monitor(self, retcode=0):
     """Waits for a fuzzer to complete and symbolizes its logs.

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/fuchsia_reproducible_crash.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/fuchsia_reproducible_crash.txt
@@ -1,0 +1,51 @@
+==14454== ERROR: libFuzzer: deadly signal
+Warning: Permanently added '[localhost.corp.google.com]:53263' (ED25519) to the list of known hosts.
+INFO: Seed: 3976025544
+INFO: Loaded 1 modules   (14 inline 8-bit counters): 14 [0x5332f2cf8090, 0x5332f2cf809e),
+INFO: Loaded 1 PC tables (14 PCs): 14 [0x5332f2cf80a0,0x5332f2cf8180),
+INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
+INFO: A corpus is not provided, starting from an empty corpus
+#2	INITED cov: 5 ft: 5 corp: 1/1b exec/s: 0 rss: 30Mb
+#225	NEW    cov: 6 ft: 6 corp: 2/2b lim: 6 exec/s: 0 rss: 30Mb L: 1/1 MS: 3 ChangeBit-ShuffleBytes-ChangeBit-
+#239	NEW    cov: 7 ft: 7 corp: 3/8b lim: 6 exec/s: 0 rss: 30Mb L: 6/6 MS: 4 InsertByte-CMP-ChangeByte-CrossOver- DE: "\x01\x00\x00\x00"-
+#270	REDUCE cov: 7 ft: 7 corp: 3/7b lim: 6 exec/s: 0 rss: 30Mb L: 5/5 MS: 1 EraseBytes-
+#309	REDUCE cov: 7 ft: 7 corp: 3/5b lim: 6 exec/s: 0 rss: 30Mb L: 3/3 MS: 4 CopyPart-CopyPart-EraseBytes-EraseBytes-
+#396	REDUCE cov: 8 ft: 8 corp: 4/8b lim: 6 exec/s: 0 rss: 30Mb L: 3/3 MS: 2 CopyPart-ChangeBit-
+#464	NEW    cov: 9 ft: 9 corp: 5/10b lim: 6 exec/s: 0 rss: 30Mb L: 2/3 MS: 3 CopyPart-EraseBytes-EraseBytes-
+#520	REDUCE cov: 9 ft: 9 corp: 5/9b lim: 6 exec/s: 0 rss: 30Mb L: 2/3 MS: 1 EraseBytes-
+==14454== ERROR: libFuzzer: deadly signal
+NOTE: libFuzzer has rudimentary signal handlers.
+      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
+SUMMARY: libFuzzer: deadly signal
+Warning: Permanently added '[localhost.corp.google.com]:53263' (ED25519) to the list of known hosts.
+dso: id=88668a286c5c0e12 base=0x00005332f2c44000 name=/pkg/bin/basic_fuzzer
+dso: id=b715d488354a413b base=0x00005a9510140000 name=libc++.so.2
+dso: id=a889bd8ebd385a59 base=0x000058554cfe3000 name=libunwind.so.1
+dso: id=1699f35c2dc6b5e3 base=0x0000237685d86000 name=libc++abi.so.1
+dso: id=b08681628058b008 base=0x00004329b78bc000 name=libclang_rt.asan.so
+dso: id=0baa718c4f9739dc base=0x00007b70dbada000 name=<vDSO>
+dso: id=4e7da3de6c4cacb2 base=0x00007bc363909000 name=libfdio.so
+dso: id=46e83932b8bc1add base=0x00007602e25fb000 name=libc.so
+   #0    0x00004329b790d331 in __sanitizer_print_stack_trace ../recipe_cleanup/clangmRcYL3/llvm_build_dir/tools/clang/stage2-bins/runtimes/runtimes-x86_64-unknown-fuchsia-bins/compiler-rt/lib/asan/asan_stack.cc:86 <libclang_rt.asan.so>+0x51331
+   #1.1  0x00004329b790d35e in Unwind ../recipe_cleanup/clangmRcYL3/llvm_build_dir/tools/clang/stage2-bins/runtimes/runtimes-x86_64-unknown-fuchsia-bins/compiler-rt/lib/asan/../sanitizer_common/sanitizer_stacktrace.h:115 <libclang_rt.asan.so>+0x5135e
+   #1    0x00004329b790d35e in __sanitizer_print_stack_trace ../recipe_cleanup/clangmRcYL3/llvm_build_dir/tools/clang/stage2-bins/runtimes/runtimes-x86_64-unknown-fuchsia-bins/compiler-rt/lib/asan/asan_stack.cc:86 <libclang_rt.asan.so>+0x5135e
+   #2    0x00005332f2cb9a95 in fuzzer::PrintStackTrace() <<application>>+0x75a95
+   #3    0x00005332f2ca0579 in fuzzer::Fuzzer::CrashCallback() <<application>>+0x5c579
+   #4    0x00005332f2cb9c25 in fuzzer::(anonymous namespace)::StaticCrashHandler() ../recipe_cleanup/clangmRcYL3/llvm_build_dir/tools/clang/stage2-bins/runtimes/runtimes-x86_64-unknown-fuchsia-bins/compiler-rt/lib/fuzzer/FuzzerUtilFuchsia.cpp:164 <<application>>+0x75c25
+   #5    0x00005332f2cb9c0e in CrashTrampolineAsm <<application>>+0x75c0e
+   #6    0x00005332f2cf10f1 in foo_function(unsigned char const*, unsigned long) ../../out/default/../../examples/fuzzer/basic.cc:12 <<application>>+0xad0f1
+   #7    0x00005332f2cf11ac in bar_function(unsigned char const*, unsigned long) ../../out/default/../../examples/fuzzer/basic.cc:21 <<application>>+0xad1ac
+   #8    0x00005332f2cf11ea in LLVMFuzzerTestOneInput ../../out/default/../../examples/fuzzer/basic.cc:25 <<application>>+0xad1ea
+   #9    0x00005332f2ca1b93 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) <<application>>+0x5db93
+   #10   0x00005332f2ca1394 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) <<application>>+0x5d394
+   #11   0x00005332f2ca3579 in fuzzer::Fuzzer::MutateAndTestOne() <<application>>+0x5f579
+   #12   0x00005332f2ca42c5 in fuzzer::Fuzzer::Loop(std::Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) <<application>>+0x602c5
+   #13   0x00005332f2c94118 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) <<application>>+0x50118
+   #14   0x00005332f2cbac02 in main ../recipe_cleanup/clangmRcYL3/llvm_build_dir/tools/clang/stage2-bins/runtimes/runtimes-x86_64-unknown-fuchsia-bins/compiler-rt/lib/fuzzer/FuzzerMain.cpp:19 <<application>>+0x76c02
+   #15   0x00007602e26925fe in start_main ../../out/default.zircon/../../zircon/third_party/ulib/musl/src/env/__libc_start_main.c:93 <libc.so>+0x975fe
+
+MS: 1 ChangeByte-; base unit: 6e41c5a19b9646fe31c77ed7a16829913888c33e
+0x48,0x49,0x21,
+HI!
+artifact_prefix='data/'; Test unit written to /usr/local/google/home/flowerhack/arash2/clusterfuzz/bot/resources/fuchsia/build/out/default/test_data/fuzzing/example_fuzzers/basic_fuzzer/2019-09-16T23:25:50.754886/crash-7a8dc3985d2a90fb6e62e94910fc11d31949c348
+Base64: SEkh

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1358,6 +1358,21 @@ class StackAnalyzerTestcase(unittest.TestCase):
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
+  def test_fuchsia_reproducible_crash(self):
+    """Test for Fuchsia ASan crashes found via reproduction."""
+    # TODO(flowerhack): right now, we get the logs from reproducer runs, and
+    # then post-process them to be in a format ClusterFuzz understands. Once we
+    # patch Fuchsia to emit logs properly the first time, update this test
+    # accordingly.
+    data = self._read_test_data('fuchsia_reproducible_crash.txt')
+    expected_type = 'Fatal-signal'
+    expected_state = 'CrashTrampolineAsm\nfoo_function\nbar_function\n'
+    expected_address = ''
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
 
   def test_windows_asan_divide_by_zero(self):
     """Test for Windows ASan divide by zero crashes."""

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1358,6 +1358,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
+
   def test_fuchsia_reproducible_crash(self):
     """Test for Fuchsia ASan crashes found via reproduction."""
     # TODO(flowerhack): right now, we get the logs from reproducer runs, and


### PR DESCRIPTION
To detect crashes from reproducer runs, we need to (1) properly return
the return code from the fuzz run, and (2) check for some text that only
occurs in reproducer runs.  This CL tweaks some of the code in
util/fuchsia to propertly return this information, and tweaks the way
that code is called, accordingly.

In addition, the way Fuchsia dumps logs by default means that the
stacktrace occurs *before* the `==ERROR: .*` line, which confuses the
stack analyzer, so we tweak the log processing subroutine to drop that
line at the beginning.

Finally, we re-add in some code that was accidentally removed, which
suppresses stdout during fuzzing runs (quiet=True), since Clusterfuzz
can prematurely halt jobs that appear to have crashed, before we've
finished processing all the Fuchsia logs.

And, finally-finally, there's an actual implementation of
run_single_testcase in the Fuchsia runner here :)