### PR TITLE
Fix google-auth to 1.8.1.

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,6 +3,7 @@ configparser==3.7.4
 firebase-admin==2.16.0
 future==0.17.1
 google-api-python-client==1.7.4
+google-auth==1.8.1
 google-auth-oauthlib==0.2.0
 google-cloud-datastore==1.7.0
 google-cloud-monitoring==0.30.1


### PR DESCRIPTION
There was a bug in 1.8.0 causing exceptions (#1245).