### PR TITLE
Fix base_handler and handler tests for Python 3.

### DIFF
--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -216,7 +216,7 @@ class Handler(webapp2.RequestHandler):
 
       status = 500
       values = {
-          'message': exception.message,
+          'message': str(exception),
           'email': helpers.get_user_email(),
           'traceDump': traceback.format_exc(),
           'status': status,
@@ -241,7 +241,7 @@ class Handler(webapp2.RequestHandler):
         self.render_json(values, status)
       else:
         if status == 403 or status == 401:
-          self.render_forbidden(exception.message)
+          self.render_forbidden(str(exception))
         else:
           self.render('error.html', values, status)
     except Exception:
@@ -250,7 +250,7 @@ class Handler(webapp2.RequestHandler):
   def handle_exception_exception(self):
     """Catch exception in handle_exception and format it properly."""
     exception = sys.exc_info()[1]
-    values = {'message': exception.message, 'traceDump': traceback.format_exc()}
+    values = {'message': str(exception), 'traceDump': traceback.format_exc()}
     logging.exception(exception)
     if helpers.should_render_json(
         self.request.headers.get('accept', ''),

--- a/src/appengine/handlers/testcase_detail/redo.py
+++ b/src/appengine/handlers/testcase_detail/redo.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Handler for redoing."""
+from builtins import str
+
 from base import tasks
 from handlers import base_handler
 from handlers.testcase_detail import show
@@ -28,7 +30,7 @@ class Handler(base_handler.Handler):
     try:
       tasks.redo_testcase(testcase, testcase_tasks, user_email)
     except tasks.InvalidRedoTask as error:
-      raise helpers.EarlyExitException(error.message, 400)
+      raise helpers.EarlyExitException(str(error), 400)
 
     helpers.log('Redo testcase %d: %s' % (testcase.key.id(), testcase_tasks),
                 helpers.MODIFY_OPERATION)

--- a/src/appengine/libs/helpers.py
+++ b/src/appengine/libs/helpers.py
@@ -14,6 +14,7 @@
 """helper.py is a kitchen sink. It contains static methods that are used by
    multiple handlers."""
 
+from builtins import str
 import logging
 import sys
 import traceback
@@ -50,7 +51,7 @@ class EarlyExitException(Exception):
     """Build dict that is used for JSON serialisation."""
     return {
         'traceDump': self.trace_dump,
-        'message': self.message,
+        'message': str(self),
         'email': get_user_email(),
         'status': self.status,
         'type': self.__class__.__name__
@@ -139,8 +140,8 @@ def get_or_exit(fn,
     pass
   except Exception:
     raise EarlyExitException(
-        '%s (%s: %s)' % (error_message, sys.exc_info()[0],
-                         sys.exc_info()[1].message), 500)
+        '%s (%s: %s)' % (error_message, sys.exc_info()[0], str(
+            sys.exc_info()[1])), 500)
 
   if non_empty_fn(result):
     return result

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -213,7 +213,7 @@ class LibFuzzerEngine(engine.Engine):
 
       stat_overrides.update(result.stats)
     except (MergeError, engine.TimeoutError) as e:
-      logs.log_warn('Merge failed.', error=e.message)
+      logs.log_warn('Merge failed.', error=str(e))
 
     stat_overrides['new_units_added'] = new_units_added
 

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -466,10 +466,10 @@ class CorpusPruner(object):
           bad_units_path, CORPUS_PRUNING_TIMEOUT)
     except engine.TimeoutError as e:
       raise CorpusPruningException(
-          'Corpus pruning timed out while minimizing corpus\n' + e.message)
+          'Corpus pruning timed out while minimizing corpus\n' + str(e))
     except engine.Error as e:
       raise CorpusPruningException(
-          'Corpus pruning failed to minimize corpus\n' + e.message)
+          'Corpus pruning failed to minimize corpus\n' + str(e))
 
     symbolized_output = stack_symbolizer.symbolize_stacktrace(result.logs)
 
@@ -512,10 +512,10 @@ class CrossPollinator(object):
           output=symbolized_output)
     except engine.TimeoutError as e:
       logs.log_error('Corpus pruning timed out while merging shared corpus: ' +
-                     e.message)
+                     str(e))
     except engine.Error as e:
       raise CorpusPruningException(
-          'Corpus pruning failed to merge shared corpus\n' + e.message)
+          'Corpus pruning failed to merge shared corpus\n' + str(e))
 
 
 def do_corpus_pruning(context, last_execution_failed, revision):

--- a/src/python/bot/tasks/impact_task.py
+++ b/src/python/bot/tasks/impact_task.py
@@ -325,7 +325,7 @@ def execute_task(testcase_id, job_type):
   except BuildFailedException as error:
     testcase = data_handler.get_testcase_by_id(testcase_id)
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
-                                         error.message)
+                                         str(error))
     tasks.add_task(
         'impact',
         testcase_id,

--- a/src/python/bot/untrusted_runner/host.py
+++ b/src/python/bot/untrusted_runner/host.py
@@ -158,7 +158,9 @@ def _wrap_call(func, num_retries=config.RPC_RETRY_ATTEMPTS):
         # exception.
         if 'TimeoutError' in repr(e):
           # TODO(ochang): Replace with generic TimeoutError in Python 3.
-          raise engine.TimeoutError(e.message)
+          # Use __str__ to avoid newstrs. TODO(ochang): Use plain str() once
+          # migrated to Python 3.
+          raise engine.TimeoutError(e.__str__())
 
         if num_retries == 0:
           # Just re-raise the original exception if this RPC is not configured

--- a/src/python/tests/appengine/common/tasks_test.py
+++ b/src/python/tests/appengine/common/tasks_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for tasks."""
+from builtins import str
 from future import standard_library
 standard_library.install_aliases()
 import os
@@ -38,7 +39,7 @@ class RedoTestcaseTest(unittest.TestCase):
     with self.assertRaises(tasks.InvalidRedoTask) as cm:
       tasks.redo_testcase(None, ['blame', 'rand'], 'test@user.com')
 
-    self.assertEqual("The task 'rand' is invalid.", cm.exception.message)
+    self.assertEqual("The task 'rand' is invalid.", str(cm.exception))
 
 
 @test_utils.integration

--- a/src/python/tests/appengine/handlers/base_handler_test.py
+++ b/src/python/tests/appengine/handlers/base_handler_test.py
@@ -117,7 +117,7 @@ class HandlerTest(unittest.TestCase):
     app = webtest.TestApp(webapp2.WSGIApplication([('/', HtmlHandler)]))
     response = app.get('/')
     self.assertEqual(response.status_int, 200)
-    self.assertEqual(response.body, '<html><body>value\n</body></html>')
+    self.assertEqual(response.body, b'<html><body>value\n</body></html>')
 
   def test_render_html_exception(self):
     """Ensure it renders HTML exception correctly."""
@@ -125,8 +125,8 @@ class HandlerTest(unittest.TestCase):
         webapp2.WSGIApplication([('/', ExceptionHtmlHandler)]))
     response = app.get('/', expect_errors=True)
     self.assertEqual(response.status_int, 500)
-    self.assertRegexpMatches(response.body, '.*unique_message.*')
-    self.assertRegexpMatches(response.body, '.*test@test.com.*')
+    self.assertRegexpMatches(response.body, b'.*unique_message.*')
+    self.assertRegexpMatches(response.body, b'.*test@test.com.*')
 
   def test_forbidden_not_logged_in(self):
     """Ensure it renders forbidden response correctly (when not logged in)."""
@@ -145,8 +145,8 @@ class HandlerTest(unittest.TestCase):
         webapp2.WSGIApplication([('/', AccessDeniedExceptionHandler)]))
     response = app.get('/', expect_errors=True)
     self.assertEqual(response.status_int, 403)
