### PR TITLE
Replace App Engine memcache with Cloud Memorystore Redis.

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -260,10 +260,10 @@ def main():
       default='us-central1-f',
       help='Region for GCE VMs.')
   parser_create_config.add_argument(
-      '--appengine-region',
+      '--appengine-location',
       type=str,
       default='us-central',
-      help='Region for App Engine.json.')
+      help='Location for App Engine.')
 
   subparsers.add_parser(
       'integration_tests', help='Run end-to-end integration tests.')

--- a/configs/test/gae/prod/app.yaml
+++ b/configs/test/gae/prod/app.yaml
@@ -58,4 +58,4 @@ includes:
   - skip_files.yaml
 
 vpc_access_connector:
-  name: "projects/test-project/locations/us-central1/connectors/connector"
+  name: "projects/test-project/locations/gae-region/connectors/connector"

--- a/configs/test/gae/prod/app.yaml
+++ b/configs/test/gae/prod/app.yaml
@@ -56,3 +56,6 @@ basic_scaling:
 
 includes:
   - skip_files.yaml
+
+vpc_access_connector:
+  name: "projects/test-project/locations/us-central1/connectors/connector"

--- a/configs/test/gae/prod/cron-service.yaml
+++ b/configs/test/gae/prod/cron-service.yaml
@@ -50,4 +50,4 @@ includes:
   - skip_files.yaml
 
 vpc_access_connector:
-  name: "projects/test-project/locations/us-central1/connectors/connector"
+  name: "projects/test-project/locations/gae-region/connectors/connector"

--- a/configs/test/gae/prod/cron-service.yaml
+++ b/configs/test/gae/prod/cron-service.yaml
@@ -48,3 +48,6 @@ basic_scaling:
 
 includes:
   - skip_files.yaml
+
+vpc_access_connector:
+  name: "projects/test-project/locations/us-central1/connectors/connector"

--- a/configs/test/gae/staging/staging.yaml
+++ b/configs/test/gae/staging/staging.yaml
@@ -58,4 +58,4 @@ includes:
   - skip_files.yaml
 
 vpc_access_connector:
-  name: "projects/test-project/locations/us-central1/connectors/connector"
+  name: "projects/test-project/locations/gae-region/connectors/connector"

--- a/configs/test/gae/staging/staging.yaml
+++ b/configs/test/gae/staging/staging.yaml
@@ -56,3 +56,6 @@ basic_scaling:
 
 includes:
   - skip_files.yaml
+
+vpc_access_connector:
+  name: "projects/test-project/locations/us-central1/connectors/connector"

--- a/configs/test/redis/instance.yaml
+++ b/configs/test/redis/instance.yaml
@@ -1,0 +1,23 @@
+# Copyright 2019 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: memorystore-instance.jinja
+
+resources:
+- name: redis
+  type: memorystore-instance.jinja
+  properties:
+    region: us-central1
+    memorySizeGb: 1

--- a/configs/test/redis/instance.yaml
+++ b/configs/test/redis/instance.yaml
@@ -19,5 +19,5 @@ resources:
 - name: redis
   type: memorystore-instance.jinja
   properties:
-    region: us-central1
+    region: gae-region
     memorySizeGb: 1

--- a/configs/test/redis/memorystore-instance.jinja
+++ b/configs/test/redis/memorystore-instance.jinja
@@ -1,0 +1,26 @@
+# Copyright 2019 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- name: {{ env["deployment"] }}-instance
+  type: gcp-types/redis-v1:projects.locations.instances
+  properties:
+    parent: projects/{{ env["project"] }}/locations/{{ properties["region"] }}
+    instanceId: {{ env["deployment"] }}-instance
+    authorizedNetwork: projects/{{ env["project"] }}/global/networks/default
+    memorySizeGb: {{ properties["memorySizeGb"] }}
+    tier: BASIC
+    {% if properties["displayName"] %}
+    displayName: {{ properties["displayName"] }}
+    {% endif %}

--- a/src/appengine/handlers/fuzzer_stats.py
+++ b/src/appengine/handlers/fuzzer_stats.py
@@ -314,14 +314,14 @@ def build_results(fuzzer, jobs, group_by, date_start, date_end):
   return _build_todays_results(fuzzer, jobs, group_by, date_start, date_end)
 
 
-@memoize.wrap(memoize.MemcacheLarge(MEMCACHE_TODAY_TTL_IN_SECONDS))
+@memoize.wrap(memoize.Memcache(MEMCACHE_TODAY_TTL_IN_SECONDS))
 def _build_todays_results(fuzzer, jobs, group_by, date_start, date_end):
   """Wrapper around _build_results that is intended for use by queries where
   date_end is today. Caches results for 15 minutes."""
   return _build_results(fuzzer, jobs, group_by, date_start, date_end)
 
 
