### PR TITLE
Remove custom-crash-state hack and set it properly in stack analyzer.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -256,13 +256,6 @@ class LibFuzzerEngine(engine.Engine):
     self._merge_new_units(target_path, options.corpus_dir, new_corpus_dir,
                           options.fuzz_corpus_dirs, arguments, parsed_stats)
 
-    # Add custom crash state based on fuzzer name (if needed).
-    project_qualified_fuzzer_name = (
-        data_types.fuzz_target_project_qualified_name(
-            utils.current_project(), os.path.basename(target_path)))
-    launcher.add_custom_crash_state_if_needed(project_qualified_fuzzer_name,
-                                              log_lines, parsed_stats)
-
     fuzz_logs = '\n'.join(log_lines)
     crashes = []
     if crash_testcase_file_path:
@@ -272,6 +265,9 @@ class LibFuzzerEngine(engine.Engine):
           engine.Crash(crash_testcase_file_path, fuzz_logs, arguments,
                        actual_duration))
 
+    project_qualified_fuzzer_name = (
+        data_types.fuzz_target_project_qualified_name(
+            utils.current_project(), os.path.basename(target_path)))
     launcher.analyze_and_update_recommended_dictionary(
         runner, project_qualified_fuzzer_name, log_lines, options.corpus_dir,
         arguments)

--- a/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/logging_oom_no_issue.txt
+++ b/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/logging_oom_no_issue.txt
@@ -733,7 +733,6 @@ P57 940 57 940 5\x0a\x09 *;55\x0a 7 \x973use_cmp\xc1 7 939 5\x0a\x0940 #593\xb0s
 #141007	NEW    cov: 8111 ft: 1354 corp: 300/155Kb exec/s: 594 rss: 2098Mb L: 159 MS: 5 ChangeASCIIInt-ChangeByte-CMP-ChangeBinInt-ShuffleBytes- DE: "71826a1fbbf93c1a2f21c5004b3"-
 artifact_prefix='/'; Test unit written to /oom-8f149ff4204ba7c2964724cfc509916f8bbcf0ef
 Base64: UDU3IDk0MCA1NyA5NDAgNQoJICo7NTUKIDcglzN1c2VfY21wwSA3IDkzOSA1Cgk0MCAjNTkzsHNlX2NtUFDBUDpQcFBQUFBQUFBQUFA3MTgyNmExZmJiZjkzYzFhMmYyMWM1MDA0YjNQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFCws1BQUFBQUFBQUFBQIDggOTM5IDkg
-custom-crash-state: libreoffice_ppmfuzzer
 SUMMARY: libFuzzer: out-of-memory
 stat::number_of_executed_units: 141013
 stat::average_exec_per_sec:     594

--- a/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/logging_sanitizer_warnings_no_issue.txt
+++ b/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/logging_sanitizer_warnings_no_issue.txt
@@ -57,7 +57,6 @@ SCARINESS: 24 (2-byte-read-heap-buffer-overflow-far-from-bounds)
     #18 0x41e5c8 in _start
 
 Address 0x61d0000ffc68 is a wild pointer.
-custom-crash-state: libarchive_fuzzer
 SUMMARY: AddressSanitizer: heap-buffer-overflow (/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_libarchive_77ea478b318ee8043f24c087f94cd0ba1edb3f3a/revisions/libarchive_fuzzer+0x5de3fa)
 Shadow bytes around the buggy address:
   0x0c3a80017f30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa

--- a/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/logging_slow_units_no_issue.txt
+++ b/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/logging_slow_units_no_issue.txt
@@ -56,7 +56,6 @@ Base64: Lit7ODg5fTB9UFB8Lit7ODg5fTB9UFB8Lit7ODg5fTB9UFB8Lit7ODg5fTB9UFB8Lit7ODg5
     #23 0x7f551b12782f in __libc_start_main
     #24 0x41cb38 in _start
 
-custom-crash-state: re2_fuzzer
 SUMMARY: libFuzzer: timeout
 stat::number_of_executed_units: 4333
 stat::average_exec_per_sec:     9

--- a/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/oom_issue.txt
+++ b/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/oom_issue.txt
@@ -57,6 +57,5 @@ stat::new_units_added:          0
 stat::slowest_unit_time_sec:    0
 stat::peak_rss_mb:              3015
 
