### PR TITLE
Resurface TimeoutError more generally.

### DIFF
--- a/src/python/bot/untrusted_runner/host.py
+++ b/src/python/bot/untrusted_runner/host.py
@@ -159,6 +159,11 @@ def _wrap_call(func, num_retries=config.RPC_RETRY_ATTEMPTS):
           # TODO(ochang): Replace with generic TimeoutError in Python 3.
           raise engine.TimeoutError(e.message)
 
+        if num_retries == 0:
+          # Just re-raise the original exception if this RPC is not configured
+          # for retries.
+          raise
+
         logs.log_warn('Failed RPC: ' + str(e))
         if retry_attempt == num_retries:
           # Last attempt.

--- a/src/python/bot/untrusted_runner/tasks_host.py
+++ b/src/python/bot/untrusted_runner/tasks_host.py
@@ -114,14 +114,7 @@ def process_testcase(engine_name, tool_name, target_name, arguments,
       output_path=file_host.rebase_to_worker_root(output_path),
       timeout=timeout)
 
-  try:
-    response = host.stub().ProcessTestcase(request)
-  except grpc.RpcError as e:
-    # Resurface the right exception.
-    if 'TimeoutError' in str(e):
-      raise engine.TimeoutError(e.message)
-    else:
-      raise
+  response = host.stub().ProcessTestcase(request)
 
   rebased_output_path = file_host.rebase_to_worker_root(output_path)
   file_host.copy_file_from_worker(rebased_output_path, output_path)
@@ -195,8 +188,6 @@ def engine_reproduce(engine_impl, target_name, testcase_path, arguments,
       # Resurface the right exception.
       raise testcase_manager.TargetNotFoundError('Failed to find target ' +
                                                  target_name)
-    if 'TimeoutError' in str(e):
-      raise engine.TimeoutError(e.message)
     else:
       raise
 


### PR DESCRIPTION
Check for the error in the host's RPC wrapper, rather than in each
implementation of the RPC call.