### PR TITLE
Add more tests for the reproduce tool.

### DIFF
--- a/src/local/butler/reproduce.py
+++ b/src/local/butler/reproduce.py
@@ -31,6 +31,7 @@ from urllib import parse
 from base import json_utils
 from base import utils
 from bot import testcase_manager
+from bot.fuzzers import init
 from bot.tasks import commands
 from bot.tasks import setup
 from build_management import build_manager
@@ -51,6 +52,8 @@ CONFIG_DIRECTORY = os.path.join(
 DISPLAY = ':99'
 PROCESS_START_WAIT_SECONDS = 2
 SUPPORTED_PLATFORMS = ['android', 'fuchsia', 'linux', 'mac']
+
+FILENAME_RESPONSE_HEADER = 'x-goog-meta-filename'
 
 
 class SerializedTestcase(object):
@@ -118,7 +121,7 @@ def _download_testcase(testcase_id, testcase, configuration):
     raise errors.ReproduceToolUnrecoverableError(
         'Unable to download test case.')
 
-  bot_absolute_filename = response['x-goog-meta-filename']
+  bot_absolute_filename = response[FILENAME_RESPONSE_HEADER]
   # Store the test case in the config directory for debuggability.
   testcase_directory = os.path.join(CONFIG_DIRECTORY, 'current-testcase')
   shell.remove_directory(testcase_directory, recreate=True)
@@ -418,6 +421,9 @@ def _cleanup():
 
 def execute(args):
   """Attempt to reproduce a crash then report on the result."""
+  # Initialize fuzzing engines.
+  init.run()
+
   # The current working directory may change while we're running.
   absolute_build_dir = os.path.abspath(args.build_dir)
   try:

--- a/src/local/butler/reproduce_tool/http_utils.py
+++ b/src/local/butler/reproduce_tool/http_utils.py
@@ -31,6 +31,8 @@ CONFIG_DIRECTORY = os.path.join(
     os.path.expanduser('~'), '.config', 'clusterfuzz')
 AUTHORIZATION_CACHE_FILE = os.path.join(CONFIG_DIRECTORY, 'authorization-cache')
 
+AUTHORIZATION_HEADER = 'x-clusterfuzz-authorization'
+
 
 class SuppressOutput(object):
   """Suppress stdout and stderr.
@@ -101,10 +103,10 @@ def request(url,
         force_reauthorization=True,
         configuration=configuration)
 
-  if 'x-clusterfuzz-authorization' in response:
+  if AUTHORIZATION_HEADER in response:
     shell.create_directory(
         os.path.dirname(AUTHORIZATION_CACHE_FILE), create_intermediates=True)
-    utils.write_data_to_file(response['x-clusterfuzz-authorization'],
+    utils.write_data_to_file(response[AUTHORIZATION_HEADER],
                              AUTHORIZATION_CACHE_FILE)
 
   return response, content

--- a/src/python/tests/core/local/butler/reproduce_test.py
+++ b/src/python/tests/core/local/butler/reproduce_test.py
@@ -17,14 +17,18 @@ import os
 import tempfile
 import unittest
 
+from datastore import data_types
 from local.butler import reproduce
+from local.butler.reproduce_tool import errors
 from system import environment
 from system import shell
 from tests.test_libs import helpers
 from tests.test_libs import test_utils
+from tests.test_libs.reproduce_tool_fakes import FakeConfig
+from tests.test_libs.reproduce_tool_fakes import FakeResponse
 
 
-def _fake_get_testcase(*_):
+def _fake_get_echo_testcase(*_):
   """Fake test case output intended to run "echo -n"."""
   testcase_map = {
       'crash_state': 'state',
@@ -48,17 +52,43 @@ def _fake_get_testcase(*_):
   return reproduce.SerializedTestcase(testcase_map)
 
 
-# TODO(mbarbella): This test seems to be causing a side-effect that's leading
-# to issues running it in parallel with other tests. The root cause is still
-# unknown, but it's not ideal to have to separate these tests out.
-@unittest.skipIf(not environment.get_value('REPRODUCE_TOOL_TESTS'),
-                 'Skipping reproduce tool tests.')
+def _fake_get_libfuzzer_testcase(*_):
+  """Fake test case output intended to run "echo -n"."""
+  testcase_map = {
+      'crash_state': 'state',
+      'security_flag': False,
+      'gestures': [],
+      'flaky_stack': False,
+      'job_type': 'test_job',
+      'redzone': 32,
+      'additional_metadata': '{}',
+      'fuzzer_name': 'libFuzzer',
+      'job_definition': 'APP_NAME = launcher.py\n',
+      'overridden_fuzzer_name': 'libFuzzer_test_fuzzer',
+      'platform': environment.platform().lower(),
+      'minimized_arguments': '',
+      'window_argument': '',
+      'timeout_multiplier': 1.0,
+      'serialized_fuzz_target': {
+          'binary': 'test_fuzzer',
+          'engine': 'libFuzzer',
+          'project': 'test_project',
+      },
+      'one_time_crasher_flag': False,
+  }
+
+  return reproduce.SerializedTestcase(testcase_map)
+
+
+@test_utils.reproduce_tool
 @test_utils.with_cloud_emulators('datastore')
 class ReproduceTest(unittest.TestCase):
   """Tests for the full reproduce tool."""
 
   def setUp(self):
     helpers.patch(self, [
+        'bot.fuzzers.engine.get',
+        'bot.testcase_manager.engine_reproduce',
         'config.local_config.ProjectConfig',
         'local.butler.reproduce._download_testcase',
         'local.butler.reproduce._get_testcase',
@@ -71,22 +101,25 @@ class ReproduceTest(unittest.TestCase):
     ])
     helpers.patch_environ(self)
 
-    self.mock._download_testcase.return_value = '/tmp/testcase'
-    self.mock._get_testcase.side_effect = _fake_get_testcase
     self.mock._setup_x.return_value = []
     self.mock.get_boolean.return_value = True
+    self.mock._download_testcase.return_value = '/tmp/testcase'
     self.mock.run_process.return_value = (0, 0, '/tmp/testcase')
 
     self.build_directory = tempfile.mkdtemp()
-    self.binary_path = os.path.join(self.build_directory, 'echo')
-    with open(self.binary_path, 'w') as f:
-      f.write('test')
 
   def tearDown(self):
     shell.remove_directory(self.build_directory)
 
   def test_reproduce_with_echo(self):
-    """See if the reproduce tool can run a job configured to execute "echo"."""
+    """Ensure that the tool can run a job configured to execute "echo"."""
+    self.mock.get.return_value = None
+    self.mock._get_testcase.side_effect = _fake_get_echo_testcase
+
+    binary_path = os.path.join(self.build_directory, 'echo')
+    with open(binary_path, 'w') as f:
+      f.write('test')
+
     crash_retries = 3
     disable_xvfb = False
     verbose = False
@@ -96,10 +129,102 @@ class ReproduceTest(unittest.TestCase):
                                disable_xvfb, verbose, disable_android_setup)
     reproduce._cleanup()
     self.mock.run_process.assert_called_with(
-        self.binary_path + ' -n /tmp/testcase',
+        binary_path + ' -n /tmp/testcase',
         current_working_directory=self.build_directory,
         gestures=[],
         timeout=10)
 
     # The tool does an initial run before running |crash_retries| times.
     self.assertEqual(self.mock.run_process.call_count, crash_retries + 1)
+
+  def test_reproduce_with_libfuzzer(self):
+    """Ensure that the tool can run on a libFuzzer target."""
+    self.mock.get.return_value = 'fake engine object'
+    self.mock._get_testcase.side_effect = _fake_get_libfuzzer_testcase
+
+    crash_retries = 3
+    disable_xvfb = False
+    verbose = False
+    disable_android_setup = False
+    reproduce._reproduce_crash('https://localhost/testcase-detail/1',
+                               self.build_directory, crash_retries,
+                               disable_xvfb, verbose, disable_android_setup)
+    reproduce._cleanup()
+    self.mock.engine_reproduce.assert_called_with(
+        'fake engine object', 'test_fuzzer', '/tmp/testcase', [], 10)
+
+    # The tool does an initial run before running |crash_retries| times.
+    self.assertEqual(self.mock.engine_reproduce.call_count, crash_retries + 1)
+
+
+@test_utils.reproduce_tool
+class DownloadTestcaseTest(unittest.TestCase):
+  """Tests for _download_testcase."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'base.utils.write_data_to_file',
+        'local.butler.reproduce_tool.http_utils.request',
+        'system.archive.unpack',
+        'system.archive.get_file_list',
+    ])
+    helpers.patch_environ(self)
+
+    self.config = FakeConfig()
+
+  def test_initial_request_failed(self):
+    """Ensure that we bail out if the initial request fails."""
+    self.mock.request.return_value = (FakeResponse(500), '')
+    testcase = reproduce.SerializedTestcase('{}')
+    with self.assertRaises(errors.ReproduceToolUnrecoverableError):
+      reproduce._download_testcase(1, testcase, self.config)
+
+  def test_non_archived_testcase(self):
+    """Ensure that we properly unpack non-archived test cases."""
+    self.mock.request.return_value = (FakeResponse(200, filename='test.html'),
+                                      'html data')
+    testcase = reproduce.SerializedTestcase({
+        'archive_state': data_types.ArchiveStatus.NONE,
+        'minimized_keys': 'key',
+    })
+
+    reproduce._download_testcase(1, testcase, self.config)
+    self.mock.write_data_to_file.assert_called_once_with(
+        'html data',
+        os.path.join(reproduce.CONFIG_DIRECTORY, 'current-testcase',
+                     'test.html'))
+
+  def test_archived_testcase(self):
+    """Ensure that we properly unpack archived test cases."""
+    self.mock.request.return_value = (FakeResponse(200, filename='test.zip'),
+                                      'zip data')
+    self.mock.get_file_list.return_value = ['test.html', 'resource.js']
+    testcase = reproduce.SerializedTestcase({
+        'archive_state': data_types.ArchiveStatus.ALL,
+        'absolute_path': '/path/to/test.html',
+        'minimized_keys': 'key',
+    })
+
+    current_testcase_directory = os.path.join(reproduce.CONFIG_DIRECTORY,
+                                              'current-testcase')
+    zip_path = os.path.join(current_testcase_directory, 'test.zip')
+
+    reproduce._download_testcase(1, testcase, self.config)
+    self.mock.write_data_to_file.assert_called_once_with('zip data', zip_path)
+
+    self.mock.unpack.assert_called_once_with(zip_path,
+                                             current_testcase_directory)
+
+  def test_archive_missing_file(self):
+    """Ensure that we raise if the archive is missing an expected file."""
+    self.mock.request.return_value = (FakeResponse(200, filename='test.zip'),
+                                      'zip data')
+    self.mock.get_file_list.return_value = []
+    testcase = reproduce.SerializedTestcase({
+        'archive_state': data_types.ArchiveStatus.ALL,
+        'absolute_path': '/path/to/test.html',
+        'minimized_keys': 'key',
+    })
+
+    with self.assertRaises(errors.ReproduceToolUnrecoverableError):
+      reproduce._download_testcase(1, testcase, self.config)

