### PR TITLE
Increase memory allocated to Fuchsia VMs to 3GB.

### DIFF
--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -136,7 +136,7 @@ class QemuProcess(object):
 
     # yapf: disable
     qemu_args = [
-        '-m', '2048',
+        '-m', '3072',
         '-nographic',
         '-kernel', qemu_vars['kernel_path'],
         '-initrd', qemu_vars['initrd_path'],


### PR DESCRIPTION
The previous value of 2GB was the same as the `rss_limit_mb`, so in
conditions with high memory usage the system would OOM before libFuzzer
could have a chance to catch it.