### PR TITLE
Migrate corpus pruning to engine interface.

### DIFF
--- a/src/python/bot/fuzzers/engine.py
+++ b/src/python/bot/fuzzers/engine.py
@@ -136,7 +136,7 @@ class Engine(object):
       A FuzzResult object.
 
     Raises:
-      TimeoutError: If the minimization exceeds max_time.
+      TimeoutError: If the corpus minimization exceeds max_time.
       MergeError: If the merge failed in some other way.
     """
     raise NotImplementedError
@@ -156,7 +156,7 @@ class Engine(object):
       A ReproduceResult.
 
     Raises:
-      TimeoutError: If the minimization exceeds max_time.
+      TimeoutError: If the testcase minimization exceeds max_time.
     """
     raise NotImplementedError
 

--- a/src/python/bot/fuzzers/engine.py
+++ b/src/python/bot/fuzzers/engine.py
@@ -18,6 +18,11 @@ from builtins import object
 _ENGINES = {}
 
 
+class TimeoutError(Exception):
+  """TimeoutError."""
+  # TODO(ochang): Remove once migrated to Python 3.
+
+
 class FuzzOptions(object):
   """Represents options passed to the engine. Can be overridden to provide more
   options."""
@@ -108,6 +113,9 @@ class Engine(object):
 
     Returns:
       A ReproduceResult.
+
+    Raises:
+      TimeoutError: If the reproduction exceeds max_time.
     """
     raise NotImplementedError
 
@@ -126,6 +134,10 @@ class Engine(object):
 
     Returns:
       A FuzzResult object.
+
+    Raises:
+      TimeoutError: If the minimization exceeds max_time.
+      MergeError: If the merge failed in some other way.
     """
     raise NotImplementedError
 
@@ -142,6 +154,9 @@ class Engine(object):
 
     Returns:
       A ReproduceResult.
+
+    Raises:
+      TimeoutError: If the minimization exceeds max_time.
     """
     raise NotImplementedError
 
@@ -157,6 +172,9 @@ class Engine(object):
 
     Returns:
       A ReproduceResult.
+
+    Raises:
+      TimeoutError: If the cleanse exceeds max_time.
     """
     raise NotImplementedError
 

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -377,7 +377,7 @@ class LibFuzzerEngine(engine.Engine):
       A Result object.
 
     Raises:
-      TimeoutError: If the minimization exceeds max_time.
+      TimeoutError: If the corpus minimization exceeds max_time.
       MergeError: If the merge failed in some other way.
     """
     runner = libfuzzer.get_runner(target_path)
@@ -417,7 +417,7 @@ class LibFuzzerEngine(engine.Engine):
       A ReproduceResult.
 
     Raises:
-      TimeoutError: If the minimization exceeds max_time.
+      TimeoutError: If the testcase minimization exceeds max_time.
     """
     runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path)

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -336,6 +336,9 @@ class LibFuzzerEngine(engine.Engine):
 
     Returns:
       A ReproduceResult.
+
+    Raises:
+      TimeoutError: If the reproduction exceeds max_time.
     """
     runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path)
@@ -350,6 +353,10 @@ class LibFuzzerEngine(engine.Engine):
 
     result = runner.run_single_testcase(
         input_path, timeout=max_time, additional_args=arguments)
+
+    if result.timed_out:
+      raise engine.TimeoutError('Reproducing timed out: ' + result.output)
+
     return engine.ReproduceResult(result.command, result.return_code,
                                   result.time_executed, result.output)
 
@@ -368,6 +375,10 @@ class LibFuzzerEngine(engine.Engine):
 
     Returns:
       A Result object.
+
+    Raises:
+      TimeoutError: If the minimization exceeds max_time.
+      MergeError: If the merge failed in some other way.
     """
     runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path)
@@ -381,10 +392,11 @@ class LibFuzzerEngine(engine.Engine):
         artifact_prefix=reproducers_dir)
 
     if merge_result.timed_out:
-      raise MergeError('Merging new testcases timed out')
+      raise engine.TimeoutError('Merging new testcases timed out: ' +
+                                merge_result.output)
 
     if merge_result.return_code != 0:
-      raise MergeError('Merging new testcases failed')
+      raise MergeError('Merging new testcases failed: ' + merge_result.output)
 
     # TODO(ochang): Get crashes found during merge.
     return engine.FuzzResult(merge_result.output, merge_result.command, [], {},
@@ -403,6 +415,9 @@ class LibFuzzerEngine(engine.Engine):
 
     Returns:
       A ReproduceResult.
+
+    Raises:
+      TimeoutError: If the minimization exceeds max_time.
     """
     runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path)
@@ -414,6 +429,9 @@ class LibFuzzerEngine(engine.Engine):
         max_time,
         artifact_prefix=minimize_tmp_dir,
         additional_args=arguments)
+
+    if result.timed_out:
+      raise engine.TimeoutError('Minimization timed out: ' + result.output)
 
     return engine.ReproduceResult(result.command, result.return_code,
                                   result.time_executed, result.output)
@@ -430,6 +448,9 @@ class LibFuzzerEngine(engine.Engine):
 
     Returns:
       A ReproduceResult.
+
+    Raises:
+      TimeoutError: If the cleanse exceeds max_time.
     """
     runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path)