-@memoize.wrap(memoize.MemcacheLarge(MEMCACHE_OLD_TTL_IN_SECONDS))
+@memoize.wrap(memoize.Memcache(MEMCACHE_OLD_TTL_IN_SECONDS))
 def _build_old_results(fuzzer, jobs, group_by, date_start, date_end):
   """Wrapper around _build_results that is intended for use by queries where
   date_end is before today. Caches results for 24 hours."""

--- a/src/local/butler/appengine.py
+++ b/src/local/butler/appengine.py
@@ -157,3 +157,20 @@ def symlink_config_dir():
   config_dir = os.getenv('CONFIG_DIR_OVERRIDE', constants.TEST_CONFIG_DIR)
   common.symlink(src=config_dir, target=os.path.join(SRC_DIR_PY, 'config'))
   common.symlink(src=config_dir, target=os.path.join(SRC_DIR_GO, 'config'))
+
+
+def region_from_location(location):
+  """Convert an app engine location ID to a region."""
+  if not location[-1].isdigit():
+    # e.g. us-central -> us-central1
+    location += '1'
+
+  return location
+
+
+def region(project):
+  """Get the App Engine region."""
+  _, location = common.execute(
+      'gcloud app describe --project={project} '
+      '--format="value(locationId)"'.format(project=project))
+  return region_from_location(location.strip())

--- a/src/local/butler/appengine.py
+++ b/src/local/butler/appengine.py
@@ -170,7 +170,10 @@ def region_from_location(location):
 
 def region(project):
   """Get the App Engine region."""
-  _, location = common.execute(
+  return_code, location = common.execute(
       'gcloud app describe --project={project} '
       '--format="value(locationId)"'.format(project=project))
+  if return_code:
+    raise RuntimeError('Could not get App Engine region')
+
   return region_from_location(location.strip())

--- a/src/local/butler/appengine.py
+++ b/src/local/butler/appengine.py
@@ -38,13 +38,16 @@ def _get_target_directory(yaml_path):
   return SRC_DIR_GO if _is_go_yaml(yaml_path) else SRC_DIR_PY
 
 
-def _add_env_vars_if_needed(yaml_path):
+def _add_env_vars_if_needed(yaml_path, additional_env_vars):
   """Add environment variables to yaml file if necessary."""
   # Defer imports since our python paths have to be set up first.
   import yaml
   from src.python.config import local_config
 
   env_values = local_config.ProjectConfig().get('env')
+  if additional_env_vars:
+    env_values.update(additional_env_vars)
+
   if not env_values:
     return
 
@@ -65,7 +68,7 @@ def _add_env_vars_if_needed(yaml_path):
     yaml.safe_dump(data, f)
 
 
-def copy_yamls_and_preprocess(paths):
+def copy_yamls_and_preprocess(paths, additional_env_vars=None):
   """Copy paths to appengine source directories since they reference sources
   and otherwise, deployment fails."""
   rebased_paths = []
@@ -80,7 +83,7 @@ def copy_yamls_and_preprocess(paths):
     shutil.copy(path, rebased_path)
     os.chmod(rebased_path, 0o600)
 
-    _add_env_vars_if_needed(rebased_path)
+    _add_env_vars_if_needed(rebased_path, additional_env_vars)
     rebased_paths.append(rebased_path)
 
   return rebased_paths

--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -277,7 +277,7 @@ def execute(args):
                     domain_verification_tag, bucket_replacements,
                     args.appengine_location, args.gce_zone,
                     args.firebase_api_key)
-  nrev_dir = os.getcwd()
+  prev_dir = os.getcwd()
   os.chdir(args.new_config_dir)
 
   # Deploy App Engine and finish verification of domain.

--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -58,6 +58,7 @@ _REQUIRED_SERVICES = (
     'stackdriver.googleapis.com',
     'storage-api.googleapis.com',
     'storage-component.googleapis.com',
+    'vpcaccess.googleapis.com',
 )
 
 _NUM_RETRIES = 2

--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -28,6 +28,7 @@ from googleapiclient import discovery
 import google_auth_httplib2
 import httplib2
 
+from local.butler import appengine
 from local.butler import common
 
 _REQUIRED_SERVICES = (
@@ -162,19 +163,21 @@ def project_bucket(project_id, bucket_name):
 
 
 def create_new_config(gcloud, project_id, new_config_dir,
-                      domain_verification_tag, bucket_replacements, gce_zone,
-                      firebase_api_key):
+                      domain_verification_tag, bucket_replacements,
+                      gae_location, gce_zone, firebase_api_key):
   """Create a new config directory."""
   if os.path.exists(new_config_dir):
     print('Overwriting existing directory.')
     shutil.rmtree(new_config_dir)
 
