### PR TITLE
Increase max gRPC metadata size.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -556,7 +556,7 @@ class LibFuzzerEngine(engine.Engine):
         additional_args=arguments)
 
     if result.timed_out:
-      raise engine.TimeoutError('Cleanse timed out.')
+      raise engine.TimeoutError('Cleanse timed out\n' + result.output)
 
     return engine.ReproduceResult(result.command, result.return_code,
                                   result.time_executed, result.output)

--- a/src/python/bot/untrusted_runner/config.py
+++ b/src/python/bot/untrusted_runner/config.py
@@ -31,6 +31,7 @@ RPC_RETRY_ATTEMPTS = 1
 GRPC_OPTIONS = (
     ('grpc.max_send_message_length', -1),
     ('grpc.max_receive_message_length', -1),
+    ('grpc.max_metadata_size', 32 * 1024 * 1024),
 )
 
 NUM_WORKER_THREADS = 4


### PR DESCRIPTION
Exception messages can be larger than the default ([8KB](https://github.com/grpc/grpc/blob/0263f75105827119789324cf5edaf6580a2ca39f/src/core/ext/transport/chttp2/transport/chttp2_transport.cc#L63)).

In the case of libFuzzer, we are already truncating all output to 1MB
per new_process's max_stdout_len argument.