### PR TITLE
Fix exception with FuzzResult in _minimize_corpus_two_step.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -420,7 +420,7 @@ class LibFuzzerEngine(engine.Engine):
     max_time -= result_1.time_executed
     if max_time <= 0:
       raise engine.TimeoutError('Merging new testcases timed out\n' +
-                                result_1.output)
+                                result_1.logs)
 
     # Step 2. Process the new corpus units as well.
     result_2 = self.minimize_corpus(


### PR DESCRIPTION
Fixes
```
AttributeError: 'FuzzResult' object has no attribute 'output'
at _minimize_corpus_two_step (/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/libFuzzer/engine.py:423)
at _merge_new_units (/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/libFuzzer/engine.py:206)
at fuzz (/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/libFuzzer/engine.py:316)
at run_engine_fuzzer (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1260)
at do_engine_fuzzing (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1538)
at run (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1820)
at execute_task (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1900)
at run_command (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:204)
at process_command (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:378)
at wrapper (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:150)
at task_loop (/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py:97)
```