### PR TITLE
Initialize NDB context for threads created by utils.timeout

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -739,7 +739,9 @@ def timeout(duration):
         THREAD_POOL = multiprocessing.pool.ThreadPool(processes=3)
 
       try:
-        async_result = THREAD_POOL.apply_async(func, args=args, kwds=kwargs)
+        from datastore import ndb_init  # Avoid circular import.
+        async_result = THREAD_POOL.apply_async(
+            ndb_init.thread_wrapper(func), args=args, kwds=kwargs)
         return async_result.get(timeout=duration)
       except multiprocessing.TimeoutError:
         # Sleep for some minutes in order to wait for flushing metrics.

--- a/src/python/datastore/ndb_init.py
+++ b/src/python/datastore/ndb_init.py
@@ -14,6 +14,7 @@
 """NDB initialization."""
 
 import contextlib
+import functools
 import threading
 
 from google.cloud import ndb
@@ -58,3 +59,15 @@ def context():
     ndb_context.set_cache_policy(False)
 
     yield ndb_context
+
+
+def thread_wrapper(func):
+  """Wrapper for thread targets to initialize an NDB context, since contexts are
+  thread local."""
+
+  @functools.wraps(func)
+  def _wrapper(*args, **kwargs):
+    with context():
+      return func(*args, **kwargs)
+
+  return _wrapper


### PR DESCRIPTION
NDB contexts are per thread.