### PR TITLE
Minor follow up fixes for the Jira bug tracker support.

### DIFF
--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
+++ b/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/go/cloud/db/types/types.go
+++ b/src/go/cloud/db/types/types.go
@@ -89,6 +89,8 @@ type Config struct {
 	PreviousHash                        string         `datastore:"previous_hash"`
 	URL                                 string         `datastore:"url"`
 	ClientCredentials                   string         `datastore:"client_credentials,noindex"`
+	JiraURL                             string         `datastore:"jira_url"`
+	JiraCredentials                     string         `datastore:"jira_credentials,noindex"`
 	BuildApiaryServiceAccountEmail      string         `datastore:"build_apiary_service_account_email"`
 	BuildApiaryServiceAccountPrivateKey string         `datastore:"build_apiary_service_account_private_key,noindex"`
 	TestAccountEmail                    string         `datastore:"test_account_email"`

--- a/src/python/tests/appengine/libs/issue_management/jira/__init__.py
+++ b/src/python/tests/appengine/libs/issue_management/jira/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/python/tests/appengine/libs/issue_management/jira/jira_test.py
+++ b/src/python/tests/appengine/libs/issue_management/jira/jira_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Some of the bots are reporting an error which is rather confusing (https://console.cloud.google.com/errors/CJHMu9O6p87LQg?time=P30D&project=google.com:clusterfuzz)

```
  message: "Command: ['python', '/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py'] None (exit=1)
Traceback (most recent call last):
  File "/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py", line 44, in <module>
    from base import tasks
  File "/mnt/scratch0/clusterfuzz/src/python/base/tasks.py", line 29, in <module>
    from datastore import data_types
  File "/mnt/scratch0/clusterfuzz/src/python/datastore/data_types.py", line 707, in <module>
    class Config(Model):
  File "/mnt/scratch0/clusterfuzz/src/python/datastore/data_types.py", line 718, in Config
    jira_url = StringProperty(default='')
NameError: name 'StringProperty' is not defined" 
```

Lines in the stacktrace are off, for example.

This PR doesn't seem to bring in any functional difference, but is a good reason to re-deploy and see if the issue still persists.