### PR TITLE
Remove PYTHONPATH when running gsutil.

### DIFF
--- a/src/python/bot/untrusted_runner/environment.py
+++ b/src/python/bot/untrusted_runner/environment.py
@@ -43,6 +43,7 @@ FORWARDED_ENVIRONMENT_VARIABLES = [
         r'^GSUTIL_PATH$',
         r'^JOB_NAME$',
         r'^MSAN_OPTIONS$',
+        r'^PATH$',
         r'^QUARANTINE_BUCKET$',
         r'^SHARED_CORPUS_BUCKET$',
         r'^STRATEGY_SELECTION_DISTRIBUTION$',
@@ -54,6 +55,7 @@ FORWARDED_ENVIRONMENT_VARIABLES = [
         r'^UBSAN_OPTIONS$',
         r'^UNPACK_ALL_FUZZ_TARGETS_AND_FILES$',
         r'^USE_MINIJAIL$',
+        r'^USER$',
     )
 ]
 

--- a/src/python/google_cloud_utils/gsutil.py
+++ b/src/python/google_cloud_utils/gsutil.py
@@ -96,7 +96,7 @@ class GSUtilRunner(object):
     self.gsutil_runner = _process_runner(
         _get_gsutil_path(), default_args=default_gsutil_args)
 
-  def run_gsutil(self, arguments, timeout=None, quiet=False):
+  def run_gsutil(self, arguments, quiet=False, **kwargs):
     """Run GSUtil."""
     if quiet:
       arguments = ['-q'] + arguments
@@ -107,7 +107,7 @@ class GSUtilRunner(object):
       # Python 2.
       env.pop('PYTHONPATH')
 
-    return self.gsutil_runner.run_and_wait(arguments, timeout=timeout, env=env)
+    return self.gsutil_runner.run_and_wait(arguments, env=env, **kwargs)
 
   def rsync(self,
             source,
@@ -143,7 +143,7 @@ class GSUtilRunner(object):
   def download_file(self, gcs_url, file_path, timeout=None):
     """Download a file from GCS."""
     command = ['cp', _filter_path(gcs_url), file_path]
-    result = self.gsutil_runner.run_and_wait(command, timeout=timeout)
+    result = self.run_gsutil(command, timeout=timeout)
     if result.return_code:
       logs.log_error('GSUtilRunner.download_file failed:\nCommand: %s\n'
                      'Url: %s\n'
@@ -171,7 +171,7 @@ class GSUtilRunner(object):
       command.append('-Z')
 
     command.extend([file_path, _filter_path(gcs_url, write=True)])
-    result = self.gsutil_runner.run_and_wait(command, timeout=timeout)
+    result = self.run_gsutil(command, timeout=timeout)
 
     # Check result of command execution, log output if command failed.
     if result.return_code:
@@ -199,7 +199,7 @@ class GSUtilRunner(object):
     sync_corpus_command = ['cp', '-I', _filter_path(gcs_url, write=True)]
     filenames_buffer = '\n'.join(file_paths)
 
-    result = self.gsutil_runner.run_and_wait(
+    result = self.run_gsutil(
         sync_corpus_command,
         input_data=filenames_buffer.encode('utf-8'),
         timeout=timeout)

--- a/src/python/google_cloud_utils/gsutil.py
+++ b/src/python/google_cloud_utils/gsutil.py
@@ -101,7 +101,13 @@ class GSUtilRunner(object):
     if quiet:
       arguments = ['-q'] + arguments
 
-    return self.gsutil_runner.run_and_wait(arguments, timeout=timeout)
+    env = os.environ.copy()
+    if 'PYTHONPATH' in env:
+      # GSUtil may be on Python 3, and our PYTHONPATH breaks it because we're on
+      # Python 2.
+      env.pop('PYTHONPATH')
+
+    return self.gsutil_runner.run_and_wait(arguments, timeout=timeout, env=env)
 
   def rsync(self,
             source,

--- a/src/python/tests/core/google_cloud_utils/gsutil_test.py
+++ b/src/python/tests/core/google_cloud_utils/gsutil_test.py
@@ -16,6 +16,7 @@
 import os
 
 from pyfakefs import fake_filesystem_unittest
+import mock
 
 from google_cloud_utils import gsutil
 from tests.test_libs import helpers as test_helpers
@@ -43,7 +44,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-q', 'rsync', '-r', '-d', 'gs://source_bucket/source_path',
             'gs://target_bucket/target_path'
         ],
-        timeout=18000)
+        timeout=18000,
+        env=mock.ANY)
 
   def test_rsync_local_gcs_1(self):
     """Test rsync."""
@@ -58,7 +60,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '/local/source_bucket/objects/source_path',
             '/local/target_bucket/objects/target_path'
         ],
-        timeout=18000)
+        timeout=18000,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))
 
   def test_rsync_remote_gcs_2(self):
@@ -72,7 +75,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-q', 'rsync', '-r', '-d', 'gs://source_bucket/source_path',
             'gs://target_bucket/target_path'
         ],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
 
   def test_rsync_local_gcs_2(self):
     """Test rsync."""
