### PR TITLE
Revert "Properly handle utf-8 encoded inputs to newstr_to_native_str."

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -946,4 +946,4 @@ def cpu_count():
 
 # TODO(mbarbella): Delete this once fully migrated to Python 3.
 def newstr_to_native_str(s):
-  return future_utils.native(str(s, encoding='utf-8')).encode()
+  return future_utils.native(str(s)).encode()

--- a/src/python/system/new_process.py
+++ b/src/python/system/new_process.py
@@ -278,17 +278,10 @@ class ProcessRunner(object):
     # TODO(mbarbella): Remove this after the Python 3 conversion. Subprocess
     # contains some explicit type checks, causing errors when newstrs are used.
     if env:
-      new_env = {}
-      for k, v in env.items():
-        try:
-          new_env[utils.decode_to_unicode(k)] = utils.newstr_to_native_str(v)
-        except UnicodeDecodeError:
-          # If any non-unicode keys or values are already set in the
-          # environment, we know those aren't of type newstr (since they could
-          # not have been decoded in the first place).
-          new_env[k] = v
-
-      env = new_env
+      env = {
+          utils.newstr_to_native_str(k): utils.newstr_to_native_str(v)
+          for k, v in env.items()
+      }
 
     return ChildProcess(
         subprocess.Popen(


### PR DESCRIPTION
Reverts google/clusterfuzz#1363.

This caused some the original exceptions to reappear and it looks like it didn't fix the actual issue. Will investigate a better solution soon.