### PR TITLE
Use right job type when making decisions for variant task.

### DIFF
--- a/src/local/butler/reproduce.py
+++ b/src/local/butler/reproduce.py
@@ -234,6 +234,8 @@ def _prepare_initial_environment(build_directory, iterations, verbose):
   # Some functionality must be disabled when running the tool.
   environment.set_value('REPRODUCE_TOOL', True)
 
+  environment.set_value('TASK_NAME', 'reproduce')
+
   # Force logging to console for this process and child processes.
   if verbose:
     environment.set_value('LOG_TO_CONSOLE', True)
@@ -261,7 +263,8 @@ def _update_environment_for_testcase(testcase, build_directory):
   fuzzer_directory = setup.get_fuzzer_directory(testcase.fuzzer_name)
   environment.set_value('FUZZER_DIR', fuzzer_directory)
 
-  setup.prepare_environment_for_testcase(testcase)
+  task_name = environment.get_value('TASK_NAME')
+  setup.prepare_environment_for_testcase(testcase, testcase.job_type, task_name)
 
   build_manager.set_environment_vars(
       [environment.get_value('FUZZER_DIR'), build_directory])

--- a/src/python/bot/tasks/analyze_task.py
+++ b/src/python/bot/tasks/analyze_task.py
@@ -157,7 +157,7 @@ def execute_task(testcase_id, job_type):
     environment.set_value('CRASH_RETRIES', metadata.retries)
 
   # Setup testcase and get absolute testcase path.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase)
+  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return
 

--- a/src/python/bot/tasks/impact_task.py
+++ b/src/python/bot/tasks/impact_task.py
@@ -311,7 +311,7 @@ def execute_task(testcase_id, job_type):
     return
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase)
+  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return
 

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -359,7 +359,7 @@ def execute_task(testcase_id, job_type):
   # fuzzer.
   minimize_fuzzer_override = environment.get_value('MINIMIZE_FUZZER_OVERRIDE')
   file_list, input_directory, testcase_file_path = setup.setup_testcase(
-      testcase, fuzzer_override=minimize_fuzzer_override)
+      testcase, job_type, fuzzer_override=minimize_fuzzer_override)
   if not file_list:
     return
 

--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -192,7 +192,7 @@ def find_fixed_range(testcase_id, job_type):
     return
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase)
+  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return
 

