### PR TITLE
Don't change reproducibility label if another exists.

### DIFF
--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -1039,6 +1039,15 @@ def update_issue_labels_for_flaky_testcase(policy, testcase, issue):
   if not testcase.one_time_crasher_flag:
     return
 
+  # Make sure that no other reproducible testcases associated with this issue
+  # are open. If yes, no need to update label.
+  similar_testcase = data_types.Testcase.query(
+      data_types.Testcase.bug_information == testcase.bug_information,
+      ndb_utils.is_true(data_types.Testcase.open),
+      ndb_utils.is_false(data_types.Testcase.one_time_crasher_flag)).get()
+  if similar_testcase:
+    return
+
   reproducible_label = policy.label('reproducible')
   unreproducible_label = policy.label('unreproducible')
   if not reproducible_label or not unreproducible_label:

--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -1041,11 +1041,11 @@ def update_issue_labels_for_flaky_testcase(policy, testcase, issue):
 
   # Make sure that no other reproducible testcases associated with this issue
   # are open. If yes, no need to update label.
-  similar_testcase = data_types.Testcase.query(
+  similar_reproducible_testcase = data_types.Testcase.query(
       data_types.Testcase.bug_information == testcase.bug_information,
       ndb_utils.is_true(data_types.Testcase.open),
       ndb_utils.is_false(data_types.Testcase.one_time_crasher_flag)).get()
-  if similar_testcase:
+  if similar_reproducible_testcase:
     return
 
   reproducible_label = policy.label('reproducible')

--- a/src/python/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/python/tests/appengine/handlers/cron/cleanup_test.py
@@ -1530,7 +1530,8 @@ class UpdateIssueLabelsForFlakyTestcaseTest(unittest.TestCase):
     self.assertEqual('', self.issue._monorail_issue.comment)
 
   def test_skip_if_another_reproducible_testcase(self):
-    """Test that we change label on issue if the testcase is now flaky."""
+    """Test that we don't change label on issue if another reproducible
+    testcase exists."""
     similar_testcase = test_utils.create_generic_testcase()
     similar_testcase.one_time_crasher_flag = False
     similar_testcase.open = True

--- a/src/python/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/python/tests/appengine/handlers/cron/cleanup_test.py
@@ -1494,6 +1494,7 @@ class UpdateIssueLabelsForFlakyTestcaseTest(unittest.TestCase):
     """Test that we change label on issue if the testcase is now flaky."""
     self.issue.labels.add('Reproducible')
     self.testcase.one_time_crasher_flag = True
+    self.testcase.put()
     cleanup.update_issue_labels_for_flaky_testcase(self.policy, self.testcase,
                                                    self.issue)
 
@@ -1508,6 +1509,7 @@ class UpdateIssueLabelsForFlakyTestcaseTest(unittest.TestCase):
     issue is already marked unreproducible."""
     self.issue.labels.add('Unreproducible')
     self.testcase.one_time_crasher_flag = True
+    self.testcase.put()
     cleanup.update_issue_labels_for_flaky_testcase(self.policy, self.testcase,
                                                    self.issue)
 
@@ -1519,6 +1521,23 @@ class UpdateIssueLabelsForFlakyTestcaseTest(unittest.TestCase):
     """Test that we don't change labels if the testcase is reproducible."""
     self.issue.labels.add('Reproducible')
     self.testcase.one_time_crasher_flag = False
+    self.testcase.put()
+    cleanup.update_issue_labels_for_flaky_testcase(self.policy, self.testcase,
+                                                   self.issue)
+
+    self.assertIn('Reproducible', self.issue.labels)
+    self.assertNotIn('Unreproducible', self.issue.labels)
+    self.assertEqual('', self.issue._monorail_issue.comment)
+
+  def test_skip_if_another_reproducible_testcase(self):
+    """Test that we change label on issue if the testcase is now flaky."""
+    similar_testcase = test_utils.create_generic_testcase()
+    similar_testcase.one_time_crasher_flag = False
+    similar_testcase.open = True
+    similar_testcase.put()
+
+    self.issue.labels.add('Reproducible')
+    self.testcase.one_time_crasher_flag = True
     cleanup.update_issue_labels_for_flaky_testcase(self.policy, self.testcase,
                                                    self.issue)
 


### PR DESCRIPTION
Multiple testcases can be attached to a bug. If one testcase
becomes unreproducible, but there is still another reproducible
one attached to it, don't update the main reproducibility label
as otherwise it creates confusion.