### PR TITLE
Support setting testcase metadata when a testcase archive is provided.

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -363,12 +363,10 @@ class UploadHandlerCommon(object):
     if testcase_metadata:
       try:
         testcase_metadata = json.loads(testcase_metadata)
-        if not isinstance(testcase_metadata, dict):
-          raise helpers.EarlyExitException('Metadata is not a JSON object.',
-                                           400)
       except Exception:
         raise helpers.EarlyExitException('Invalid metadata JSON.', 400)
-
+      if not isinstance(testcase_metadata, dict):
+        raise helpers.EarlyExitException('Metadata is not a JSON object.', 400)
     if issue_labels:
       testcase_metadata['issue_labels'] = issue_labels
 
@@ -459,9 +457,6 @@ class UploadHandlerCommon(object):
         archive_state = data_types.ArchiveStatus.FUZZED
       if archive_state:
         if multiple_testcases:
-          if testcase_metadata:
-            raise helpers.EarlyExitException(
-                'Testcase metadata not supported with multiple testcases.', 400)
           # Create a job to unpack an archive.
           metadata = data_types.BundledArchiveMetadata()
           metadata.blobstore_key = key
@@ -499,6 +494,9 @@ class UploadHandlerCommon(object):
           upload_metadata.uploader_email = email
           upload_metadata.retries = retries
           upload_metadata.bug_summary_update_flag = bug_summary_update_flag
+          upload_metadata.quiet_flag = quiet_flag
+          upload_metadata.additional_metadata_string = json.dumps(
+              testcase_metadata)
           upload_metadata.put()
 
           helpers.log('Uploaded multiple testcases.', helpers.VIEW_OPERATION)

--- a/src/go/cloud/db/types/types.go
+++ b/src/go/cloud/db/types/types.go
@@ -427,23 +427,24 @@ type TestcaseGroup struct {
 
 // TestcaseUploadMetadata is auto-generated from data_types.py.
 type TestcaseUploadMetadata struct {
-	Key                  *datastore.Key `datastore:"__key__"`
-	Timestamp            time.Time      `datastore:"timestamp"`
-	Filename             string         `datastore:"filename"`
-	Status               string         `datastore:"status"`
-	UploaderEmail        string         `datastore:"uploader_email"`
-	BotName              string         `datastore:"bot_name"`
-	TestcaseID           int            `datastore:"testcase_id"`
-	DuplicateOf          int            `datastore:"duplicate_of"`
-	BlobstoreKey         string         `datastore:"blobstore_key"`
-	Timeout              int            `datastore:"timeout"`
-	Bundled              bool           `datastore:"bundled"`
-	PathInArchive        string         `datastore:"path_in_archive,noindex"`
-	OriginalBlobstoreKey string         `datastore:"original_blobstore_key"`
-	SecurityFlag         bool           `datastore:"security_flag"`
-	Retries              int            `datastore:"retries"`
-	BugSummaryUpdateFlag bool           `datastore:"bug_summary_update_flag"`
-	QuietFlag            bool           `datastore:"quiet_flag"`
+	Key                      *datastore.Key `datastore:"__key__"`
+	Timestamp                time.Time      `datastore:"timestamp"`
+	Filename                 string         `datastore:"filename"`
+	Status                   string         `datastore:"status"`
+	UploaderEmail            string         `datastore:"uploader_email"`
+	BotName                  string         `datastore:"bot_name"`
+	TestcaseID               int            `datastore:"testcase_id"`
+	DuplicateOf              int            `datastore:"duplicate_of"`
+	BlobstoreKey             string         `datastore:"blobstore_key"`
+	Timeout                  int            `datastore:"timeout"`
+	Bundled                  bool           `datastore:"bundled"`
+	PathInArchive            string         `datastore:"path_in_archive,noindex"`
+	OriginalBlobstoreKey     string         `datastore:"original_blobstore_key"`
+	SecurityFlag             bool           `datastore:"security_flag"`
+	Retries                  int            `datastore:"retries"`
+	BugSummaryUpdateFlag     bool           `datastore:"bug_summary_update_flag"`
+	QuietFlag                bool           `datastore:"quiet_flag"`
+	AdditionalMetadataString string         `datastore:"additional_metadata_string,noindex"`
 }
 
 // TestcaseVariant is auto-generated from data_types.py.

--- a/src/python/bot/tasks/unpack_task.py
+++ b/src/python/bot/tasks/unpack_task.py
@@ -15,6 +15,7 @@
 from user upload."""
 
 import os
+import json
 
 from base import tasks
 from datastore import data_handler
@@ -64,9 +65,15 @@ def execute_task(metadata_id, job_type):
     tasks.add_task('unpack', metadata_id, job_type)
     return
 
+  # Get additional testcase metadata (if any).
+  additional_metadata = None
+  if upload_metadata.additional_metadata_string:
+    additional_metadata = json.loads(upload_metadata.additional_metadata_string)
+
   archive_state = data_types.ArchiveStatus.NONE
   bundled = True
   file_list = archive.get_file_list(archive_path)
+
   for file_path in file_list:
     absolute_file_path = os.path.join(testcases_directory, file_path)
     filename = os.path.basename(absolute_file_path)
@@ -97,7 +104,7 @@ def execute_task(metadata_id, job_type):
         metadata.app_launch_command, metadata.fuzzer_name,
         metadata.overridden_fuzzer_name, metadata.fuzzer_binary_name, bundled,
         upload_metadata.retries, upload_metadata.bug_summary_update_flag,
-        upload_metadata.quiet_flag)
+        upload_metadata.quiet_flag, additional_metadata)
 
   # The upload metadata for the archive is not needed anymore since we created
   # one for each testcase.

--- a/src/python/bot/tasks/unpack_task.py
+++ b/src/python/bot/tasks/unpack_task.py
@@ -14,8 +14,8 @@
 """Unpack task for unpacking a multi-testcase archive
 from user upload."""
 
-import os
 import json
+import os
 
 from base import tasks
 from datastore import data_handler

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -849,6 +849,9 @@ class TestcaseUploadMetadata(Model):
   # Flag to indicate if we are running in quiet mode (e.g. bug updates).
   quiet_flag = ndb.BooleanProperty()
 
+  # Additional testcase metadata dict stored as a string.
+  additional_metadata_string = TextProperty(indexed=False)
+
 
 class JobTemplate(Model):
   # Job template name.


### PR DESCRIPTION
This makes it possible to set team labels when an archive with multiple testcases is uploaded.