### PR TITLE
Fix grpc exception from huge libFuzzer cleanse output.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -556,7 +556,7 @@ class LibFuzzerEngine(engine.Engine):
         additional_args=arguments)
 
     if result.timed_out:
-      raise engine.TimeoutError('Cleanse timed out\n' + result.output)
+      raise engine.TimeoutError('Cleanse timed out.')
 
     return engine.ReproduceResult(result.command, result.return_code,
                                   result.time_executed, result.output)


### PR DESCRIPTION
Remove the output altogether from exception message.