--- a/src/python/tests/core/local/butler/reproduce_tool/__init__.py
+++ b/src/python/tests/core/local/butler/reproduce_tool/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/python/tests/core/local/butler/reproduce_tool/config_test.py
+++ b/src/python/tests/core/local/butler/reproduce_tool/config_test.py
@@ -1,0 +1,56 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reproduce tool configuration tests."""
+import unittest
+
+from local.butler.reproduce_tool import config
+from local.butler.reproduce_tool import errors
+from tests.test_libs import helpers
+from tests.test_libs.reproduce_tool_fakes import FakeResponse
+
+
+class ReproduceToolConfigurationTest(unittest.TestCase):
+  """Tests for ReproduceToolConfiguration."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'local.butler.reproduce_tool.http_utils.request',
+    ])
+
+  def test_local_server(self):
+    """Ensure that we can get the configuration for a local server."""
+    self.mock.request.return_value = (FakeResponse(200), '{"x": 1}')
+    configuration = config.ReproduceToolConfiguration(
+        'http://localhost:9000/testcase-detail/1')
+
+    self.assertEqual(configuration.get('x'), 1)
+    self.mock.request.assert_called_once_with(
+        'http://localhost:9000/reproduce-tool/get-config', body={})
+
+  def test_https_server(self):
+    """Ensure that we can get the configuration for an HTTPS server."""
+    self.mock.request.return_value = (FakeResponse(200), '{"x": 1}')
+    configuration = config.ReproduceToolConfiguration(
+        'https://clusterfuzz/testcase-detail/1')
+
+    self.assertEqual(configuration.get('x'), 1)
+    self.mock.request.assert_called_once_with(
+        'https://clusterfuzz/reproduce-tool/get-config', body={})
+
+  def test_failure(self):
+    """Ensure that we raise an exception if the server encounters an error."""
+    self.mock.request.return_value = (FakeResponse(403), '{"x": 1}')
+
+    with self.assertRaises(errors.ReproduceToolUnrecoverableError):
+      config.ReproduceToolConfiguration('https://clusterfuzz/testcase-detail/1')

