### PR TITLE
[fuchsia] Refactor QEMU lifecycle code.

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -26,9 +26,7 @@ from bot.fuzzers import engine_common
 from bot.fuzzers import utils as fuzzer_utils
 from bot.fuzzers.libFuzzer import constants
 from platforms import fuchsia
-from platforms.fuchsia.device import run_qemu_instance
-from platforms.fuchsia.device import setup_qemu_instance
-from platforms.fuchsia.device import setup_qemu_values
+from platforms.fuchsia.device import QemuProcess
 from platforms.fuchsia.util.device import Device
 from platforms.fuchsia.util.fuzzer import Fuzzer
 from platforms.fuchsia.util.host import Host
@@ -376,9 +374,16 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
 
   FUZZER_TEST_DATA_REL_PATH = os.path.join('test_data', 'fuzzing')
 
-  def _setup_fuzzer_and_device(self):
-    """ Build a Fuzzer object based on the QEMU values.
-    Call this only after setup_qemu_values()"""
+  def _setup_qemu_device_and_fuzzer(self):
+    """Initialize QEMU, then build a Device and Fuzzer object
+    based on its settings."""
+    if not self.qemu:
+      self.qemu = QemuProcess()
+
+    self.qemu.create()
+
+    # These environment variables are set when a QemuProcess is `create`ed.
+    # We need them in order to ssh / otherwise communicate with the VM.
     fuchsia_pkey_path = environment.get_value('FUCHSIA_PKEY_PATH')
     fuchsia_portnum = environment.get_value('FUCHSIA_PORTNUM')
     fuchsia_resources_dir = environment.get_value('FUCHSIA_RESOURCES_DIR')
@@ -387,6 +392,9 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
       raise fuchsia.errors.FuchsiaConfigError(
           ('FUCHSIA_PKEY_PATH, FUCHSIA_PORTNUM, or FUCHSIA_RESOURCES_DIR was '
            'not set'))
+
+    # Fuzzer objects communicate with the VM via a Device object,
+    # which we set up here.
     fuchsia_resources_dir_plus_build = os.path.join(fuchsia_resources_dir,
                                                     self.FUCHSIA_BUILD_REL_PATH)
     self.host = Host.from_dir(fuchsia_resources_dir_plus_build)
@@ -400,20 +408,19 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     test_data_dir = os.path.join(fuchsia_resources_dir_plus_build,
                                  self.FUZZER_TEST_DATA_REL_PATH, package,
                                  target)
+
+    # Finally, we set up the Fuzzer object itself, which will run our fuzzer!
     self.fuzzer = Fuzzer(
         self.device, package, target, output=test_data_dir, foreground=True)
 
   def __init__(self, executable_path, default_args=None):
+    self.qemu = None
+    self._setup_qemu_device_and_fuzzer()
     super(FuchsiaQemuLibFuzzerRunner, self).__init__(
-        executable_path=executable_path, default_args=default_args)
-
-    qemu_path, qemu_args = setup_qemu_values(initial_setup=False)
-    qemu_process = setup_qemu_instance(qemu_path, qemu_args)
-    self._setup_fuzzer_and_device()
-    self.qemu_instance = run_qemu_instance(qemu_process)
+      executable_path=executable_path, default_args=default_args)
 
   def __del__(self):
-    self.qemu_instance.kill()
+    self.qemu.kill()
 
   def get_command(self, additional_args=None):
     # TODO(flowerhack): Update this to dynamically pick a result from "fuzz
@@ -461,13 +468,26 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
       self._restart_qemu()
       self._test_qemu_ssh()
 
+  @retry.wrap(retries=SSH_RETRIES, delay=SSH_WAIT, function='_test_qemu_ssh')
+  def _test_qemu_ssh(self):
+    """Tests that a VM is up and can be successfully SSH'd into.
+    Raises an exception if no success after MAX_SSH_RETRIES."""
+    ssh_test_process = new_process.ProcessRunner(
+        'ssh',
+        self.device.get_ssh_cmd(
+            ['ssh', 'localhost', 'echo running on fuchsia!'])[1:])
+    result = ssh_test_process.run_and_wait()
+    if result.return_code or result.timed_out:
+      raise fuchsia.errors.FuchsiaConnectionError(
+          'Failed to establish initial SSH connection: ' +
+          str(result.return_code) + " , " + str(result.command) + " , " +
+          str(result.output))
+    return result
+
   def _restart_qemu(self):
     """Restart QEMU."""