-custom-crash-state: pdf_fm2js_fuzzer
 SIGTERMed
 /mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-release-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libfuzzer-linux-release-404048/pdf_fm2js_fuzzer: no process found

--- a/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/timeout_issue.txt
+++ b/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/issue_logs/timeout_issue.txt
@@ -49,4 +49,3 @@ stat::new_units_added:          1
 stat::slowest_unit_time_sec:    0
 stat::peak_rss_mb:              99
 
-custom-crash-state: skia_path_fuzzer

--- a/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/report_logs/test_fuzzer_2.txt
+++ b/src/python/tests/appengine/handlers/performance_report/performance_analyzer_data/libfuzzer/report_logs/test_fuzzer_2.txt
@@ -34,7 +34,6 @@ artifact_prefix='/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/'; Test u
     #18 0x5296f8 in main third_party/libFuzzer/src/FuzzerMain.cpp:20:10
     #19 0x7f03421b9f44 in __libc_start_main /build/eglibc-SvCtMH/eglibc-2.19/csu/libc-start.c:287
 
-custom-crash-state: icu_ucasemap_fuzzer
 SUMMARY: libFuzzer: timeout
 stat::number_of_executed_units: 2093
 stat::average_exec_per_sec:     32

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/launcher_test_data/corrupted_stats.txt
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/launcher_test_data/corrupted_stats.txt
@@ -19,7 +19,6 @@ MS: 0 ; base unit: 0000000000000000000000000000000000000000
 \xff\xff\xff\x01\x00\x00\x00\x0c\x0c\x0c\x0c\x0c\xff\xf2\x14\xe3\x00*\x00\x00\x00\x00\x15\xcf\xff\x007\x047U\x8c,\x0c\x0c\x0c\x0c\xff\xf2\x149\x00c\x00\x00\x15\x002\x0c3\x0c\x14\x0c
 artifact_prefix='c:\clusterfuzz\bot\inputs\fuzzer-testcases/'; Test unit written to c:\clusterfuzz\bot\inputs\fuzzer-testcases/oom-2b1256adb7bff4d0b70a3edca49756177ef40306
 Base64: ////AQAAAAwMDAwM//IU4wAqAAAAABXP/wA3BDdVjCwMDAwM//IUOQBjAAAVADIMMwwUDA==
-custom-crash-state: mediasource_MP3_pipeline_integration_fuzzer
 SUMMARY: libFuzzer: out-of-memory
 stat::number_of_executed_units: 1142
 stat::average_exec_per_sec:     40

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/launcher_test_data/oom_expected.txt
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/launcher_test_data/oom_expected.txt
@@ -59,7 +59,6 @@ Live Heap Allocations: 2236539140 bytes in 4979 chunks; quarantined: 9002806 byt
 
 MS: 1 ChangeBit-; base unit: 251d1c6ee4136b020b7eb0900c5e40bc83b133a4
 artifact_prefix='/fake/'; Test unit written to /fake/oom-755e18dc1b20912de7556d11380e540231dc292c
-custom-crash-state: fake_fuzzer
 SUMMARY: libFuzzer: out-of-memory
 stat::number_of_executed_units: 90667
 stat::average_exec_per_sec:     53

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/launcher_test_data/oom_in_seed_corpus.txt
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/launcher_test_data/oom_in_seed_corpus.txt
@@ -117,7 +117,6 @@ MS: 2 InsertByte-ManualDict- DE: "https://"-; base unit: b87d6b4ffdcb428bc6ab242
 
 artifact_prefix='/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/'; Test unit written to /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/oom-da39a3ee5e6b4b0d3255bfef95601890afd80709
 Base64:
-custom-crash-state: origin_trial_token_fuzzer
 SUMMARY: libFuzzer: out-of-memory
 stat::number_of_executed_units: 19380
 stat::average_exec_per_sec:     74

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/launcher_test_data/timeout.txt
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/launcher_test_data/timeout.txt
@@ -40,7 +40,6 @@ MS: 0 ; base unit: 0000000000000000000000000000000000000000
 #15 0x49f221 in main /src/libfuzzer/FuzzerMain.cpp:20:10
 #16 0x7f0d6f37282f in __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/libc-start.c:291
 #17 0x41fa18 in _start
