### PR TITLE
Make honggfuzz binary executable.

### DIFF
--- a/src/python/bot/fuzzers/honggfuzz/engine.py
+++ b/src/python/bot/fuzzers/honggfuzz/engine.py
@@ -118,6 +118,7 @@ class HonggfuzzEngine(engine.Engine):
     Returns:
       A FuzzOptions object.
     """
+    os.chmod(target_path, 0o775)
     arguments = []
     dict_path = dictionary_manager.get_default_dictionary_path(target_path)
     if os.path.exists(dict_path):
@@ -187,6 +188,7 @@ class HonggfuzzEngine(engine.Engine):
     Returns:
       A ReproduceResult.
     """
+    os.chmod(target_path, 0o775)
     runner = new_process.ProcessRunner(target_path)
     with open(input_path) as f:
       result = runner.run_and_wait(timeout=max_time, stdin=f)

--- a/src/python/bot/fuzzers/honggfuzz/engine.py
+++ b/src/python/bot/fuzzers/honggfuzz/engine.py
@@ -55,6 +55,7 @@ def _get_runner():
   if not os.path.exists(honggfuzz_path):
     raise HonggfuzzError('honggfuzz not found in build')
 
+  os.chmod(honggfuzz_path, 0o755)
   return new_process.ProcessRunner(honggfuzz_path)
 
 


### PR DESCRIPTION
Some builds may not have an executable honggfuzz binary.