### PR TITLE
[fuchsia] Test SSH connectivity before attempting reproduction.

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -466,6 +466,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
                           timeout=None,
                           additional_args=None):
     # We need to push the testcase to the device and pass in the name.
+    self._test_qemu_ssh()
     testcase_path_name = os.path.basename(os.path.normpath(testcase_path))
     self.device.store(testcase_path, self.fuzzer.data_path())
 


### PR DESCRIPTION
We've been seeing SSH connection refused problems when running
reproducers (but not when running fuzzers); in an effort to root-cause
the problem, let's actually test the ssh connection before connecting.

If we notice CF dies at test_qemu_ssh() consistently, it's a strong
signal that perhaps the QEMU VM is dying prematurely.

If we notice CF dies *after* test_qemu_ssh() consistently, it's a signal
that perhaps something about our specific ssh call while running
reproducers is incorrect.