### PR TITLE
[fuchsia] Update regex for finding relevant logs.

### DIFF
--- a/src/python/platforms/fuchsia/util/device.py
+++ b/src/python/platforms/fuchsia/util/device.py
@@ -251,7 +251,7 @@ class Device(object):
           A list of the test artifacts (e.g. crashes) reported in the logs.
         """
     pid = -1
-    pid_pattern = re.compile(r'==([0-9]*)==')
+    pid_pattern = re.compile(r'==([0-9]+)==')
     mutation_pattern = re.compile(r'^MS: [0-9]*')
     artifacts = []
     artifact_pattern = re.compile(r'Test unit written to data/(\S*)')


### PR DESCRIPTION
Something in one of our fuzzers is matching on '==([0-9]*)==' with
'==()=='.  Unfortunately, this match tries to use the value of [0-9]* to
process logs from a specific PID, and thus fails because the captured
value is ''.

We can fix this by converting the regex to find [0-9]+ instead.

If this becomes a recurring issue, perhaps we can update Fuchsia to emit
logs in a more guaranteed-unique structure?