### PR TITLE
Use sanitizer options symbolize=1 when dataflow tracing is enabled (#1346).

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -239,7 +239,7 @@ class LibFuzzerEngine(engine.Engine):
     """
     profiler.start_if_needed('libfuzzer_fuzz')
     runner = libfuzzer.get_runner(target_path)
-    libfuzzer.set_sanitizer_options(target_path)
+    libfuzzer.set_sanitizer_options(target_path, fuzz_options=options)
 
     # Directory to place new units.
     new_corpus_dir = self._create_temp_corpus_dir('new')

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1534,10 +1534,6 @@ def set_sanitizer_options(fuzzer_path, fuzz_options=None):
     # Focus function feature does not work without symbolization.
     sanitizer_options['symbolize'] = 1
     environment.update_symbolizer_options(sanitizer_options)
-
-    # But we still need to disable symbolization inlined frames to make sure
-    # deduplication works correctly.
-    sanitizer_options['symbolize_inline_frames'] = 'false'
   environment.set_memory_tool_options(sanitizer_options_var, sanitizer_options)
 
 

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1522,7 +1522,7 @@ def parse_log_stats(log_lines):
   return log_stats
 
 
-def set_sanitizer_options(fuzzer_path):
+def set_sanitizer_options(fuzzer_path, fuzz_options=None):
   """Sets sanitizer options based on .options file overrides and what this
   script requires."""
   engine_common.process_sanitizer_options_overrides(fuzzer_path)
@@ -1530,6 +1530,9 @@ def set_sanitizer_options(fuzzer_path):
   sanitizer_options = environment.get_memory_tool_options(
       sanitizer_options_var, {})
   sanitizer_options['exitcode'] = constants.TARGET_ERROR_EXITCODE
+  if fuzz_options and fuzz_options.use_dataflow_tracing:
+    # Focus function feature does not work without symbolization.
+    sanitizer_options['symbolize'] = 1
   environment.set_memory_tool_options(sanitizer_options_var, sanitizer_options)
 
 

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1523,8 +1523,8 @@ def parse_log_stats(log_lines):
 
 
 def set_sanitizer_options(fuzzer_path, fuzz_options=None):
-  """Sets sanitizer options based on .options file overrides and what this
-  script requires."""
+  """Sets sanitizer options based on .options file overrides, FuzzOptions (if
+  provided), and what this script requires."""
   engine_common.process_sanitizer_options_overrides(fuzzer_path)
   sanitizer_options_var = environment.get_current_memory_tool_var()
   sanitizer_options = environment.get_memory_tool_options(

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1533,6 +1533,10 @@ def set_sanitizer_options(fuzzer_path, fuzz_options=None):
   if fuzz_options and fuzz_options.use_dataflow_tracing:
     # Focus function feature does not work without symbolization.
     sanitizer_options['symbolize'] = 1
+
+    # But we still need to disable symbolization inlined frames to make sure
+    # deduplication works correctly.
+    sanitizer_options['symbolize_inline_frames'] = 'false'
   environment.set_memory_tool_options(sanitizer_options_var, sanitizer_options)
 
 

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1533,6 +1533,7 @@ def set_sanitizer_options(fuzzer_path, fuzz_options=None):
   if fuzz_options and fuzz_options.use_dataflow_tracing:
     # Focus function feature does not work without symbolization.
     sanitizer_options['symbolize'] = 1
+    environment.update_symbolizer_options(sanitizer_options)
 
     # But we still need to disable symbolization inlined frames to make sure
     # deduplication works correctly.

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -770,7 +770,7 @@ def set_environment_parameters_from_file(file_path):
 
 def update_symbolizer_options(tool_options, symbolize_inline_frames=False):
   """Checks and updates the necessary symbolizer options such as
-  # `external_symbolizer_path` and `symbolize_inline_frames`."""
+  `external_symbolizer_path` and `symbolize_inline_frames`."""
   if 'external_symbolizer_path' not in tool_options:
     llvm_symbolizer_path_arg = _quote_value_if_needed(
         get_llvm_symbolizer_path())

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -768,6 +768,19 @@ def set_environment_parameters_from_file(file_path):
       set_value(environment_variable, environment_variable_value)
 
 
+def update_symbolizer_options(tool_options, symbolize_inline_frames=False):
+  """Checks and updates the necessary symbolizer options such as
+  # `external_symbolizer_path` and `symbolize_inline_frames`."""
+  if 'external_symbolizer_path' not in tool_options:
+    llvm_symbolizer_path_arg = _quote_value_if_needed(
+        get_llvm_symbolizer_path())
+    tool_options.update({'external_symbolizer_path': llvm_symbolizer_path_arg})
+  if 'symbolize_inline_frames' not in tool_options:
+    tool_options.update({
+        'symbolize_inline_frames': str(symbolize_inline_frames).lower()
+    })
+
+
 def reset_current_memory_tool_options(redzone_size=0,
                                       malloc_context_size=0,
                                       leaks=True,
@@ -807,16 +820,8 @@ def reset_current_memory_tool_options(redzone_size=0,
     tool_options.update(_parse_memory_tool_options(additional_tool_options))
 
   if tool_options.get('symbolize') == 1:
-    if 'external_symbolizer_path' not in tool_options:
-      llvm_symbolizer_path_arg = _quote_value_if_needed(
-          get_llvm_symbolizer_path())
-      tool_options.update({
-          'external_symbolizer_path': llvm_symbolizer_path_arg
-      })
-    if 'symbolize_inline_frames' not in tool_options:
-      tool_options.update({
-          'symbolize_inline_frames': str(symbolize_inline_frames).lower()
-      })
+    update_symbolizer_options(
+        tool_options, symbolize_inline_frames=symbolize_inline_frames)
 
   # Join the options.
   joined_tool_options = join_memory_tool_options(tool_options)


### PR DESCRIPTION
This is needed to fix https://github.com/google/oss-fuzz/issues/3311.

I'll also make a change in libFuzzer to break loudly when the symbolizer is not available.