### PR TITLE
Fix issue with reproduce_with_retries.

### DIFF
--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -630,6 +630,9 @@ class TestcaseRunner(object):
       crash_result = self.run(round_number)
       state = self._get_crash_state(round_number, crash_result)
 
+      if not crash_result.is_crash():
+        continue
+
       if not expected_state:
         logs.log('Crash stacktrace comparison skipped.')
         return crash_result
@@ -672,6 +675,9 @@ class TestcaseRunner(object):
 
       crash_result = self.run(round_number)
       state = self._get_crash_state(round_number, crash_result)
+
+      if not crash_result.is_crash():
+        continue
 
       # If we don't have an expected crash state, set it to the one from initial
       # crash.


### PR DESCRIPTION
- In |reproduce_with_retries|, when |compare_crash|=False
 (e.g. in analyze, variant and minimiz task), we just return result
  after round 1 even if the result is not a crash. This causes fix (#979)
  to not work and is also incorrect, since we should keep retrying until
  we get a crash and return that crash result.
- Also, fix similar issue in |test_reproduce_reliability|. This does not
  cause a bug but causes incorrect log message that "Detected a crash
  with an unrelated state" on NULL. We shouldn't be resetting
  |expected_state| and continuing in the loop if there was no crash.
- Add tests.