### PR TITLE
Allow fuzzer weights to recover from 0.

### DIFF
--- a/src/appengine/handlers/cron/fuzzer_and_job_weights.py
+++ b/src/appengine/handlers/cron/fuzzer_and_job_weights.py
@@ -364,7 +364,9 @@ def update_job_weights():
     multiplier = DEFAULT_MULTIPLIER
     if environment.is_engine_fuzzer_job(job.name):
       targets_count = ndb.Key(data_types.FuzzTargetsCount, job.name).get()
-      if targets_count:
+      # If the count is 0, it may be due to a bad build or some other issue. Use
+      # the default weight in that case to allow for recovery.
+      if targets_count and targets_count.count:
         multiplier = targets_count.count
 
     update_job_weight(job.name, multiplier)

--- a/src/python/tests/appengine/handlers/cron/fuzzer_and_job_weights_test.py
+++ b/src/python/tests/appengine/handlers/cron/fuzzer_and_job_weights_test.py
@@ -292,6 +292,7 @@ class TestUpdateJobWeights(unittest.TestCase):
             'libfuzzer_ubsan_job',
             'libfuzzer_tsan_job',
             'libfuzzer_cfi_job',
+            'libfuzzer_asan_job2',
         ],
         'afl': ['afl_asan_job',],
         'blackbox': ['asan_blackbox_job',]
@@ -308,6 +309,7 @@ class TestUpdateJobWeights(unittest.TestCase):
     data_types.FuzzTargetsCount(id='libfuzzer_tsan_job', count=5).put()
     data_types.FuzzTargetsCount(id='libfuzzer_cfi_job', count=5).put()
     data_types.FuzzTargetsCount(id='afl_asan_job', count=10).put()
+    data_types.FuzzTargetsCount(id='libfuzzer_asan_job2', count=0).put()
 
   def test_update_job_weights(self):
     """Test update job weights."""
@@ -323,3 +325,4 @@ class TestUpdateJobWeights(unittest.TestCase):
     self.assertEqual(0.5, get_result('libfuzzer_cfi_job').multiplier)
     self.assertEqual(5.0, get_result('afl_asan_job').multiplier)
     self.assertEqual(15.0, get_result('asan_blackbox_job').multiplier)
+    self.assertEqual(15.0, get_result('libfuzzer_asan_job2').multiplier)


### PR DESCRIPTION
If the target count drops to 0, we may never recover otherwise.