### PR TITLE
Fix chrome stack parsing regexes to not allow unsymbolized functions.

### DIFF
--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -81,9 +81,9 @@ CHROME_CHECK_FAILURE_REGEX = re.compile(
 CHROME_STACK_FRAME_REGEX = re.compile(
     r'[ ]*(#(?P<frame_id>[0-9]+)[ ]'  # frame id (2)
     r'([xX0-9a-fA-F]+)[ ])'  # addr (3)
-    r'(.+)')  # rest, usually fun (4); may have off
+    r'([^/\\]+)$')  # rest, usually fun (4); may have off
 CHROME_WIN_STACK_FRAME_REGEX = re.compile(
-    r'[ ]*(.+) '  # fun (1)
+    r'[ ]*([^/\\]+) '  # fun (1)
     r'\[([xX0-9a-fA-F]+)\+'  # fun_base (2)
     r'(\d+)\]'  # off[dec] (3)
     r'( \((.*):(\d+)\))?')  # if available, file (5) and line (6)
@@ -91,7 +91,7 @@ CHROME_MAC_STACK_FRAME_REGEX = re.compile(
     r'(?P<frame_id>\d+)\s+'  # frame id (1)
     r'(([\w ]+)|(\?\?\?))\s+'  # image (2)
     r'([xX0-9a-fA-F]+)\s+'  # addr[hex] (5)
-    r'(.*)\s*\+\s*'  # fun (6)
+    r'([^/\\]+)\s*\+\s*'  # fun (6)
     r'(\d+)')  # off[dec] (7)
 MSAN_TSAN_REGEX = re.compile(
     r'.*(ThreadSanitizer|MemorySanitizer):[ ]*([^(:]+)')

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/check_failure_chrome.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/check_failure_chrome.txt
@@ -5,6 +5,7 @@
 [24222:24246:0324/233643:ERROR:bad_message.cc(18)] Terminating renderer for bad IPC message, reason 77
 [24256:24256:0324/233644:FATAL:latency_info.cc(299)] Check failed: !terminated_.
 #0 0x7f48a3cf4141 __interceptor_backtrace
+#0 0x7f48a3cf4141 /usr/lib/x86_64-linux-gnu/libx.so
 #1 0x7f48a51f99e0 base::debug::StackTrace::StackTrace()
 #2 0x7f48a526964d logging::LogMessage::~LogMessage()
 #3 0x7f48b4856ef4 ui::LatencyInfo::AddLatencyNumberWithTimestampImpl()


### PR DESCRIPTION
These regexes were only supposed to parse symbolized frames.
Unsymbolized frames need to be ignored, so don't use if path
chars / or \ are found.