-custom-crash-state: imagemagick_encoder_miff_fuzzer
 SUMMARY: libFuzzer: timeout
 stat::number_of_executed_units: 5769
 stat::average_exec_per_sec:     16

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_oom.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_oom.txt
@@ -13,6 +13,5 @@ Live Heap Allocations: 2379484 bytes from 64 allocations; showing top 50%
     #4 0x915a48 in main /src/llvm/lib/Fuzzer/FuzzerMain.cpp:21:10
     #5 0x7f2c7742582f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
 
-custom-crash-state: freetype2_fuzzer
 SUMMARY: libFuzzer: out-of-memory
 

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_oom_malloc.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_oom_malloc.txt
@@ -13,6 +13,5 @@ Live Heap Allocations: 2379484 bytes from 64 allocations; showing top 50%
     #4 0x915a48 in main /src/llvm/lib/Fuzzer/FuzzerMain.cpp:21:10
     #5 0x7f2c7742582f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
 
-custom-crash-state: freetype2_fuzzer
 SUMMARY: libFuzzer: out-of-memory
 

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_timeout.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_timeout.txt
@@ -28,5 +28,4 @@ ALARM: working on the last Unit for 5 seconds
     #24 0x5897be in main out/Fuzzer/../../third_party/libFuzzer/src/FuzzerMain.cpp:21:10
     #25 0x7f6146b3ef44 in __libc_start_main /build/eglibc-oGUzwX/eglibc-2.19/csu/libc-start.c:287
 
-custom-crash-state: pdfium_fuzzer
 SUMMARY: libFuzzer: timeout

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/oom4.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/oom4.txt
@@ -15,5 +15,4 @@ Running: /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/2865ac1ef97c5b82f
 #12 0x40a250 in main third_party/libFuzzer/src/FuzzerMain.cpp:20:10
 #13 0x7f41340d382f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/libc-start.c:291
 ==7320==HINT: if you don't care about these errors you may set =allocator_may_return_null=1
-custom-crash-state: pdf_jpx_fuzzer
 SUMMARY: MemorySanitizer: allocation-size-too-big (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-release-msan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libfuzzer-linux-release-569934/pdf_jpx_fuzzer+0x35c73d)

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -230,7 +230,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('android_null_stack.txt')
     expected_type = 'UNKNOWN'
     expected_address = '0xb6e43000'
-    expected_state = 'Surfaceflinger'
+    expected_state = 'Surfaceflinger\n'
     expected_stacktrace = data
     expected_security_flag = True
 
@@ -2124,7 +2124,9 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
   def test_oom4(self):
     """Test an out of memory stacktrace."""
+    os.environ['FUZZ_TARGET'] = 'pdf_jpx_fuzzer'
     os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
+
     data = self._read_test_data('oom4.txt')
     expected_type = 'Out-of-memory'
     expected_address = ''
@@ -2138,8 +2140,10 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
   def test_libfuzzer_timeout_enabled(self):
     """Test a libFuzzer timeout stacktrace (with reporting enabled)."""
-    data = self._read_test_data('libfuzzer_timeout.txt')
+    os.environ['FUZZ_TARGET'] = 'pdfium_fuzzer'
     os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
+
+    data = self._read_test_data('libfuzzer_timeout.txt')
     expected_type = 'Timeout'
     expected_address = ''
     expected_state = 'pdfium_fuzzer\n'
@@ -2165,8 +2169,10 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
   def test_libfuzzer_oom_without_redzone(self):
     """Test a libFuzzer OOM stacktrace with no redzone."""
-    data = self._read_test_data('libfuzzer_oom.txt')
+    os.environ['FUZZ_TARGET'] = 'freetype2_fuzzer'
     os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
+
+    data = self._read_test_data('libfuzzer_oom.txt')
     expected_type = 'Out-of-memory'
     expected_address = ''
     expected_state = 'freetype2_fuzzer\n'
@@ -2185,9 +2191,11 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
   def test_libfuzzer_oom_with_small_redzone(self):
     """Test a libFuzzer OOM stacktrace with redzone equal or smaller than 64."""
-    data = self._read_test_data('libfuzzer_oom.txt')
+    os.environ['FUZZ_TARGET'] = 'freetype2_fuzzer'
     os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
     os.environ['REDZONE'] = '64'
+
+    data = self._read_test_data('libfuzzer_oom.txt')
     expected_type = 'Out-of-memory'
     expected_address = ''
     expected_state = 'freetype2_fuzzer\n'


### PR DESCRIPTION
This stopped working for fuzz target timeout and oom with the
new engine impl. Removing this hack and making it properly work.