@@ -441,6 +462,9 @@ class LibFuzzerEngine(engine.Engine):
         max_time,
         artifact_prefix=cleanse_tmp_dir,
         additional_args=arguments)
+
+    if result.timed_out:
+      raise engine.TimeoutError('Cleanse timed out: ' + result.output)
 
     return engine.ReproduceResult(result.command, result.return_code,
                                   result.time_executed, result.output)

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -467,8 +467,9 @@ class CorpusPruner(object):
       raise CorpusPruningException('Corpus pruning failed to merge corpus: ' +
                                    e.message)
 
-    # Sanity check that there are files in minimized corpus after merging.
     symbolized_output = stack_symbolizer.symbolize_stacktrace(result.logs)
+
+    # Sanity check that there are files in minimized corpus after merging.
     if not shell.get_directory_file_count(minimized_corpus_path):
       raise CorpusPruningException(
           'Corpus pruning failed to merge corpus: %s.' % symbolized_output)

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -415,7 +415,7 @@ class CorpusPruner(object):
         continue
 
       if not crash_analyzer.is_memory_tool_crash(result.output):
-        # Didn't crash or time out.
+        # Didn't crash.
         continue
 
       # Get memory tool crash information.

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1152,8 +1152,11 @@ def _run_libfuzzer_tool(tool_name,
   if set_dedup_flags:
     _set_dedup_flags()
 
-  result = run_libfuzzer_engine(tool_name, fuzzer_display.target, arguments,
-                                testcase_file_path, output_file_path, timeout)
+  try:
+    result = run_libfuzzer_engine(tool_name, fuzzer_display.target, arguments,
+                                  testcase_file_path, output_file_path, timeout)
+  except engine.TimeoutError:
+    logs.log_warn('LibFuzzer timed out.')
 
   if set_dedup_flags:
     _unset_dedup_flags()

--- a/src/python/bot/untrusted_runner/tasks_host.py
+++ b/src/python/bot/untrusted_runner/tasks_host.py
@@ -188,6 +188,8 @@ def engine_reproduce(engine_impl, target_name, testcase_path, arguments,
       # Resurface the right exception.
       raise testcase_manager.TargetNotFoundError('Failed to find target ' +
                                                  target_name)
+    if 'TimeoutError' in str(e):
+      raise engine.TimeoutError(e.message)
     else:
       raise
 

--- a/src/python/bot/untrusted_runner/tasks_impl.py
+++ b/src/python/bot/untrusted_runner/tasks_impl.py
@@ -27,7 +27,6 @@ from bot.tasks import fuzz_task
 from bot.tasks import minimize_task
 from datastore import data_types
 from protos import untrusted_runner_pb2
-from system import environment
 
 
 def _proto_to_fuzz_target(proto):

--- a/src/python/bot/untrusted_runner/tasks_impl.py
+++ b/src/python/bot/untrusted_runner/tasks_impl.py
@@ -50,7 +50,7 @@ def prune_corpus(request, _):
       _proto_to_fuzz_target(request.fuzz_target), [
           _proto_to_cross_pollinate_fuzzer(proto)
           for proto in request.cross_pollinate_fuzzers
-      ], environment.get_value('USE_MINIJAIL'))
+      ])
 
   result = corpus_pruning_task.do_corpus_pruning(
       context, request.last_execution_failed, request.revision)

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -542,7 +542,7 @@ class IntegrationTests(BaseIntegrationTest):
     target_path = engine_common.find_fuzzer_path(DATA_DIR,
                                                  'crash_with_A_fuzzer')
     result = engine_impl.minimize_testcase(target_path, [], testcase_path,
-                                           minimize_output_path, 30)
+                                           minimize_output_path, 60)
     self.assertTrue(result)
     self.assertTrue(os.path.exists(minimize_output_path))
     with open(minimize_output_path) as f:
@@ -558,7 +558,7 @@ class IntegrationTests(BaseIntegrationTest):
     target_path = engine_common.find_fuzzer_path(DATA_DIR,
                                                  'crash_with_A_fuzzer')
     result = engine_impl.cleanse(target_path, [], testcase_path,
-                                 cleanse_output_path, 30)
+                                 cleanse_output_path, 60)
     self.assertTrue(result)
     self.assertTrue(os.path.exists(cleanse_output_path))
     with open(cleanse_output_path) as f:
