### PR TITLE
Fix regression in engine pipeline with setting redzone,disable-ubsan flag

### DIFF
--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1502,6 +1502,10 @@ class FuzzingSession(object):
         self.data_directory, self.fuzz_target.project_qualified_name())
     self.sync_corpus(sync_corpus_directory)
 
+    # Reset memory tool options.
+    environment.reset_current_memory_tool_options(
+        redzone_size=self.redzone, disable_ubsan=self.disable_ubsan)
+
     revision = environment.get_value('APP_REVISION')
     crashes = []
     fuzzer_metadata = {}

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1345,6 +1345,7 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
     ])
     test_utils.set_up_pyfakefs(self)
 
+    os.environ['JOB_NAME'] = 'libfuzzer_asan_test'
     os.environ['FUZZ_INPUTS'] = '/fuzz-inputs'
     os.environ['FUZZ_INPUTS_DISK'] = '/fuzz-inputs-disk'
     os.environ['BUILD_DIR'] = '/build_dir'


### PR DESCRIPTION
This matches what we do in blackbox fuzzing pipeline.