### PR TITLE
Add env variable to avoid system temp cleanup.

### DIFF
--- a/bot/env.yaml
+++ b/bot/env.yaml
@@ -109,6 +109,11 @@ REINSTALL_APP_BEFORE_EACH_TASK: false
 # necessary to reproduce most crashes.
 REQUIRED_APP_ARGS: ''
 
+# Flag to determine if system temp directory (e.g. /tmp on posix platforms)
+# should be cleared after every task run. This can be set to avoid interfering
+# with other processes on system using the system temp directory.
+SKIP_SYSTEM_TEMP_CLEANUP: false
+
 # Default testcase crash timeout.
 TEST_TIMEOUT: 10
 

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -169,6 +169,11 @@ def clear_system_temp_directory():
     except:
       pass
 
+  if environment.get_value('SKIP_SYSTEM_TEMP_CLEANUP'):
+    # This provides a way to avoid clearing system temporary directory when it
+    # can interfere with other processes on the system.
+    return
+
   # Cache system temp directory to avoid iterating through the system dir list
   # on every gettempdir call. Also, it helps to avoid a case where temp dir
   # fills up the disk and gets ignored by gettempdir.


### PR DESCRIPTION
When running fuzzing on host machine (e.g. Android with physical
devices), we can interfere with other processes maintaining state
in temp directory. Provide an environment variable to disable the
cleanup.