### PR TITLE
Add a delay after starting fuchsia.

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -372,7 +372,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
   FUCHSIA_BUILD_REL_PATH = os.path.join('build', 'out', 'default')
 
   SSH_RETRIES = 3
-  SSH_WAIT = 2
+  SSH_WAIT = 3
 
   FUZZER_TEST_DATA_REL_PATH = os.path.join('test_data', 'fuzzing')
 

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import os
 import socket
 import subprocess
+import time
 
 from metrics import logs
 from platforms.fuchsia import errors

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -30,6 +30,8 @@ from system import environment
 from system import new_process
 from system import shell
 
+_QEMU_WAIT_SECONDS = 30
+
 
 def setup_qemu_values(initial_setup=True):
   """Sets up and runs a QEMU VM in the background.
@@ -141,6 +143,7 @@ def setup_qemu_instance(qemu_path, qemu_args):
 
 def run_qemu_instance(qemu_process):
   qemu_popen = qemu_process.run(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  time.sleep(_QEMU_WAIT_SECONDS)
   return qemu_popen
 
 


### PR DESCRIPTION
Previously we were relying solely on the SSH expontential backoff, which
is not enough time, as we would wait a maximum of 2 + 4 + 8 = 14 seconds
for QEMU to get ready.

Also increase the exponential backoff for retrying SSH a little to use
powers of 3.