### PR TITLE
Properly check for failed build setup in fuzz_task. 

### DIFF
--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1805,23 +1805,25 @@ class FuzzingSession(object):
     # can provide a revision to use via |APP_REVISION|.
     dataflow_bucket_path = environment.get_value('DATAFLOW_BUILD_BUCKET_PATH')
     target_weights = fuzzer_selection.get_fuzz_target_weights()
-    if (build_manager.setup_build(
+
+    build_setup_result = build_manager.setup_build(
         environment.get_value('APP_REVISION'), target_weights=target_weights)
-        and dataflow_bucket_path):
+    if build_setup_result and dataflow_bucket_path:
       # Some fuzzing jobs may use auxiliary builds, such as DFSan instrumented
       # builds accompanying libFuzzer builds to enable DFT-based fuzzing.
-      build_manager.setup_trunk_build(
-          [dataflow_bucket_path], build_prefix='DATAFLOW')
-
-    # Save fuzz targets count to aid with CPU weighting.
-    self._save_fuzz_targets_count()
+      if not build_manager.setup_trunk_build(
+          [dataflow_bucket_path], build_prefix='DATAFLOW'):
+        logs.log_error('Failed to set up dataflow build.')
 
     # Check if we have an application path. If not, our build failed
     # to setup correctly.
-    if not build_manager.check_app_path():
+    if not build_setup_result or not build_manager.check_app_path():
       _track_fuzzer_run_result(self.fuzzer_name, 0, 0,
                                FuzzErrorCode.BUILD_SETUP_FAILED)
       return
+
+    # Save fuzz targets count to aid with CPU weighting.
+    self._save_fuzz_targets_count()
 
     # Check if we have a bad build, i.e. one that crashes on startup.
     # If yes, bail out.

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1803,24 +1803,24 @@ class FuzzingSession(object):
     # Set up a custom or regular build based on revision. By default, fuzzing
     # is done on trunk build (using revision=None). Otherwise, a job definition
     # can provide a revision to use via |APP_REVISION|.
-    dataflow_bucket_path = environment.get_value('DATAFLOW_BUILD_BUCKET_PATH')
     target_weights = fuzzer_selection.get_fuzz_target_weights()
 
     build_setup_result = build_manager.setup_build(
         environment.get_value('APP_REVISION'), target_weights=target_weights)
-    if build_setup_result and dataflow_bucket_path:
-      # Some fuzzing jobs may use auxiliary builds, such as DFSan instrumented
-      # builds accompanying libFuzzer builds to enable DFT-based fuzzing.
-      if not build_manager.setup_trunk_build(
-          [dataflow_bucket_path], build_prefix='DATAFLOW'):
-        logs.log_error('Failed to set up dataflow build.')
-
     # Check if we have an application path. If not, our build failed
     # to setup correctly.
     if not build_setup_result or not build_manager.check_app_path():
       _track_fuzzer_run_result(self.fuzzer_name, 0, 0,
                                FuzzErrorCode.BUILD_SETUP_FAILED)
       return
+
+    dataflow_bucket_path = environment.get_value('DATAFLOW_BUILD_BUCKET_PATH')
+    if dataflow_bucket_path:
+      # Some fuzzing jobs may use auxiliary builds, such as DFSan instrumented
+      # builds accompanying libFuzzer builds to enable DFT-based fuzzing.
+      if not build_manager.setup_trunk_build(
+          [dataflow_bucket_path], build_prefix='DATAFLOW'):
+        logs.log_error('Failed to set up dataflow build.')
 
     # Save fuzz targets count to aid with CPU weighting.
     self._save_fuzz_targets_count()


### PR DESCRIPTION
Previously we were relying on checking APP_PATH, which will not always
exist for engine fuzzers.