### PR TITLE
Fix for test failure.

### DIFF
--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -356,6 +356,7 @@ def kill_leftover_emulators():
   kill_process('dev_appserver.py')
   kill_process('CloudDatastore.jar')
   kill_process('pubsub-emulator')
+  kill_process('run_bot')
 
 
 def get_platform():

--- a/src/python/tests/core/bot/testcase_manager_test.py
+++ b/src/python/tests/core/bot/testcase_manager_test.py
@@ -760,7 +760,6 @@ class UntrustedEngineReproduceTest(
     """Set up."""
     super(UntrustedEngineReproduceTest, self).setUp()
     environment.set_value('JOB_NAME', 'libfuzzer_asan_job')
-    environment.set_value('USE_MINIJAIL', False)
 
     job = data_types.Job(
         name='libfuzzer_asan_job',

--- a/src/python/tests/test_libs/untrusted_runner_helpers.py
+++ b/src/python/tests/test_libs/untrusted_runner_helpers.py
@@ -164,7 +164,7 @@ class UntrustedRunnerIntegrationTest(unittest.TestCase):
   def tearDownClass(cls):
     if cls.bot_proc:
       try:
-        cls.bot_proc.terminate()
+        cls.bot_proc.kill()
       except OSError:
         # Could already be killed.
         pass

--- a/src/python/tests/test_libs/untrusted_runner_helpers.py
+++ b/src/python/tests/test_libs/untrusted_runner_helpers.py
@@ -164,7 +164,7 @@ class UntrustedRunnerIntegrationTest(unittest.TestCase):
   def tearDownClass(cls):
     if cls.bot_proc:
       try:
-        cls.bot_proc.kill()
+        cls.bot_proc.terminate()
       except OSError:
         # Could already be killed.
         pass


### PR DESCRIPTION
The untrusted worker process can stick around after a test is run, so kill it to be sure.