### PR TITLE
Update issue metadata in progression tasks (#1103).

### DIFF
--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -413,6 +413,25 @@ def get_issue_components(fuzz_target_path):
   return get_issue_metadata(fuzz_target_path, COMPONENTS_FILE_EXTENSION)
 
 
+def get_all_issue_metadata(fuzz_target_path):
+  """Get issue related metadata for a target."""
+  metadata = {}
+
+  issue_labels = get_issue_labels(fuzz_target_path)
+  if issue_labels:
+    metadata['issue_labels'] = ','.join(issue_labels)
+
+  issue_components = get_issue_components(fuzz_target_path)
+  if issue_components:
+    metadata['issue_components'] = ','.join(issue_components)
+
+  issue_owners = get_issue_owners(fuzz_target_path)
+  if issue_owners:
+    metadata['issue_owners'] = ','.join(issue_owners)
+
+  return metadata
+
+
 def format_fuzzing_strategies(fuzzing_strategies):
   """Format the strategies used for logging purposes."""
   if not fuzzing_strategies:

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1238,18 +1238,8 @@ def run_engine_fuzzer(engine_impl, target_name, sync_corpus_directory,
   fuzzer_metadata = {
       'fuzzer_binary_name': target_name,
   }
-  issue_labels = engine_common.get_issue_labels(target_path)
-  if issue_labels:
-    fuzzer_metadata['issue_labels'] = ','.join(issue_labels)
 
-  issue_components = engine_common.get_issue_components(target_path)
-  if issue_components:
-    fuzzer_metadata['issue_components'] = ','.join(issue_components)
-
-  issue_owners = engine_common.get_issue_owners(target_path)
-  if issue_owners:
-    fuzzer_metadata['issue_owners'] = ','.join(issue_owners)
-
+  fuzzer_metadata.update(engine_common.get_all_issue_metadata(target_path))
   return result, fuzzer_metadata
 
 


### PR DESCRIPTION
Issue components, labels can be incorrectly specified and fixed later,
so update this with the information from the latest build.