@@ -89,7 +93,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '/local/source_bucket/objects/source_path',
             '/local/target_bucket/objects/target_path'
         ],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))
 
   def test_rsync_remote_gcs_3(self):
@@ -103,7 +108,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-q', 'rsync', '-r', 'gs://source_bucket/source_path',
             'gs://target_bucket/target_path'
         ],
-        timeout=18000)
+        timeout=18000,
+        env=mock.ANY)
 
   def test_rsync_local_gcs_3(self):
     """Test rsync."""
@@ -119,7 +125,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-q', 'rsync', '-r', '/local/source_bucket/objects/source_path',
             '/local/target_bucket/objects/target_path'
         ],
-        timeout=18000)
+        timeout=18000,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))
 
   def test_rsync_remote_gcs_4(self):
@@ -134,7 +141,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-q', 'rsync', '-r', 'gs://source_bucket/source_path',
             'gs://target_bucket/target_path'
         ],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
 
   def test_rsync_local_gcs_4(self):
     """Test rsync."""
@@ -151,7 +159,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-q', 'rsync', '-r', '/local/source_bucket/objects/source_path',
             '/local/target_bucket/objects/target_path'
         ],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))
 
   def test_rsync_remote_gcs_5(self):
@@ -167,7 +176,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-q', 'rsync', '-r', '-x', '"*.txt$"',
             'gs://source_bucket/source_path', 'gs://target_bucket/target_path'
         ],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
 
   def test_rsync_local_gcs_5(self):
     """Test rsync."""
@@ -186,7 +196,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '/local/source_bucket/objects/source_path',
             '/local/target_bucket/objects/target_path'
         ],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))
 
   def test_download_file_remote_gcs_1(self):
@@ -196,7 +207,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
     self.mock.run_and_wait.assert_called_with(
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', 'gs://source_bucket/source_path', '/target_path'],
-        timeout=None)
+        timeout=None,
+        env=mock.ANY)
 
   def test_download_file_local_gcs_1(self):
     """Test download_file."""
@@ -206,7 +218,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
     self.mock.run_and_wait.assert_called_with(
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', '/local/source_bucket/objects/source_path', '/target_path'],
-        timeout=None)
+        timeout=None,
+        env=mock.ANY)
 
   def test_download_file_remote_gcs_2(self):
     """Test download_file."""
@@ -215,7 +228,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
     self.mock.run_and_wait.assert_called_with(
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', 'gs://source_bucket/source_path', '/target_path'],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
 
   def test_download_file_local_gcs_2(self):
     """Test download_file."""
@@ -225,7 +239,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
     self.mock.run_and_wait.assert_called_with(
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', '/local/source_bucket/objects/source_path', '/target_path'],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
 
   def test_upload_file_remote_gcs_1(self):
     """Test upload_file."""
@@ -234,7 +249,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
     self.mock.run_and_wait.assert_called_with(
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', '/source_path', 'gs://target_bucket/target_path'],
-        timeout=None)
+        timeout=None,
+        env=mock.ANY)
 
   def test_upload_file_local_gcs_1(self):
     """Test upload_file."""
@@ -245,7 +261,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
     self.mock.run_and_wait.assert_called_with(
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', '/source_path', '/local/target_bucket/objects/target_path'],
-        timeout=None)
+        timeout=None,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))
 
   def test_upload_file_remote_gcs_2(self):
@@ -261,7 +278,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-h', 'a:b', 'cp', '-Z', '/source_path',
             'gs://target_bucket/target_path'
         ],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
 
   def test_upload_file_local_gcs_2(self):
     """Test upload_file."""
@@ -278,7 +296,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
             '-h', 'a:b', 'cp', '-Z', '/source_path',
             '/local/target_bucket/objects/target_path'
         ],
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))
 
   def test_upload_files_to_url_remote_gcs_1(self):
@@ -289,7 +308,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', '-I', 'gs://target_bucket/target_path'],
         input_data='/source_path1\n/source_path2',
-        timeout=None)
+        timeout=None,
+        env=mock.ANY)
 
   def test_upload_files_local_gcs_1(self):
     """Test upload_files_to_url."""
@@ -301,7 +321,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', '-I', '/local/target_bucket/objects/target_path'],
         input_data='/source_path1\n/source_path2',
-        timeout=None)
+        timeout=None,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))
 
   def test_upload_files_remote_gcs_2(self):
@@ -314,7 +335,8 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', '-I', 'gs://target_bucket/target_path'],
         input_data='/source_path1\n/source_path2',
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
 
   def test_upload_files_to_url_local_gcs_2(self):
     """Test upload_files_to_url."""
@@ -328,5 +350,6 @@ class GSUtilRunnerTest(fake_filesystem_unittest.TestCase):
         self.gsutil_runner_obj.gsutil_runner,
         ['cp', '-I', '/local/target_bucket/objects/target_path'],
         input_data='/source_path1\n/source_path2',
-        timeout=1337)
+        timeout=1337,
+        env=mock.ANY)
     self.assertTrue(os.path.exists('/local/target_bucket/objects'))


### PR DESCRIPTION
gsutil may be on Python 3, which won't work with our Python 2
PYTHONPATH.