### PR TITLE
[fuchsia] Add sanitizer extension names as needed.

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -405,9 +405,9 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
                                  self.FUZZER_TEST_DATA_REL_PATH, package,
                                  target)
 
-    sanitizer = ''
+    is_zircon_fuzzer = False
     if pkg == 'zircon_fuzzers':
-      sanitizer = 'asan'
+      is_zircon_fuzzer = True
 
     # Finally, we set up the Fuzzer object itself, which will run our fuzzer!
     self.fuzzer = Fuzzer(
@@ -416,7 +416,8 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
         target,
         output=test_data_dir,
         foreground=True,
-        sanitizer='asan')
+        sanitizer='asan',
+        is_zircon_fuzzer=is_zircon_fuzzer)
 
   def __init__(self, executable_path, default_args=None):
     # We always assume QEMU is running on __init__, since build_manager sets

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -405,9 +405,18 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
                                  self.FUZZER_TEST_DATA_REL_PATH, package,
                                  target)
 
+    sanitizer = ''
+    if pkg == 'zircon_fuzzers':
+      sanitizer = 'asan'
+
     # Finally, we set up the Fuzzer object itself, which will run our fuzzer!
     self.fuzzer = Fuzzer(
-        self.device, package, target, output=test_data_dir, foreground=True)
+        self.device,
+        package,
+        target,
+        output=test_data_dir,
+        foreground=True,
+        sanitizer='asan')
 
   def __init__(self, executable_path, default_args=None):
     # We always assume QEMU is running on __init__, since build_manager sets

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -405,20 +405,16 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
                                  self.FUZZER_TEST_DATA_REL_PATH, package,
                                  target)
 
-    is_zircon_fuzzer = False
-    if package == 'zircon_fuzzers':
-      is_zircon_fuzzer = True
-
     # Finally, we set up the Fuzzer object itself, which will run our fuzzer!
+    sanitizer = environment.get_memory_tool_name(
+        environment.get_value('JOB_NAME')).lower()
     self.fuzzer = Fuzzer(
         self.device,
         package,
         target,
         output=test_data_dir,
         foreground=True,
-        sanitizer=environment.get_memory_tool_name(
-            environment.get_value('JOB_NAME')).lower(),
-        is_zircon_fuzzer=is_zircon_fuzzer)
+        sanitizer=sanitizer)
 
   def __init__(self, executable_path, default_args=None):
     # We always assume QEMU is running on __init__, since build_manager sets

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -406,7 +406,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
                                  target)
 
     is_zircon_fuzzer = False
-    if pkg == 'zircon_fuzzers':
+    if package == 'zircon_fuzzers':
       is_zircon_fuzzer = True
 
     # Finally, we set up the Fuzzer object itself, which will run our fuzzer!
@@ -416,7 +416,8 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
         target,
         output=test_data_dir,
         foreground=True,
-        sanitizer=environment.get_memory_tool_name(get_value('JOB_NAME')).lower(),
+        sanitizer=environment.get_memory_tool_name(
+            environment.get_value('JOB_NAME')).lower(),
         is_zircon_fuzzer=is_zircon_fuzzer)
 
   def __init__(self, executable_path, default_args=None):

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -416,7 +416,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
         target,
         output=test_data_dir,
         foreground=True,
-        sanitizer='asan',
+        sanitizer=environment.get_memory_tool_name(get_value('JOB_NAME')).lower(),
         is_zircon_fuzzer=is_zircon_fuzzer)
 
   def __init__(self, executable_path, default_args=None):

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -751,8 +751,10 @@ class FuchsiaBuild(RegularBuild):
     host = Host.from_dir(os.path.join(build_dir, self.FUCHSIA_BUILD_REL_PATH))
     # Right now, we only care about ASAN fuzzers.
     return [
-        str(target[0] + '/' + target[1])
-        for target in Fuzzer.filter(host.fuzzers, '', 'asan')
+        str(target[0] + '/' + target[1]) for target in Fuzzer.filter(
+            host.fuzzers, '',
+            environment.get_memory_tool_name(environment.get_value('JOB_NAME'))
+            .lower())
     ]
 
   def setup(self):

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -749,9 +749,10 @@ class FuchsiaBuild(RegularBuild):
     from platforms.fuchsia.util.fuzzer import Fuzzer
     from platforms.fuchsia.util.host import Host
     host = Host.from_dir(os.path.join(build_dir, self.FUCHSIA_BUILD_REL_PATH))
