### PR TITLE
Take engine into account when setting FuzzerJob weights.

### DIFF
--- a/src/appengine/handlers/cron/fuzzer_and_job_weights.py
+++ b/src/appengine/handlers/cron/fuzzer_and_job_weights.py
@@ -37,6 +37,7 @@ SpecificationMatch = collections.namedtuple('SpecificationMatch',
 
 DEFAULT_MULTIPLIER = 30.0  # Used for blackbox and jobs that are not yet run.
 DEFAULT_SANITIZER_WEIGHT = 0.1
+DEFAULT_ENGINE_WEIGHT = 1.0
 
 SANITIZER_BASE_WEIGHT = 0.1
 
@@ -47,6 +48,12 @@ SANITIZER_WEIGHTS = {
     'MSAN': 2 * SANITIZER_BASE_WEIGHT,
     'TSAN': 1 * SANITIZER_BASE_WEIGHT,
     'UBSAN': 1 * SANITIZER_BASE_WEIGHT,
+}
+
+ENGINE_WEIGHTS = {
+    'libFuzzer': 1.0,
+    'afl': 1.0,
+    'honggfuzz': 0.2,
 }
 
 
@@ -346,6 +353,9 @@ def update_job_weight(job_name, multiplier):
   """Update a job weight."""
   tool_name = environment.get_memory_tool_name(job_name)
   multiplier *= SANITIZER_WEIGHTS.get(tool_name, DEFAULT_SANITIZER_WEIGHT)
+
+  engine = environment.get_engine_for_job(job_name)
+  multiplier *= ENGINE_WEIGHTS.get(engine, DEFAULT_ENGINE_WEIGHT)
 
   query = data_types.FuzzerJob.query(data_types.FuzzerJob.job == job_name)
   changed_weights = []

--- a/src/python/tests/appengine/handlers/cron/fuzzer_and_job_weights_test.py
+++ b/src/python/tests/appengine/handlers/cron/fuzzer_and_job_weights_test.py
@@ -295,6 +295,7 @@ class TestUpdateJobWeights(unittest.TestCase):
             'libfuzzer_asan_job2',
         ],
         'afl': ['afl_asan_job',],
+        'honggfuzz': ['honggfuzz_asan_job'],
         'blackbox': ['asan_blackbox_job',]
     }
 
@@ -310,6 +311,7 @@ class TestUpdateJobWeights(unittest.TestCase):
     data_types.FuzzTargetsCount(id='libfuzzer_cfi_job', count=5).put()
     data_types.FuzzTargetsCount(id='afl_asan_job', count=10).put()
     data_types.FuzzTargetsCount(id='libfuzzer_asan_job2', count=0).put()
+    data_types.FuzzTargetsCount(id='honggfuzz_asan_job', count=10).put()
 
   def test_update_job_weights(self):
     """Test update job weights."""
@@ -326,3 +328,4 @@ class TestUpdateJobWeights(unittest.TestCase):
     self.assertEqual(5.0, get_result('afl_asan_job').multiplier)
     self.assertEqual(15.0, get_result('asan_blackbox_job').multiplier)
     self.assertEqual(15.0, get_result('libfuzzer_asan_job2').multiplier)
+    self.assertEqual(1.0, get_result('honggfuzz_asan_job').multiplier)


### PR DESCRIPTION
AFL and libFuzzer have a weight of 1.0, while honggfuzz (which is still
experimental) is given 0.2.