### PR TITLE
Remove uneeded LD_LIBRARY_PATH for Android engine_test.

### DIFF
--- a/docs/production-setup/clusterfuzz.md
+++ b/docs/production-setup/clusterfuzz.md
@@ -157,4 +157,4 @@ We provide [Docker images] for running ClusterFuzz bots.
 [Google Compute Engine]: https://cloud.google.com/compute/
 [service account]: https://cloud.google.com/iam/docs/creating-managing-service-account-keys
 [Docker images]: https://github.com/google/clusterfuzz/tree/master/docker
-[preemptible]: {{ site.baseurl }}/architecture/#bots
+[preemptible]: {{ site.baseurl }}/architecture/#fuzzing-bots

--- a/docs/production-setup/setting_up_bots.md
+++ b/docs/production-setup/setting_up_bots.md
@@ -217,7 +217,7 @@ the *Bots* page.
 [deploy]: #deploying-new-changes
 [fuzzing engine]: {{ site.baseurl }}/reference/glossary/#fuzzing-engine
 [job]: {{ site.baseurl }}/reference/glossary/#job-type
-[preemptible]: {{ site.baseurl }}/architecture/#bots
+[preemptible]: {{ site.baseurl }}/architecture/#fuzzing-bots
 [sanitizer]: {{ site.baseurl }}/reference/glossary/#sanitizer
 [AddressSanitizer]: https://clang.llvm.org/docs/AddressSanitizer.html
 [LeakSanitizer]: https://clang.llvm.org/docs/LeakSanitizer.html

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -961,9 +961,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     self.adb_path = android.adb.get_adb_path()
     self.hwasan_options = 'HWASAN_OPTIONS="%s"' % quote(
         environment.get_value('HWASAN_OPTIONS'))
-    self.ld_library_path = (
-        'LD_LIBRARY_PATH=' +
-        android.sanitizer.get_ld_library_path_for_sanitizers())
 
   def device_path(self, local_path):
     """Return device path for a local path."""
@@ -989,7 +986,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
                                    ['-timeout=60', '-rss_limit_mb=2048'], 65)
 
     self.assertEqual([
-        self.adb_path, 'shell', self.ld_library_path, self.hwasan_options,
+        self.adb_path, 'shell', self.hwasan_options,
         self.device_path(target_path), '-timeout=60', '-rss_limit_mb=2048',
         '-runs=100',
         self.device_path(testcase_path)
@@ -1019,7 +1016,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     self.assertEqual([
         self.adb_path,
         'shell',
-        self.ld_library_path,
         self.hwasan_options,
         self.device_path(target_path),
         '-max_len=256',
@@ -1055,7 +1051,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     self.assertEqual([
         self.adb_path,
         'shell',
-        self.ld_library_path,
         self.hwasan_options,
         self.device_path(target_path),
         '-max_len=100',
@@ -1103,7 +1098,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     self.assertEqual([
         self.adb_path,
         'shell',
-        self.ld_library_path,
         self.hwasan_options,
         self.device_path(target_path),
         '-max_len=256',


### PR DESCRIPTION
This is not needed for newer HWASan builds.