@@ -1122,7 +1122,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     target_path = engine_common.find_fuzzer_path(ANDROID_DATA_DIR,
                                                  'crash_with_A_fuzzer')
     result = engine_impl.minimize_testcase(target_path, [], testcase_path,
-                                           minimize_output_path, 30)
+                                           minimize_output_path, 60)
     self.assertTrue(result)
     self.assertTrue(os.path.exists(minimize_output_path))
     with open(minimize_output_path) as f:
@@ -1138,7 +1138,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     target_path = engine_common.find_fuzzer_path(ANDROID_DATA_DIR,
                                                  'crash_with_A_fuzzer')
     result = engine_impl.cleanse(target_path, [], testcase_path,
-                                 cleanse_output_path, 30)
+                                 cleanse_output_path, 60)
     self.assertTrue(result)
     self.assertTrue(os.path.exists(cleanse_output_path))
     with open(cleanse_output_path) as f:

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -542,7 +542,7 @@ class IntegrationTests(BaseIntegrationTest):
     target_path = engine_common.find_fuzzer_path(DATA_DIR,
                                                  'crash_with_A_fuzzer')
     result = engine_impl.minimize_testcase(target_path, [], testcase_path,
-                                           minimize_output_path, 60)
+                                           minimize_output_path, 120)
     self.assertTrue(result)
     self.assertTrue(os.path.exists(minimize_output_path))
     with open(minimize_output_path) as f:
@@ -558,7 +558,7 @@ class IntegrationTests(BaseIntegrationTest):
     target_path = engine_common.find_fuzzer_path(DATA_DIR,
                                                  'crash_with_A_fuzzer')
     result = engine_impl.cleanse(target_path, [], testcase_path,
-                                 cleanse_output_path, 60)
+                                 cleanse_output_path, 120)
     self.assertTrue(result)
     self.assertTrue(os.path.exists(cleanse_output_path))
     with open(cleanse_output_path) as f:
@@ -1122,7 +1122,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     target_path = engine_common.find_fuzzer_path(ANDROID_DATA_DIR,
                                                  'crash_with_A_fuzzer')
     result = engine_impl.minimize_testcase(target_path, [], testcase_path,
-                                           minimize_output_path, 60)
+                                           minimize_output_path, 120)
     self.assertTrue(result)
     self.assertTrue(os.path.exists(minimize_output_path))
     with open(minimize_output_path) as f:
@@ -1138,7 +1138,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     target_path = engine_common.find_fuzzer_path(ANDROID_DATA_DIR,
                                                  'crash_with_A_fuzzer')
     result = engine_impl.cleanse(target_path, [], testcase_path,
-                                 cleanse_output_path, 60)
+                                 cleanse_output_path, 120)
     self.assertTrue(result)
     self.assertTrue(os.path.exists(cleanse_output_path))
     with open(cleanse_output_path) as f:

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
@@ -22,6 +22,7 @@ import shutil
 import tempfile
 import unittest
 
+from bot.fuzzers.libFuzzer import engine as libFuzzer_engine
 from bot.tasks import corpus_pruning_task
 from datastore import data_handler
 from datastore import data_types
@@ -48,6 +49,7 @@ class CorpusPruningTest(unittest.TestCase):
 
   def setUp(self):
     helpers.patch(self, [
+        'bot.fuzzers.engine.get',
         'bot.fuzzers.engine_common.unpack_seed_corpus_if_needed',
         'bot.tasks.task_creation.create_tasks',
         'bot.tasks.setup.update_fuzzer_and_data_bundles',
@@ -61,6 +63,7 @@ class CorpusPruningTest(unittest.TestCase):
     ])
 
     helpers.patch_environ(self)
+    self.mock.get.return_value = libFuzzer_engine.LibFuzzerEngine()
     self.mock.setup_build.side_effect = self._mock_setup_build
     self.mock.rsync_to_disk.side_effect = self._mock_rsync_to_disk
     self.mock.rsync_from_disk.side_effect = self._mock_rsync_from_disk
@@ -238,11 +241,13 @@ class CorpusPruningTestUntrusted(
     environment.set_value('JOB_NAME', 'libfuzzer_asan_job')
 
     helpers.patch(self, [
+        'bot.fuzzers.engine.get',
         'bot.fuzzers.libFuzzer.fuzzer.LibFuzzer.fuzzer_directory',
         'base.tasks.add_task',
         'datastore.data_handler.get_data_bundle_bucket_name',
     ])
 
+    self.mock.get.return_value = libFuzzer_engine.LibFuzzerEngine()
     self.mock.fuzzer_directory.return_value = os.path.join(
         environment.get_value('ROOT_DIR'), 'src', 'python', 'bot', 'fuzzers',
         'libFuzzer')


### PR DESCRIPTION
Rather than creating and running the LibFuzzerRunners directly.

This is the first step to making this more engine-agnostic

Also clean up various bits of minijail setup code.