--- a/src/python/bot/tasks/regression_task.py
+++ b/src/python/bot/tasks/regression_task.py
@@ -227,7 +227,7 @@ def find_regression_range(testcase_id, job_type):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase)
+  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     testcase = data_handler.get_testcase_by_id(testcase_id)
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -95,7 +95,7 @@ def _copy_testcase_to_device_and_setup_environment(testcase,
     android.adb.run_shell_command(['chmod', '0755', device_testcase_file_path])
 
 
-def _get_application_arguments(testcase, task_name):
+def _get_application_arguments(testcase):
   """Get application arguments to use for setting up |testcase|. Use minimized
    arguments if available. For variant task, where we run a testcase against
    another job type, use both minimized arguments and application arguments
@@ -104,17 +104,22 @@ def _get_application_arguments(testcase, task_name):
   if not testcase_args:
     return None
 
+  task_name = environment.get_value('TASK_NAME')
   if task_name != 'variant':
     return testcase_args
+
+  # Use job from environment as variant task uses a different job than
+  # |testcase.job_type|.
+  job_type = environment.get_value('JOB_NAME')
 
   # TODO(aarya): Use %TESTCASE% explicitly since it will not exist with new
   # engine impl libFuzzer testcases and AFL's launcher.py requires it as the
   # first argument. Remove once AFL is migrated to the new engine impl.
-  if environment.is_afl_job(testcase.job_type):
+  if environment.is_afl_job(job_type):
     return '%TESTCASE%'
 
   job_args = data_handler.get_value_from_job_definition(
-      testcase.job_type, 'APP_ARGS', default='')
+      job_type, 'APP_ARGS', default='')
   job_args_list = shlex.split(job_args)
   testcase_args_list = shlex.split(testcase_args)
   testcase_args_filtered_list = [
@@ -130,10 +135,10 @@ def _get_application_arguments(testcase, task_name):
   return app_args
 
 
-def _setup_memory_tools_environment(testcase, task_name):
+def _setup_memory_tools_environment(testcase):
   """Set up environment for various memory tools used."""
   env = testcase.get_metadata('env')
-  if not env or task_name == 'minimize':
+  if not env:
     environment.reset_current_memory_tool_options(redzone_size=testcase.redzone)
     return
 
@@ -146,8 +151,7 @@ def _setup_memory_tools_environment(testcase, task_name):
 
 def prepare_environment_for_testcase(testcase):
   """Set various environment variables based on the test case."""
-  task_name = environment.get_value('TASK_NAME')
-  _setup_memory_tools_environment(testcase, task_name)
+  _setup_memory_tools_environment(testcase)
 
   # Setup environment variable for windows size and location properties.
   # Explicit override to avoid using the default one from job definition since
@@ -168,7 +172,7 @@ def prepare_environment_for_testcase(testcase):
   # Override APP_ARGS with minimized arguments (if available). Don't do this
   # for variant task since other job types can have its own set of required
   # arguments, so use the full set of arguments of that job.
-  app_args = _get_application_arguments(testcase, task_name)
+  app_args = _get_application_arguments(testcase)
   if app_args:
     environment.set_value('APP_ARGS', app_args)
 
@@ -177,7 +181,7 @@ def setup_testcase(testcase, fuzzer_override=None):
   """Sets up the testcase and needed dependencies like fuzzer,
   data bundle, etc."""
   fuzzer_name = fuzzer_override or testcase.fuzzer_name
-  job_type = testcase.job_type
+  job_type = environment.get_value('JOB_NAME')
   task_name = environment.get_value('TASK_NAME')
   testcase_fail_wait = environment.get_value('FAIL_WAIT')
   testcase_id = testcase.key.id()

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -144,7 +144,7 @@ def _setup_memory_tools_environment(testcase):
     environment.set_memory_tool_options(options_name, options_value)
 
 
-def prepare_environment_for_testcase(testcase, task_name, job_type):
+def prepare_environment_for_testcase(testcase, job_type, task_name):
   """Set various environment variables based on the test case."""
   _setup_memory_tools_environment(testcase)
 
@@ -238,7 +238,7 @@ def setup_testcase(testcase, job_type, fuzzer_override=None):
     # Get local blacklist without this testcase's entry.
     leak_blacklist.copy_global_to_local_blacklist(excluded_testcase=testcase)
 
-  prepare_environment_for_testcase(testcase, task_name, job_type)
+  prepare_environment_for_testcase(testcase, job_type, task_name)
 
   return file_list, input_directory, testcase_file_path
 

--- a/src/python/bot/tasks/symbolize_task.py
+++ b/src/python/bot/tasks/symbolize_task.py
@@ -49,7 +49,7 @@ def execute_task(testcase_id, job_type):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase)
+  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return
 

--- a/src/python/bot/tasks/variant_task.py
+++ b/src/python/bot/tasks/variant_task.py
@@ -39,7 +39,7 @@ def execute_task(testcase_id, job_type):
   # Setup testcase and its dependencies.
   fuzzer_override = builtin_fuzzers.get_fuzzer_for_job(job_type)
   file_list, _, testcase_file_path = setup.setup_testcase(
-      testcase, fuzzer_override=fuzzer_override)
+      testcase, job_type, fuzzer_override=fuzzer_override)
   if not file_list:
     return
 

--- a/src/python/tests/core/bot/tasks/setup_test.py
+++ b/src/python/tests/core/bot/tasks/setup_test.py
@@ -56,7 +56,6 @@ class GetApplicationArgumentsTest(unittest.TestCase):
     data_types.Job(
         name='linux_asan_chrome',
         environment_string=('APP_ARGS = --orig-arg1 --orig-arg2')).put()
-
     data_types.Job(
         name='linux_msan_chrome_variant',
         environment_string=(
@@ -76,84 +75,82 @@ class GetApplicationArgumentsTest(unittest.TestCase):
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
-    environment.set_value('TASK_NAME', 'minimize')
-    self.assertEqual(None, setup._get_application_arguments(self.testcase))
-
-    environment.set_value('TASK_NAME', 'variant')
-    environment.set_value('JOB_NAME', 'linux_msan_chrome_variant')
-    self.assertEqual(None, setup._get_application_arguments(self.testcase))
+    self.assertEqual(
+        None,
+        setup._get_application_arguments(self.testcase, 'linux_asan_chrome',
+                                         'minimize'))
+    self.assertEqual(
+        None,
+        setup._get_application_arguments(
+            self.testcase, 'linux_msan_chrome_variant', 'variant'))
 
   def test_minimized_arguments_for_non_variant_task(self):
     """Test that minimized arguments are returned for non-variant tasks."""
-    environment.set_value('TASK_NAME', 'minimize')
-
     self.testcase.minimized_arguments = '--orig-arg2'
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual('--orig-arg2',
-                     setup._get_application_arguments(self.testcase))
+    self.assertEqual(
+        '--orig-arg2',
+        setup._get_application_arguments(self.testcase, 'linux_asan_chrome',
+                                         'minimize'))
 
   def test_no_unique_minimized_arguments_for_variant_task(self):
     """Test that only APP_ARGS is returned if minimized arguments have no
     unique arguments, for variant task."""
-    environment.set_value('TASK_NAME', 'variant')
-    environment.set_value('JOB_NAME', 'linux_msan_chrome_variant')
-
     self.testcase.minimized_arguments = '--arg2'
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual('--arg1 --arg2 --arg3="--flag1 --flag2"',
-                     setup._get_application_arguments(self.testcase))
+    self.assertEqual(
+        '--arg1 --arg2 --arg3="--flag1 --flag2"',
+        setup._get_application_arguments(
+            self.testcase, 'linux_msan_chrome_variant', 'variant'))
 
   def test_some_duplicate_minimized_arguments_for_variant_task(self):
     """Test that both minimized arguments and APP_ARGS are returned with
     duplicate args stripped from minimized arguments for variant task."""
-    environment.set_value('TASK_NAME', 'variant')
-    environment.set_value('JOB_NAME', 'linux_msan_chrome_variant')
-
     self.testcase.minimized_arguments = '--arg3="--flag1 --flag2" --arg4'
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual('--arg4 --arg1 --arg2 --arg3="--flag1 --flag2"',
-                     setup._get_application_arguments(self.testcase))
+    self.assertEqual(
+        '--arg4 --arg1 --arg2 --arg3="--flag1 --flag2"',
+        setup._get_application_arguments(
+            self.testcase, 'linux_msan_chrome_variant', 'variant'))
 
   def test_unique_minimized_arguments_for_variant_task(self):
     """Test that both minimized arguments and APP_ARGS are returned when they
     don't have common args for variant task."""
-    environment.set_value('TASK_NAME', 'variant')
-    environment.set_value('JOB_NAME', 'linux_msan_chrome_variant')
-
     self.testcase.minimized_arguments = '--arg5'
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual('--arg5 --arg1 --arg2 --arg3="--flag1 --flag2"',
-                     setup._get_application_arguments(self.testcase))
+    self.assertEqual(
+        '--arg5 --arg1 --arg2 --arg3="--flag1 --flag2"',
+        setup._get_application_arguments(
+            self.testcase, 'linux_msan_chrome_variant', 'variant'))
 
   def test_no_job_app_args_for_variant_task(self):
     """Test that only minimized arguments is returned when APP_ARGS is not set
     in job definition."""
-    environment.set_value('TASK_NAME', 'variant')
-    environment.set_value('JOB_NAME', 'libfuzzer_msan_chrome_variant')
-
     self.testcase.minimized_arguments = '--arg5'
     self.testcase.job_type = 'libfuzzer_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual('--arg5', setup._get_application_arguments(self.testcase))
+    self.assertEqual(
+        '--arg5',
+        setup._get_application_arguments(
+            self.testcase, 'libfuzzer_msan_chrome_variant', 'variant'))
 
   def test_afl_job_for_variant_task(self):
     """Test that we use a different argument list if this is an afl variant
     task."""
-    environment.set_value('TASK_NAME', 'variant')
-    environment.set_value('JOB_NAME', 'afl_asan_chrome_variant')
-
     self.testcase.minimized_arguments = '--arg5'
     self.testcase.job_type = 'libfuzzer_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual('%TESTCASE%',
-                     setup._get_application_arguments(self.testcase))
+    self.assertEqual(
+        '%TESTCASE%',
+        setup._get_application_arguments(self.testcase,
+                                         'afl_asan_chrome_variant', 'variant'))

