### PR TITLE
Preliminary environment setup for Python 3. 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,44 @@
+# This is currently only used for Python 3.
+
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+beautifulsoup4 = "==4.5.1"
+ecdsa = "==0.13.3"
+extras = "==1.0.0"
+fixtures = "==3.0.0"
+funcsigs = "==1.0.2"
+linecache2 = "==1.0.0"
+mock = "==2.0.0"
+mox3 = "==0.18.0"
+parameterized = "==0.6.1"
+pbr = "==1.10.0"
+pyfakefs = "==3.4.3"
+pylint = "~=2.4"
+python-mimeparse = "==1.5.2"
+PyYAML = "==5.1"
+six = "==1.12.0"
+testtools = "==2.2.0"
+traceback2 = "==1.4.0"
+unittest2 = "==1.1.0"
+waitress = "==1.4.2"
+WebTest = "==2.0.23"
+yapf = "==0.22.0"
+
+[dev-packages]
+crcmod = "==1.7"
+Fabric = "==1.14.1"
+future = "==0.17.1"
+google-compute-engine = "==2.8.13"
+grpcio-tools = "==1.15.0"
+nodeenv = "==1.0.0"
+paramiko = "==2.6.0"
+protobuf = "==3.6.1"
+psutil = "==5.4.7"
+# tensorflow = "==1.8.0"  # does not seem to be available
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,605 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "badd7e5d2d8d1c84867c147ad2b0c81f08ecc5e19725414954ff55fd88cc006c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "argparse": {
+            "hashes": [
+                "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4",
+                "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314"
+            ],
+            "version": "==1.4.0"
+        },
+        "astroid": {
+            "hashes": [
+                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
+                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
+            ],
+            "version": "==2.3.3"
+        },
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:35815098d9d0bf5d3a782346a3945b000592d0e93e2538a502d0d6807130d675",
+                "sha256:3c9474036afda9136aac6463def733f81017bf9ef3510d25634f335b0c87f5e1",
+                "sha256:bb3dba571c2f7ddcaf3e70ad8b67878a85ac41889dcba75a30b8f7b0b5960b6d"
+            ],
+            "index": "pypi",
+            "version": "==4.5.1"
+        },
+        "ecdsa": {
+            "hashes": [
+                "sha256:163c80b064a763ea733870feb96f9dd9b92216cfcacd374837af18e4e8ec3d4d",
+                "sha256:9814e700890991abeceeb2242586024d4758c8fc18445b194a49bd62d85861db"
+            ],
+            "index": "pypi",
+            "version": "==0.13.3"
+        },
+        "extras": {
+            "hashes": [
+                "sha256:132e36de10b9c91d5d4cc620160a476e0468a88f16c9431817a6729611a81b4e",
+                "sha256:f689f08df47e2decf76aa6208c081306e7bd472630eb1ec8a875c67de2366e87"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
+        "fixtures": {
+            "hashes": [
+                "sha256:2a551b0421101de112d9497fb5f6fd25e5019391c0fbec9bad591ecae981420d",
+                "sha256:fcf0d60234f1544da717a9738325812de1f42c2fa085e2d9252d8fff5712b2ef"
+            ],
+            "index": "pypi",
+            "version": "==3.0.0"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "index": "pypi",
+            "version": "==1.0.2"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
+                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+            ],
+            "version": "==4.3.21"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+            ],
+            "version": "==1.4.3"
+        },
+        "linecache2": {
+            "hashes": [
+                "sha256:4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c",
+                "sha256:e78be9c0a0dfcbac712fe04fbf92b96cddae80b1b842f24248214c8496f006ef"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
+        "mox3": {
+            "hashes": [
+                "sha256:01faf6ae7cebda8e570b62795e063b48908d1c9aaa857da9c1b5997921c0c83a",
+                "sha256:fbe9f71ffcd3ce2f46770effe5d429d62b674560a57c76f347877179056735e5"
+            ],
+            "index": "pypi",
+            "version": "==0.18.0"
+        },
+        "parameterized": {
+            "hashes": [
+                "sha256:caf58e717097735de0d7e15386a46ffa5ce25bb6a13a43716a8854a8d34841e2",
+                "sha256:cf5fa4f295dfb823cebdb27a00566113f2fbb71c7d5ca7b7a1019fd20c8a0811"
+            ],
+            "index": "pypi",
+            "version": "==0.6.1"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:186428c270309e6fdfe2d5ab0949ab21ae5f7dea831eab96701b86bd666af39c",
+                "sha256:f5cf7265a80636ecff66806d13494cbf9d77a3758a65fd8b4d4d4bee81b0c375"
+            ],
+            "index": "pypi",
+            "version": "==1.10.0"
+        },
+        "pyfakefs": {
+            "hashes": [
+                "sha256:226e8f141e40c19d10693f8df4968407eb47100705796640ee0dc5990bd6f109",
+                "sha256:8312f143b37b014cdd4641ac1f4eac0c47bb881774a3d0be125997133e609a6b"
+            ],
+            "index": "pypi",
+            "version": "==3.4.3"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
+                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+            ],
+            "index": "pypi",
+            "version": "==2.4.4"
+        },
+        "python-mimeparse": {
+            "hashes": [
+                "sha256:bef134a59598cc6aa598f84553162aa7a0c01f3f431588225bb9a208964b1827"
+            ],
+            "index": "pypi",
+            "version": "==1.5.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
+            ],
+            "index": "pypi",
+            "version": "==5.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "index": "pypi",
+            "version": "==1.12.0"
+        },
+        "testtools": {
+            "hashes": [
+                "sha256:80f606607a6e4ce4d0e24e5b786562aa42c581906f3c070607a4265f3da65810",
+                "sha256:9b21a293cd33853956b1d3834c294d77a6ad0ab0eb1c077f858be433f0f225bb"
+            ],
+            "index": "pypi",
+            "version": "==2.2.0"
+        },
+        "traceback2": {
+            "hashes": [
+                "sha256:05acc67a09980c2ecfedd3423f7ae0104839eccb55fc645773e1caa0951c3030",
+                "sha256:8253cebec4b19094d67cc5ed5af99bf1dba1285292226e98a31929f87a5d6b23"
+            ],
+            "index": "pypi",
+            "version": "==1.4.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
+            "version": "==1.4.1"
+        },
+        "unittest2": {
+            "hashes": [
+                "sha256:13f77d0875db6d9b435e1d4f41e74ad4cc2eb6e1d5c824996092b3430f088bb8",
+                "sha256:22882a0e418c284e1f718a822b3b022944d53d2d908e1690b319a9d3eb2c0579"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
+        },
+        "waitress": {
+            "hashes": [
+                "sha256:67a60a376f0eb335ed88967c42b73983a58d66a2a72eb9009a42725f7453b142",
+                "sha256:cbf1c62fc41393a6f27cb78483f8f6e252630a3598984668244b7bf4e35856f1"
+            ],
+            "index": "pypi",
+            "version": "==1.4.2"
+        },
+        "webob": {
+            "hashes": [
+                "sha256:a3c89a8e9ba0aeb17382836cdb73c516d0ecf6630ec40ec28288f3ed459ce87b",
+                "sha256:aa3a917ed752ba3e0b242234b2a373f9c4e2a75d35291dcbe977649bd21fd108"
+            ],
+            "version": "==1.8.6"
+        },
+        "webtest": {
+            "hashes": [
+                "sha256:0831371d415fac39177d1fab4e180510713401a71edd9181373efe123e85cb3e",
+                "sha256:879da5c2310b75c74dffa23a45a7a74d09c2a0fcc7e7a128b4f92a4f64722e97"
+            ],
+            "index": "pypi",
+            "version": "==2.0.23"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+            ],
+            "version": "==1.11.2"
+        },
+        "yapf": {
+            "hashes": [
+                "sha256:6567745f0b6656f9c33a73c56a393071c699e6284a70d793798ab6e3769d25ec",
+                "sha256:a98a6eacca64d2b920558f4a2f78150db9474de821227e60deaa29f186121c63"
+            ],
+            "index": "pypi",
+            "version": "==0.22.0"
+        }
+    },
+    "develop": {
+        "bcrypt": {
+            "hashes": [
+                "sha256:0258f143f3de96b7c14f762c770f5fc56ccd72f8a1857a451c1cd9a655d9ac89",
+                "sha256:0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42",
+                "sha256:19a4b72a6ae5bb467fea018b825f0a7d917789bcfe893e53f15c92805d187294",
+                "sha256:5432dd7b34107ae8ed6c10a71b4397f1c853bd39a4d6ffa7e35f40584cffd161",
+                "sha256:6305557019906466fc42dbc53b46da004e72fd7a551c044a827e572c82191752",
+                "sha256:69361315039878c0680be456640f8705d76cb4a3a3fe1e057e0f261b74be4b31",
+                "sha256:6fe49a60b25b584e2f4ef175b29d3a83ba63b3a4df1b4c0605b826668d1b6be5",
+                "sha256:74a015102e877d0ccd02cdeaa18b32aa7273746914a6c5d0456dd442cb65b99c",
+                "sha256:763669a367869786bb4c8fcf731f4175775a5b43f070f50f46f0b59da45375d0",
+                "sha256:8b10acde4e1919d6015e1df86d4c217d3b5b01bb7744c36113ea43d529e1c3de",
+                "sha256:9fe92406c857409b70a38729dbdf6578caf9228de0aef5bc44f859ffe971a39e",
+                "sha256:a190f2a5dbbdbff4b74e3103cef44344bc30e61255beb27310e2aec407766052",
+                "sha256:a595c12c618119255c90deb4b046e1ca3bcfad64667c43d1166f2b04bc72db09",
+                "sha256:c9457fa5c121e94a58d6505cadca8bed1c64444b83b3204928a866ca2e599105",
+                "sha256:cb93f6b2ab0f6853550b74e051d297c27a638719753eb9ff66d1e4072be67133",
+                "sha256:ce4e4f0deb51d38b1611a27f330426154f2980e66582dc5f438aad38b5f24fc1",
+                "sha256:d7bdc26475679dd073ba0ed2766445bb5b20ca4793ca0db32b399dccc6bc84b7",
+                "sha256:ff032765bb8716d9387fd5376d987a937254b0619eff0972779515b5c98820bc"
+            ],
+            "version": "==3.1.7"
+        },
+        "boto": {
+            "hashes": [
+                "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8",
+                "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"
+            ],
+            "version": "==2.49.0"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
+                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
+                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
+                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
+                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
+                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
+                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
+                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
+                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
+                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
+                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
+                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
+                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
+                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
+                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
+                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
+                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
+                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
+                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
+                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
+                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
+                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
+                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
+                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
+                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
+                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
+                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
+                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
+                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
+                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
+                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
+                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
+                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
+            ],
+            "version": "==1.13.2"
+        },
+        "crcmod": {
+            "hashes": [
+                "sha256:50586ab48981f11e5b117523d97bb70864a2a1af246cf6e4f5c4a21ef4611cd1",
+                "sha256:69a2e5c6c36d0f096a7beb4cd34e5f882ec5fd232efb710cdb85d4ff196bd52e",
+                "sha256:737fb308fa2ce9aed2e29075f0d5980d4a89bfbec48a368c607c5c63b3efb90e",
+                "sha256:dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e"
+            ],
+            "index": "pypi",
+            "version": "==1.7"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
+                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
+                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
+                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
+                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
+                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
+                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
+                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
+                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
+                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
+                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
+                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
+                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
+                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
+                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
+                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
+                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
+                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
+                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
+                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
+                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
+            ],
+            "version": "==2.8"
+        },
+        "distro": {
+            "hashes": [
+                "sha256:362dde65d846d23baee4b5c058c8586f219b5a54be1cf5fc6ff55c4578392f57",
+                "sha256:eedf82a470ebe7d010f1872c17237c79ab04097948800029994fa458e52fb4b4"
+            ],
+            "version": "==1.4.0"
+        },
+        "fabric": {
+            "hashes": [
+                "sha256:2bb6c6922cbdfe35884c937bfcff63c70750c18456b0707898112c5ceaab38c6",
+                "sha256:66097883bb3e5beecacae92b82b2bd489d10a8fd4f06ce1cb27019de2e6d76a8"
+            ],
+            "index": "pypi",
+            "version": "==1.14.1"
+        },
+        "future": {
+            "hashes": [
+                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+            ],
+            "index": "pypi",
+            "version": "==0.17.1"
+        },
+        "google-compute-engine": {
+            "hashes": [
+                "sha256:358363a10169f890bac78cf9d7105132cdd2c1546fa8d9caa35c04a7cf7cfba7"
+            ],
+            "index": "pypi",
+            "version": "==2.8.13"
+        },
+        "grpcio": {
+            "hashes": [
+                "sha256:066630f6b62bffa291dacbee56994279a6a3682b8a11967e9ccaf3cc770fc11e",
+                "sha256:07e95762ca6b18afbeb3aa2793e827c841152d5e507089b1db0b18304edda105",
+                "sha256:0a0fb2f8e3a13537106bc77e4c63005bc60124a6203034304d9101921afa4e90",
+                "sha256:0c61b74dcfb302613926e785cb3542a0905b9a3a86e9410d8cf5d25e25e10104",
+                "sha256:13383bd70618da03684a8aafbdd9e3d9a6720bf8c07b85d0bc697afed599d8f0",
+                "sha256:1c6e0f6b9d091e3717e9a58d631c8bb4898be3b261c2a01fe46371fdc271052f",
+                "sha256:1cf710c04689daa5cc1e598efba00b028215700dcc1bf66fcb7b4f64f2ea5d5f",
+                "sha256:2da5cee9faf17bb8daf500cd0d28a17ae881ab5500f070a6aace457f4c08cac4",
+                "sha256:2f78ebf340eaf28fa09aba0f836a8b869af1716078dfe8f3b3f6ff785d8f2b0f",
+                "sha256:33a07a1a8e817d733588dbd18e567caad1a6fe0d440c165619866cd490c7911a",
+                "sha256:3d090c66af9c065b7228b07c3416f93173e9839b1d40bb0ce3dd2aa783645026",
+                "sha256:42b903a3596a10e2a3727bae2a76f8aefd324d498424b843cfa9606847faea7b",
+                "sha256:4fffbb58134c4f23e5a8312ac3412db6f5e39e961dc0eb5e3115ce5aa16bf927",
+                "sha256:57be5a6c509a406fe0ffa6f8b86904314c77b5e2791be8123368ad2ebccec874",
+                "sha256:5b0fa09efb33e2af4e8822b4eb8b2cbc201d562e3e185c439be7eaeee2e8b8aa",
+                "sha256:5ef42dfc18f9a63a06aca938770b69470bb322e4c137cf08cf21703d1ef4ae5c",
+                "sha256:6a43d2f2ff8250f200fdf7aa31fa191a997922aa9ea1182453acd705ad83ab72",
+                "sha256:6d8ab28559be98b02f8b3a154b53239df1aa5b0d28ff865ae5be4f30e7ed4d3f",
+                "sha256:6e47866b7dc14ca3a12d40c1d6082e7bea964670f1c5315ea0fb8b0550244d64",
+                "sha256:6edda1b96541187f73aab11800d25f18ee87e53d5f96bb74473873072bf28a0e",
+                "sha256:7109c8738a8a3c98cfb5dda1c45642a8d6d35dc00d257ab7a175099b2b4daecd",
+                "sha256:8d866aafb08657c456a18c4a31c8526ea62de42427c242b58210b9eae6c64559",
+                "sha256:9939727d9ae01690b24a2b159ac9dbca7b7e8e6edd5af6a6eb709243cae7b52b",
+                "sha256:99fd873699df17cb11c542553270ae2b32c169986e475df0d68a8629b8ef4df7",
+                "sha256:b6fda5674f990e15e1bcaacf026428cf50bce36e708ddcbd1de9673b14aab760",
+                "sha256:bdb2f3dcb664f0c39ef1312cd6acf6bc6375252e4420cf8f36fff4cb4fa55c71",
+                "sha256:bfd7d3130683a1a0a50c456273c21ec8a604f2d043b241a55235a78a0090ee06",
+                "sha256:c6c2db348ac73d73afe14e0833b18abbbe920969bf2c5c03c0922719f8020d06",
+                "sha256:cb7a4b41b5e2611f85c3402ac364f1d689f5d7ecbc24a55ef010eedcd6cf460f",
+                "sha256:cd3d3e328f20f7c807a862620c6ee748e8d57ba2a8fc960d48337ed71c6d9d32",
+                "sha256:d1a481777952e4f99b8a6956581f3ee866d7614100d70ae6d7e07327570b85ce",
+                "sha256:d1d49720ed636920bb3d74cedf549382caa9ad55aea89d1de99d817068d896b2",
+                "sha256:d42433f0086cccd192114343473d7dbd4aae9141794f939e2b7b83efc57543db",
+                "sha256:d44c34463a7c481e076f691d8fa25d080c3486978c2c41dca09a8dd75296c2d7",
+                "sha256:d7e5b7af1350e9c8c17a7baf99d575fbd2de69f7f0b0e6ebd47b57506de6493a",
+                "sha256:d9542366a0917b9b48bab1fee481ac01f56bdffc52437b598c09e7840148a6a9",
+                "sha256:df7cdfb40179acc9790a462c049e0b8e109481164dd7ad1a388dd67ff1528759",
+                "sha256:e1a9d9d2e7224d981aea8da79260c7f6932bf31ce1f99b7ccfa5eceeb30dc5d0",
+                "sha256:ed10e5fad105ecb0b12822f924e62d0deb07f46683a0b64416b17fd143daba1d",
+                "sha256:f0ec5371ce2363b03531ed522bfbe691ec940f51f0e111f0500fc0f44518c69d",
+                "sha256:f6580a8a4f5e701289b45fd62a8f6cb5ec41e4d77082424f8b676806dcd22564",
+                "sha256:f7b83e4b2842d44fce3cdc0d54db7a7e0d169a598751bf393601efaa401c83e0",
+                "sha256:ffec45b0db18a555fdfe0c6fa2d0a3fceb751b22b31e8fcd14ceed7bde05481e"
+            ],
+            "version": "==1.26.0"
+        },
+        "grpcio-tools": {
+            "hashes": [
+                "sha256:01fc9dcbb1a8e8f763ec143930519e5e8551a25a4d1b7706a10809c8339b0377",
+                "sha256:0346fdfd5307f9283a1fc0b8936d57a123636c66aca2f402303941a2c805f20f",
+                "sha256:0d0039e1226d037c04cb6300254f13eb87c60d88abd5a14b99c32b881e06dacd",
+                "sha256:1e57e1cc9945c5f838b3270d04634bc9076486bf064359f20c8761a98126dce2",
+                "sha256:2bf8761307f54fdf116372bc7580ee5fa899c5fafca75e0f833c8339613d77f5",
+                "sha256:3c3599a6882532801a5757955b70836d70a3da2f187937e0a6835dce5c11f05f",
+                "sha256:3cfea4815236aa7c875150cc402d168bfcb6c0884cc753d53cde3099a8920efd",
+                "sha256:4172f50c24d5b4135023b4193ce5fe6e7515dcbb91b4ee01f20459b816aee0a0",
+                "sha256:421f8815fd6173c5110e5bb2c682c29bdb694b598641379a9a773e04a907f0d8",
+                "sha256:6002e05ef8c20de23887fccb8c74b55f85544a822c06dad618ebc90c409c2d83",
+                "sha256:61a418f4ce288d44eee9acbb30fd73255083d35ca481f40954c2932f3efe621b",
+                "sha256:6678191ee6ddc0c02ae6be9d5f759a904e61866e29c2ab8df85a88798aca681f",
+                "sha256:6e71cbcfd22ff15ba89b3856e1bb390084315b27f822cc1266f73864820fae81",
+                "sha256:7329622e9ac365dd0751c337e5c99ccfec9a8b60a5cc44d58bb7e569b5ea7c81",
+                "sha256:7576d16d6c1f2946a1ea495dc57d849afd29df547fd125d4a4f213e3ee976417",
+                "sha256:9738e750aa207d4651d719c0f5e3cf1e0bf2b6b6088bf6c15fd93a9b64580b55",
+                "sha256:989f3479e69ab3a72f70065de6d000a611a25a53166711981a3e8c99671d5705",
+                "sha256:a984e5c7f456a6e65ef00899151187ff520c8f42222944ad4b85b136321ce949",
+                "sha256:a9a98c293d54de819c2cac138f48cffe78890a2abfc6cfa42985ee8897121764",
+                "sha256:aa4f8f5c6f059d5c3ae756821494821545b1ebc203c1ed12c1366fe011dc2a5c",
+                "sha256:ac5962315518b0eb271b429ff01e6da3bf36eff54aa0234502c10238164c5237",
+                "sha256:af8683a74a43d9cc76d316c90d3369072cfc0e9b2833a4a21c0d0d6082d63161",
+                "sha256:b1bba27c6cf2d967d35d7aea2be4495b8b82596dccf941237d960509c22a8c56",
+                "sha256:b8b33d1ebbd1860b116e83ca655b696c314cd34b0c2336b75a3c882d28299274",
+                "sha256:bdee353eb9ec9353d83613b35853276c72c60516b595569e2624575bf3fdbeab",
+                "sha256:ce0415c33ff47e7ac4aea9d6a283fc8fc05bebe6857e7431b584be9d253fa193",
+                "sha256:cfbb7db17980ab099aa8ca50f2c178d86af8e8b84317ff9993d291d31362a09f",
+                "sha256:d04e1d148eb27c4582c76324182771a459d82bfc3f6500303fee17775f06298d",
+                "sha256:dab46b5362775fe1f45d72ab00d85bed04c83f0ef041e4d99f5d33d07318ae28",
+                "sha256:e586f7ba57c7bf9ac7131145f16a1eececd4e063296c219c22131d4f019e8140",
+                "sha256:e71e0bf098a7c1c1d53dbabea1cc61b3a01a31994851a05721bc9fecdda21266",
+                "sha256:f61c6f6394201344754e139370adbec3ee390aa53e5d1063b64569d131f70611"
+            ],
+            "index": "pypi",
+            "version": "==1.15.0"
+        },
+        "nodeenv": {
+            "hashes": [
+                "sha256:def2a6d927bef8d17c1776edbd5bbc8b7a5f0eee159af53b9924d559fc8d3202"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
+        "paramiko": {
+            "hashes": [
+                "sha256:99f0179bdc176281d21961a003ffdb2ec369daac1a1007241f53374e376576cf",
+                "sha256:f4b2edfa0d226b70bd4ca31ea7e389325990283da23465d572ed1f70a7583041"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:10394a4d03af7060fa8a6e1cbf38cea44be1467053b0aea5bbfcb4b13c4b88c4",
+                "sha256:1489b376b0f364bcc6f89519718c057eb191d7ad6f1b395ffd93d1aa45587811",
+                "sha256:1931d8efce896981fe410c802fd66df14f9f429c32a72dd9cfeeac9815ec6444",
+                "sha256:196d3a80f93c537f27d2a19a4fafb826fb4c331b0b99110f985119391d170f96",
+                "sha256:46e34fdcc2b1f2620172d3a4885128705a4e658b9b62355ae5e98f9ea19f42c2",
+                "sha256:4b92e235a3afd42e7493b281c8b80c0c65cbef45de30f43d571d1ee40a1f77ef",
+                "sha256:574085a33ca0d2c67433e5f3e9a0965c487410d6cb3406c83bdaf549bfc2992e",
+                "sha256:59cd75ded98094d3cf2d79e84cdb38a46e33e7441b2826f3838dcc7c07f82995",
+                "sha256:5ee0522eed6680bb5bac5b6d738f7b0923b3cafce8c4b1a039a6107f0841d7ed",
+                "sha256:65917cfd5da9dfc993d5684643063318a2e875f798047911a9dd71ca066641c9",
+                "sha256:685bc4ec61a50f7360c9fd18e277b65db90105adbf9c79938bd315435e526b90",
+                "sha256:92e8418976e52201364a3174e40dc31f5fd8c147186d72380cbda54e0464ee19",
+                "sha256:9335f79d1940dfb9bcaf8ec881fb8ab47d7a2c721fb8b02949aab8bbf8b68625",
+                "sha256:a7ee3bb6de78185e5411487bef8bc1c59ebd97e47713cba3c460ef44e99b3db9",
+                "sha256:ceec283da2323e2431c49de58f80e1718986b79be59c266bb0509cbf90ca5b9e",
+                "sha256:e7a5ccf56444211d79e3204b05087c1460c212a2c7d62f948b996660d0165d68",
+                "sha256:fcfc907746ec22716f05ea96b7f41597dfe1a1c088f861efb8a0d4f4196a6f10"
+            ],
+            "index": "pypi",
+            "version": "==3.6.1"
+        },
+        "psutil": {
+            "hashes": [
+                "sha256:0d8da7333549a998556c18eb2af3ce902c28d66ceb947505c008f91e9f988abd",
+                "sha256:1914bacbd2fc2af8f795daa44b9d2e0649a147460cfd21b1a70a124472f66d40",
+                "sha256:215d61a901e67b1a35e14c6aedef317f7fa7e6075a20c150fd11bd2c906d2c83",
+                "sha256:51057c03aea251ad6667c2bba259bc7ed3210222d3a74152c84e3ab06e1da0ba",
+                "sha256:5b6322b167a5ba0c5463b4d30dfd379cd4ce245a1162ebf8fc7ab5c5ffae4f3b",
+                "sha256:a890c3e490493f21da2817ffc92822693bc0d6bcac9999caa04ffce8dd4e7132",
+                "sha256:b34611280a2d0697f1c499e15e936d88109170194b390599c98bab8072a71f05",
+                "sha256:cea2557ee6a9faa2c100947637ded68414e12b851633c4ce26e0311b2a2ed539",
+                "sha256:d081707ef0081920533db30200a2d30d5c0ea9cf6afa7cf8881ae4516cc69c48"
+            ],
+            "index": "pypi",
+            "version": "==5.4.7"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
+        },
+        "pynacl": {
+            "hashes": [
+                "sha256:05c26f93964373fc0abe332676cb6735f0ecad27711035b9472751faa8521255",
+                "sha256:0c6100edd16fefd1557da078c7a31e7b7d7a52ce39fdca2bec29d4f7b6e7600c",
+                "sha256:0d0a8171a68edf51add1e73d2159c4bc19fc0718e79dec51166e940856c2f28e",
+                "sha256:1c780712b206317a746ace34c209b8c29dbfd841dfbc02aa27f2084dd3db77ae",
+                "sha256:2424c8b9f41aa65bbdbd7a64e73a7450ebb4aa9ddedc6a081e7afcc4c97f7621",
+                "sha256:2d23c04e8d709444220557ae48ed01f3f1086439f12dbf11976e849a4926db56",
+                "sha256:30f36a9c70450c7878053fa1344aca0145fd47d845270b43a7ee9192a051bf39",
+                "sha256:37aa336a317209f1bb099ad177fef0da45be36a2aa664507c5d72015f956c310",
+                "sha256:4943decfc5b905748f0756fdd99d4f9498d7064815c4cf3643820c9028b711d1",
+                "sha256:53126cd91356342dcae7e209f840212a58dcf1177ad52c1d938d428eebc9fee5",
+                "sha256:57ef38a65056e7800859e5ba9e6091053cd06e1038983016effaffe0efcd594a",
+                "sha256:5bd61e9b44c543016ce1f6aef48606280e45f892a928ca7068fba30021e9b786",
+                "sha256:6482d3017a0c0327a49dddc8bd1074cc730d45db2ccb09c3bac1f8f32d1eb61b",
+                "sha256:7d3ce02c0784b7cbcc771a2da6ea51f87e8716004512493a2b69016326301c3b",
+                "sha256:a14e499c0f5955dcc3991f785f3f8e2130ed504fa3a7f44009ff458ad6bdd17f",
+                "sha256:a39f54ccbcd2757d1d63b0ec00a00980c0b382c62865b61a505163943624ab20",
+                "sha256:aabb0c5232910a20eec8563503c153a8e78bbf5459490c49ab31f6adf3f3a415",
+                "sha256:bd4ecb473a96ad0f90c20acba4f0bf0df91a4e03a1f4dd6a4bdc9ca75aa3a715",
+                "sha256:bf459128feb543cfca16a95f8da31e2e65e4c5257d2f3dfa8c0c1031139c9c92",
+                "sha256:e2da3c13307eac601f3de04887624939aca8ee3c9488a0bb0eca4fb9401fc6b1",
+                "sha256:f67814c38162f4deb31f68d590771a29d5ae3b1bd64b75cf232308e5c74777e0"
+            ],
+            "version": "==1.3.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "index": "pypi",
+            "version": "==1.12.0"
+        }
+    }
+}

