### PR TITLE
Dataflow strategy: use traces from the build, auto-focus, no fork (#1346).

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/constants.py
+++ b/src/python/bot/fuzzers/libFuzzer/constants.py
@@ -26,7 +26,7 @@ DATA_FLOW_TRACE_FLAG = '-data_flow_trace='
 
 DICT_FLAG = '-dict='
 
-FOCUS_FUNCTION_AUTO_ARGUMENT = '-focus_function=auto'
+FOCUS_FUNCTION_FLAG = '-focus_function='
 
 FORK_FLAG = '-fork='
 

--- a/src/python/bot/fuzzers/libFuzzer/constants.py
+++ b/src/python/bot/fuzzers/libFuzzer/constants.py
@@ -22,9 +22,11 @@ defined in this function that end with the suffix "_FLAG" should contain
 # libFuzzer flags.
 ARTIFACT_PREFIX_FLAG = '-artifact_prefix='
 
-COLLECT_DATA_FLOW_FLAG = '-collect_data_flow='
+DATA_FLOW_TRACE_FLAG = '-data_flow_trace='
 
 DICT_FLAG = '-dict='
+
+FOCUS_FUNCTION_AUTO_ARGUMENT = '-focus_function=auto'
 
 FORK_FLAG = '-fork='
 

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1414,7 +1414,8 @@ def remove_fuzzing_arguments(arguments):
       constants.MAX_LEN_FLAG,  # This may shrink the testcases.
       constants.RUNS_FLAG,  # Make sure we don't have any '-runs' argument.
       constants.FORK_FLAG,  # It overrides `-merge` argument.
-      constants.COLLECT_DATA_FLOW_FLAG,  # Used for fuzzing only.
+      constants.DATA_FLOW_TRACE_FLAG,  # Used for fuzzing only.
+      constants.FOCUS_FUNCTION_FLAG,  # Used for fuzzing only.
   ]:
     fuzzer_utils.extract_argument(arguments, argument)
 
@@ -1553,7 +1554,7 @@ def pick_strategies(strategy_pool, fuzzer_path, corpus_directory,
     if os.path.exists(dataflow_trace_dir):
       arguments.append(
           '%s%s' % (constants.DATA_FLOW_TRACE_FLAG, dataflow_trace_dir))
-      arguments.append(constants.FOCUS_FUNCTION_AUTO_ARGUMENT)
+      arguments.append('%s%s' % (constants.FOCUS_FUNCTION_FLAG, 'auto'))
       fuzzing_strategies.append(strategy.DATAFLOW_TRACING_STRATEGY.name)
     else:
       logs.log_error(

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1595,7 +1595,6 @@ def pick_strategies(strategy_pool, fuzzer_path, corpus_directory,
     arguments.append(constants.VALUE_PROFILE_ARGUMENT)
     fuzzing_strategies.append(strategy.VALUE_PROFILE_STRATEGY.name)
 
-  # DataFlow Tracing requires fork mode, always use it with DFT strategy.
   # FIXME: Disable for now to avoid severe battery drainage. Stabilize and
   # re-enable with a lower process count.
   is_android = environment.platform() == 'ANDROID'
@@ -1604,6 +1603,8 @@ def pick_strategies(strategy_pool, fuzzer_path, corpus_directory,
   # Fork mode is disabled on ephemeral bots due to a bug on the platform.
   is_ephemeral = environment.is_ephemeral()
 
+  # Do not use fork mode for DFT-based fuzzing. This is needed in order to
+  # collect readable and actionable logs from fuzz targets running with DFT.
   if (not is_fuchsia and not is_android and not is_ephemeral and
       not use_dataflow_tracing and
       strategy_pool.do_strategy(strategy.FORK_STRATEGY)):

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1605,7 +1605,7 @@ def pick_strategies(strategy_pool, fuzzer_path, corpus_directory,
 
   if (not is_fuchsia and not is_android and not is_ephemeral and
       not use_dataflow_tracing and
-       strategy_pool.do_strategy(strategy.FORK_STRATEGY)):
+      strategy_pool.do_strategy(strategy.FORK_STRATEGY)):
     max_fuzz_threads = environment.get_value('MAX_FUZZ_THREADS', 1)
     num_fuzz_processes = max(1, utils.cpu_count() // max_fuzz_threads)
     arguments.append('%s%d' % (constants.FORK_FLAG, num_fuzz_processes))


### PR DESCRIPTION
Instead of `-collect_data_flow=<DATAFLOW_BINARY> -fork=1`, use `-data_flow_trace=<DATAFLOW_TRACE_DIR> -focus_function=auto` and intentionally do not use the fork mode (at least for now).