-    self.assertRegexpMatches(response.body, '.*Access Denied.*')
-    self.assertRegexpMatches(response.body, '.*this_random_message.*')
+    self.assertRegexpMatches(response.body, b'.*Access Denied.*')
+    self.assertRegexpMatches(response.body, b'.*this_random_message.*')
 
   def test_redirect_another_page(self):
     """Test redirect to another page."""

--- a/src/python/tests/appengine/handlers/testcase_detail/download_testcase_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/download_testcase_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Download testcase tests."""
+from builtins import str
 import unittest
 import webapp2
 import webtest
@@ -118,4 +119,4 @@ class GetTestcaseBlobInfoTest(unittest.TestCase):
     self.assertEqual(400, cm.exception.status)
     self.assertEqual((
         "The testcase (%d) doesn't have fuzzed keys." % self.testcase.key.id()),
-                     cm.exception.message)
+                     str(cm.exception))

--- a/src/python/tests/appengine/handlers/testcase_detail/show_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/show_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """show tests."""
 # pylint: disable=protected-access
+from builtins import str
 from past.builtins import basestring
 import collections
 import datetime
@@ -445,7 +446,7 @@ class GetTestcaseTest(unittest.TestCase):
       show.get_testcase_detail_by_id(None)
 
     self.assertEqual(cm.exception.status, 404)
-    self.assertEqual(cm.exception.message, 'No test case specified!')
+    self.assertEqual(str(cm.exception), 'No test case specified!')
 
   def test_no_testcase(self):
     """Test invalid testcase."""
@@ -453,7 +454,7 @@ class GetTestcaseTest(unittest.TestCase):
       show.get_testcase_detail_by_id(1)
 
     self.assertEqual(cm.exception.status, 404)
-    self.assertEqual(cm.exception.message, 'Invalid test case!')
+    self.assertEqual(str(cm.exception), 'Invalid test case!')
 
   def test_forbidden(self):
     """Test forbidden testcase."""
@@ -464,7 +465,7 @@ class GetTestcaseTest(unittest.TestCase):
       show.get_testcase_detail_by_id(2)
 
     self.assertEqual(cm.exception.status, 403)
-    self.assertEqual(cm.exception.message, '')
+    self.assertEqual(str(cm.exception), '')
 
   def test_reproducible_get(self):
     """Test valid reproducible testcase."""

--- a/src/python/tests/appengine/handlers/testcase_list_test.py
+++ b/src/python/tests/appengine/handlers/testcase_list_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """testcase_list tests."""
 from builtins import range
+from builtins import str
 import datetime
 import mock
 import unittest
@@ -128,7 +129,7 @@ class GroupFilterTest(unittest.TestCase):
       self.filter.add(self.query, {'group': '123x4'})
 
     self.query.filter.assert_has_calls([])
-    self.assertEqual("'group' must be int.", cm.exception.message)
+    self.assertEqual("'group' must be int.", str(cm.exception))
 
 
 @test_utils.with_cloud_emulators('datastore')

--- a/src/python/tests/appengine/libs/filters_test.py
+++ b/src/python/tests/appengine/libs/filters_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """filters tests"""
 
+from builtins import str
 import mock
 import unittest
 
@@ -83,7 +84,7 @@ class SimpleFilterTest(unittest.TestCase):
     with self.assertRaises(helpers.EarlyExitException) as cm:
       fltr.add(self.query, {'param': ''})
 
-    self.assertEqual("'param' is required.", cm.exception.message)
+    self.assertEqual("'param' is required.", str(cm.exception))
     self.assertEqual(400, cm.exception.status)
     self.query.filter.assert_not_called()
 

--- a/src/python/tests/appengine/libs/helpers_test.py
+++ b/src/python/tests/appengine/libs/helpers_test.py
@@ -14,6 +14,7 @@
 """helpers tests."""
 # pylint: disable=protected-access
 
+from builtins import str
 import unittest
 
 from libs import auth
@@ -76,7 +77,7 @@ class GetOrExitTest(unittest.TestCase):
       helpers.get_or_exit(fn, 'not_found', 'error')
 
     self.assertEqual(catched.exception.status, 404)
-    self.assertEqual(catched.exception.message, 'not_found')
+    self.assertEqual(str(catched.exception), 'not_found')
 
   def test_get_or_exit_tuple_none(self):
     """Ensure it raises 404 when the value is a tuple of None."""
@@ -85,7 +86,7 @@ class GetOrExitTest(unittest.TestCase):
       helpers.get_or_exit(fn, 'not_found', 'error')
 
     self.assertEqual(catched.exception.status, 404)
-    self.assertEqual(catched.exception.message, 'not_found')
+    self.assertEqual(str(catched.exception), 'not_found')
 
   def test_get_or_exit_not_found_exception(self):
     """Ensure it raises 404 when `fn` throws a recognised exception."""
@@ -98,7 +99,7 @@ class GetOrExitTest(unittest.TestCase):
           fn, 'not_found', 'error', not_found_exception=TestNotFoundException)
 
     self.assertEqual(catched.exception.status, 404)
-    self.assertEqual(catched.exception.message, 'not_found')
+    self.assertEqual(str(catched.exception), 'not_found')
 
   def test_get_or_exit_other_exception(self):
     """Ensure it raises 500 when `fn` throws an unknown exception."""
@@ -110,8 +111,9 @@ class GetOrExitTest(unittest.TestCase):
       helpers.get_or_exit(fn, 'not_found', 'other')
 
     self.assertEqual(catched.exception.status, 500)
-    self.assertEqual(catched.exception.message,
-                     "other (<type 'exceptions.Exception'>: message)")
+    self.assertEqual(
+        str(catched.exception),
+        "other (<type 'exceptions.Exception'>: message)")
 
 
 class GetUserEmailTest(unittest.TestCase):

--- a/src/python/tests/core/bot/tasks/commands_test.py
+++ b/src/python/tests/core/bot/tasks/commands_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """commands tests."""
+from builtins import str
 from future import standard_library
 standard_library.install_aliases()
 import datetime
@@ -60,7 +61,7 @@ class SetTaskPayloadTest(unittest.TestCase):
     task.payload.return_value = 'payload something'
     with self.assertRaises(Exception) as cm:
       self.assertEqual('payload something', dummy_exception(task))
-    self.assertEqual('payload something', cm.exception.message)
+    self.assertEqual('payload something', str(cm.exception))
     self.assertEqual({'task_payload': 'payload something'}, cm.exception.extras)
     self.assertIsNone(os.getenv('TASK_PAYLOAD'))
 

--- a/src/python/tests/core/bot/tasks/impact_task_test.py
+++ b/src/python/tests/core/bot/tasks/impact_task_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """impact_task tests."""
+from builtins import str
 import mock
 import unittest
 
@@ -481,7 +482,7 @@ class GetImpactOnBuild(unittest.TestCase):
     with self.assertRaises(impact_task.BuildFailedException) as cm:
       impact_task.get_impact_on_build('stable', '52', self.testcase, 'path')
 
-    self.assertEqual('Build setup failed for Stable', cm.exception.message)
+    self.assertEqual('Build setup failed for Stable', str(cm.exception))
 
   def test_app_failed(self):
     """Test raising AppFailedException."""

--- a/src/python/tests/core/google_cloud_utils/big_query_test.py
+++ b/src/python/tests/core/google_cloud_utils/big_query_test.py
@@ -620,7 +620,7 @@ class QueryTest(unittest.TestCase):
       client.query('sql', timeout=10, max_results=100, offset=50)
 
     self.assertEqual("Timeout: the query doesn't finish within 10 seconds.",
-                     cm.exception.message)
+                     str(cm.exception))
 
     self.query.execute.assert_called_once_with()
     self.jobs.query.assert_called_once_with(


### PR DESCRIPTION
- Exception's 'message' attribute is removed in Python 3. Use str()
instead. Fix all other instances while we're here.
- Fix some bytes vs str comparisons.