+    # Right now, we only care about ASAN fuzzers.
     return [
         str(target[0] + '/' + target[1])
-        for target in Fuzzer.filter(host.fuzzers, '')
+        for target in Fuzzer.filter(host.fuzzers, '', 'asan')
     ]
 
   def setup(self):

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -749,12 +749,12 @@ class FuchsiaBuild(RegularBuild):
     from platforms.fuchsia.util.fuzzer import Fuzzer
     from platforms.fuchsia.util.host import Host
     host = Host.from_dir(os.path.join(build_dir, self.FUCHSIA_BUILD_REL_PATH))
-    # Right now, we only care about ASAN fuzzers.
+
+    sanitizer = environment.get_memory_tool_name(
+        environment.get_value('JOB_NAME')).lower()
     return [
-        str(target[0] + '/' + target[1]) for target in Fuzzer.filter(
-            host.fuzzers, '',
-            environment.get_memory_tool_name(environment.get_value('JOB_NAME'))
-            .lower())
+        str(target[0] + '/' + target[1])
+        for target in Fuzzer.filter(host.fuzzers, '', sanitizer)
     ]
 
   def setup(self):

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -138,7 +138,7 @@ class Fuzzer(object):
     self._results_output = self.host.join('test_data', 'fuzzing', self.pkg,
                                           self.tgt)
     self._foreground = foreground
-    self.is_zircon_fuzzer=is_zircon_fuzzer
+    self.is_zircon_fuzzer = is_zircon_fuzzer
 
   def __str__(self):
     return self.pkg + '/' + self.tgt
@@ -192,9 +192,9 @@ class Fuzzer(object):
 
   def url(self):
     tgt = self.tgt
-    if is_zircon_fuzzer:
-      tgt = tgt + '.' + sanitizer
-    return 'fuchsia-pkg://fuchsia.com/%s#meta/%s.cmx' % (self.pkg, self.tgt)
+    if self.is_zircon_fuzzer:
+      tgt = self.tgt + '.' + self.sanitizer
+    return 'fuchsia-pkg://fuchsia.com/%s#meta/%s.cmx' % (self.pkg, tgt)
 
   def run(self, fuzzer_args, logfile=None):
     fuzz_cmd = ['run', self.url(), '-artifact_prefix=data/'] + fuzzer_args

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -105,7 +105,7 @@ class Fuzzer(object):
           continue
       # Remove the sanitizer extension name.
       # Clusterfuzz only needs to know foo/bar, not foo/bar.asan.
-      filtered.append((pkg, os.path.splitext(tgt[0])))
+      filtered.append((pkg, os.path.splitext(tgt)[0]))
     return filtered
 
   @classmethod
@@ -124,8 +124,7 @@ class Fuzzer(object):
                tgt,
                output=None,
                foreground=False,
-               sanitizer='',
-               is_zircon_fuzzer=False):
+               sanitizer=''):
     self.device = device
     self.host = device.host
     self.pkg = pkg
@@ -139,7 +138,7 @@ class Fuzzer(object):
     self._results_output = self.host.join('test_data', 'fuzzing', self.pkg,
                                           self.tgt)
     self._foreground = foreground
-    self.is_zircon_fuzzer = is_zircon_fuzzer
+    self.is_zircon_fuzzer = pkg == 'zircon_fuzzers'
 
   def __str__(self):
     return self.pkg + '/' + self.tgt

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -121,7 +121,8 @@ class Fuzzer(object):
                tgt,
                output=None,
                foreground=False,
-               sanitizer=''):
+               sanitizer='',
+               is_zircon_fuzzer=False):
     self.device = device
     self.host = device.host
     self.pkg = pkg
@@ -135,6 +136,7 @@ class Fuzzer(object):
     self._results_output = self.host.join('test_data', 'fuzzing', self.pkg,
                                           self.tgt)
     self._foreground = foreground
+    self.is_zircon_fuzzer=is_zircon_fuzzer
 
   def __str__(self):
     return self.pkg + '/' + self.tgt
@@ -188,7 +190,7 @@ class Fuzzer(object):
 
   def url(self):
     tgt = self.tgt
