### PR TITLE
libFuzzer minimization fix

### DIFF
--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -54,7 +54,6 @@ from system import shell
 
 IPCDUMP_TIMEOUT = 60
 COMBINED_IPCDUMP_TIMEOUT = 60 * 3
-LIBFUZZER_CRASH_CHECK_RETRIES = 3
 MAX_DEADLINE_EXCEEDED_ATTEMPTS = 3
 MAX_TEMPORARY_FILE_BASENAME_LENGTH = 32
 MINIMIZE_SANITIZER_OPTIONS_RETRIES = 3
@@ -1233,7 +1232,7 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
 
   # Get initial crash state.
   initial_crash_result = _run_libfuzzer_testcase(
-      testcase, testcase_file_path, crash_retries=LIBFUZZER_CRASH_CHECK_RETRIES)
+      testcase, testcase_file_path, crash_retries=None)
   if not initial_crash_result.is_crash():
     logs.log_warn('Did not crash. Output:\n' +
                   initial_crash_result.get_stacktrace(symbolized=True))

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1070,7 +1070,7 @@ def do_js_minimization(test_function, get_temp_file, data, deadline, threads,
                               threads, cleanup_interval, delete_temp_files)
 
 
-def _run_libfuzzer_testcase(testcase, testcase_file_path):
+def _run_libfuzzer_testcase(testcase, testcase_file_path, crash_retries=1):
   """Run libFuzzer testcase, and return the CrashResult."""
   # Cleanup any existing application instances and temp directories.
   process_handler.cleanup_stale_processes()
@@ -1088,7 +1088,7 @@ def _run_libfuzzer_testcase(testcase, testcase_file_path):
       testcase_file_path,
       test_timeout,
       compare_crash=False,
-      crash_retries=LIBFUZZER_CRASH_CHECK_RETRIES)
+      crash_retries=crash_retries)
 
 
 def run_libfuzzer_engine(tool_name, target_name, arguments, testcase_path,
@@ -1232,7 +1232,8 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
   last_crash_result = None
 
   # Get initial crash state.
-  initial_crash_result = _run_libfuzzer_testcase(testcase, testcase_file_path)
+  initial_crash_result = _run_libfuzzer_testcase(
+      testcase, testcase_file_path, crash_retries=LIBFUZZER_CRASH_CHECK_RETRIES)
   if not initial_crash_result.is_crash():
     logs.log_warn('Did not crash. Output:\n' +
                   initial_crash_result.get_stacktrace(symbolized=True))

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1232,7 +1232,7 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
 
   # Get initial crash state.
   initial_crash_result = _run_libfuzzer_testcase(
-      testcase, testcase_file_path, crash_retries=None)
+      testcase, testcase_file_path, crash_retries=None)  # Use default retries.
   if not initial_crash_result.is_crash():
     logs.log_warn('Did not crash. Output:\n' +
                   initial_crash_result.get_stacktrace(symbolized=True))

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -54,6 +54,7 @@ from system import shell
 
 IPCDUMP_TIMEOUT = 60
 COMBINED_IPCDUMP_TIMEOUT = 60 * 3
+LIBFUZZER_CRASH_CHECK_RETRIES = 3
 MAX_DEADLINE_EXCEEDED_ATTEMPTS = 3
 MAX_TEMPORARY_FILE_BASENAME_LENGTH = 32
 MINIMIZE_SANITIZER_OPTIONS_RETRIES = 3
@@ -1087,7 +1088,7 @@ def _run_libfuzzer_testcase(testcase, testcase_file_path):
       testcase_file_path,
       test_timeout,
       compare_crash=False,
-      crash_retries=1)
+      crash_retries=LIBFUZZER_CRASH_CHECK_RETRIES)
 
 
 def run_libfuzzer_engine(tool_name, target_name, arguments, testcase_path,


### PR DESCRIPTION
Fix for some unreproducible timeout cases.

When making a decision to minimize, we try to check if this is a
crash or not in |initial_crash_result|. This is only done once,
we can try more times just in case first one requires binary to
load in memory and is slow.