### PR TITLE
Fix exception.

### DIFF
--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1157,6 +1157,7 @@ def _run_libfuzzer_tool(tool_name,
                                   testcase_file_path, output_file_path, timeout)
   except engine.TimeoutError:
     logs.log_warn('LibFuzzer timed out.')
+    return None, None
 
   if set_dedup_flags:
     _unset_dedup_flags()


### PR DESCRIPTION
```
UnboundLocalError: local variable 'result' referenced before assignment
at _run_libfuzzer_tool (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/minimize_task.py:1165)
at do_libfuzzer_minimization (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/minimize_task.py:1308)
at execute_task (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/minimize_task.py:395)
at run_command (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:204)
at process_command (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:378)
at wrapper (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:150)
at task_loop (/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py:97)
```