--- a/src/python/tests/core/local/butler/reproduce_tool/http_utils_test.py
+++ b/src/python/tests/core/local/butler/reproduce_tool/http_utils_test.py
@@ -1,0 +1,90 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reproduce tool HTTP utility tests."""
+import unittest
+
+from local.butler.reproduce_tool import http_utils
+from tests.test_libs import helpers
+from tests.test_libs.reproduce_tool_fakes import FakeConfig
+from tests.test_libs.reproduce_tool_fakes import FakeHttp
+from tests.test_libs.reproduce_tool_fakes import FakeResponse
+
+
+class RequestTest(unittest.TestCase):
+  """Tests for the request function."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'base.utils.read_data_from_file',
+        'base.utils.write_data_to_file',
+        'httplib2.Http',
+        'local.butler.reproduce_tool.prompts.get_string',
+        'webbrowser.open',
+    ])
+
+    self.config = FakeConfig()
+
+  def test_multiple_auth_failures(self):
+    """Ensure that we don't recurse indefinitely if auth fails persistently."""
+    http = FakeHttp([(FakeResponse(401), {}), (FakeResponse(401), {})])
+    self.mock.Http.return_value = http
+    response, _ = http_utils.request('https://url/', configuration=self.config)
+
+    # Ensure that all expected requests were made.
+    self.assertEqual(http.replies, [])
+
+    self.assertEqual(response.status, 401)
+
+  def test_unauthenticated_request(self):
+    """Ensure that we can make an unauthenticated request."""
+    http = FakeHttp([(FakeResponse(200), {})])
+    self.mock.Http.return_value = http
+    response, _ = http_utils.request('https://url/', body='test body')
+
+    # Ensure that all expected requests were made.
+    self.assertEqual(http.replies, [])
+
+    self.assertEqual(http.last_body, '"test body"')
+    self.assertEqual(http.last_headers, {})
+    self.assertEqual(response.status, 200)
+
+  def test_authentication(self):
+    """Ensure that we can authenticate properly if needed."""
+    http = FakeHttp([(FakeResponse(401), {}), (FakeResponse(
+        200, include_auth_header=True), {})])
+    self.mock.Http.return_value = http
+    response, _ = http_utils.request('https://url/', configuration=self.config)
+
+    # Ensure that all expected requests were made.
+    self.assertEqual(http.replies, [])
+
+    self.mock.write_data_to_file.assert_called_once_with(
+        'fake auth token', http_utils.AUTHORIZATION_CACHE_FILE)
+    self.assertEqual(response.status, 200)
+
+  def test_authenticated_request(self):
+    """Ensure that we reuse credentials if we've previously authenticated."""
+    http = FakeHttp([(FakeResponse(200), {})])
+    self.mock.Http.return_value = http
+    self.mock.read_data_from_file.return_value = 'cached auth token'
+    response, _ = http_utils.request('https://url/', configuration=self.config)
+
+    # Ensure that all expected requests were made.
+    self.assertEqual(http.replies, [])
+
+    self.assertEqual(http.last_headers, {
+        'Authorization': 'cached auth token',
+        'User-Agent': 'clusterfuzz-reproduce'
+    })
+    self.assertEqual(response.status, 200)

