### PR TITLE
Minimize task: do not remove UBSAN_OPTIONS=silence_unsigned_overflow=1.

### DIFF
--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -68,7 +68,7 @@ IPC_MESSAGE_UTIL_EXECUTABLE_FOR_PLATFORM = {
 # unneeded when reproducing a given crash, but after the bug is fixed, the lack
 # of these options might prevent ClusterFuzz from verifying the fix and closing
 # the bug. See https://github.com/google/oss-fuzz/issues/3227 for example.
-MANDATORY_SANITIZER_OPTIONS = [
+MANDATORY_OSS_FUZZ_OPTIONS = [
     'silence_unsigned_overflow',
 ]
 
@@ -1274,7 +1274,7 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
 
     minimized_options = options.copy()
     for options_name, options_value in six.iteritems(options):
-      if options_name in MANDATORY_SANITIZER_OPTIONS:
+      if utils.is_oss_fuzz() and options_name in MANDATORY_OSS_FUZZ_OPTIONS:
         continue
 
       minimized_options.pop(options_name)

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -64,6 +64,14 @@ IPC_MESSAGE_UTIL_EXECUTABLE_FOR_PLATFORM = {
     'WINDOWS': 'ipc_message_util.exe',
 }
 
+# These options should not ever be removed during minimization. They might seem
+# unneeded when reproducing a given crash, but after the bug is fixed, the lack
+# of these options might prevent ClusterFuzz from verifying the fix and closing
+# the bug. See https://github.com/google/oss-fuzz/issues/3227 for example.
+MANDATORY_SANITIZER_OPTIONS = [
+    'silence_unsigned_overflow',
+]
+
 
 class MinimizationPhase(object):
   """Effectively an enum to represent the current phase of minimization."""
@@ -1266,6 +1274,9 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
 
     minimized_options = options.copy()
     for options_name, options_value in six.iteritems(options):
+      if options_name in MANDATORY_SANITIZER_OPTIONS:
+        continue
+
       minimized_options.pop(options_name)
       environment.set_memory_tool_options(options_env_var, minimized_options)
 

--- a/src/python/tests/core/bot/tasks/minimize_task_test.py
+++ b/src/python/tests/core/bot/tasks/minimize_task_test.py
@@ -184,13 +184,20 @@ class MinimizeTaskTestUntrusted(
     self._setup_env(job_type='libfuzzer_asan_job')
     environment.set_value('APP_ARGS', testcase.minimized_arguments)
     environment.set_value('LIBFUZZER_MINIMIZATION_ROUNDS', 3)
+    environment.set_value('UBSAN_OPTIONS',
+                          'unneeded_option=1:silence_unsigned_overflow=1')
     minimize_task.execute_task(testcase.key.id(), 'libfuzzer_asan_job')
 
     testcase = data_handler.get_testcase_by_id(testcase.key.id())
     self.assertNotEqual('', testcase.minimized_keys)
     self.assertNotEqual('NA', testcase.minimized_keys)
     self.assertNotEqual(testcase.fuzzed_keys, testcase.minimized_keys)
-    self.assertEqual({'ASAN_OPTIONS': {}}, testcase.get_metadata('env'))
+    self.assertEqual({
+        'ASAN_OPTIONS': {},
+        'UBSAN_OPTIONS': {
+            'silence_unsigned_overflow': 1
+        }
+    }, testcase.get_metadata('env'))
 
     blobs.read_blob_to_disk(testcase.minimized_keys, testcase_path)
 

--- a/src/python/tests/core/bot/tasks/minimize_task_test.py
+++ b/src/python/tests/core/bot/tasks/minimize_task_test.py
@@ -153,6 +153,9 @@ class MinimizeTaskTestUntrusted(
 
   def test_minimize(self):
     """Test minimize."""
+    helpers.patch(self, ['base.utils.is_oss_fuzz'])
+    self.mock.is_oss_fuzz.return_value = True
+
     testcase_file_path = os.path.join(self.temp_dir, 'testcase')
     with open(testcase_file_path, 'wb') as f:
       f.write('EEE')


### PR DESCRIPTION
PTAL. I don't fully like this because it means we will never remove that flag even for non OSS-Fuzz jobs (which may not need this option at all, as they don't enable unsigned integer overflow check).

However, I suspect that `UBSAN_OPTIONS` are always non empty anyways, therefore it might be acceptable to always have this flag in there, even when it's not used.

See https://github.com/google/oss-fuzz/issues/3227 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19679 for more info.