### PR TITLE
Fix issue with UBSan overriding symbolize parameter of ASan.

### DIFF
--- a/src/python/base/tasks.py
+++ b/src/python/base/tasks.py
@@ -426,7 +426,7 @@ def redo_testcase(testcase, tasks, user_email):
     testcase.minimized_keys = ''
     testcase.set_metadata('redo_minimize', True, update_testcase=False)
     metadata_keys_to_clear += [
-        'current_minimization_phase_attempts', 'minimization_phase'
+        'env', 'current_minimization_phase_attempts', 'minimization_phase'
     ]
 
     # If this testcase was archived during minimization, update the state.

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -130,10 +130,10 @@ def _get_application_arguments(testcase, task_name):
   return app_args
 
 
-def _setup_memory_tools_environment(testcase):
+def _setup_memory_tools_environment(testcase, task_name):
   """Set up environment for various memory tools used."""
   env = testcase.get_metadata('env')
-  if not env:
+  if not env or task_name == 'minimize':
     environment.reset_current_memory_tool_options(redzone_size=testcase.redzone)
     return
 
@@ -146,7 +146,8 @@ def _setup_memory_tools_environment(testcase):
 
 def prepare_environment_for_testcase(testcase):
   """Set various environment variables based on the test case."""
-  _setup_memory_tools_environment(testcase)
+  task_name = environment.get_value('TASK_NAME')
+  _setup_memory_tools_environment(testcase, task_name)
 
   # Setup environment variable for windows size and location properties.
   # Explicit override to avoid using the default one from job definition since
@@ -167,7 +168,6 @@ def prepare_environment_for_testcase(testcase):
   # Override APP_ARGS with minimized arguments (if available). Don't do this
   # for variant task since other job types can have its own set of required
   # arguments, so use the full set of arguments of that job.
-  task_name = environment.get_value('TASK_NAME')
   app_args = _get_application_arguments(testcase, task_name)
   if app_args:
     environment.set_value('APP_ARGS', app_args)

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -191,6 +191,10 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
   # If yes, set UBSAN_OPTIONS and enable suppressions.
   if get_value('UBSAN'):
     ubsan_options = join_memory_tool_options(get_ubsan_options())
+
+    # Remove |symbolize| explicitly to avoid overridding ASan defaults.
+    ubsan_options.pop('symbolize', None)
+
     set_value('UBSAN_OPTIONS', ubsan_options)
 
   return asan_options


### PR DESCRIPTION
In a ASan+UBSan build, ASAN_OPTIONS=symbolize=0
UBSAN_OPTIONS=symbolize=1 causes the symbolize=1 to take preference.
This breaks the symbolize=0 defaults which is needed to skip
inline frames in crash state.
Also, make sure minimize task skips current |env| value. This is
also needed to fix existing testcases.