### PR TITLE
Fix timeout issues.

### DIFF
--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1225,8 +1225,8 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
     else:
       task_creation.mark_unreproducible_if_flaky(testcase, True)
 
-  timeout = environment.get_value('LIBFUZZER_MINIMIZATION_TIMEOUT', 180)
-  rounds = environment.get_value('LIBFUZZER_MINIMIZATION_ROUNDS', 10)
+  timeout = environment.get_value('LIBFUZZER_MINIMIZATION_TIMEOUT', 600)
+  rounds = environment.get_value('LIBFUZZER_MINIMIZATION_ROUNDS', 5)
   current_testcase_path = testcase_file_path
   last_crash_result = None
 

--- a/src/python/google_cloud_utils/big_query.py
+++ b/src/python/google_cloud_utils/big_query.py
@@ -30,7 +30,7 @@ from metrics import logs
 from system import environment
 
 REQUEST_TIMEOUT = 60
-QUERY_TIMEOUT = 5 * 60
+QUERY_TIMEOUT = 10 * 60
 QUERY_MAX_RESULTS = 10000
 QUERY_RETRY_COUNT = 3
 QUERY_RETRY_DELAY = 3


### PR DESCRIPTION
- Increase big query timeout from 300->600 sec since it hits with
  large number of projects.
- Increase libfuzzer minimization timeout from 180->600 sec, also
  decrease number of retries from 10->5.