### PR TITLE
Commit missing review comment fix from previous change.

### DIFF
--- a/src/python/bot/minimizer/html_minimizer.py
+++ b/src/python/bot/minimizer/html_minimizer.py
@@ -188,7 +188,7 @@ class HTMLMinimizer(minimizer.Minimizer):  # pylint:disable=abstract-method
     return tokens
 
   @staticmethod
-  def combine_worker_tokens(tokens, prefix='', suffix=''):
+  def combine_worker_tokens(tokens, prefix=b'', suffix=b''):
     """Combine tokens for a worker minimizer."""
     return prefix + b''.join(tokens) + suffix
 


### PR DESCRIPTION
TBR for a fix intended for the previous change. This codepath is unused since we never use the default values, so no need to redeploy specifically for it.