### PR TITLE
Upload testcases fixes.

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -363,9 +363,9 @@ class UploadHandlerCommon(object):
 
     # If we have a AFL or libFuzzer target, use that for arguments.
     # Launch command looks like
-    # python launcher.py {testcase_path} {target_name}
+    # python launcher.py {testcase_path}
     if target_name:
-      additional_arguments = '%%TESTCASE%% %s' % target_name
+      additional_arguments = '%%TESTCASE%%'
 
     # Certain modifications such as app launch command, issue updates are only
     # allowed for privileged users.
@@ -395,6 +395,8 @@ class UploadHandlerCommon(object):
     else:
       crash_revision = 0
 
+    if bug_information == '0':  # Auto-recover from this bad input.
+      bug_information = None
     if bug_information and not bug_information.isdigit():
       raise helpers.EarlyExitException('Bug is not a number.', 400)
 

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -1257,7 +1257,7 @@ def create_user_uploaded_testcase(key,
   else:
     testcase.absolute_path = filename
   testcase.gestures = gestures
-  if bug_information:
+  if bug_information and bug_information.isdigit() and int(bug_information):
     testcase.bug_information = bug_information
   if platform_id:
     testcase.platform_id = platform_id.strip().lower()


### PR DESCRIPTION
- Don't allow setting bug information to 0. This can be
  a mistake from uploaders, so auto-recover from it.
- Remove the unused target name from engine testcases.