### PR TITLE
Remove symbolize=1 from LSAN_OPTIONS.

### DIFF
--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -409,7 +409,6 @@ def get_lsan_options():
   lsan_suppressions_path = get_suppressions_file('lsan')
   lsan_options = {
       'print_suppressions': 0,
-      'symbolize': 1,
   }
 
   # Add common sanitizer options.


### PR DESCRIPTION
Defer to symbolize from ASAN_OPTIONS.

This was breaking our de-duplication because it caused inline frames to
be included in the crash state. A better long term fix in the future
will be to ignore inline frames in stack_analyzer instead, after which
we can turn this back on and get suppressions working again.