-    self.qemu_instance.kill()
-    qemu_path, qemu_args = setup_qemu_values(initial_setup=False)
-    qemu_process = setup_qemu_instance(qemu_path, qemu_args)
-    self._setup_fuzzer_and_device()
-    self.qemu_instance = run_qemu_instance(qemu_process)
+    self.qemu.kill()
+    self._setup_qemu_device_and_fuzzer()
 
   def fuzz(self,
            corpus_directories,
@@ -532,22 +552,6 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
 
   def ssh_command(self, *args):
     return ['ssh'] + self.ssh_root + list(args)
-
-  @retry.wrap(retries=SSH_RETRIES, delay=SSH_WAIT, function='_test_qemu_ssh')
-  def _test_qemu_ssh(self):
-    """Tests that a VM is up and can be successfully SSH'd into.
-    Raises an exception if no success after MAX_SSH_RETRIES."""
-    ssh_test_process = new_process.ProcessRunner(
-        'ssh',
-        self.device.get_ssh_cmd(
-            ['ssh', 'localhost', 'echo running on fuchsia!'])[1:])
-    result = ssh_test_process.run_and_wait()
-    if result.return_code or result.timed_out:
-      raise fuchsia.errors.FuchsiaConnectionError(
-          'Failed to establish initial SSH connection: ' +
-          str(result.return_code) + " , " + str(result.command) + " , " +
-          str(result.output))
-    return result
 
 
 class MinijailLibFuzzerRunner(engine_common.MinijailEngineFuzzerRunner,

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -421,7 +421,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     # restart QEMU anyway.
     self._setup_device_and_fuzzer(qemu_is_running=True)
     super(FuchsiaQemuLibFuzzerRunner, self).__init__(
-      executable_path=executable_path, default_args=default_args)
+        executable_path=executable_path, default_args=default_args)
 
   def get_command(self, additional_args=None):
     # TODO(flowerhack): Update this to dynamically pick a result from "fuzz

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -419,9 +419,9 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     # We always assume QEMU is running on __init__, since build_manager sets
     # it up initially. If this isn't the case, _test_ssh will detect and
     # restart QEMU anyway.
-    self._setup_device_and_fuzzer(qemu_is_running=True)
     super(FuchsiaQemuLibFuzzerRunner, self).__init__(
         executable_path=executable_path, default_args=default_args)
+    self._setup_device_and_fuzzer(qemu_is_running=True)
 
   def get_command(self, additional_args=None):
     # TODO(flowerhack): Update this to dynamically pick a result from "fuzz

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -766,6 +766,16 @@ class FuchsiaBuild(Build):
     fuchsia_resources_dir = fuchsia.device.initialize_resources_dir()
     environment.set_value('FUCHSIA_RESOURCES_DIR', fuchsia_resources_dir)
 
+    # We set these values here, rather than in initial_qemu_setup, since
+    # SYMBOLIZE_REL_PATH and LLVM_SYMBOLIZER_REL_PATH are properties of the
+    # Build object.
+    symbolize_path = os.path.join(fuchsia_resources_dir,
+                                  self.SYMBOLIZE_REL_PATH)
+    os.chmod(symbolize_path, 0o777)
+    llvm_symbolizer_path = os.path.join(fuchsia_resources_dir,
+                                        self.LLVM_SYMBOLIZER_REL_PATH)
+    os.chmod(llvm_symbolizer_path, 0o777)
+
     logs.log('Retrieved build r%d.' % self.revision)
     logs.log('Extracting fuzz targets.' + fuchsia_resources_dir)
     environment.set_value(
@@ -773,13 +783,6 @@ class FuchsiaBuild(Build):
         os.path.join(fuchsia_resources_dir, self.FUCHSIA_DIR_REL_PATH))
     # TODO(flowerhack): Update here once Fuchsia understand revision tracking.
     environment.set_value('APP_REVISION', '0')
-
-    symbolize_path = os.path.join(fuchsia_resources_dir,
-                                  self.SYMBOLIZE_REL_PATH)
-    os.chmod(symbolize_path, 0o777)
-    llvm_symbolizer_path = os.path.join(fuchsia_resources_dir,
-                                        self.LLVM_SYMBOLIZER_REL_PATH)
-    os.chmod(llvm_symbolizer_path, 0o777)
 
     host = Host.from_dir(
         os.path.join(fuchsia_resources_dir, self.FUCHSIA_BUILD_REL_PATH))
@@ -799,7 +802,7 @@ class FuchsiaBuild(Build):
       logs.log('Extracted fuzz target ' + fuzz_target)
 
     self._setup_application_path()
-    fuchsia.device.setup_qemu_values()
+    fuchsia.device.initial_qemu_setup()
     return True
 
 

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -801,8 +801,14 @@ class FuchsiaBuild(Build):
       environment.set_value('FUZZ_TARGET', fuzz_target)
       logs.log('Extracted fuzz target ' + fuzz_target)
 
+    logs.log('Initializing QEMU.')
+    # Kill any stale processes that may be left over from previous build.
+    process_handler.terminate_processes_matching_names('qemu_system-x86_64')
     self._setup_application_path()
     fuchsia.device.initial_qemu_setup()
+    qemu = fuchsia.device.QemuProcess()
+    qemu.create()
+    qemu.run()
     return True
 
 

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -40,6 +40,7 @@ from metrics import logs
 from platforms import android
 from system import archive
 from system import environment
+from system import process_handler
 from system import shell
 
 # The default environment variables for specifying build bucket paths.

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -807,9 +807,7 @@ class FuchsiaBuild(Build):
     process_handler.terminate_processes_matching_names('qemu_system-x86_64')
     self._setup_application_path()
     fuchsia.device.initial_qemu_setup()
-    qemu = fuchsia.device.QemuProcess()
-    qemu.create()
-    qemu.run()
+    fuchsia.device.start_qemu()
     return True
 
 

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -97,8 +97,8 @@ def initial_qemu_setup():
                   qemu_vars['fuchsia_zbi'])
 
 
