### PR TITLE
Don't set FUZZ_TARGET_COUNT when FUZZ_TARGET is already set.

### DIFF
--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -264,9 +264,6 @@ def _get_build_directory(bucket_path, job_name):
 
 def _set_random_fuzz_target_for_fuzzing_if_needed(fuzz_targets, target_weights):
   """Sets a random fuzz target for fuzzing."""
-  fuzz_targets = list(fuzz_targets)
-  environment.set_value('FUZZ_TARGET_COUNT', len(fuzz_targets))
-
   fuzz_target = environment.get_value('FUZZ_TARGET')
   if fuzz_target:
     logs.log('Use previously picked fuzz target %s for fuzzing.' % fuzz_target)
@@ -278,6 +275,9 @@ def _set_random_fuzz_target_for_fuzzing_if_needed(fuzz_targets, target_weights):
   if not fuzz_targets:
     logs.log_error('No fuzz targets found. Unable to pick random one.')
     return None
+
+  fuzz_targets = list(fuzz_targets)
+  environment.set_value('FUZZ_TARGET_COUNT', len(fuzz_targets))
 
   fuzz_target = fuzzer_selection.select_fuzz_target(fuzz_targets,
                                                     target_weights)

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -738,8 +738,8 @@ class FuchsiaBuild(RegularBuild):
     sanitizer = environment.get_memory_tool_name(
         environment.get_value('JOB_NAME')).lower()
     return [
-        str(target[0] + '/' + target[1])
-        for target in Fuzzer.filter(host.fuzzers, '', sanitizer, example_fuzzers=False)
+        str(target[0] + '/' + target[1]) for target in Fuzzer.filter(
+            host.fuzzers, '', sanitizer, example_fuzzers=False)
     ]
 
   def setup(self):

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -272,11 +272,11 @@ def _set_random_fuzz_target_for_fuzzing_if_needed(fuzz_targets, target_weights):
   if not environment.is_engine_fuzzer_job():
     return None
 
+  fuzz_targets = list(fuzz_targets)
   if not fuzz_targets:
     logs.log_error('No fuzz targets found. Unable to pick random one.')
     return None
 
-  fuzz_targets = list(fuzz_targets)
   environment.set_value('FUZZ_TARGET_COUNT', len(fuzz_targets))
 
   fuzz_target = fuzzer_selection.select_fuzz_target(fuzz_targets,

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -1848,6 +1848,7 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
         '/revisions',
         file_match_callback=None,
         trusted=True)
+    self.assertEqual(3, environment.get_value('FUZZ_TARGET_COUNT'))
 
   def test_setup_nonfuzz(self):
     """Tests setting up a build during a non-fuzz task."""
@@ -1873,6 +1874,7 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
         '/revisions',
         file_match_callback=None,
         trusted=True)
+    self.assertIsNone(environment.get_value('FUZZ_TARGET_COUNT'))
 
   def test_delete(self):
     """Test deleting this build."""


### PR DESCRIPTION
In the case of split target builds,
_set_random_fuzz_target_for_fuzzing_if_needed may be called twice: first
to actually pick the target, and again when we defer to the regular
build setup, which will incorrectly set the count as there is now only
1.