### PR TITLE
Add crash signature for libFuzzer overwrites-const-input.

### DIFF
--- a/src/appengine/handlers/cron/cleanup.py
+++ b/src/appengine/handlers/cron/cleanup.py
@@ -50,7 +50,9 @@ TOP_CRASHES_LIMIT = 5
 TOP_CRASHES_DAYS_LOOKBEHIND = 7
 TOP_CRASHES_MIN_THRESHOLD = 50 * TOP_CRASHES_DAYS_LOOKBEHIND
 TOP_CRASHES_IGNORE_CRASH_TYPES = [
-    'Hang', 'Out-of-memory', 'Stack-overflow', 'Timeout'
+    'Out-of-memory',
+    'Stack-overflow',
+    'Timeout',
 ]
 TOP_CRASHES_IGNORE_CRASH_STATES = ['NULL']
 

--- a/src/appengine/handlers/cron/triage.py
+++ b/src/appengine/handlers/cron/triage.py
@@ -35,7 +35,7 @@ from metrics import crash_stats
 from metrics import logs
 
 UNREPRODUCIBLE_CRASH_IGNORE_CRASH_TYPES = [
-    'Hang', 'Out-of-memory', 'Stack-overflow', 'Timeout'
+    'Out-of-memory', 'Stack-overflow', 'Timeout'
 ]
 TRIAGE_MESSAGE_KEY = 'triage_message'
 

--- a/src/python/crash_analysis/crash_analyzer.py
+++ b/src/python/crash_analysis/crash_analyzer.py
@@ -284,6 +284,9 @@ def is_security_issue(crash_stacktrace, crash_type, crash_address):
   if crash_type == 'Missing-library':
     return False
 
+  if crash_type == 'Overwrites-const-input':
+    return False
+
   # LeakSanitizer, finds memory leaks.
   if '-leak' in crash_type:
     return False

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -44,9 +44,9 @@ CRASH_STACKTRACE_END_MARKER = 'CRASH OUTPUT ENDS HERE'
 
 # Skips using crash state similarity for these types.
 CRASH_TYPES_WITH_UNIQUE_STATE = [
-    'Hang',
     'Missing-library',
     'Out-of-memory',
+    'Overwrites-const-input',
     'Timeout',
     # V8 correctness failures use metadata from the fuzz test cases as crash
     # state. This is not suitable for using levenshtein distance for

--- a/src/python/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/python/tests/appengine/handlers/cron/cleanup_test.py
@@ -1030,13 +1030,12 @@ class GetTopCrashesForAllProjectsAndPlatforms(unittest.TestCase):
         block='day',
         days=7,
         group_by='platform',
-        where_clause=(
-            'crash_type NOT IN UNNEST('
-            '["Hang", "Out-of-memory", "Stack-overflow", "Timeout"]) AND '
-            'crash_state NOT IN UNNEST(["NULL"]) AND '
-            'job_type IN UNNEST(["job"]) AND '
-            'platform LIKE "linux%" AND '
-            'project = "project"'),
+        where_clause=('crash_type NOT IN UNNEST('
+                      '["Out-of-memory", "Stack-overflow", "Timeout"]) AND '
+                      'crash_state NOT IN UNNEST(["NULL"]) AND '
+                      'job_type IN UNNEST(["job"]) AND '
+                      'platform LIKE "linux%" AND '
+                      'project = "project"'),
         group_having_clause='',
         sort_by='total_count',
         offset=0,

--- a/src/python/tests/appengine/handlers/cron/triage_test.py
+++ b/src/python/tests/appengine/handlers/cron/triage_test.py
@@ -174,7 +174,7 @@ class CrashImportantTest(unittest.TestCase):
     testcase.one_time_crasher_flag = True
     testcase.put()
 
-    for crash_type in ['Hang', 'Out-of-memory', 'Stack-overflow', 'Timeout']:
+    for crash_type in ['Out-of-memory', 'Stack-overflow', 'Timeout']:
       testcase.crash_type = crash_type
       self.assertFalse(triage._is_crash_important(testcase))
 

--- a/src/python/tests/appengine/handlers/testcase_detail/show_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/show_test.py
@@ -157,10 +157,6 @@ class ConvertToLinesTest(unittest.TestCase):
     """Test convert timeout."""
     self._test_special_type('Timeout something')
 
-  def test_convert_hang(self):
-    """Test convert hang."""
-    self._test_special_type('Hang something')
-
   def test_convert_v8_correctness(self):
     """Test convert V8 correctness failure."""
     self._test_special_type('V8 correctness failure something')

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_overwrites_const_input.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/libfuzzer_overwrites_const_input.txt
@@ -1,0 +1,11 @@
+==1== ERROR: libFuzzer: fuzz target overwrites its const input
+    #0 0x52a761 in __sanitizer_print_stack_trace /src/llvm/projects/compiler-rt/lib/asan/asan_stack.cpp:86:3
+    #1 0x4746f8 in fuzzer::PrintStackTrace() /src/llvm/projects/compiler-rt/lib/fuzzer/FuzzerUtil.cpp:205:5
+    #2 0x45b483 in fuzzer::Fuzzer::CrashOnOverwrittenData() /src/llvm/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:518:3
+    #3 0x45a49c in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:564:5
+    #4 0x444f91 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:292:6
+    #5 0x44ac4e in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:774:9
+    #6 0x474dc2 in main /src/llvm/projects/compiler-rt/lib/fuzzer/FuzzerMain.cpp:19:10
+    #7 0x7ff9d5db082f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/libc-start.c:291
+    #8 0x41e348 in _start
+SUMMARY: libFuzzer: overwrites-const-input

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2753,3 +2753,17 @@ class StackAnalyzerTestcase(unittest.TestCase):
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
+
+  def test_libfuzzer_overwrites_const_input(self):
+    """Test for libFuzzer when target tries to overwrite const input."""
+    os.environ['FUZZ_TARGET'] = 'ap-mgmt'
+    data = self._read_test_data('libfuzzer_overwrites_const_input.txt')
+    expected_type = 'Overwrites-const-input'
+    expected_address = ''
+    expected_state = 'ap-mgmt\n'
+
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)


### PR DESCRIPTION
Also, remove an obsolete hang crash type. This was used in Chromium
long time back and is no longer present on open testcases.