### PR TITLE
Catch merge failures due to timeouts.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -210,8 +210,8 @@ class LibFuzzerEngine(engine.Engine):
       new_units_added = new_corpus_len - old_corpus_len
 
       stat_overrides.update(result.stats)
-    except MergeError:
-      logs.log_warn('Merge failed', target=os.path.basename(target_path))
+    except (MergeError, engine.TimeoutError):
+      logs.log_warn('Merge failed.')
 
     stat_overrides['new_units_added'] = new_units_added
 


### PR DESCRIPTION
engine.TimeoutError is new and needs to be caught, otherwise
we lose crashes during fuzzing when merge fails due to timeouts.