### PR TITLE
Increase unused fuzz target removal threshold.

### DIFF
--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -42,7 +42,6 @@ from metrics import logs
 
 GENERIC_INCORRECT_COMMENT = (
     '\n\nIf this is incorrect, please add the {label_text}')
-
 OSS_FUZZ_INCORRECT_COMMENT = ('\n\nIf this is incorrect, please file a bug on '
                               'https://github.com/google/oss-fuzz/issues/new')
 
@@ -55,12 +54,7 @@ TOP_CRASHES_IGNORE_CRASH_TYPES = [
 ]
 TOP_CRASHES_IGNORE_CRASH_STATES = ['NULL']
 
-# FIXME: Remove from this list once these crashes are fixed.
-TOP_CRASHES_IGNORE_CRASH_STATE_KEYWORDS = [
-    'Zygote', '__printf_chk', 'gtk_', 'sandbox::'
-]
-
-FUZZ_TARGET_UNUSED_THRESHOLD = 7
+FUZZ_TARGET_UNUSED_THRESHOLD = 15
 UNUSED_HEARTBEAT_THRESHOLD = 15
 
 
@@ -272,9 +266,6 @@ def get_top_crashes_for_all_projects_and_platforms():
           (json.dumps(TOP_CRASHES_IGNORE_CRASH_TYPES),
            json.dumps(TOP_CRASHES_IGNORE_CRASH_STATES), json.dumps(list(jobs)),
            json.dumps(platform.lower() + '%'), json.dumps(project_name)))
-
-      for keyword in TOP_CRASHES_IGNORE_CRASH_STATE_KEYWORDS:
-        where_clause += ' AND crash_state NOT LIKE "%%%s%%"' % keyword
 
       _, rows = crash_stats.get(
           end=last_hour,

--- a/src/python/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/python/tests/appengine/handlers/cron/cleanup_test.py
@@ -1036,11 +1036,7 @@ class GetTopCrashesForAllProjectsAndPlatforms(unittest.TestCase):
             'crash_state NOT IN UNNEST(["NULL"]) AND '
             'job_type IN UNNEST(["job"]) AND '
             'platform LIKE "linux%" AND '
-            'project = "project" AND '
-            'crash_state NOT LIKE "%Zygote%" AND '
-            'crash_state NOT LIKE "%__printf_chk%" AND '
-            'crash_state NOT LIKE "%gtk_%" AND '
-            'crash_state NOT LIKE "%sandbox::%"'),
+            'project = "project"'),
         group_having_clause='',
         sort_by='total_count',
         offset=0,
@@ -1996,7 +1992,7 @@ class CleanupUnusedFuzzTargetsTest(unittest.TestCase):
     data_types.FuzzTargetJob(
         fuzz_target_name='libFuzzer_binary1',
         job='job1',
-        last_run=datetime.datetime(2018, 1, 23)).put()
+        last_run=datetime.datetime(2018, 1, 15)).put()
 
     # FuzzTarget should be removed. No FuzzTargetJobs.
     data_types.FuzzTarget(
@@ -2009,11 +2005,11 @@ class CleanupUnusedFuzzTargetsTest(unittest.TestCase):
     data_types.FuzzTargetJob(
         fuzz_target_name='libFuzzer_binary3',
         job='job1',
-        last_run=datetime.datetime(2018, 1, 25)).put()
+        last_run=datetime.datetime(2018, 1, 20)).put()
     data_types.FuzzTargetJob(
         fuzz_target_name='libFuzzer_binary3',
         job='job2',
-        last_run=datetime.datetime(2018, 1, 23)).put()
+        last_run=datetime.datetime(2018, 1, 15)).put()
 
     # FuzzTarget should not be removed. All FuzzTargetJob valid.
     data_types.FuzzTarget(
@@ -2021,11 +2017,11 @@ class CleanupUnusedFuzzTargetsTest(unittest.TestCase):
     data_types.FuzzTargetJob(
         fuzz_target_name='libFuzzer_binary4',
         job='job1',
-        last_run=datetime.datetime(2018, 1, 25)).put()
+        last_run=datetime.datetime(2018, 1, 20)).put()
     data_types.FuzzTargetJob(
         fuzz_target_name='libFuzzer_binary4',
         job='job2',
-        last_run=datetime.datetime(2018, 1, 25)).put()
+        last_run=datetime.datetime(2018, 1, 20)).put()
 
     cleanup.cleanup_unused_fuzz_targets_and_jobs()
 


### PR DESCRIPTION
If bots are down for a week, we don't want existing testcases to
be closed. Increase the time period for now.
Also, remove a chromium top crasher hack.