### PR TITLE
Remove App Engine SDK from bot Docker images.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -67,13 +67,6 @@ RUN curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh && \
     sed -i 's/flush_interval 5s/flush_interval 60s/' /etc/google-fluentd/google-fluentd.conf
 COPY clusterfuzz-fluentd.conf /etc/google-fluentd/config.d/clusterfuzz.conf
 
-# Install App Engine SDK.
-ENV APPENGINE_FILE=google_appengine_1.9.75.zip \
-    APPENGINE_SDK_PATH=/data/google_appengine
-RUN wget https://commondatastorage.googleapis.com/clusterfuzz-data/$APPENGINE_FILE && \
-    unzip $APPENGINE_FILE && \
-    rm $APPENGINE_FILE
-
 # Hack to force google to be a namespace package.
 # https://github.com/google/protobuf/issues/1296#issuecomment-264264926
 RUN echo "import google; import pkgutil; pkgutil.extend_path(google.__path__, google.__name__)" > /usr/local/lib/python2.7/dist-packages/gae.pth
@@ -84,7 +77,7 @@ ENV INSTALL_DIRECTORY /mnt/scratch0
 ENV BOT_TMPDIR $INSTALL_DIRECTORY/tmp
 ENV ROOT_DIR $INSTALL_DIRECTORY/clusterfuzz
 ENV UPDATE_WEB_TESTS True
-ENV PYTHONPATH $APPENGINE_SDK_PATH:$INSTALL_DIRECTORY/clusterfuzz/src
+ENV PYTHONPATH $INSTALL_DIRECTORY/clusterfuzz/src
 ENV RUN_CMD "python $ROOT_DIR/src/python/bot/startup/run.py"
 
 # Passwordless sudo (needed for AFL launcher).

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -49,12 +49,10 @@ WORKDIR /workspace
 
 ENV BOT_TMPDIR /tmp
 ENV ROOT_DIR /workspace
-ENV PYTHONPATH $APPENGINE_SDK_PATH:$ROOT_DIR/src
+ENV PYTHONPATH $ROOT_DIR/src
 
 COPY requirements.txt /tmp
 RUN pip install -r /tmp/requirements.txt && pip install --upgrade pip
-
-ENV APPENGINE_DIRECTORY $APPENGINE_SDK_PATH
 
 ENV TEST_BOT_ENVIRONMENT 1
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/docker/oss-fuzz/host/start_host.py
+++ b/docker/oss-fuzz/host/start_host.py
@@ -64,8 +64,7 @@ def start_bot_instance(instance_num):
 
   env['ROOT_DIR'] = bot_root_directory
   env['BOT_TMPDIR'] = tmp_directory
-  env['PYTHONPATH'] = (
-      '%s/src:%s' % (bot_root_directory, env['APPENGINE_SDK_PATH']))
+  env['PYTHONPATH'] = os.path.join(bot_root_directory, 'src')
 
   if os.path.exists(bot_root_directory):
     shutil.rmtree(bot_root_directory)


### PR DESCRIPTION
The CI still has the necessary utilities for dev_appserver etc from APT.