### PR TITLE
Add support for additional automatic components/labels/ccs.

### DIFF
--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -245,7 +245,6 @@ def _get_additional_values(testcase, name):
   values = data_handler.get_additional_values_for_variable(
       name, testcase.job_type, testcase.fuzzer_name)
 
-  # TODO(ochang): Find a less hacky way of concatenating multiple values.
   return values + data_handler.get_additional_values_for_variable(
       name + '_1', testcase.job_type, testcase.fuzzer_name)
 

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -240,6 +240,16 @@ def _get_from_metadata(testcase, name):
       remove_empty=True)
 
 
+def _get_additional_values(testcase, name):
+  """Get additional values from the job or fuzzer environment."""
+  values = data_handler.get_additional_values_for_variable(
+      name, testcase.job_type, testcase.fuzzer_name)
+
+  # TODO(ochang): Find a less hacky way of concatenating multiple values.
+  return values + data_handler.get_additional_values_for_variable(
+      name + '_1', testcase.job_type, testcase.fuzzer_name)
+
+
 def file_issue(testcase,
                issue_tracker,
                security_severity=None,
@@ -277,20 +287,18 @@ def file_issue(testcase,
     update_issue_impact_labels(testcase, issue)
 
   # Add additional labels from the job definition and fuzzer.
-  additional_labels = data_handler.get_additional_values_for_variable(
-      'AUTOMATIC_LABELS', testcase.job_type, testcase.fuzzer_name)
+  additional_labels = _get_additional_values(testcase, 'AUTOMATIC_LABELS')
   for label in additional_labels:
     issue.labels.add(label)
 
   # Add additional components from the job definition and fuzzer.
-  automatic_components = data_handler.get_additional_values_for_variable(
-      'AUTOMATIC_COMPONENTS', testcase.job_type, testcase.fuzzer_name)
+  automatic_components = _get_additional_values(testcase,
+                                                'AUTOMATIC_COMPONENTS')
   for component in automatic_components:
     issue.components.add(component)
 
   # Add issue assignee from the job definition and fuzzer.
-  automatic_assignee = data_handler.get_additional_values_for_variable(
-      'AUTOMATIC_ASSIGNEE', testcase.job_type, testcase.fuzzer_name)
+  automatic_assignee = _get_additional_values(testcase, 'AUTOMATIC_ASSIGNEE')
   if automatic_assignee:
     issue.status = policy.status('assigned')
     issue.assignee = automatic_assignee[0]
@@ -298,8 +306,7 @@ def file_issue(testcase,
     issue.status = properties.status
 
   # Add additional ccs from the job definition and fuzzer.
-  ccs = data_handler.get_additional_values_for_variable(
-      'AUTOMATIC_CCS', testcase.job_type, testcase.fuzzer_name)
+  ccs = _get_additional_values(testcase, 'AUTOMATIC_CCS')
 
   # For externally contributed fuzzers, potentially cc the author.
   # Use fully qualified fuzzer name if one is available.

--- a/src/python/tests/appengine/libs/issue_filer_test.py
+++ b/src/python/tests/appengine/libs/issue_filer_test.py
@@ -353,6 +353,49 @@ class IssueFilerTests(unittest.TestCase):
         'component2',
     ], issue_tracker._itm.last_issue.components)
 
+  def test_testcase_automatic_issue_data(self):
+    """Tests issue filing with automatic labels, assignees, CCs and components."""
+    data_types.Job(
+        name='job',
+        environment_string=('AUTOMATIC_LABELS = auto\n'
+                            'AUTOMATIC_LABELS_1 = auto_1\n'
+                            'AUTOMATIC_COMPONENTS = auto\n'
+                            'AUTOMATIC_COMPONENTS_1 = auto_1\n'
+                            'AUTOMATIC_ASSIGNEE = auto\n'
+                            'AUTOMATIC_ASSIGNEE_1 = auto_1\n'
+                            'AUTOMATIC_CCS = auto\n'
+                            'AUTOMATIC_CCS_1 = auto_1\n'),
+        platform='linux').put()
+
+    self.mock.get.return_value = CHROMIUM_POLICY
+    issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
+    issue_filer.file_issue(self.testcase5, issue_tracker)
+    self.assertItemsEqual([
+        'ClusterFuzz',
+        'Reproducible',
+        'Pri-1',
+        'Stability-Crash',
+        'Type-Bug',
+        'label1',
+        'label2',
+        'auto',
+        'auto_1',
+    ], issue_tracker._itm.last_issue.labels)
+
+    self.assertEqual('auto', issue_tracker._itm.last_issue.owner)
+
+    self.assertItemsEqual([
+        'auto',
+        'auto_1',
+    ], issue_tracker._itm.last_issue.cc)
+
+    self.assertItemsEqual([
+        'component1',
+        'component2',
+        'auto',
+        'auto_1',
+    ], issue_tracker._itm.last_issue.components)
+
   def test_testcase_metadata_invalid(self):
     """Tests issue filing with invalid metadata."""
     self.mock.get.return_value = CHROMIUM_POLICY

--- a/src/python/tests/appengine/libs/issue_filer_test.py
+++ b/src/python/tests/appengine/libs/issue_filer_test.py
@@ -354,7 +354,8 @@ class IssueFilerTests(unittest.TestCase):
     ], issue_tracker._itm.last_issue.components)
 
   def test_testcase_automatic_issue_data(self):
-    """Tests issue filing with automatic labels, assignees, CCs and components."""
+    """Tests issue filing with automatic labels, assignees, CCs and
+    components."""
     data_types.Job(
         name='job',
         environment_string=('AUTOMATIC_LABELS = auto\n'


### PR DESCRIPTION
Through AUTOMATIC_CCS_1, AUTOMATIC_LABELS_1, AUTOMATIC_COMPONENTS_1 etc.
This is needed for e.g. environments where we always want to attach a
label, regardless of the job.