### PR TITLE
Remove build_manager.remove_unused_builds.

### DIFF
--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -333,9 +333,6 @@ def run():
     # Download new layout tests once per day.
     update_tests_if_needed()
 
-    # Remove unused builds once per day.
-    build_manager.remove_unused_builds()
-
     # Check overall free disk space. If we are running too low, clear all
     # data directories like builds, fuzzers, data bundles, etc.
     shell.clear_data_directories_on_low_disk_space()

--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -31,7 +31,6 @@ from bot.init_scripts import fuchsia as fuchsia_init
 from bot.init_scripts import linux as linux_init
 from bot.init_scripts import mac as mac_init
 from bot.init_scripts import windows as windows_init
-from build_management import build_manager
 from config import local_config
 from datastore import data_handler
 from google_cloud_utils import storage

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -15,19 +15,15 @@
 
 from builtins import object
 from builtins import range
-import datetime
 import os
 import re
-import six
 import subprocess
 import time
 
 from collections import namedtuple
 from distutils import spawn
 
-from base import dates
 from base import errors
-from base import persistent_cache
 from base import utils
 from build_management import revisions
 from datastore import data_types

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -56,9 +56,6 @@ BUILD_TYPE_SUBSTRINGS = [
     '-beta', '-stable', '-debug', '-release', '-symbolized'
 ]
 
-# Persistent cache key for tracking when last unused build check was done.
-LAST_UNUSED_BUILD_CHECK_KEY = 'last_unused_build_check'
-
 # Build eviction constants.
 MAX_EVICTED_BUILDS = 100
 MIN_FREE_DISK_SPACE_CHROMIUM = 10 * 1024 * 1024 * 1024  # 10 GB


### PR DESCRIPTION
This is extremely slow on deployments with a large number of jobs, since
it iterates over all jobs.

This is also unnecessary when we have build eviction.