-class QemuException(Exception):
-  """Exception for errors handling QEMU."""
+class QemuError(Exception):
+  """Error for errors handling QEMU."""
   pass
 
 
@@ -178,12 +178,13 @@ class QemuProcess(object):
   def run(self):
     """Actually runs a QEMU VM, assuming `create` has already been called."""
     if not self.process_runner:
-      raise QemuException('Attempted to `run` QEMU VM before calling `create`')
+      raise QemuError('Attempted to `run` QEMU VM before calling `create`')
     self.popen = self.process_runner.run(
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     time.sleep(_QEMU_WAIT_SECONDS)
 
   def kill(self):
+    """ Kills the currently-running QEMU VM, if there is one. """
     if not self.popen:
       return
     self.popen.kill()

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -65,6 +65,7 @@ def _fetch_qemu_vars():
     raise errors.FuchsiaConfigError('Could not find FUCHSIA_RESOURCES_DIR')
 
   # Then, save and chmod the associated paths.
+  qemu_vars['fuchsia_resources_dir'] = fuchsia_resources_dir
   qemu_vars['qemu_path'] = os.path.join(
       fuchsia_resources_dir, 'qemu-for-fuchsia', 'bin', 'qemu-system-x86_64')
   os.chmod(qemu_vars['qemu_path'], 0o550)

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -191,6 +191,12 @@ class QemuProcess(object):
     self.popen.kill()
 
 
+def start_qemu():
+  qemu = QemuProcess()
+  qemu.create()
+  qemu.run()
+
+
 def initialize_resources_dir():
   """Download Fuchsia QEMU resources from GCS bucket."""
   # This module depends on multiprocessing, which is not available in


### PR DESCRIPTION
Suggestions welcome, if anyone's got ideas for making this bit of code
more clear/obvious, but I think this at least reads more clearly than
what we had before.

QemuProcess handles all the work of creating, running, and killing QEMU
instances.  To interface properly with the VM (e.g. via SSH), you
should:

.create() a VM,
call _setup_qemu_device_and_fuzzer, which will use the env vars set in
.create() to configure a proper SSH command,
and then run() the VM.

This looks a bit more clean than the stuff we were passing around before
via various setup functions.