### PR TITLE
Don't exception out when fuzzer build directory is not found.

### DIFF
--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -276,6 +276,14 @@ def dump_big_query_data(stats, testcase_file_path, fuzzer_command):
 
 def find_fuzzer_path(build_directory, fuzzer_name):
   """Find the fuzzer path with the given name."""
+  if not build_directory:
+    # Grey-box fuzzers might not have the build directory for a particular job
+    # configuration when doing variant task testing (e.g. Android on-device
+    # fuzz target might not exist on host). In this case, treat it similar to
+    # target not found by returning None.
+    logs.log_warn('No build directory found for fuzzer: %s' % fuzzer_name)
+    return None
+
   if environment.platform() == 'FUCHSIA':
     # Fuchsia targets are not on disk.
     return fuzzer_name

--- a/src/python/tests/core/bot/fuzzers/engine_common_test.py
+++ b/src/python/tests/core/bot/fuzzers/engine_common_test.py
@@ -254,6 +254,10 @@ class FindFuzzerPathTest(fake_filesystem_unittest.TestCase):
     self.fs.create_dir(os.path.join(self.build_dir, self.fuzzer_name))
     self.assertIsNone(self._find_fuzzer_path())
 
+  def test_no_build_directory(self):
+    """Test that no exception occurs when there is no build directory set."""
+    self.assertIsNone(engine_common.find_fuzzer_path(None, self.fuzzer_name))
+
 
 class GetStrategyProbabilityTest(unittest.TestCase):
   """Tests get_strategy_probability."""


### PR DESCRIPTION
This is expected when doing variant task on a job where build
does not exist (e.g. fuzz target does not exist for that config).