--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -148,14 +148,21 @@ else
 fi
 
 # Setup virtualenv.
-rm -rf ENV
-virtualenv ENV
-source ENV/bin/activate
+if [[ -n "$PY3" ]]; then
+  sudo apt-get install -y pipenv
+  pipenv install --python 3.7
+  pipenv install --dev
+  source "$(pipenv --venv)/bin/activate"
+else
+  rm -rf ENV
+  virtualenv ENV
+  source ENV/bin/activate
 
-# Install needed python packages.
-pip install --upgrade pip
-pip install --upgrade -r docker/ci/requirements.txt
-pip install --upgrade -r src/local/requirements.txt
+  # Install needed python packages.
+  pip install --upgrade pip
+  pip install --upgrade -r docker/ci/requirements.txt
+  pip install --upgrade -r src/local/requirements.txt
+fi
 
 if [ $install_android_emulator ]; then
   ANDROID_SDK_INSTALL_DIR=local/bin/android-sdk
@@ -192,9 +199,18 @@ else
 fi
 
 set +x
+if [[ -n "$PY3" ]]; then
+echo "
+
+Installation succeeded!
+Please load environment by running 'pipenv shell'.
+
+"
+else
 echo "
 
 Installation succeeded!
 Please load virtualenv environment by running 'source ENV/bin/activate'.
 
 "