-    if sanitizer:
+    if is_zircon_fuzzer:
       tgt = tgt + '.' + sanitizer
     return 'fuchsia-pkg://fuchsia.com/%s#meta/%s.cmx' % (self.pkg, self.tgt)
 

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -102,7 +102,9 @@ class Fuzzer(object):
       if sanitizer:
         if not Fuzzer._matches_sanitizer(tgt, sanitizer):
           continue
-      filtered.append((pkg, tgt))
+      # Remove the sanitizer extension name.
+      # Clusterfuzz only needs to know foo/bar, not foo/bar.asan.
+      filtered.append((pkg, os.path.splitext(tgt[0])))
     return filtered
 
   @classmethod

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -62,6 +62,7 @@ class Fuzzer(object):
     ext = ext[1:]
     if ext == sanitizer:
       return True
+    # If there's no extension, assume it's an ASAN fuzzer.
     if sanitizer == 'asan' and ext == '':
       return True
     return False

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -808,6 +808,7 @@ class IntegrationTestFuchsia(BaseIntegrationTest):
 
     Additionally, tests that pushing a corpus to the target works & produces
     an expanded corpus."""
+    environment.set_value('JOB_NAME', 'libfuzzer_asan_fuchsia')
     environment.set_value('FUZZ_TARGET', 'example_fuzzers/trap_fuzzer')
     build_manager.setup_build()
 
@@ -837,6 +838,7 @@ class IntegrationTestFuchsia(BaseIntegrationTest):
   def test_fuzzer_can_boot_and_run_reproducer(self):
     """Tests running a testcase that should cause a fast, predictable crash."""
     environment.set_value('FUZZ_TARGET', 'example_fuzzers/overflow_fuzzer')
+    environment.set_value('JOB_NAME', 'libfuzzer_asan_fuchsia')
     build_manager.setup_build()
     testcase_path, _ = setup_testcase_and_corpus('fuchsia_crash',
                                                  'empty_corpus')

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -200,6 +200,8 @@ class FuchsiaBuildTest(unittest.TestCase):
         'fuchsia-([0-9]+).zip')
     environment.set_value('OS_OVERRIDE', 'FUCHSIA')
 
+    self.maxDiff = None  # pylint: disable=invalid-name
+
   def tearDown(self):
     shutil.rmtree(self.temp_dir)
 
@@ -212,6 +214,27 @@ class FuchsiaBuildTest(unittest.TestCase):
     self.assertIsNotNone(os.environ['FUZZ_TARGET'])
     self.assertEqual('example_fuzzers/trap_fuzzer', os.environ['FUZZ_TARGET'])
     self.assertEqual(20190926201257, environment.get_value('APP_REVISION'))
+
+    # pylint: disable=protected-access
+    targets = build._get_fuzz_targets_from_dir(build.build_dir)
+    self.assertItemsEqual([
+        'example_fuzzers/baz_fuzzer',
+        'example_fuzzers/overflow_fuzzer',
+        'example_fuzzers/trap_fuzzer',
+        'ledger_fuzzers/p2p_sync_fuzzer',
+        'ledger_fuzzers/encoding_fuzzer',
+        'ledger_fuzzers/commit_pack_fuzzer',
+        'bluetooth_fuzzers/basic_mode_rx_engine_fuzzer',
+        'bluetooth_fuzzers/enhanced_retransmission_mode_rx_engine_fuzzer',
+        'mdns_fuzzers/packet_reader_fuzzer',
+        'zircon_fuzzers/nhlt-fuzzer',
+        'zircon_fuzzers/zstd-fuzzer',
+        'zircon_fuzzers/utf_conversion-fuzzer',
+        'zircon_fuzzers/zbi-bootfs-fuzzer',
+        'zircon_fuzzers/lz4-decompress-fuzzer',
+        'zircon_fuzzers/lz4-fuzzer',
+        'zircon_fuzzers/noop-fuzzer',
+    ], targets)
 
 
 class RegularBuildTest(fake_filesystem_unittest.TestCase):


### PR DESCRIPTION
Zircon fuzzers have an extension indicating what type of sanitizer they
use.  However, we want to group targets with different sanitizers
together.  So, add the ability to fitler fuzzers by sanitizer type, and
dynamically modify the URL based on the sanitizer being used.