### PR TITLE
Fix for google-fluentd credentials when using service acccount.

### DIFF
--- a/docker/base/setup_common.sh
+++ b/docker/base/setup_common.sh
@@ -45,7 +45,7 @@ fi
 
 # Running without credentials will cause this to fail.
 if [[ -z "$LOCAL_SRC" ]]; then
-  service google-fluentd restart
+  /etc/init.d/google-fluentd restart
 fi
 
 # Prevent anything from being written to downloads directory.


### PR DESCRIPTION
Instead of using "service google-fluentd start", call
/etc/init.d/google-fluentd directly so that the
GOOGLE_APPLIATION_CREDENTIALS environment variable is taken into
account.