### PR TITLE
Fix regression with AFL variant task not working.

### DIFF
--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -128,7 +128,16 @@ CHROMIUM_ISSUE_PREDATOR_WRONG_CL_LABEL = 'Test-Predator-Wrong-CLs'
 
 MISSING_VALUE_STRING = '---'
 
-# FIXME: Move these "enums" into seperate file(s).
+
+def clone_entity(e, **extra_args):
+  """Clones a DataStore entity and returns the clone."""
+  ent_class = e.__class__
+  # pylint: disable=protected-access
+  props = dict((v._code_name, v.__get__(e, ent_class))
+               for v in ent_class._properties.itervalues()
+               if not isinstance(v, ndb.ComputedProperty))
+  props.update(extra_args)
+  return ent_class(**props)
 
 
 class SecuritySeverity(object):

--- a/src/python/tests/core/bot/tasks/variant_task_test.py
+++ b/src/python/tests/core/bot/tasks/variant_task_test.py
@@ -1,0 +1,83 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""variant_task tests."""
+import unittest
+
+from bot.tasks import variant_task
+from datastore import data_types
+from tests.test_libs import helpers
+from tests.test_libs import test_utils
+
+
+@test_utils.with_cloud_emulators('datastore')
+class GetVariantTestcaseForJob(unittest.TestCase):
+  """Test _get_variant_testcase_for_job."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+
+  def test_same_job(self):
+    """Test variant task with same job."""
+    testcase = test_utils.create_generic_testcase()
+    variant_testcase = variant_task._get_variant_testcase_for_job(  # pylint: disable=protected-access
+        testcase, testcase.job_type)
+    self.assertEqual(testcase, variant_testcase)
+
+  def test_blackbox_fuzzer_job(self):
+    """Test variant task with blackbox fuzzer job."""
+    testcase = test_utils.create_generic_testcase()
+    testcase.job_type = 'linux_asan_project'
+    testcase.put()
+
+    variant_testcase = variant_task._get_variant_testcase_for_job(  # pylint: disable=protected-access
+        testcase, 'linux_msan_project')
+    self.assertEqual(testcase, variant_testcase)
+
+  def test_engine_fuzzer_job(self):
+    """Test variant task with an engine fuzzer job."""
+    testcase = data_types.Testcase(
+        job_type='libfuzzer_asan_project',
+        fuzzer_name='libFuzzer',
+        overridden_fuzzer_name='libfuzzer_project_binary_name',
+        project_name='project',
+        crash_type='crash-type',
+        crash_address='0x1337',
+        crash_state='A\nB\nC\n',
+        crash_revision=1337)
+    testcase.set_metadata(
+        'fuzzer_binary_name', 'binary_name', update_testcase=True)
+
+    job = data_types.Job()
+    job.name = 'afl_asan_project'
+    job.environment_string = 'PROJECT_NAME = project\n'
+    job.put()
+
+    variant_testcase = variant_task._get_variant_testcase_for_job(  # pylint: disable=protected-access
+        testcase, 'afl_asan_project')
+    self.assertNotEqual(testcase, variant_testcase)
+    self.assertEqual(None, variant_testcase.key)
+    self.assertEqual('afl', variant_testcase.fuzzer_name)
+    self.assertEqual('afl_project_binary_name',
+                     variant_testcase.overridden_fuzzer_name)
+    self.assertEqual('afl_asan_project', variant_testcase.job_type)
+
+    self.assertEqual('crash-type', variant_testcase.crash_type)
+    self.assertEqual('0x1337', variant_testcase.crash_address)
+    self.assertEqual('A\nB\nC\n', variant_testcase.crash_state)
+    self.assertEqual(1337, variant_testcase.crash_revision)
+    self.assertEqual('binary_name',
+                     variant_testcase.get_metadata('fuzzer_binary_name'))
+
+    variant_testcase.put()
+    self.assertEqual(None, variant_testcase.key)


### PR DESCRIPTION
After new engine impl was enabled in testcase_manager's
test_for_crash_with_retries, it uses the testcase.get_fuzz_target
which picks up original fuzzing engine and not the one for the
variant task. For those cases, use a cloned testcase with the
right fuzzer_name and overridden_fuzzer_name so that it sets up
AFL engine fuzzing properly.