### PR TITLE
[fuchsia] Filter out example fuzzers.

### DIFF
--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -720,13 +720,6 @@ class RegularBuild(Build):
 
 class FuchsiaBuild(RegularBuild):
   """Represents a Fuchsia build."""
-  # If we properly subclass RegularBuild, checking revision numbers for
-  # different builds (and other nice things) should automagically "just work."
-  # This'll mean (1) downloading in the standard _build_dir instead of our
-  # artisinal FUCHSIA_RESOURCES_DIR, and (2) create new build buckets with
-  # the name format `gs://bucket/path/fuchsia-resources-([0-9]+).zip, and
-  # (3) do some refactoring on the RegularBuild logic so we can keep using our
-  # target selection logic.
 
   SYMBOLIZE_REL_PATH = os.path.join('build', 'zircon', 'prebuilt', 'downloads',
                                     'symbolize')
@@ -746,7 +739,7 @@ class FuchsiaBuild(RegularBuild):
         environment.get_value('JOB_NAME')).lower()
     return [
         str(target[0] + '/' + target[1])
-        for target in Fuzzer.filter(host.fuzzers, '', sanitizer)
+        for target in Fuzzer.filter(host.fuzzers, '', sanitizer, False)
     ]
 
   def setup(self):

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -739,7 +739,7 @@ class FuchsiaBuild(RegularBuild):
         environment.get_value('JOB_NAME')).lower()
     return [
         str(target[0] + '/' + target[1])
-        for target in Fuzzer.filter(host.fuzzers, '', sanitizer, False)
+        for target in Fuzzer.filter(host.fuzzers, '', sanitizer, example_fuzzers=False)
     ]
 
   def setup(self):

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -75,7 +75,7 @@ class Fuzzer(object):
     production). """
     # We want to remove the noop-fuzzer regardless of the extension.
     tgt = os.path.splitext(tgt)[0]
-    return (pkg == 'example_fuzzers' or tgt == 'noop-fuzzer')
+    return pkg == 'example_fuzzers' or tgt == 'noop-fuzzer'
 
   @classmethod
   def filter(cls, fuzzers, name, sanitizer=None, example_fuzzers=True):

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -69,7 +69,16 @@ class Fuzzer(object):
     return False
 
   @classmethod
-  def filter(cls, fuzzers, name, sanitizer=None):
+  def _is_example(cls, pkg, tgt):
+    """ Returns whether or not a given pkg/tgt pair is an example fuzzer.
+    (Helper function to prevent us from wasting cycles on example fuzzers in
+    production). """
+    # We want to remove the noop-fuzzer regardless of the extension.
+    tgt = os.path.splitext(tgt)[0]
+    return (pkg == 'example_fuzzers' or tgt == 'noop-fuzzer')
+
+  @classmethod
+  def filter(cls, fuzzers, name, sanitizer=None, example_fuzzers=True):
     """Filters a list of fuzzer names.
 
       Takes a list of fuzzer names in the form `pkg`/`tgt` and a name to filter
@@ -103,6 +112,9 @@ class Fuzzer(object):
           continue
       if sanitizer:
         if not Fuzzer._matches_sanitizer(tgt, sanitizer):
+          continue
+      if not example_fuzzers:
+        if Fuzzer._is_example(pkg, tgt):
           continue
       # Remove the sanitizer extension name.
       # Clusterfuzz only needs to know foo/bar, not foo/bar.asan.


### PR DESCRIPTION
Fuchsia has a set of example fuzzers that are useful for testing, but
which we only want selected if it's explicitly set via FUZZ_TARGET.

Otherwise, we only want "real" fuzzers to be picked during standard runs
(e.g. on Clusterfuzz bots).