### PR TITLE
Speed up cross pollinate fuzzer list operation.

### DIFF
--- a/src/appengine/handlers/cron/corpus_backup.py
+++ b/src/appengine/handlers/cron/corpus_backup.py
@@ -76,6 +76,7 @@ class MakePublicHandler(base_handler.Handler):
   def get(self):
     """Handle a GET request."""
     jobs = ndb_utils.get_all_from_model(data_types.Job)
+    default_backup_bucket = utils.default_backup_bucket()
     for job in jobs:
       job_environment = job.get_environment()
       if utils.string_is_true(job_environment.get('EXPERIMENTAL')):
@@ -86,7 +87,8 @@ class MakePublicHandler(base_handler.Handler):
         # There won't be any corpus backups for these jobs. Skip.
         continue
 
-      corpus_backup_bucket_name = job_environment.get('BACKUP_BUCKET')
+      corpus_backup_bucket_name = job_environment.get('BACKUP_BUCKET',
+                                                      default_backup_bucket)
       if not corpus_backup_bucket_name:
         # No backup bucket found. Skip.
         continue

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -798,6 +798,14 @@ def write_data_to_file(content, file_path, append=False):
 
 
 @memoize.wrap(memoize.FifoInMemory(1))
+def default_backup_bucket():
+  """Return the default backup bucket for this instance of ClusterFuzz."""
+  # Do not use |BACKUP_BUCKET| environment variable as that is the overridden
+  # backup bucket from job type and is not the default backup bucket.
+  return local_config.ProjectConfig().get('env.BACKUP_BUCKET')
+
+
+@memoize.wrap(memoize.FifoInMemory(1))
 def default_project_name():
   """Return the default project name for this instance of ClusterFuzz."""
   # Do not use |PROJECT_NAME| environment variable as that is the overridden

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -733,14 +733,15 @@ def _get_cross_pollinate_fuzzers(engine, current_fuzzer_name):
 
   jobs = {}
   for job in data_types.Job.query():
-    backup_bucket_name = job.get_environment().get('BACKUP_BUCKET',
-                                                   default_backup_bucket)
+    job_environment = job.get_environment()
+    backup_bucket_name = job_environment.get('BACKUP_BUCKET',
+                                             default_backup_bucket)
     if not backup_bucket_name:
       # Skip jobs that don't do corpus backups.
       continue
 
-    corpus_engine_name = job.get_environment().get(
-        'CORPUS_FUZZER_NAME_OVERRIDE', engine)
+    corpus_engine_name = job_environment.get('CORPUS_FUZZER_NAME_OVERRIDE',
+                                             engine)
     jobs[job.name] = JobMetadata(backup_bucket_name, corpus_engine_name)
 
   for target, target_job in zip(targets, target_jobs):

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -103,9 +103,6 @@ CorpusCrash = collections.namedtuple('CorpusCrash', [
     'security_flag',
 ])
 
-JobMetadata = collections.namedtuple(
-    'JobMetadata', ['backup_bucket_name', 'corpus_engine_name'])
-
 
 def _get_corpus_file_paths(corpus_path):
   """Return full paths to corpus files in |corpus_path|."""
@@ -725,43 +722,40 @@ def _process_corpus_crashes(context, result):
 
 def _get_cross_pollinate_fuzzers(engine, current_fuzzer_name):
   """Return a list of fuzzer objects to use for cross pollination."""
-  cross_pollinate_fuzzers = {}
+  cross_pollinate_fuzzers = []
 
   target_jobs = list(fuzz_target_utils.get_fuzz_target_jobs(engine=engine))
   targets = fuzz_target_utils.get_fuzz_targets_for_target_jobs(target_jobs)
-  default_backup_bucket = utils.default_backup_bucket()
 
-  jobs = {}
-  for job in data_types.Job.query():
+  targets_and_jobs = [(target, target_job)
+                      for target, target_job in zip(targets, target_jobs)
+                      if target_job.fuzz_target_name != current_fuzzer_name]
+  selected_targets_and_jobs = random.SystemRandom().sample(
+      targets_and_jobs, min(
+          len(targets_and_jobs), CROSS_POLLINATE_FUZZER_COUNT))
+
+  default_backup_bucket = utils.default_backup_bucket()
+  for target, target_job in selected_targets_and_jobs:
+    job = data_types.Job.query(data_types.Job.name == target_job.job).get()
+    if not job:
+      continue
+
     job_environment = job.get_environment()
     backup_bucket_name = job_environment.get('BACKUP_BUCKET',
                                              default_backup_bucket)
     if not backup_bucket_name:
-      # Skip jobs that don't do corpus backups.
       continue
-
     corpus_engine_name = job_environment.get('CORPUS_FUZZER_NAME_OVERRIDE',
                                              engine)
-    jobs[job.name] = JobMetadata(backup_bucket_name, corpus_engine_name)
 
-  for target, target_job in zip(targets, target_jobs):
-    if (target_job.fuzz_target_name == current_fuzzer_name or
-        target_job.fuzz_target_name in cross_pollinate_fuzzers):
-      continue
+    cross_pollinate_fuzzers.append(
+        CrossPollinateFuzzer(
+            target,
+            backup_bucket_name,
+            corpus_engine_name,
+        ))
 
-    if target_job.job not in jobs:
-      continue
-
-    job = jobs[target_job.job]
-    cross_pollinate_fuzzers[target_job.fuzz_target_name] = CrossPollinateFuzzer(
-        target,
-        job.backup_bucket_name,
-        job.corpus_engine_name,
-    )
-
-  return random.SystemRandom().sample(
-      list(cross_pollinate_fuzzers.values()),
-      min(len(cross_pollinate_fuzzers), CROSS_POLLINATE_FUZZER_COUNT))
+  return cross_pollinate_fuzzers
 
 
 def _save_coverage_information(context, result):


### PR DESCRIPTION
Previously we were query a job entity for every fuzz target. Now it only queries jobs for the selected targets+jobs. This has slight downside of getting an empty list when jobs don't have backup bucket, but in most cases, we do have one (also default bucket in project.yaml is used).
Also, use the default backup bucket from project.yaml when available, otherwise we wont pollinate for cases when a default one is used everywhere.