### PR TITLE
Fuzzer Stats: handle missing values for corpora stats (follow up #1372).

### DIFF
--- a/src/python/metrics/fuzzer_stats.py
+++ b/src/python/metrics/fuzzer_stats.py
@@ -500,6 +500,9 @@ class CorpusSizeField(BaseCoverageField):
       corpus_size_bytes = coverage_info.quarantine_size_bytes
       corpus_location = coverage_info.quarantine_location
 
+    if corpus_size_units is None or corpus_size_bytes is None:
+      return None
+
     display_value = '%d (%s)' % (corpus_size_units,
                                  utils.get_size_string(corpus_size_bytes))
 

--- a/src/python/metrics/fuzzer_stats.py
+++ b/src/python/metrics/fuzzer_stats.py
@@ -500,6 +500,7 @@ class CorpusSizeField(BaseCoverageField):
       corpus_size_bytes = coverage_info.quarantine_size_bytes
       corpus_location = coverage_info.quarantine_location
 
+    # If the values aren't specified, return None to show the default '--' text.
     if corpus_size_units is None or corpus_size_bytes is None:
       return None
 


### PR DESCRIPTION
Fixes https://console.cloud.google.com/errors/CL3_lZejgoXFfg?time=PT1H&project=clusterfuzz-external

This is happening when fuzzer coverage tasks runs before the corpus pruning for a corresponding fuzz target succeeded. Not sure how it worked previously, either:
- Go initialized those fields with 0 by default
- we just never ran into this

Anyways, I think explicit `--` being shown is better than a fake `0`, so this is a good change.

Tested on staging.