### PR TITLE
Speculative fix for query failures in triage task.

### DIFF
--- a/src/appengine/index.yaml
+++ b/src/appengine/index.yaml
@@ -535,6 +535,12 @@ indexes:
   - name: overridden_fuzzer_name
   - name: timestamp
 
+- kind: Testcase
+  properties:
+    - name: bug_information
+    - name: open
+    - name: one_time_crasher_flag
+
 - kind: _AE_Pipeline_Record
   properties:
   - name: is_root_pipeline


### PR DESCRIPTION
Query in _associate_testcase_with_existing_issue_if_needed
fails sporadically on some cron runs. Trying this as a
speculative fix.