### PR TITLE
Add an extra layer of line minimization before JS and HTML minimization. 

### DIFF
--- a/src/python/bot/minimizer/html_minimizer.py
+++ b/src/python/bot/minimizer/html_minimizer.py
@@ -88,6 +88,8 @@ class HTMLMinimizer(minimizer.Minimizer):  # pylint:disable=abstract-method
     # Do an initial line-by-line minimization to filter out noise.
     line_minimizer = delta_minimizer.DeltaMinimizer(self.test_function,
                                                     **self.kwargs)
+    # Do two line minimizations to make up for the fact that minimzations on
+    # bots don't always minimize as much as they can.
     for _ in range(2):
       data = line_minimizer.minimize(data)
 

--- a/src/python/bot/minimizer/html_minimizer.py
+++ b/src/python/bot/minimizer/html_minimizer.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 
 from builtins import object
+from builtins import range
 import functools
 
 from . import chunk_minimizer

--- a/src/python/bot/minimizer/html_minimizer.py
+++ b/src/python/bot/minimizer/html_minimizer.py
@@ -87,7 +87,8 @@ class HTMLMinimizer(minimizer.Minimizer):  # pylint:disable=abstract-method
     # Do an initial line-by-line minimization to filter out noise.
     line_minimizer = delta_minimizer.DeltaMinimizer(self.test_function,
                                                     **self.kwargs)
-    data = line_minimizer.minimize(data)
+    for _ in range(2):
+      data = line_minimizer.minimize(data)
 
     tokens = self.get_tokens_and_metadata(data)
     for index, token in enumerate(tokens):

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1054,7 +1054,7 @@ def do_js_minimization(test_function, get_temp_file, data, deadline, threads,
   # Start by using a generic line minimizer on the test.
   for _ in range(2):
     data = do_line_minimization(test_function, get_temp_file, data, deadline,
-                              threads, cleanup_interval, delete_temp_files)
+                                threads, cleanup_interval, delete_temp_files)
 
   tokenizer = AntlrTokenizer(JavaScriptLexer)
 

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1052,7 +1052,8 @@ def do_js_minimization(test_function, get_temp_file, data, deadline, threads,
                        cleanup_interval, delete_temp_files):
   """Javascript minimization strategy."""
   # Start by using a generic line minimizer on the test.
-  data = do_line_minimization(test_function, get_temp_file, data, deadline,
+  for _ in range(2):
+    data = do_line_minimization(test_function, get_temp_file, data, deadline,
                               threads, cleanup_interval, delete_temp_files)
 
   tokenizer = AntlrTokenizer(JavaScriptLexer)

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1052,6 +1052,8 @@ def do_js_minimization(test_function, get_temp_file, data, deadline, threads,
                        cleanup_interval, delete_temp_files):
   """Javascript minimization strategy."""
   # Start by using a generic line minimizer on the test.
+  # Do two line minimizations to make up for the fact that minimzations on bots
+  # don't always minimize as much as they can.
   for _ in range(2):
     data = do_line_minimization(test_function, get_temp_file, data, deadline,
                                 threads, cleanup_interval, delete_temp_files)


### PR DESCRIPTION
Hopefully a fix to the fact that line minimization on bots does not minimize as well as it does locally 