### PR TITLE
Avoid logging a warning on empty directories in Android.

### DIFF
--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -67,7 +67,8 @@ def bad_state_reached():
 def copy_local_directory_to_remote(local_directory, remote_directory):
   """Copies local directory contents to a device directory."""
   create_directory_if_needed(remote_directory)
-  run_command(['push', '%s/*' % local_directory, remote_directory])
+  if os.listdir(local_directory):
+    run_command(['push', '%s/*' % local_directory, remote_directory])
 
 
 def copy_local_file_to_remote(local_file_path, remote_file_path):


### PR DESCRIPTION
We already create the remote directory first. If local directory
is empty, don't run the push command as '/*' will fail.