### PR TITLE
Speculative fix for RPC exceptions.

### DIFF
--- a/src/python/bot/untrusted_runner/host.py
+++ b/src/python/bot/untrusted_runner/host.py
@@ -157,7 +157,7 @@ def _wrap_call(func, num_retries=config.RPC_RETRY_ATTEMPTS):
       except grpc.RpcError as e:
         # For timeouts, which aren't fatal errors, resurface the right
         # exception.
-        if 'TimeoutError' in e:
+        if 'TimeoutError' in str(e, encoding='utf-8', errors='ignore'):
           # TODO(ochang): Replace with generic TimeoutError in Python 3.
           raise engine.TimeoutError(e.message)
 

--- a/src/python/bot/untrusted_runner/tasks_host.py
+++ b/src/python/bot/untrusted_runner/tasks_host.py
@@ -186,7 +186,7 @@ def engine_reproduce(engine_impl, target_name, testcase_path, arguments,
   try:
     response = host.stub().EngineReproduce(request)
   except grpc.RpcError as e:
-    if 'TargetNotFoundError' in str(e):
+    if 'TargetNotFoundError' in str(e, encoding='utf-8', errors='ignore'):
       # Resurface the right exception.
       raise testcase_manager.TargetNotFoundError('Failed to find target ' +
                                                  target_name)


### PR DESCRIPTION
PTAL. We started seeing a bunch of RPC exceptions after I removed the explicit str conversion here. This doesn't feel great to me either, but at least it won't break again after the unicode literal conversion. I'm not sure this behavior makes sense in pure Python 3, though.