### PR TITLE
Increase monitoring retry deadline.

### DIFF
--- a/src/python/metrics/monitor.py
+++ b/src/python/metrics/monitor.py
@@ -45,7 +45,7 @@ from system import environment
 
 CUSTOM_METRIC_PREFIX = 'custom.googleapis.com/'
 FLUSH_INTERVAL_SECONDS = 10 * 60  # 10 minutes.
-RETRY_DEADLINE_SECONDS = 90
+RETRY_DEADLINE_SECONDS = 3 * 60  # 3 minutes.
 MAX_TIME_SERIES_PER_CALL = 200
 
 _retry_wrap = retry.Retry(


### PR DESCRIPTION
Speculative fix for borg bot exceptions.
```
Failed to flush metrics.
Traceback (most recent call last):
  File "/mnt/scratch0/clusterfuzz/src/python/metrics/monitor.py", line 107, in run
    create_time_series(project_path, time_series)
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/retry.py", line 286, in retry_wrapped_func
    on_error=on_error,
  File "/mnt/scratch0/clusterfuzz/src/third_party/google/api_core/retry.py", line 206, in retry_target
    last_exc,
  File "/mnt/scratch0/clusterfuzz/src/third_party/six.py", line 740, in raise_from
    raise value
RetryError: Deadline of 90.0s exceeded while calling <functools.partial object at 0x7ec30a301c00>, last exception: 504 Deadline Exceeded
```