### PR TITLE
[fuchsia] Simplify log-processing code.

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -420,7 +420,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     # list" and then run that fuzzer.
     return self.ssh_command('ls')
 
-  def process_logs_and_crash(self, artifact_prefix=None):
+  def process_logs_and_crash(self, artifact_prefix):
     """Fetch symbolized logs and crashes."""
     if not artifact_prefix:
       return
@@ -441,12 +441,9 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
             crash_name = line_match.group(3).replace('data/', '')
             # Save the crash locally.
             self.device.fetch(
-                self.fuzzer.data_path(crash_name), self.fuzzer.results_output())
+                self.fuzzer.data_path(crash_name), artifact_prefix)
             # Then update the crash report to point to that file.
             crash_testcase_file_path = os.path.join(artifact_prefix, crash_name)
-            shutil.move(
-                os.path.join(self.fuzzer.results_output(), crash_name),
-                crash_testcase_file_path)
             line = re.sub(crash_location_regex,
                           r'\1\2' + crash_testcase_file_path, line)
           new_file.write(line)
@@ -513,7 +510,6 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     # TODO(flowerhack): Pass libfuzzer args (additional_args) here
     return_code = self.fuzzer.start(['repro', 'data/' + testcase_path_name])
     self.fuzzer.monitor(return_code)
-    self.process_logs_and_crash()
 
     with open(self.fuzzer.logfile) as logfile:
       symbolized_output = logfile.read()


### PR DESCRIPTION
We only need to call process_logs_and_crash when *fuzzing* (as opposed
to reproducing), since the processing is used to determine how to pull
down the testcase once fuzzing is complete.  Reproduction simply has a
testcase_path passed in.

Additionally, we modify the call to device.fetch() to simply store the
result in artifact_prefix directly, rather than results_output.