--- a/src/python/tests/test_libs/reproduce_tool_fakes.py
+++ b/src/python/tests/test_libs/reproduce_tool_fakes.py
@@ -1,0 +1,76 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fake objects used in reproduce tool tests."""
+from builtins import object
+
+from local.butler import reproduce
+from local.butler.reproduce_tool import http_utils
+
+
+class FakeResponse(object):
+  """Fake response object."""
+
+  def __init__(self, status, include_auth_header=False, filename=None):
+    self.status = status
+    self.include_auth_header = include_auth_header
+    self.filename = filename
+
+  def __contains__(self, item):
+    if item == http_utils.AUTHORIZATION_HEADER and self.include_auth_header:
+      return True
+    if item == reproduce.FILENAME_RESPONSE_HEADER and self.filename:
+      return True
+
+    return False
+
+  def __getitem__(self, item):
+    if item == http_utils.AUTHORIZATION_HEADER and self.include_auth_header:
+      return 'fake auth token'
+    if item == reproduce.FILENAME_RESPONSE_HEADER and self.filename:
+      return self.filename
+
+    return None
+
+
+class FakeHttp(object):
+  """Fake HTTP object. Stores information on the last request."""
+
+  def __init__(self, replies):
+    self.replies = replies
+    self.last_url = None
+    self.last_method = None
+    self.last_headers = None
+    self.last_body = None
+
+  def request(self, url, method, headers, body):
+    """Return a predetermined response and content."""
+    self.last_url = url
+    self.last_method = method
+    self.last_headers = headers
+    self.last_body = body
+
+    return self.replies.pop(0)
+
+
+class FakeConfig(object):
+  """Fake configuration object."""
+
+  def get(self, key):
+    """Fake get."""
+    if key == 'oauth_url':
+      return 'https://oauth-url/'
+    if key == 'testcase_download_url':
+      return 'https://clusterfuzz/testcase-detail/download-testcase'
+
+    raise Exception('Unexpected config key access: ' + key)

--- a/src/python/tests/test_libs/test_utils.py
+++ b/src/python/tests/test_libs/test_utils.py
@@ -117,6 +117,14 @@ def slow(func):
                              func)
 
 
+def reproduce_tool(func):
+  """Slow tests which are skipped during presubmit."""
+  return unittest.skipIf(
+      not environment.get_value('REPRODUCE_TOOL_TESTS', False),
+      'Skipping reproduce tool tests.')(
+          func)
+
+
 def android_device_required(func):
   """Skip Android-specific tests if we cannot run them."""
   reason = None


### PR DESCRIPTION
In the end I don't think adding the actual libFuzzer target is necessary. This ensures we go down the proper code paths for engine fuzzers (and it caught that we weren't properly following it before).