### PR TITLE
Attach automatic labels and components to testcase metadata.

### DIFF
--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1249,7 +1249,7 @@ def _get_issue_metadata_from_environment(variable_name):
   # Allow a variation with a '_1' to specified. This is needed in cases where
   # this is specified in both the job and the bot environment.
   values.extend(environment.get_value(variable_name + '_1', '').split())
-  return [value.strip() for value in values]
+  return [value.strip() for value in values if value.strip()]
 
 
 def _add_issue_metadata_from_environment(metadata):
@@ -1268,7 +1268,7 @@ def _add_issue_metadata_from_environment(metadata):
 
   labels = _get_issue_metadata_from_environment('AUTOMATIC_LABELS')
   if labels:
-    metadata['issue_labels'] = _append(metadata.get('issue_labels'), components)
+    metadata['issue_labels'] = _append(metadata.get('issue_labels'), labels)
 
 
 def run_engine_fuzzer(engine_impl, target_name, sync_corpus_directory,

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1243,6 +1243,34 @@ def get_strategy_distribution_from_ndb():
   return distribution
 
 
+def _get_issue_metadata_from_environment(variable_name):
+  """Get issue metadata from environment."""
+  values = environment.get_value(variable_name, '').split()
+  # Allow a variation with a '_1' to specified. This is needed in cases where
+  # this is specified in both the job and the bot environment.
+  values.extend(environment.get_value(variable_name + '_1', '').split())
+  return [value.strip() for value in values]
+
+
+def _add_issue_metadata_from_environment(metadata):
+  """Add issue metadata from environment."""
+
+  def _append(old, new_values):
+    if not old:
+      return ','.join(new_values)
+
+    return ','.join(old.split(',') + new_values)
+
+  components = _get_issue_metadata_from_environment('AUTOMATIC_COMPONENTS')
+  if components:
+    metadata['issue_components'] = _append(
+        metadata.get('issue_components'), components)
+
+  labels = _get_issue_metadata_from_environment('AUTOMATIC_LABELS')
+  if labels:
+    metadata['issue_labels'] = _append(metadata.get('issue_labels'), components)
+
+
 def run_engine_fuzzer(engine_impl, target_name, sync_corpus_directory,
                       testcase_directory):
   """Run engine for fuzzing."""
@@ -1278,6 +1306,7 @@ def run_engine_fuzzer(engine_impl, target_name, sync_corpus_directory,
   }
 
   fuzzer_metadata.update(engine_common.get_all_issue_metadata(target_path))
+  _add_issue_metadata_from_environment(fuzzer_metadata)
   return result, fuzzer_metadata
 
 
@@ -1461,6 +1490,7 @@ class FuzzingSession(object):
       file_host.push_testcases_to_worker()
 
     fuzzer_metadata = get_fuzzer_metadata_from_output(fuzzer_output)
+    _add_issue_metadata_from_environment(fuzzer_metadata)
 
     # Filter fuzzer output, set to default value if empty.
     if fuzzer_output:

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1350,8 +1350,8 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
     os.environ['FUZZ_INPUTS_DISK'] = '/fuzz-inputs-disk'
     os.environ['BUILD_DIR'] = '/build_dir'
     os.environ['MAX_TESTCASES'] = '2'
-    os.environ['AUTOMATIC_LABELS'] = 'auto,auto1'
-    os.environ['AUTOMATIC_COMPONENTS'] = 'auto,auto1'
+    os.environ['AUTOMATIC_LABELS'] = 'auto_label,auto_label1'
+    os.environ['AUTOMATIC_COMPONENTS'] = 'auto_component,auto_component1'
 
     self.fs.create_file('/build_dir/test_target')
     self.fs.create_file(
@@ -1393,10 +1393,14 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
 
     crashes, fuzzer_metadata = session.do_engine_fuzzing(engine_impl)
     self.assertDictEqual({
-        'fuzzer_binary_name': 'test_target',
-        'issue_components': 'component1,component2,auto,auto1',
-        'issue_labels': 'label1,label2,auto,auto1',
-        'issue_owners': 'owner1@email.com',
+        'fuzzer_binary_name':
+            'test_target',
+        'issue_components':
+            'component1,component2,auto_component,auto_component1',
+        'issue_labels':
+            'label1,label2,auto_label,auto_label1',
+        'issue_owners':
+            'owner1@email.com',
     }, fuzzer_metadata)
 
     log_time = datetime.datetime(1970, 1, 1, 0, 0)
@@ -1501,28 +1505,33 @@ class AddIssueMetadataFromEnvironmentTest(unittest.TestCase):
 
   def test_add_no_existing(self):
     """Test adding issue metadata when there are none existing."""
-    os.environ['AUTOMATIC_LABELS'] = 'auto'
-    os.environ['AUTOMATIC_LABELS_1'] = 'auto1'
-    os.environ['AUTOMATIC_COMPONENTS'] = 'auto'
-    os.environ['AUTOMATIC_COMPONENTS_1'] = 'auto1'
+    os.environ['AUTOMATIC_LABELS'] = 'auto_label'
+    os.environ['AUTOMATIC_LABELS_1'] = 'auto_label1'
+    os.environ['AUTOMATIC_COMPONENTS'] = 'auto_component'
+    os.environ['AUTOMATIC_COMPONENTS_1'] = 'auto_component1'
 
     metadata = {}
     fuzz_task._add_issue_metadata_from_environment(metadata)
     self.assertDictEqual({
-        'issue_components': 'auto,auto1',
-        'issue_labels': 'auto,auto1',
+        'issue_components': 'auto_component,auto_component1',
+        'issue_labels': 'auto_label,auto_label1',
     }, metadata)
 
   def test_add_append(self):
     """Test adding issue metadata when there are already existing metadata."""
-    os.environ['AUTOMATIC_LABELS'] = 'auto'
-    os.environ['AUTOMATIC_LABELS_1'] = 'auto1'
-    os.environ['AUTOMATIC_COMPONENTS'] = 'auto'
-    os.environ['AUTOMATIC_COMPONENTS_1'] = 'auto1'
+    os.environ['AUTOMATIC_LABELS'] = 'auto_label'
+    os.environ['AUTOMATIC_LABELS_1'] = 'auto_label1'
+    os.environ['AUTOMATIC_COMPONENTS'] = 'auto_component'
+    os.environ['AUTOMATIC_COMPONENTS_1'] = 'auto_component1'
 
-    metadata = {'issue_components': 'existing', 'issue_labels': 'existing'}
+    metadata = {
+        'issue_components': 'existing_component',
+        'issue_labels': 'existing_label'
+    }
     fuzz_task._add_issue_metadata_from_environment(metadata)
     self.assertDictEqual({
-        'issue_components': 'existing,auto,auto1',
-        'issue_labels': 'existing,auto,auto1',
+        'issue_components':
+            'existing_component,auto_component,auto_component1',
+        'issue_labels':
+            'existing_label,auto_label,auto_label1',
     }, metadata)


### PR DESCRIPTION
Also allow a variation of the AUTOMATIC_{LABELS,COMPONENTS,etc} vars
with a '_1' suffix to allow this to be specified in both the job and the
bot environment.