### PR TITLE
Add an extra log message in the beginning of the FuzzerCoverage cron task.

### DIFF
--- a/src/go/server/cron/coverage.go
+++ b/src/go/server/cron/coverage.go
@@ -230,6 +230,7 @@ func readJSON(ctx context.Context, url string, data interface{}) error {
 
 // FuzzerCoverage gets the latest code coverage stats and links to reports.
 func FuzzerCoverage(w http.ResponseWriter, r *http.Request) {
+	logs.Logf("FuzzerCoverage task started.")
 	cfg := config.NewProjectConfig()
 	bucket := cfg.GetString("coverage.reports.bucket")
 	url := latestReportInfoDir(bucket)


### PR DESCRIPTION
A speculative fix, just trying to change the code a bit (this message would be useful anyways) and re-deploy.