### PR TITLE
Fix order of project templates.

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -106,18 +106,18 @@ LIBFUZZER_MSAN_JOB = JobInfo('libfuzzer_msan_', 'libfuzzer', 'memory',
                              ['libfuzzer', 'engine_msan'])
 LIBFUZZER_UBSAN_JOB = JobInfo('libfuzzer_ubsan_', 'libfuzzer', 'undefined',
                               ['libfuzzer', 'engine_ubsan'])
+LIBFUZZER_ASAN_I386_JOB = JobInfo(
+    'libfuzzer_asan_i386_',
+    'libfuzzer',
+    'address', ['libfuzzer', 'engine_asan'],
+    architecture='i386')
+
 AFL_ASAN_JOB = JobInfo(
     'afl_asan_',
     'afl',
     'address', ['afl', 'engine_asan'],
     minimize_job_override=LIBFUZZER_ASAN_JOB)
 NO_ENGINE_ASAN_JOB = JobInfo('asan_', 'none', 'address', [])
-
-LIBFUZZER_ASAN_I386_JOB = JobInfo(
-    'libfuzzer_asan_i386_',
-    'libfuzzer',
-    'address', ['libfuzzer', 'engine_asan'],
-    architecture='i386')
 
 JOB_MAP = {
     'libfuzzer': {

--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -101,11 +101,11 @@ class JobInfo(object):
 # The order of templates is important here. Later templates override settings in
 # the earlier ones. An engine template may override vars set for a sanitizer.
 LIBFUZZER_ASAN_JOB = JobInfo('libfuzzer_asan_', 'libfuzzer', 'address',
-                             ['engine_asan', 'libfuzzer', 'prune'])
+                             ['libfuzzer', 'engine_asan', 'prune'])
 LIBFUZZER_MSAN_JOB = JobInfo('libfuzzer_msan_', 'libfuzzer', 'memory',
-                             ['engine_msan', 'libfuzzer'])
+                             ['libfuzzer', 'engine_msan'])
 LIBFUZZER_UBSAN_JOB = JobInfo('libfuzzer_ubsan_', 'libfuzzer', 'undefined',
-                              ['engine_ubsan', 'libfuzzer'])
+                              ['libfuzzer', 'engine_ubsan'])
 AFL_ASAN_JOB = JobInfo(
     'afl_asan_',
     'afl',

--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -109,14 +109,14 @@ LIBFUZZER_UBSAN_JOB = JobInfo('libfuzzer_ubsan_', 'libfuzzer', 'undefined',
 AFL_ASAN_JOB = JobInfo(
     'afl_asan_',
     'afl',
-    'address', ['engine_asan', 'afl'],
+    'address', ['afl', 'engine_asan'],
     minimize_job_override=LIBFUZZER_ASAN_JOB)
 NO_ENGINE_ASAN_JOB = JobInfo('asan_', 'none', 'address', [])
 
 LIBFUZZER_ASAN_I386_JOB = JobInfo(
     'libfuzzer_asan_i386_',
     'libfuzzer',
-    'address', ['engine_asan', 'libfuzzer'],
+    'address', ['libfuzzer', 'engine_asan'],
     architecture='i386')
 
 JOB_MAP = {


### PR DESCRIPTION
Part of #1043.

Make engine template higher precedence than the engine template.