### PR TITLE
Add debug logging for the argv passed to libFuzzer launcher.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/launcher.py
+++ b/src/python/bot/fuzzers/libFuzzer/launcher.py
@@ -566,6 +566,7 @@ def main(argv):
   atexit.register(fuzzer_utils.cleanup)
 
   # Initialize variables.
+  logs.log('argv passed to the launcher: "%s"' % str(argv))
   arguments = argv[1:]
   testcase_file_path = arguments.pop(0)
 


### PR DESCRIPTION
temporary measure just to understand what's wrong with the arguments order