### PR TITLE
libFuzzer: improve logs parsing for binaries running in fork mode.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/stats.py
+++ b/src/python/bot/fuzzers/libFuzzer/stats.py
@@ -46,10 +46,11 @@ LIBFUZZER_LOG_DICTIONARY_REGEX = re.compile(r'Dictionary: \d+ entries')
 LIBFUZZER_LOG_END_REGEX = re.compile(r'Done\s+\d+\s+runs.*')
 LIBFUZZER_LOG_IGNORE_REGEX = re.compile(r'.*WARNING:.*Sanitizer')
 LIBFUZZER_LOG_LINE_REGEX = re.compile(
-    r'^#\d+.*(READ|INITED|NEW|pulse|REDUCE|RELOAD|DONE)')
+    r'^#\d+[\s]*(READ|INITED|NEW|pulse|REDUCE|RELOAD|DONE|:)\s.*')
 LIBFUZZER_LOG_SEED_CORPUS_INFO_REGEX = re.compile(
     r'INFO:\s+seed corpus:\s+files:\s+(\d+).*rss:\s+(\d+)Mb.*')
-LIBFUZZER_LOG_START_INITED_REGEX = re.compile(r'#\d+\s+INITED\s+.*')
+LIBFUZZER_LOG_START_INITED_REGEX = re.compile(
+    r'(#\d+\s+INITED\s+|INFO:\s+-fork=\d+:\s+fuzzing in separate process).*')
 LIBFUZZER_MERGE_LOG_STATS_REGEX = re.compile(
     r'MERGE-OUTER:\s+\d+\s+new files with'
     r'\s+(\d+)\s+new features added;'
@@ -259,8 +260,6 @@ def parse_performance_features(log_lines, strategies, arguments):
 
     match = LIBFUZZER_MODULES_LOADED_REGEX.match(line)
     if match:
-      # TODO(mmoroz): this is missing cases when fuzz target binary does not
-      # have edge coverage instrumentation (e.g. Go targets).
       stats['startup_crash_count'] = 0
       stats['edges_total'] = int(match.group(2))
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_stats_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_stats_test.py
@@ -121,8 +121,28 @@ class PerformanceStatsTest(unittest.TestCase):
 
   def test_parse_log_and_stats_go_fuzz(self):
     """Test stats parsing and additional performance features extraction
-    without applying of stat_overrides."""
+    without applying of stat_overrides for a Go fuzz target."""
     log_lines = self._read_test_data('go_fuzz_log.txt')
+    parsed_stats = stats.parse_performance_features(log_lines, [],
+                                                    ['-max_len=1337'])
+    self.assertEqual(0, parsed_stats['crash_count'])
+    self.assertEqual(0, parsed_stats['corpus_crash_count'])
+    self.assertEqual(0, parsed_stats['startup_crash_count'])
+
+  def test_parse_log_and_stats_go_fork_fuzz(self):
+    """Test stats parsing and additional performance features extraction
+    without applying of stat_overrides for a Go fuzz target in form mode."""
+    log_lines = self._read_test_data('go_fork_fuzz_log.txt')
+    parsed_stats = stats.parse_performance_features(log_lines, [],
+                                                    ['-max_len=1337'])
+    self.assertEqual(0, parsed_stats['crash_count'])
+    self.assertEqual(0, parsed_stats['corpus_crash_count'])
+    self.assertEqual(0, parsed_stats['startup_crash_count'])
+
+  def test_parse_log_and_stats_fork_fuzz(self):
+    """Test stats parsing and additional performance features extraction
+    without applying of stat_overrides for a fuzz target in fork mode."""
+    log_lines = self._read_test_data('fork_fuzz_log.txt')
     parsed_stats = stats.parse_performance_features(log_lines, [],
                                                     ['-max_len=1337'])
     self.assertEqual(0, parsed_stats['crash_count'])

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_stats_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_stats_test.py
@@ -131,7 +131,7 @@ class PerformanceStatsTest(unittest.TestCase):
 
   def test_parse_log_and_stats_go_fork_fuzz(self):
     """Test stats parsing and additional performance features extraction
-    without applying of stat_overrides for a Go fuzz target in form mode."""
+    without applying of stat_overrides for a Go fuzz target in fork mode."""
     log_lines = self._read_test_data('go_fork_fuzz_log.txt')
     parsed_stats = stats.parse_performance_features(log_lines, [],
                                                     ['-max_len=1337'])

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_test_data/fork_fuzz_log.txt
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_test_data/fork_fuzz_log.txt
@@ -1,0 +1,23 @@
+Command: /mnt/scratch0/clusterfuzz/resources/platform/linux/minijail0 -f /tmp/tmpL48QXz -U -m '0 1337 1' -T static -c 0 -n -v -p -l -I -k proc,/proc,proc,1 -P /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-1062366/tmpo4sx0e -b /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-1062366/tmpczzzLy,/tmp,1 -b /lib,/lib,0 -b /lib32,/lib32,0 -b /lib64,/lib64,0 -b /usr/lib,/usr/lib,0 -b /usr/lib32,/usr/lib32,0 -b /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_zlib_b798cdb6c6db308d8c54cde60579b7897243b308/revisions,/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_zlib_b798cdb6c6db308d8c54cde60579b7897243b308/revisions,0 -b /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds-dataflow_zlib_293cddb7b1264b5228116e2535684a23e3a71181/dataflow,/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds-dataflow_zlib_293cddb7b1264b5228116e2535684a23e3a71181/dataflow,0 -b /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_zlib_b798cdb6c6db308d8c54cde60579b7897243b308/revisions,/out,0 -b /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-1062366/new,/new,1 -b /mnt/scratch0/clusterfuzz/bot/inputs/data-bundles/global/zlib_uncompress2_fuzzer,/zlib_uncompress2_fuzzer,1 -b /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases,/fuzzer-testcases,1 /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_zlib_b798cdb6c6db308d8c54cde60579b7897243b308/revisions/zlib_uncompress2_fuzzer -timeout=25 -rss_limit_mb=2560 -collect_data_flow=/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds-dataflow_zlib_293cddb7b1264b5228116e2535684a23e3a71181/dataflow/zlib_uncompress2_fuzzer -fork=1 -artifact_prefix=/fuzzer-testcases/ -max_total_time=6150 -print_final_stats=1 /new /zlib_uncompress2_fuzzer
+Bot: oss-fuzz-linux-zone3-worker-zlib-ncdx
+Time ran: 6258.58569407
+
+INFO: Seed: 96674931
+INFO: Loaded 1 modules   (664 inline 8-bit counters): 664 [0x7c7b50, 0x7c7de8),
+INFO: Loaded 1 PC tables (664 PCs): 664 [0x5846f8,0x587078),
+INFO: -fork=1: fuzzing in separate process(s)
+INFO: -fork=1: 648 seed inputs, starting to fuzz in /tmp/libFuzzerTemp.1.dir
+#59248: cov: 300 ft: 1346 corp: 648 exec/s 29624 oom/timeout/crash: 0/0/0 time: 3s job: 1 dft_time: 1
+#122564: cov: 300 ft: 1346 corp: 648 exec/s 21105 oom/timeout/crash: 0/0/0 time: 7s job: 2 dft_time: 1
+#183056: cov: 300 ft: 1346 corp: 648 exec/s 15123 oom/timeout/crash: 0/0/0 time: 13s job: 3 dft_time: 1
+#283280: cov: 300 ft: 1346 corp: 648 exec/s 20044 oom/timeout/crash: 0/0/0 time: 20s job: 4 dft_time: 1
+#397256: cov: 300 ft: 1346 corp: 648 exec/s 18996 oom/timeout/crash: 0/0/0 time: 27s job: 5 dft_time: 1
+#508977: cov: 300 ft: 1346 corp: 648 exec/s 15960 oom/timeout/crash: 0/0/0 time: 36s job: 6 dft_time: 1
+#623899: cov: 300 ft: 1346 corp: 648 exec/s 14365 oom/timeout/crash: 0/0/0 time: 46s job: 7 dft_time: 2
+#770395: cov: 300 ft: 1347 corp: 649 exec/s 16277 oom/timeout/crash: 0/0/0 time: 57s job: 8 dft_time: 1
+#83688424: cov: 300 ft: 1347 corp: 649 exec/s 21229 oom/timeout/crash: 0/0/0 time: 6037s job: 108 dft_time: 0
+#84955243: cov: 300 ft: 1347 corp: 649 exec/s 11516 oom/timeout/crash: 0/0/0 time: 6147s job: 109 dft_time: 0
+#86430386: cov: 300 ft: 1347 corp: 649 exec/s 13289 oom/timeout/crash: 0/0/0 time: 6258s job: 110 dft_time: 0
+INFO: fuzzed for 6258 seconds, wrapping up soon
+INFO: exiting: 0 time: 6258s
+cf::fuzzing_strategies: fork:1,dataflow_tracing:1

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_test_data/go_fork_fuzz_log.txt
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/libfuzzer_test_data/go_fork_fuzz_log.txt
@@ -1,0 +1,28 @@
+Command: /mnt/scratch0/clusterfuzz/resources/platform/linux/minijail0 -f /tmp/tmpYPTz08 -U -m '0 1337 1' -T static -c 0 -n -v -p -l -I -k proc,/proc,proc,1 -P /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-1356/tmpPQAiZ0 -b /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-1356/tmpwkdz0p,/tmp,1 -b /lib,/lib,0 -b /lib32,/lib32,0 -b /lib64,/lib64,0 -b /usr/lib,/usr/lib,0 -b /usr/lib32,/usr/lib32,0 -b /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_gonids_4fd1d07459dc0e09cc34419f8d397495d6d91ed0/revisions,/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_gonids_4fd1d07459dc0e09cc34419f8d397495d6d91ed0/revisions,0 -b /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_gonids_4fd1d07459dc0e09cc34419f8d397495d6d91ed0/revisions,/out,0 -b /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-1356/new,/new,1 -b /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-1356/mutations,/mutations,1 -b /mnt/scratch0/clusterfuzz/bot/inputs/data-bundles/global/gonids_fuzz_parserule,/gonids_fuzz_parserule,1 -b /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases,/fuzzer-testcases,1 /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_gonids_4fd1d07459dc0e09cc34419f8d397495d6d91ed0/revisions/fuzz_parserule -timeout=25 -rss_limit_mb=2560 -fork=1 -artifact_prefix=/fuzzer-testcases/ -max_total_time=5550 -print_final_stats=1 /new /mutations /gonids_fuzz_parserule
+Bot: oss-fuzz-linux-zone3-worker-gonids-l0bl
+Time ran: 5645.80244493
+
+INFO: Seed: 972166136
+INFO: 65536 Extra Counters
+INFO: -fork=1: fuzzing in separate process(s)
+INFO: -fork=1: 2430 seed inputs, starting to fuzz in /tmp/libFuzzerTemp.1.dir
+#448: cov: 0 ft: 10979 corp: 2430 exec/s 224 oom/timeout/crash: 0/0/0 time: 165s job: 1 dft_time: 0
+#4485: cov: 0 ft: 10979 corp: 2430 exec/s 1345 oom/timeout/crash: 0/0/0 time: 168s job: 2 dft_time: 0
+#6892: cov: 0 ft: 10979 corp: 2430 exec/s 601 oom/timeout/crash: 0/0/0 time: 173s job: 3 dft_time: 0
+#9222: cov: 0 ft: 10979 corp: 2430 exec/s 466 oom/timeout/crash: 0/0/0 time: 178s job: 4 dft_time: 0
+#12364: cov: 0 ft: 10979 corp: 2430 exec/s 523 oom/timeout/crash: 0/0/0 time: 184s job: 5 dft_time: 0
+#15053: cov: 0 ft: 10979 corp: 2430 exec/s 384 oom/timeout/crash: 0/0/0 time: 191s job: 6 dft_time: 0
+#16466: cov: 0 ft: 10979 corp: 2430 exec/s 176 oom/timeout/crash: 0/0/0 time: 200s job: 7 dft_time: 0
+#21019: cov: 0 ft: 10979 corp: 2430 exec/s 505 oom/timeout/crash: 0/0/0 time: 209s job: 8 dft_time: 0
+#24559: cov: 0 ft: 10979 corp: 2430 exec/s 354 oom/timeout/crash: 0/0/0 time: 219s job: 9 dft_time: 0
+#27169: cov: 0 ft: 10979 corp: 2430 exec/s 237 oom/timeout/crash: 0/0/0 time: 230s job: 10 dft_time: 0
+#28975: cov: 0 ft: 10979 corp: 2430 exec/s 150 oom/timeout/crash: 0/0/0 time: 242s job: 11 dft_time: 0
+#35971: cov: 0 ft: 10979 corp: 2430 exec/s 538 oom/timeout/crash: 0/0/0 time: 256s job: 12 dft_time: 0
+#39377: cov: 0 ft: 10979 corp: 2430 exec/s 243 oom/timeout/crash: 0/0/0 time: 270s job: 13 dft_time: 0
+#40354: cov: 0 ft: 10979 corp: 2430 exec/s 65 oom/timeout/crash: 0/0/0 time: 285s job: 14 dft_time: 0
+#49229: cov: 0 ft: 10979 corp: 2430 exec/s 554 oom/timeout/crash: 0/0/0 time: 301s job: 15 dft_time: 0
+#1116313: cov: 0 ft: 10979 corp: 2430 exec/s 341 oom/timeout/crash: 0/0/0 time: 5541s job: 102 dft_time: 0
+#1172812: cov: 0 ft: 10979 corp: 2430 exec/s 543 oom/timeout/crash: 0/0/0 time: 5645s job: 103 dft_time: 0
+INFO: fuzzed for 5645 seconds, wrapping up soon
+INFO: exiting: 0 time: 5645s
+cf::fuzzing_strategies: fork:1,corpus_mutations_radamsa:1


### PR DESCRIPTION
This fixes https://github.com/google/oss-fuzz/issues/3107