### PR TITLE
Speculative exception fix

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -153,7 +153,7 @@ def file_path_to_file_url(path):
     return ''
 
   path = path.lstrip(WINDOWS_PREFIX_PATH)
-  return urllib.parse.urljoin(u'file:', urllib.request.pathname2url(path))
+  return urllib.parse.urljoin('file:', urllib.request.pathname2url(path))
 
 
 def filter_file_list(file_list):


### PR DESCRIPTION
Should fix
```
TypeError: Cannot mix str and non-str arguments
at _coerce_args (c:\clusterfuzz\src\third_party\future\backports\urllib\parse.py:115)
at urljoin (c:\clusterfuzz\src\third_party\future\backports\urllib\parse.py:418)
at file_path_to_file_url (c:\clusterfuzz\src\python\base\utils.py:156)
at get_command_line_for_application (c:\clusterfuzz\src\python\bot\testcase_manager.py:896)
at execute_task (c:\clusterfuzz\src\python\bot\tasks\variant_task.py:98)
at run_command (c:\clusterfuzz\src\python\bot\tasks\commands.py:204)
at process_command (c:\clusterfuzz\src\python\bot\tasks\commands.py:378)
at wrapper (c:\clusterfuzz\src\python\bot\tasks\commands.py:150)
at task_loop (c:\clusterfuzz\src\python\bot\startup\run_bot.py:97)
```