--- a/src/python/tests/core/bot/tasks/setup_test.py
+++ b/src/python/tests/core/bot/tasks/setup_test.py
@@ -52,12 +52,21 @@ class GetApplicationArgumentsTest(unittest.TestCase):
 
   def setUp(self):
     helpers.patch_environ(self)
+
     data_types.Job(
         name='linux_asan_chrome',
+        environment_string=('APP_ARGS = --orig-arg1 --orig-arg2')).put()
+
+    data_types.Job(
+        name='linux_msan_chrome_variant',
         environment_string=(
             'APP_ARGS = --arg1 --arg2 --arg3="--flag1 --flag2"')).put()
 
     data_types.Job(name='libfuzzer_asan_chrome', environment_string=('')).put()
+    data_types.Job(
+        name='libfuzzer_msan_chrome_variant', environment_string=('')).put()
+    data_types.Job(
+        name='afl_asan_chrome_variant', environment_string=('')).put()
 
     self.testcase = test_utils.create_generic_testcase()
 
@@ -67,56 +76,84 @@ class GetApplicationArgumentsTest(unittest.TestCase):
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual(
-        None, setup._get_application_arguments(self.testcase, 'minimize'))
-    self.assertEqual(None,
-                     setup._get_application_arguments(self.testcase, 'variant'))
+    environment.set_value('TASK_NAME', 'minimize')
+    self.assertEqual(None, setup._get_application_arguments(self.testcase))
+
+    environment.set_value('TASK_NAME', 'variant')
+    environment.set_value('JOB_NAME', 'linux_msan_chrome_variant')
+    self.assertEqual(None, setup._get_application_arguments(self.testcase))
 
   def test_minimized_arguments_for_non_variant_task(self):
     """Test that minimized arguments are returned for non-variant tasks."""
