### PR TITLE
Use newstr in file_path_to_file_url.

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -156,8 +156,8 @@ def file_path_to_file_url(path):
   # TODO(mbarbella): urljoin has several type checks for arguments. Ensure that
   # we're passing newstr on both sides while migrating to Python 3. After
   # migrating, ensure that callers pass strs to avoid this hack.
-  return urllib.parse.urljoin(str(u'file:'),
-                              str(urllib.request.pathname2url(path)))
+  return urllib.parse.urljoin(
+      str(u'file:'), str(urllib.request.pathname2url(path)))
 
 
 def filter_file_list(file_list):

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -153,10 +153,9 @@ def file_path_to_file_url(path):
     return ''
 
   path = path.lstrip(WINDOWS_PREFIX_PATH)
-  # TODO(mbarbella): urljoin has several explicit type checks. When migrating
-  # this to Python 3, ensure that the types match.
-  return urllib.parse.urljoin(u'file:',
-                              urllib.request.pathname2url(path).decode('utf-8'))
+  # TODO(mbarbella): This is brittle since it assumes |path| can be encoded.
+  # When migrating from Python 2 to 3, ensure that callers are using strs.
+  return urllib.parse.urljoin(u'file:', urllib.request.pathname2url(str(path)))
 
 
 def filter_file_list(file_list):

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -153,7 +153,10 @@ def file_path_to_file_url(path):
     return ''
 
   path = path.lstrip(WINDOWS_PREFIX_PATH)
-  return urllib.parse.urljoin(u'file:', urllib.request.pathname2url(path))
+  # TODO(mbarbella): urljoin has several explicit type checks. When migrating
+  # this to Python 3, ensure that the types match.
+  return urllib.parse.urljoin(u'file:',
+                              urllib.request.pathname2url(path).decode('utf-8'))
 
 
 def filter_file_list(file_list):

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -156,6 +156,7 @@ def file_path_to_file_url(path):
   # TODO(mbarbella): urljoin has several type checks for arguments. Ensure that
   # we're passing newstr on both sides while migrating to Python 3. After
   # migrating, ensure that callers pass strs to avoid this hack.
+  from builtins import str
   return urllib.parse.urljoin(
       str(u'file:'), str(urllib.request.pathname2url(path)))
 

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -153,9 +153,11 @@ def file_path_to_file_url(path):
     return ''
 
   path = path.lstrip(WINDOWS_PREFIX_PATH)
-  # TODO(mbarbella): This is brittle since it assumes |path| can be encoded.
-  # When migrating from Python 2 to 3, ensure that callers are using strs.
-  return urllib.parse.urljoin(u'file:', urllib.request.pathname2url(str(path)))
+  # TODO(mbarbella): urljoin has several type checks for arguments. Ensure that
+  # we're passing newstr on both sides while migrating to Python 3. After
+  # migrating, ensure that callers pass strs to avoid this hack.
+  return urllib.parse.urljoin(str(u'file:'),
+                              str(urllib.request.pathname2url(path)))
 
 
 def filter_file_list(file_list):


### PR DESCRIPTION
I didn't realize this file hadn't yet been migrated to Python 3-style strings. This feels a bit hackier than I'd like but it seems like a reasonable stopgap until we migrate the rest of src/python to newstr.