### PR TITLE
Add support for newer nullptr pointer-overflow checks.

### DIFF
--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/ubsan_pointer_overflow_null_nonzero_offset.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/ubsan_pointer_overflow_null_nonzero_offset.txt
@@ -1,0 +1,15 @@
+Running: /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-711bfa4abfce32eefd009ed5e6aff6ad1df26753
+../../courgette/disassembler_win32.cc:241:44: runtime error: applying non-zero offset 255 to null pointer
+    #0 0x56431fe9163e in courgette::DisassemblerWin32::ParseRelocs(std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >*) courgette/disassembler_win32.cc:241:44
+    #1 0x56431fe91ed9 in courgette::DisassemblerWin32::ExtractAbs32Locations() courgette/disassembler_win32.cc:369:8
+    #2 0x56431fe67c67 in courgette::Disassembler::CreateProgram(bool) courgette/disassembler.cc:59:17
+    #3 0x56431fe62d5f in courgette::CourgetteFlow::CreateAssemblyProgramFromDisassembler(courgette::CourgetteFlow::Group, bool) courgette/courgette_flow.cc:116:33
+    #4 0x56431fcd0e20 in LLVMFuzzerTestOneInput testing/libfuzzer/fuzzers/courgette_fuzzer.cc:17:8
+    #5 0x56431fd0c7e6 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) third_party/libFuzzer/src/FuzzerLoop.cpp:556:15
+    #6 0x56431fcf1385 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) third_party/libFuzzer/src/FuzzerDriver.cpp:292:6
+    #7 0x56431fcf4489 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) third_party/libFuzzer/src/FuzzerDriver.cpp:774:9
+    #8 0x56431fd1674a in main third_party/libFuzzer/src/FuzzerMain.cpp:19:10
+    #9 0x7f79915ec82f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:291
+    #10 0x56431fcbb829 in _start (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-release-ubsan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libfuzzer-linux-release-718607/courgette_fuzzer+0x23d829)
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../courgette/disassembler_win32.cc:241:44 in
+Executed /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-711bfa4abfce32eefd009ed5e6aff6ad1df26753 in 4395 ms

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/ubsan_pointer_overflow_null_zero_offset.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/ubsan_pointer_overflow_null_zero_offset.txt
@@ -1,0 +1,21 @@
+Running: /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-1ecd3fd5c9ee4c8545301c3dd5ddc333dbe7360c
+../../third_party/freetype/src/src/cff/cffload.c:2060:51: runtime error: applying zero offset to null pointer
+    #0 0x564ca63e03d4 in cff_subfont_load third_party/freetype/src/src/cff/cffload.c:2060:51
+    #1 0x564ca63de001 in cff_font_load third_party/freetype/src/src/cff/cffload.c:2374:13
+    #2 0x564ca63d2426 in cff_face_init third_party/freetype/src/src/cff/cffobjs.c:615:15
+    #3 0x564ca63cdf98 in open_face third_party/freetype/src/src/base/ftobjs.c:1403:15
+    #4 0x564ca63c12ad in ft_open_face_internal third_party/freetype/src/src/base/ftobjs.c:2475:19
+    #5 0x564ca63c18e1 in FT_New_Memory_Face third_party/freetype/src/src/base/ftobjs.c:1493:12
+    #6 0x564ca68d4420 in CFX_Face::New(FT_LibraryRec_*, fxcrt::RetainPtr<fxcrt::Retainable> const&, pdfium::span<unsigned char const>, long) third_party/pdfium/core/fxge/cfx_face.cpp:15:7
+    #7 0x564ca68f4314 in CFX_FontMgr::NewFixedFace(fxcrt::RetainPtr<CFX_FontMgr::FontDesc> const&, pdfium::span<unsigned char const>, int) third_party/pdfium/core/fxge/cfx_fontmgr.cpp:151:7
+    #8 0x564ca68dea29 in CFX_Font::LoadEmbedded(pdfium::span<unsigned char const>, bool) third_party/pdfium/core/fxge/cfx_font.cpp:386:47
+    #9 0x564ca6c12bc9 in FPDFText_LoadFont third_party/pdfium/fpdfsdk/fpdf_edittext.cpp:493:15
+    #10 0x564ca62e7813 in LLVMFuzzerTestOneInput third_party/pdfium/testing/fuzzers/pdf_font_fuzzer.cc:22:23
+    #11 0x564ca6323806 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) third_party/libFuzzer/src/FuzzerLoop.cpp:556:15
+    #12 0x564ca63083a5 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) third_party/libFuzzer/src/FuzzerDriver.cpp:292:6
+    #13 0x564ca630b4a9 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) third_party/libFuzzer/src/FuzzerDriver.cpp:774:9
+    #14 0x564ca632d87a in main third_party/libFuzzer/src/FuzzerMain.cpp:19:10
+    #15 0x7f84246c682f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:291
+    #16 0x564ca62d2169 in _start (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-release-ubsan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libfuzzer-linux-release-718607/pdf_font_fuzzer+0x26c6169)
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../third_party/freetype/src/src/cff/cffload.c:2060:51 in
+Executed /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-1ecd3fd5c9ee4c8545301c3dd5ddc333dbe7360c in 3782 ms

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/ubsan_unknown_logs_error.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/ubsan_unknown_logs_error.txt
@@ -1,0 +1,7 @@
+Running: /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-1ecd3fd5c9ee4c8545301c3dd5ddc333dbe7360c
+../../third_party/freetype/src/src/cff/cffload.c:2060:51: runtime error: unsupported ubsan error that needs a new signature
+    #0 0x564ca63e03d4 in a ../../file:1234:1
+    #1 0x564ca63de001 in b ../../file:1234:1
+    #2 0x564ca63d2426 in c ../../file:1234:1
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../file:1234:1
+Executed /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-1ecd3fd5c9ee4c8545301c3dd5ddc333dbe7360c in 1 ms

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2795,7 +2795,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     self.mock.log_error.assert_called_once_with(
         'Unknown UBSan crash type: '
         'unsupported ubsan error that needs a new signature')
-    
+
   def test_libfuzzer_overwrites_const_input(self):
     """Test for libFuzzer when target tries to overwrite const input."""
     os.environ['FUZZ_TARGET'] = 'ap-mgmt'

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tests for the stack analyzer module."""
 
-import mock
 import os
 import unittest
 

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -498,9 +498,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('ubsan_pointer_overflow_null_zero_offset.txt')
     expected_type = 'Pointer-overflow'
     expected_address = ''
-    expected_state = ('cff_subfont_load\n'
-                      'cff_font_load\n'
-                      'cff_face_init\n')
+    expected_state = ('cff_subfont_load\n' 'cff_font_load\n' 'cff_face_init\n')
     expected_stacktrace = data
     expected_security_flag = False
 


### PR DESCRIPTION
This will also start logging an error if we hit our catch all case for UBSan so we know that new signatures need to be added.