### PR TITLE
Capture Fuchsia qemu logs in failure cases

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -521,6 +521,8 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
         # Strip non-printable characters at beginning of qemu log
         qemu_log = ''.join(c for c in f.read() if c in string.printable)
         logs.log_warn(qemu_log)
+    else:
+      logs.log_error('Qemu log not found in {}'.format(QemuProcess.LOG_PATH))
 
     start_qemu()
     self._setup_device_and_fuzzer()

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -38,6 +38,7 @@ from fuzzing import strategy
 from metrics import logs
 from platforms import android
 from platforms import fuchsia
+from platforms.fuchsia.device import QemuProcess
 from platforms.fuchsia.device import start_qemu
 from platforms.fuchsia.device import stop_qemu
 from platforms.fuchsia.util.device import Device
@@ -513,6 +514,14 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
     """Restart QEMU."""
     logs.log_warn('Connection to fuzzing VM lost. Restarting.')
     stop_qemu()
+
+    # Do this after the stop, to make sure everything is flushed
+    if os.path.exists(QemuProcess.LOG_PATH):
+      with open(QemuProcess.LOG_PATH) as f:
+        # Strip non-printable characters at beginning of qemu log
+        qemu_log = ''.join(c for c in f.read() if c in string.printable)
+        logs.log_warn(qemu_log)
+
     start_qemu()
     self._setup_device_and_fuzzer()
 

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -36,14 +36,6 @@ from system import process_handler
 _QEMU_WAIT_SECONDS = 30
 
 
-class QemuRunner(new_process.ProcessRunner):
-
-  def get_command(self, additional_args=None):
-    import pipes
-    command = super(QemuRunner, self).get_command(additional_args)
-    return ' '.join(pipes.quote(part) for part in command)
-
-
 def _fetch_qemu_vars():
   """
   Returns a dictionary with variables necessary for configuring and running
@@ -118,7 +110,7 @@ class QemuProcess(object):
 
   # For now, use a system-global log path so we don't need to pass a tempfile
   # path around everywhere
-  LOG_PATH = os.path.join(tempfile.gettempdir(), "fuchsia-qemu-log")
+  LOG_PATH = os.path.join(tempfile.gettempdir(), 'fuchsia-qemu-log')
 
   def __init__(self):
     self.process_runner = None
@@ -187,18 +179,17 @@ class QemuProcess(object):
     environment.set_value('FUCHSIA_PKEY_PATH', qemu_vars['pkey_path'])
     logs.log('Ready to run QEMU. Command: ' + qemu_vars['qemu_path'] + ' ' +
              str(qemu_args))
-    self.process_runner = QemuRunner(qemu_vars['qemu_path'], qemu_args)
+    self.process_runner = new_process.ProcessRunner(qemu_vars['qemu_path'],
+                                                    qemu_args)
 
   def run(self):
     """Actually runs a QEMU VM, assuming `create` has already been called."""
     if not self.process_runner:
       raise QemuError('Attempted to `run` QEMU VM before calling `create`')
 
-    self.logfile = open(QemuProcess.LOG_PATH, "wb")
-    # shell=True appears to be necessary to get qemu to give us non-truncated
-    # logs
+    self.logfile = open(QemuProcess.LOG_PATH, 'wb')
     self.popen = self.process_runner.run(
-        stdout=self.logfile, stderr=subprocess.PIPE, shell=True)
+        stdout=self.logfile, stderr=subprocess.PIPE)
     time.sleep(_QEMU_WAIT_SECONDS)
 
   def kill(self):

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -21,7 +21,6 @@ import shutil
 import tempfile
 import unittest
 
-import metrics
 import mock
 import parameterized
 import pyfakefs.fake_filesystem_unittest as fake_fs_unittest
@@ -34,6 +33,7 @@ from bot.fuzzers.libFuzzer import constants
 from bot.fuzzers.libFuzzer import engine
 from build_management import build_manager
 from fuzzing import strategy
+from metrics import logs
 from platforms import android
 from system import environment
 from system import new_process
@@ -870,7 +870,7 @@ class IntegrationTestsFuchsia(BaseIntegrationTest):
     test_helpers.patch(self, ['metrics.logs.log_warn'])
     # Pass-through logs just so we can see what's going on (but moving from
     # log_warn to plain log to avoid creating a loop)
-    self.mock.log_warn.side_effect = metrics.logs.log
+    self.mock.log_warn.side_effect = logs.log
 
     environment.set_value('FUZZ_TARGET', 'example_fuzzers/overflow_fuzzer')
     environment.set_value('JOB_NAME', 'libfuzzer_asan_fuchsia')
@@ -878,11 +878,11 @@ class IntegrationTestsFuchsia(BaseIntegrationTest):
     testcase_path, _ = setup_testcase_and_corpus('fuchsia_crash',
                                                  'empty_corpus')
 
-    runner = libfuzzer.FuchsiaQemuLibFuzzerRunner("fake/fuzzer")
+    runner = libfuzzer.FuchsiaQemuLibFuzzerRunner('fake/fuzzer')
     # Check that it's up properly
-    self.assertEqual(runner.device.ssh(["echo", "hello"]), 0)
+    self.assertEqual(runner.device.ssh(['echo', 'hello']), 0)
     # Force shutdown
-    runner.device.ssh(["dm", "shutdown"])
+    runner.device.ssh(['dm', 'shutdown'])
 
     # Try to fuzz against the dead qemu to trigger automatic recovery behavior
     engine_impl = engine.LibFuzzerEngine()


### PR DESCRIPTION
In some cases, qemu instances may die unexpectedly (due to system OOM,
etc). To aid in debugging, we would like to preserve the logs from qemu
(and the Fuchsia system logs, which are echoed to this console).