### PR TITLE
Fix flakiness, limit requirement for timeout crashes

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/constants.py
+++ b/src/python/bot/fuzzers/libFuzzer/constants.py
@@ -58,7 +58,12 @@ VALUE_PROFILE_ARGUMENT = '-use_value_profile=1'
 # Value for RSS_LIMIT_FLAG to catch OOM.
 DEFAULT_RSS_LIMIT_MB = 2048
 
+# Value for TIMEOUT_FLAG to catch timeouts.
 DEFAULT_TIMEOUT_LIMIT = 25
+REPRODUCTION_TIMEOUT_LIMIT = 60
+
+# String to match to determine if this is a timeout crash.
+TEST_TIMEOUT_SIGNATURE = 'libFuzzer: timeout after'
 
 # libFuzzer's exit code if a bug occurred in libFuzzer.
 LIBFUZZER_ERROR_EXITCODE = 1

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -324,6 +324,7 @@ class LibFuzzerEngine(engine.Engine):
       logs.log('Retrying timeout crash with a higher timeout: %d secs' %
                constants.REPRODUCTION_TIMEOUT_LIMIT)
       fuzzer_utils.extract_argument(arguments, constants.TIMEOUT_FLAG)
+      fuzzer_utils.extract_argument(arguments, constants.RUNS_FLAG)
       arguments.append('%s%d' % (constants.TIMEOUT_FLAG,
                                  constants.REPRODUCTION_TIMEOUT_LIMIT))
       result = runner.run_single_testcase(

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -329,7 +329,8 @@ class LibFuzzerEngine(engine.Engine):
                                  constants.REPRODUCTION_TIMEOUT_LIMIT))
       result = runner.run_single_testcase(
           input_path,
-          timeout=constants.REPRODUCTION_TIMEOUT_LIMIT + 5,  # processing buffer
+          timeout=constants.REPRODUCTION_TIMEOUT_LIMIT +
+          10,  # processing buffer.
           additional_args=arguments)
 
     return engine.ReproduceResult(result.command, result.return_code,

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/data/always_timeout_fuzzer.cc
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/data/always_timeout_fuzzer.cc
@@ -1,0 +1,20 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <cstdlib>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  for(;;);
+}


### PR DESCRIPTION
- Increase limit for timeout processing to 60 secs, but keep
  25 secs for regular crashes.
- Don't run with -runs=100, it should help reduce flakiness of
  timeout crashes. Timeout crashes should just reproduce in
  one iteration.