### PR TITLE
Speed up cleanup cron and avoid issue tracker token expiration.

### DIFF
--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -979,11 +979,6 @@ def update_issue_ccs_from_owners_file(policy, testcase, issue):
   if not issue or not issue.is_open:
     return
 
-  # If we've assigned the ccs before, it likely means we were incorrect.
-  # Don't try again for this particular issue.
-  if issue_tracker_utils.was_label_added(issue, auto_cc_label):
-    return
-
   if testcase.get_metadata('has_issue_ccs_from_owners_file'):
     return
 
@@ -993,6 +988,11 @@ def update_issue_ccs_from_owners_file(policy, testcase, issue):
       strip=True,
       remove_empty=True)
   if not ccs_list:
+    return
+
+  # If we've assigned the ccs before, it likely means we were incorrect.
+  # Don't try again for this particular issue.
+  if issue_tracker_utils.was_label_added(issue, auto_cc_label):
     return
 
   ccs_added = False
@@ -1078,18 +1078,18 @@ def update_issue_owner_and_ccs_from_predator_results(policy,
   if issue.assignee:
     return
 
+  # If there are more than 3 suspected CLs, we can't be confident in the
+  # results. Just skip any sort of notification to CL authors in this case.
+  suspected_cls = _get_predator_result_item(testcase, 'suspected_cls')
+  if not suspected_cls or len(suspected_cls) > 3:
+    return
+
   # If we've assigned an owner or cc once before, it likely means we were
   # incorrect. Don't try again for this particular issue.
   if (issue_tracker_utils.was_label_added(
       issue, data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_OWNER_LABEL) or
       issue_tracker_utils.was_label_added(
           issue, data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_CC_LABEL)):
-    return
-
-  # If there are more than 3 suspected CLs, we can't be confident in the
-  # results. Just skip any sort of notification to CL authors in this case.
-  suspected_cls = _get_predator_result_item(testcase, 'suspected_cls')
-  if not suspected_cls or len(suspected_cls) > 3:
     return
 
   # Validate that the suspected CLs have all of the information we need before

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -178,7 +178,7 @@ def was_label_added(issue, label):
     return False
 
   # Optimization that does not require pulling in issue's actions.
-  if any([label.lower() == l.lower() for l in issue.labels]):
+  if any(label.lower() == l.lower() for l in issue.labels):
     return True
 
   for action in issue.actions:

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -177,6 +177,10 @@ def was_label_added(issue, label):
   if not label:
     return False
 
+  # Optimization that does not require pulling in issue's actions.
+  if any([label.lower() == l.lower() for l in issue.labels]):
+    return True
+
   for action in issue.actions:
     for added in action.labels.added:
       if label.lower() == added.lower():


### PR DESCRIPTION
issue_tracker_utils.was_label_added is an expensive call that
requires pulling in all issue comments. It was already optimized
for most cases except these two:
- Assigning owner and ccs from predator results.
- Assigning ccs from owners file.