+fi

--- a/src/appengine/appengine_config.py
+++ b/src/appengine/appengine_config.py
@@ -37,10 +37,10 @@ IS_RUNNING_IN_PRODUCTION = (
 config_modules_path = os.path.join('config', 'modules')
 
 if IS_RUNNING_IN_PRODUCTION or IS_RUNNING_IN_DEV_APPSERVER:
-  vendor.add('third_party')
-  vendor.add('python')
+  vendor.add('third_party', 0)
+  vendor.add('python', 0)
   if os.path.exists(config_modules_path):
-    vendor.add(config_modules_path)
+    vendor.add(config_modules_path, 0)
 else:
   sys.path.insert(0, 'third_party')
   sys.path.insert(0, 'python')

--- a/src/local/butler/appengine.py
+++ b/src/local/butler/appengine.py
@@ -143,7 +143,7 @@ def symlink_dirs():
   common.remove_symlink(local_gcs_symlink_path)
 
   _, output = common.execute('bazel run //local:create_gopath', cwd='src')
-  os.environ['GOPATH'] = output.splitlines()[-1]
+  os.environ['GOPATH'] = output.decode('utf-8').splitlines()[-1]
 
 
 def build_templates():

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -121,7 +121,7 @@ def process_proc_output(proc, print_output=True):
     _print('| %s' % line.rstrip())
     lines.append(line)
 
-  return ''.join(lines)
+  return b''.join(lines)
 
 
 def execute_async(command, extra_environments=None, cwd=None):

--- a/src/local/butler/format.py
+++ b/src/local/butler/format.py
@@ -22,7 +22,9 @@ def execute(_):
   """Format changed code."""
   _, output = common.execute('git diff --name-only FETCH_HEAD')
 
-  file_paths = [f for f in output.splitlines() if os.path.exists(f)]
+  file_paths = [
+      f.decode('utf-8') for f in output.splitlines() if os.path.exists(f)
+  ]
   py_changed_file_paths = [
       f for f in file_paths if f.endswith('.py') and
       # Exclude auto-generated files.

--- a/src/local/butler/guard.py
+++ b/src/local/butler/guard.py
@@ -20,6 +20,7 @@ import sys
 def check_virtualenv():
   """Check that we're in a virtualenv."""
   if sys.version_info.major != 2:
+    # TODO(ochang): Implement check for Python 3.
     return
 
   root_path = os.path.realpath(
@@ -36,7 +37,9 @@ def check_virtualenv():
 def check_dev_requirements():
   """Check that dev requirements are installed."""
   if sys.version_info.major != 2:
+    # TODO(ochang): Implement check for Python 3.
     return
+
   freeze_output = subprocess.check_output('pip freeze', shell=True)
   installed_pips = freeze_output.strip().splitlines()
 

--- a/src/local/butler/guard.py
+++ b/src/local/butler/guard.py
@@ -14,9 +14,14 @@
 """guard.py checks virtualenv environment and dev requirements."""
 import os
 import subprocess
+import sys
 
 
 def check_virtualenv():
+  """Check that we're in a virtualenv."""
+  if sys.version_info.major != 2:
+    return
+
   root_path = os.path.realpath(
       os.path.join(os.path.dirname(__file__), '..', '..', '..'))
   is_in_virtualenv = os.getenv('VIRTUAL_ENV') == os.path.join(root_path, 'ENV')
@@ -30,6 +35,8 @@ def check_virtualenv():
 
 def check_dev_requirements():
   """Check that dev requirements are installed."""
+  if sys.version_info.major != 2:
+    return
   freeze_output = subprocess.check_output('pip freeze', shell=True)
   installed_pips = freeze_output.strip().splitlines()
 

--- a/src/local/butler/lint.py
+++ b/src/local/butler/lint.py
@@ -75,7 +75,7 @@ def _execute_command_and_track_error(command):
   if returncode != 0:
     _error()
 
-  return output
+  return output.decode('utf-8')
 
 
 def license_validate(file_path):
@@ -184,7 +184,9 @@ def execute(_):
   else:
     _, output = common.execute('git diff --name-only FETCH_HEAD')
 
-  file_paths = [f for f in output.splitlines() if os.path.exists(f)]
+  file_paths = [
+      f.decode('utf-8') for f in output.splitlines() if os.path.exists(f)
+  ]
   py_changed_file_paths = [
       f for f in file_paths
       if f.endswith('.py') and not is_auto_generated_file(f)

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -242,6 +242,7 @@ def execute(args):
     sys.path.insert(0, os.path.abspath(os.path.join('src', 'appengine')))
 
     if sys.version_info.major == 2:
+      # TODO(ochang): Remove once migrated to Python 3.
       appengine_sdk_path = appengine.find_sdk_path()
       sys.path.insert(0, appengine_sdk_path)
 

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -241,31 +241,32 @@ def execute(args):
     test_directory = APPENGINE_TEST_DIRECTORY
     sys.path.insert(0, os.path.abspath(os.path.join('src', 'appengine')))
 
-    appengine_sdk_path = appengine.find_sdk_path()
-    sys.path.insert(0, appengine_sdk_path)
+    if sys.version_info.major == 2:
+      appengine_sdk_path = appengine.find_sdk_path()
+      sys.path.insert(0, appengine_sdk_path)
 
-    # Get additional App Engine third party imports.
-    import dev_appserver
-    dev_appserver.fix_google_path()
-    sys.path.extend(dev_appserver.EXTRA_PATHS)
+      # Get additional App Engine third party imports.
+      import dev_appserver
+      dev_appserver.fix_google_path()
+      sys.path.extend(dev_appserver.EXTRA_PATHS)
 
-    # Loading appengine_config from the current project ensures that any
-    # changes to configuration there are available to all tests (e.g.
-    # sys.path modifications, namespaces, etc.)
-    try:
-      from src.appengine import appengine_config
-      (appengine_config)  # pylint: disable=pointless-statement
-    except ImportError:
-      print('Note: unable to import appengine_config.')
+      # Loading appengine_config from the current project ensures that any
+      # changes to configuration there are available to all tests (e.g.
+      # sys.path modifications, namespaces, etc.)
+      try:
+        from src.appengine import appengine_config
+        (appengine_config)  # pylint: disable=pointless-statement
+      except ImportError:
+        print('Note: unable to import appengine_config.')
 
-    # google.auth uses App Engine credentials based on importability of
-    # google.appengine.api.app_identity.
-    try:
-      from google.auth import app_engine as auth_app_engine
-      if auth_app_engine.app_identity:
-        auth_app_engine.app_identity = None
-    except ImportError:
-      pass
+      # google.auth uses App Engine credentials based on importability of
+      # google.appengine.api.app_identity.
+      try:
+        from google.auth import app_engine as auth_app_engine
+        if auth_app_engine.app_identity:
+          auth_app_engine.app_identity = None
+      except ImportError:
+        pass
   elif args.target == 'core':
     test_directory = CORE_TEST_DIRECTORY
   else:

--- a/src/python/tests/appengine/handlers/cron/manage_vms_test.py
+++ b/src/python/tests/appengine/handlers/cron/manage_vms_test.py
@@ -306,13 +306,11 @@ class CronTest(unittest.TestCase):
         'base.utils.is_oss_fuzz',
         'handlers.cron.helpers.bot_manager.BotManager',
         'system.environment.is_running_on_app_engine',
-        'google.appengine.api.app_identity.get_application_id',
         'google_cloud_utils.compute_engine_projects.load_project',
     ])
 
     self.mock.is_oss_fuzz.return_value = True
     self.mock.is_running_on_app_engine.return_value = True
-    self.mock.get_application_id.return_value = 'clusterfuzz-external'
     self.mock.load_project.return_value = compute_engine_projects.Project(
         project_id='clusterfuzz-external',
         clusters=[

--- a/src/python/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/python/tests/appengine/handlers/cron/project_setup_test.py
@@ -175,8 +175,6 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
 
     helpers.patch(self, [
         'config.local_config.ProjectConfig',
-        ('get_application_id_1',
-         'google.appengine.api.app_identity.get_application_id'),
         ('get_application_id_2', 'base.utils.get_application_id'),
         'google_cloud_utils.storage.build',
         'time.sleep',
@@ -211,7 +209,6 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     """Tests executing of cron job."""
     mock_storage = mock.MagicMock()
     mock_storage.buckets().insert().execute.return_value = 'timeCreated'
-    self.mock.get_application_id_1.return_value = 'clusterfuzz-external'
     self.mock.get_application_id_2.return_value = 'clusterfuzz-external'
     self.mock.build.return_value = mock_storage
 
@@ -1598,8 +1595,6 @@ class GenericProjectSetupTest(unittest.TestCase):
 
     helpers.patch(self, [
         'config.local_config.ProjectConfig',
-        ('get_application_id_1',
-         'google.appengine.api.app_identity.get_application_id'),
         ('get_application_id_2', 'base.utils.get_application_id'),
         'google_cloud_utils.storage.build',
         'google_cloud_utils.storage.read_data',

--- a/src/python/tests/test_libs/test_utils.py
+++ b/src/python/tests/test_libs/test_utils.py
@@ -211,8 +211,8 @@ def wait_for_emulator_ready(proc,
 def start_cloud_emulator(emulator, args=None, data_dir=None):
   """Start a cloud emulator."""
   ready_indicators = {
-      'datastore': 'is now running',
-      'pubsub': 'Server started',
+      'datastore': b'is now running',
+      'pubsub': b'Server started',
   }
 
   default_flags = {
@@ -255,8 +255,8 @@ def start_cloud_emulator(emulator, args=None, data_dir=None):
   ])
 
   for line in env_vars.splitlines():
-    key, value = line.split()[1].split('=')
-    os.environ[key.strip()] = value.strip()
+    key, value = line.split()[1].split(b'=')
+    os.environ[key.strip().decode('utf-8')] = value.strip().decode('utf-8')
 
   return EmulatorInstance(proc, port, thread, cleanup_dir)
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,6 +14,7 @@ google-cloud-profiler==1.0.3
 google-cloud-storage==1.13.2
 grpcio==1.15.0
 httplib2==0.11.3
+Jinja2==2.11.1
 jira==2.0.0
 mozprocess==1.0.0
 oauth2client==4.1.3
@@ -26,3 +27,4 @@ requests==2.21.0
 requests-toolbelt==0.9.1
 selenium==3.141.0
 sendgrid==6.0.4
+webapp2==3.0.0b1


### PR DESCRIPTION
Add Pipfile/Pipfile.lock for Python 3 dependencies. This is currently
just based on src/local/requirements.txt and docker/ci/requirements.txt, and will be cleaned up later.

Add python 3 env setup to install_deps_linux.bash. To use, set `PY3=1` before running:

```python
PY3=1 ./local/install_deps.bash
```

A separate checkout should be used from the one used for Python 2
development.

Add some minor bug fixes to get butler and core unit tests running. The vast
majority of them are still failing though.

Vendor webapp2 and Jinja2 in src/third_party, since we're no longer depending on the ones available in the App Engine SDK.

Dependent on https://github.com/google/clusterfuzz/pull/1395