### PR TITLE
Mention platform support for Fuchsia OS in docs

### DIFF
--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -78,6 +78,7 @@ Our supported systems include:
 - **Ubuntu** (14.04, 16.04, 17.10, 18.04, 18.10)
 - **Debian** 8 (jessie) or later
 - Recent versions of **macOS** with [homebrew] (experimental)
+- **Fuchsia OS** 
 
 To install the dependencies, run the script:
 ```bash


### PR DESCRIPTION
Your documentation does not mention the platform support for Fuchsia OS but it is added in version 16.0 

I added it in documentation. 