-    self.testcase.minimized_arguments = '--arg2'
+    environment.set_value('TASK_NAME', 'minimize')
+
+    self.testcase.minimized_arguments = '--orig-arg2'
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual(
-        '--arg2', setup._get_application_arguments(self.testcase, 'minimize'))
+    self.assertEqual('--orig-arg2',
+                     setup._get_application_arguments(self.testcase))
 
   def test_no_unique_minimized_arguments_for_variant_task(self):
     """Test that only APP_ARGS is returned if minimized arguments have no
     unique arguments, for variant task."""
+    environment.set_value('TASK_NAME', 'variant')
+    environment.set_value('JOB_NAME', 'linux_msan_chrome_variant')
+
     self.testcase.minimized_arguments = '--arg2'
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
     self.assertEqual('--arg1 --arg2 --arg3="--flag1 --flag2"',
-                     setup._get_application_arguments(self.testcase, 'variant'))
+                     setup._get_application_arguments(self.testcase))
 
   def test_some_duplicate_minimized_arguments_for_variant_task(self):
     """Test that both minimized arguments and APP_ARGS are returned with
     duplicate args stripped from minimized arguments for variant task."""
+    environment.set_value('TASK_NAME', 'variant')
+    environment.set_value('JOB_NAME', 'linux_msan_chrome_variant')
+
     self.testcase.minimized_arguments = '--arg3="--flag1 --flag2" --arg4'
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
     self.assertEqual('--arg4 --arg1 --arg2 --arg3="--flag1 --flag2"',
-                     setup._get_application_arguments(self.testcase, 'variant'))
+                     setup._get_application_arguments(self.testcase))
 
   def test_unique_minimized_arguments_for_variant_task(self):
     """Test that both minimized arguments and APP_ARGS are returned when they
     don't have common args for variant task."""
+    environment.set_value('TASK_NAME', 'variant')
+    environment.set_value('JOB_NAME', 'linux_msan_chrome_variant')
+
     self.testcase.minimized_arguments = '--arg5'
     self.testcase.job_type = 'linux_asan_chrome'
     self.testcase.put()
 
     self.assertEqual('--arg5 --arg1 --arg2 --arg3="--flag1 --flag2"',
-                     setup._get_application_arguments(self.testcase, 'variant'))
+                     setup._get_application_arguments(self.testcase))
 
   def test_no_job_app_args_for_variant_task(self):
     """Test that only minimized arguments is returned when APP_ARGS is not set
     in job definition."""
+    environment.set_value('TASK_NAME', 'variant')
+    environment.set_value('JOB_NAME', 'libfuzzer_msan_chrome_variant')
+
     self.testcase.minimized_arguments = '--arg5'
     self.testcase.job_type = 'libfuzzer_asan_chrome'
     self.testcase.put()
 
-    self.assertEqual('--arg5',
-                     setup._get_application_arguments(self.testcase, 'variant'))
+    self.assertEqual('--arg5', setup._get_application_arguments(self.testcase))
+
+  def test_afl_job_for_variant_task(self):
+    """Test that we use a different argument list if this is an afl variant
+    task."""
+    environment.set_value('TASK_NAME', 'variant')
+    environment.set_value('JOB_NAME', 'afl_asan_chrome_variant')
+
+    self.testcase.minimized_arguments = '--arg5'
+    self.testcase.job_type = 'libfuzzer_asan_chrome'
+    self.testcase.put()
+
+    self.assertEqual('%TESTCASE%',
+                     setup._get_application_arguments(self.testcase))

--- a/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -419,11 +419,12 @@ class UntrustedRunnerIntegrationTest(
 
   def test_setup_testcase(self):
     """Test setup_testcase."""
-    self._setup_env(job_type='job')
+    job_type = 'job'
+    self._setup_env(job_type=job_type)
     fuzz_inputs = os.environ['FUZZ_INPUTS']
 
     testcase = data_types.Testcase()
-    testcase.job_type = 'job'
+    testcase.job_type = job_type
     testcase.absolute_path = os.path.join(fuzz_inputs, 'testcase.ext')
 
     with tempfile.NamedTemporaryFile() as f:
@@ -434,7 +435,7 @@ class UntrustedRunnerIntegrationTest(
     testcase.put()
 
     file_list, input_directory, testcase_file_path = (
-        setup.setup_testcase(testcase))
+        setup.setup_testcase(testcase, job_type))
 
     self.assertItemsEqual(file_list, [
         testcase.absolute_path,


### PR DESCRIPTION
Variant task does not use testcase.job_type, but overridden
env variable JOB_NAME. Fix tests to account for it.