+  gae_region = appengine.region_from_location(gae_location)
   replacements = [
       ('test-clusterfuzz-service-account-email',
        compute_engine_service_account(gcloud, project_id)),
       ('test-clusterfuzz', project_id),
       ('test-project', project_id),
       ('domain-verification-tag', domain_verification_tag),
+      ('gae-region', gae_region),
       ('gce-zone', gce_zone),
       ('firebase-api-key', firebase_api_key),
   ]
@@ -187,13 +190,13 @@ def create_new_config(gcloud, project_id, new_config_dir,
       replace_file_contents(file_path, replacements)
 
 
-def deploy_appengine(gcloud, config_dir, appengine_region):
+def deploy_appengine(gcloud, config_dir, appengine_location):
   """Deploy to App Engine."""
   try:
     gcloud.run('app', 'describe')
   except common.GcloudError:
     # Create new App Engine app if it does not exist.
-    gcloud.run('app', 'create', '--region=' + appengine_region)
+    gcloud.run('app', 'create', '--region=' + appengine_location)
 
   subprocess.check_call([
       'python', 'butler.py', 'deploy', '--force', '--targets', 'appengine',
@@ -271,15 +274,16 @@ def execute(args):
 
   # Write new configs.
   create_new_config(gcloud, args.project_id, args.new_config_dir,
-                    domain_verification_tag, bucket_replacements, args.gce_zone,
+                    domain_verification_tag, bucket_replacements,
+                    args.appengine_location, args.gce_zone,
                     args.firebase_api_key)
-  prev_dir = os.getcwd()
+  nrev_dir = os.getcwd()
   os.chdir(args.new_config_dir)
 
   # Deploy App Engine and finish verification of domain.
   os.chdir(prev_dir)
   deploy_appengine(
-      gcloud, args.new_config_dir, appengine_region=args.appengine_region)
+      gcloud, args.new_config_dir, appengine_location=args.appengine_location)
   verifier.verify(appspot_domain)
 
   # App Engine service account requires:

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -67,9 +67,11 @@ def _get_services(paths):
 
 def _get_redis_ip(project):
   """Get the redis IP address."""
+  region = appengine.region(project)
   _, ip = common.execute('gcloud redis instances describe redis-instance '
-                         '--project={project} --region=us-central1 '
-                         '--format="value(host)"'.format(project=project))
+                         '--project={project} --region={region} '
+                         '--format="value(host)"'.format(
+                             project=project, region=region))
   return ip.strip()
 
 

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -65,6 +65,21 @@ def _get_services(paths):
   return services
 
 
+def _get_redis_ip(project):
+  """Get the redis IP address."""
+  _, ip = common.execute('gcloud redis instances describe redis-instance '
+                         '--project={project} --region=us-central1 '
+                         '--format="value(host)"'.format(project=project))
+  return ip.strip()
+
+
+def _additional_app_env_vars(project):
+  """Additional environment variables to include for App Engine."""
+  return {
+      'REDIS_HOST': _get_redis_ip(project),
+  }
+
+
 def _deploy_app_prod(project,
                      deployment_bucket,
                      yaml_paths,
@@ -73,7 +88,8 @@ def _deploy_app_prod(project,
   """Deploy app in production."""
   if deploy_appengine:
     services = _get_services(yaml_paths)
-    rebased_yaml_paths = appengine.copy_yamls_and_preprocess(yaml_paths)
+    rebased_yaml_paths = appengine.copy_yamls_and_preprocess(
+        yaml_paths, _additional_app_env_vars(project))
 
     _deploy_appengine(
         project, [INDEX_YAML_PATH] + rebased_yaml_paths,
@@ -94,7 +110,9 @@ def _deploy_app_prod(project,
 def _deploy_app_staging(project, yaml_paths):
   """Deploy app in staging."""
   services = _get_services(yaml_paths)
-  rebased_yaml_paths = appengine.copy_yamls_and_preprocess(yaml_paths)
+
+  rebased_yaml_paths = appengine.copy_yamls_and_preprocess(
+      yaml_paths, _additional_app_env_vars(project))
   _deploy_appengine(project, rebased_yaml_paths, stop_previous_version=True)
   for path in rebased_yaml_paths:
     os.remove(path)
@@ -236,6 +254,24 @@ def _update_bigquery(project):
                              os.path.join('bigquery', 'datasets.yaml'))
 
 
+def _update_redis(project):
+  """Update redis instance."""
+  _update_deployment_manager(project, 'redis',
+                             os.path.join('redis', 'instance.yaml'))
+
+  return_code, _ = common.execute(
+      'gcloud compute networks vpc-access connectors describe '
+      'connector --region=us-central1 '
+      '--project={project}'.format(project=project),
+      exit_on_error=False)
+
+  if return_code != 0:
+    common.execute('gcloud compute networks vpc-access connectors create '
+                   'connector --network=default --region=us-central1 '
+                   '--range=10.8.0.0/28 '
+                   '--project={project}'.format(project=project))
+
+
 def get_remote_sha():
   """Get remote sha of origin/master."""
   _, remote_sha_line = common.execute('git ls-remote origin refs/heads/master')
@@ -287,6 +323,7 @@ def _prod_deployment_helper(config_dir,
     _update_pubsub_queues(project)
     _update_alerts(project)
     _update_bigquery(project)
+    _update_redis(project)
 
   _deploy_app_prod(
       project,

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -259,17 +259,18 @@ def _update_redis(project):
   _update_deployment_manager(project, 'redis',
                              os.path.join('redis', 'instance.yaml'))
 
+  region = appengine.region(project)
   return_code, _ = common.execute(
       'gcloud compute networks vpc-access connectors describe '
-      'connector --region=us-central1 '
-      '--project={project}'.format(project=project),
+      'connector --region={region} '
+      '--project={project}'.format(project=project, region=region),
       exit_on_error=False)
 
   if return_code != 0:
     common.execute('gcloud compute networks vpc-access connectors create '
-                   'connector --network=default --region=us-central1 '
+                   'connector --network=default --region={region} '
                    '--range=10.8.0.0/28 '
-                   '--project={project}'.format(project=project))
+                   '--project={project}'.format(project=project, region=region))
 
 
 def get_remote_sha():

--- a/src/python/base/memoize.py
+++ b/src/python/base/memoize.py
@@ -26,6 +26,7 @@ import six
 from base import persistent_cache
 from system.environment import appengine_noop
 from system.environment import bot_noop
+from system.environment import local_noop
 
 # Thead local globals.
 _local = threading.local()
@@ -128,12 +129,14 @@ class Memcache(object):
     self.ttl_in_seconds = ttl_in_seconds
     self.key_fn = key_fn or _default_key
 
+  @local_noop
   @bot_noop
   def put(self, key, value):
     """Put (key, value) into cache."""
     _redis_client().set(
         json.dumps(key), json.dumps(value), ex=self.ttl_in_seconds)
 
+  @local_noop
   @bot_noop
   def get(self, key):
     """Get the value from cache."""

--- a/src/python/tests/core/base/memoize_test.py
+++ b/src/python/tests/core/base/memoize_test.py
@@ -217,7 +217,7 @@ class _MockRedis(object):
 
 
 class MemcacheTest(unittest.TestCase):
-  """Test Memcache.iii"""
+  """Test Memcache."""
 
   def setUp(self):
     test_helpers.patch(self, [

--- a/src/python/tests/core/local/butler/deploy_test.py
+++ b/src/python/tests/core/local/butler/deploy_test.py
@@ -91,6 +91,9 @@ class DeployTest(fake_filesystem_unittest.TestCase):
     if 'app describe' in command:
       return (0, 'us-central')
 
+    if 'describe redis-instance' in command:
+      return (0, 'redis-ip')
+
     if 'describe' in command:
       return (1, '')
 

--- a/src/python/tests/core/local/butler/deploy_test.py
+++ b/src/python/tests/core/local/butler/deploy_test.py
@@ -88,6 +88,9 @@ class DeployTest(fake_filesystem_unittest.TestCase):
       self.deploy_failure_count -= 1
       return (1, 'failure')
 
+    if 'app describe' in command:
+      return (0, 'us-central')
+
     if 'describe' in command:
       return (1, '')
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -16,6 +16,7 @@ oauth2client==4.1.3
 protobuf==3.6.1
 pytz==2018.5
 PyYAML==5.1
+redis==3.3.11
 requests==2.21.0
 requests-toolbelt==0.9.1
 selenium==3.141.0


### PR DESCRIPTION
Apart from NDB, this is the last dependency on the deprecated App Engine
SDK.

The default size (1GB) was picked based on our existing deployments, the
max of which is around 100~MB.

Also:
- Remove MemcacheLarge. It is no longer required as redis does not have
  such restrictive length restrictions on value size.
- Modify deployment to create the redis instance if needed, as well as
  the VPC connector.

This is currently only planned to be used on our App Engine instances,
and not bots.