### PR TITLE
Make launcher scripts work with testcases generated by new pipeline.

### DIFF
--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -1429,7 +1429,7 @@ def main(argv):
   atexit.register(fuzzer_utils.cleanup)
 
   # Initialize variables.
-  _, testcase_file_path = argv[:2]
+  testcase_file_path = argv[1]
   target_name = environment.get_value('FUZZ_TARGET')
 
   input_directory = environment.get_value('FUZZ_CORPUS_DIR')

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -1429,7 +1429,9 @@ def main(argv):
   atexit.register(fuzzer_utils.cleanup)
 
   # Initialize variables.
-  _, testcase_file_path, target_name = argv[:3]
+  _, testcase_file_path = argv[:2]
+  target_name = environment.get_value('FUZZ_TARGET')
+
   input_directory = environment.get_value('FUZZ_CORPUS_DIR')
   fuzzer_name = data_types.fuzz_target_project_qualified_name(
       utils.current_project(), target_name)

--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -568,7 +568,12 @@ def main(argv):
   # Initialize variables.
   arguments = argv[1:]
   testcase_file_path = arguments.pop(0)
-  target_name = arguments.pop(0)
+
+  target_name = environment.get_value('FUZZ_TARGET')
+  if arguments and arguments[0] == target_name:
+    # Pop legacy fuzz target argument.
+    arguments.pop(0)
+
   fuzzer_name = data_types.fuzz_target_project_qualified_name(
       utils.current_project(), target_name)
 

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -111,6 +111,7 @@ def run_launcher(*args):
   """Run launcher.py."""
   mock_stdout = test_utils.MockStdout()
 
+  os.environ['FUZZ_TARGET'] = args[1]
   with mock.patch('sys.stdout', mock_stdout):
     launcher.main(['launcher.py'] + list(args))
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_integration_test.py
@@ -95,6 +95,8 @@ def setup_testcase_and_corpus(testcase, corpus, fuzz=False):
 
 def run_launcher(*args):
   """Run launcher.py."""
+  os.environ['FUZZ_TARGET'] = args[1]
+
   mock_stdout = test_utils.MockStdout()
   with mock.patch('sys.stdout', mock_stdout):
     launcher.main(['launcher.py'] + list(args))

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_launcher_test.py
@@ -224,6 +224,7 @@ class LauncherTest(fake_fs_unittest.TestCase):
         [strategy.DATAFLOW_TRACING_STRATEGY])
     self.mock.decide_with_probability.return_value = False
     environment.set_value('STRATEGY_SELECTION_METHOD', 'default')
+    environment.set_value('FUZZ_TARGET', 'fake_fuzzer')
 
   @mock.patch('google_cloud_utils.storage.exists', lambda x: None)
   @mock.patch('google_cloud_utils.storage.read_data', lambda x: None)


### PR DESCRIPTION
Testcases generated by the new refactored pipeline no longer include the
target name in the arguments. Instead, we can read from FUZZ_TARGET.