### PR TITLE
Replace self.assertItemsEqual with six.assertCountEqual.

### DIFF
--- a/src/python/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/python/tests/appengine/handlers/cron/cleanup_test.py
@@ -16,9 +16,10 @@
 
 from builtins import range
 from builtins import str
-
 import datetime
 import unittest
+
+import six
 
 from datastore import data_types
 from handlers.cron import cleanup
@@ -1402,7 +1403,7 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     cleanup.update_issue_ccs_from_owners_file(self.policy, self.testcase,
                                               self.issue)
     self.assertEqual('', self.issue._monorail_issue.comment)
-    self.assertItemsEqual([], self.issue.ccs)
+    six.assertCountEqual(self, [], self.issue.ccs)
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_skipped_issue_updated_once(self):
@@ -1413,7 +1414,7 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     self.issue._monorail_issue.comments.append(comment)
     cleanup.update_issue_ccs_from_owners_file(self.policy, self.testcase,
                                               self.issue)
-    self.assertItemsEqual([], self.issue.ccs)
+    six.assertCountEqual(self, [], self.issue.ccs)
 
   def test_skipped_no_testcase_metadata(self):
     """Test that we don't add ccs if there are no issue_owners key in testcase
@@ -1422,7 +1423,7 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     cleanup.update_issue_ccs_from_owners_file(self.policy, self.testcase,
                                               self.issue)
     self.assertEqual('', self.issue._monorail_issue.comment)
-    self.assertItemsEqual([], self.issue.ccs)
+    six.assertCountEqual(self, [], self.issue.ccs)
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_skipped_empty_testcase_metadata(self):
@@ -1432,7 +1433,7 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     cleanup.update_issue_ccs_from_owners_file(self.policy, self.testcase,
                                               self.issue)
     self.assertEqual('', self.issue._monorail_issue.comment)
-    self.assertItemsEqual([], self.issue.ccs)
+    six.assertCountEqual(self, [], self.issue.ccs)
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_skipped_ccs_already_added_and_metadata_set(self):
@@ -1442,7 +1443,7 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     cleanup.update_issue_ccs_from_owners_file(self.policy, self.testcase,
                                               self.issue)
     self.assertEqual('', self.issue._monorail_issue.comment)
-    self.assertItemsEqual([], self.issue.ccs)
+    six.assertCountEqual(self, [], self.issue.ccs)
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_skipped_ccs_alread_added_and_metadata_set(self):
@@ -1454,8 +1455,8 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
     self.assertEqual(
         True, self.testcase.get_metadata('has_issue_ccs_from_owners_file'))
     self.assertEqual('', self.issue._monorail_issue.comment)
-    self.assertItemsEqual(['dev1@example1.com', 'dev2@example2.com'],
-                          sorted(self.issue.ccs))
+    six.assertCountEqual(self, ['dev1@example1.com', 'dev2@example2.com'],
+                         sorted(self.issue.ccs))
     self.assertNotIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_add_ccs_with_some_initial_ones(self):
@@ -1467,8 +1468,8 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
         'Automatically adding ccs based on OWNERS file / target commit history.'
         '\n\nIf this is incorrect, please add the ClusterFuzz-Wrong label.',
         self.issue._monorail_issue.comment)
-    self.assertItemsEqual(['dev1@example1.com', 'dev2@example2.com'],
-                          sorted(self.issue.ccs))
+    six.assertCountEqual(self, ['dev1@example1.com', 'dev2@example2.com'],
+                         sorted(self.issue.ccs))
     self.assertIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_add_ccs_without_any_initial_ones(self):
@@ -1481,8 +1482,8 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
         '\n\nIf this is incorrect, '
         'please file a bug on https://github.com/google/oss-fuzz/issues/new.',
         self.issue._monorail_issue.comment)
-    self.assertItemsEqual(['dev1@example1.com', 'dev2@example2.com'],
-                          sorted(self.issue.ccs))
+    six.assertCountEqual(self, ['dev1@example1.com', 'dev2@example2.com'],
+                         sorted(self.issue.ccs))
     self.assertIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
   def test_only_add_five_random_ccs(self):
@@ -1499,7 +1500,7 @@ class UpdateIssueCCsFromOwnersFileTest(unittest.TestCase):
         '\n\nIf this is incorrect, please add the ClusterFuzz-Wrong label.',
         self.issue._monorail_issue.comment)
 
-    self.assertItemsEqual(issue_owners[-5:], self.issue.ccs)
+    six.assertCountEqual(self, issue_owners[-5:], self.issue.ccs)
     self.assertIn('ClusterFuzz-Auto-CC', self.issue.labels)
 
 
@@ -2050,13 +2051,14 @@ class CleanupUnusedFuzzTargetsTest(unittest.TestCase):
 
     cleanup.cleanup_unused_fuzz_targets_and_jobs()
 
-    self.assertItemsEqual(
-        ['libFuzzer_binary3', 'libFuzzer_binary4'],
+    six.assertCountEqual(
+        self, ['libFuzzer_binary3', 'libFuzzer_binary4'],
         list([t.key.id() for t in data_types.FuzzTarget.query()]))
-    self.assertItemsEqual([
-        'libFuzzer_binary3/job1', 'libFuzzer_binary4/job1',
-        'libFuzzer_binary4/job2'
-    ], list([t.key.id() for t in data_types.FuzzTargetJob.query()]))
+    six.assertCountEqual(
+        self, [
+            'libFuzzer_binary3/job1', 'libFuzzer_binary4/job1',
+            'libFuzzer_binary4/job2'
+        ], list([t.key.id() for t in data_types.FuzzTargetJob.query()]))
 
 
 @test_utils.with_cloud_emulators('datastore')
@@ -2080,7 +2082,7 @@ class CleanupUnusedHeartbeatsTest(unittest.TestCase):
     data_types.Heartbeat(last_beat_time=datetime.datetime(2018, 2, 1)).put()
     cleanup.cleanup_unused_heartbeats()
 
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         {
             'task_payload': None,
             'source_version': None,

--- a/src/python/tests/appengine/handlers/cron/manage_vms_test.py
+++ b/src/python/tests/appengine/handlers/cron/manage_vms_test.py
@@ -23,6 +23,7 @@ import mock
 import unittest
 
 from google.cloud import ndb
+import six
 
 from datastore import data_types
 from google_cloud_utils import compute_engine_projects
@@ -845,7 +846,7 @@ class CronTest(unittest.TestCase):
             size=4,
             wait_for_instances=False)
 
-    self.assertItemsEqual([{
+    six.assertCountEqual(self, [{
         'instance_num': 0,
         'worker_name': u'oss-fuzz-linux-zone3-worker-proj1-0001',
         'project_name': u'proj1',

--- a/src/python/tests/appengine/handlers/cron/oss_fuzz_apply_ccs_test.py
+++ b/src/python/tests/appengine/handlers/cron/oss_fuzz_apply_ccs_test.py
@@ -16,6 +16,7 @@ from builtins import object
 import datetime
 import unittest
 
+import six
 import webapp2
 import webtest
 
@@ -148,7 +149,7 @@ class OssFuzzApplyCcsTest(unittest.TestCase):
     self.assertEqual(len(self.itm.modified_issues), 3)
 
     issue_1337 = self.itm.modified_issues[1337]
-    self.assertItemsEqual(issue_1337.cc, [
+    six.assertCountEqual(self, issue_1337.cc, [
         'user@example.com',
         'user2@example.com',
     ])
@@ -159,7 +160,7 @@ class OssFuzzApplyCcsTest(unittest.TestCase):
     self.assertNotIn(1338, self.itm.modified_issues)
 
     issue_1339 = self.itm.modified_issues[1339]
-    self.assertItemsEqual(issue_1339.cc, [
+    six.assertCountEqual(self, issue_1339.cc, [
         'user@example.com',
         'user2@example.com',
     ])
@@ -168,7 +169,7 @@ class OssFuzzApplyCcsTest(unittest.TestCase):
     self.assertEqual(issue_1339.comment, '')
 
     issue_1340 = self.itm.modified_issues[1340]
-    self.assertItemsEqual(issue_1340.cc, [
+    six.assertCountEqual(self, issue_1340.cc, [
         'user@example.com',
         'user2@example.com',
     ])

--- a/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
+++ b/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
@@ -19,6 +19,7 @@ import json
 import mock
 import unittest
 
+import six
 import webapp2
 import webtest
 
@@ -275,7 +276,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         id='proj6', name='proj7', ccs=['b@user.com']).put()
 
     self.app.get('/build-status')
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         {
             'build_type': 'fuzzing',
             'consecutive_failures': 1,
@@ -324,7 +325,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
 
     self.assertEqual(2, len(self.itm.issues))
     issue = self.itm.issues[1]
-    self.assertItemsEqual(['a@user.com'], issue.cc)
+    six.assertCountEqual(self, ['a@user.com'], issue.cc)
     self.assertEqual('New', issue.status)
     self.assertEqual('proj2: Fuzzing build failure', issue.summary)
     self.assertEqual(
@@ -345,7 +346,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
     self.assertTrue(issue.has_label('Type-Build-Failure'))
 
     issue = self.itm.issues[2]
-    self.assertItemsEqual(['b@user.com'], issue.cc)
+    six.assertCountEqual(self, ['b@user.com'], issue.cc)
     self.assertEqual('New', issue.status)
     self.assertEqual('proj6: Coverage build failure', issue.summary)
     self.assertEqual(
@@ -476,7 +477,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         build_type='fuzzing').put()
 
     self.app.get('/build-status')
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         {
             'build_type': 'fuzzing',
             'consecutive_failures': 1,

--- a/src/python/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/python/tests/appengine/handlers/cron/project_setup_test.py
@@ -23,6 +23,7 @@ import webapp2
 import webtest
 
 from google.cloud import ndb
+import six
 
 from base import utils
 from datastore import data_types
@@ -294,7 +295,8 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib1')
     self.assertEqual(job.platform, 'LIB1_LINUX')
-    self.assertItemsEqual(job.templates, ['engine_asan', 'libfuzzer', 'prune'])
+    six.assertCountEqual(self, job.templates,
+                         ['engine_asan', 'libfuzzer', 'prune'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib1/lib1-address-([0-9]+).zip\n'
@@ -314,7 +316,8 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib2')
     self.assertEqual(job.platform, 'LIB2_LINUX')
-    self.assertItemsEqual(job.templates, ['engine_asan', 'libfuzzer', 'prune'])
+    six.assertCountEqual(self, job.templates,
+                         ['engine_asan', 'libfuzzer', 'prune'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib2/lib2-address-([0-9]+).zip\n'
@@ -334,7 +337,8 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib3')
     self.assertEqual(job.platform, 'LIB3_LINUX')
-    self.assertItemsEqual(job.templates, ['engine_asan', 'libfuzzer', 'prune'])
+    six.assertCountEqual(self, job.templates,
+                         ['engine_asan', 'libfuzzer', 'prune'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib3/lib3-address-([0-9]+).zip\n'
@@ -355,7 +359,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib3')
     self.assertEqual(job.platform, 'LIB3_LINUX')
-    self.assertItemsEqual(job.templates, ['engine_asan', 'libfuzzer'])
+    six.assertCountEqual(self, job.templates, ['engine_asan', 'libfuzzer'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds-i386/lib3/lib3-address-([0-9]+).zip\n'
@@ -376,7 +380,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib3')
     self.assertEqual(job.platform, 'LIB3_LINUX')
-    self.assertItemsEqual(job.templates, ['engine_msan', 'libfuzzer'])
+    six.assertCountEqual(self, job.templates, ['engine_msan', 'libfuzzer'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib3/lib3-memory-([0-9]+).zip\n'
@@ -398,7 +402,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib3')
     self.assertEqual(job.platform, 'LIB3_LINUX')
-    self.assertItemsEqual(job.templates, ['engine_ubsan', 'libfuzzer'])
+    six.assertCountEqual(self, job.templates, ['engine_ubsan', 'libfuzzer'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib3/lib3-undefined-([0-9]+).zip\n'
@@ -418,7 +422,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib1')
     self.assertEqual(job.platform, 'LIB1_LINUX')
-    self.assertItemsEqual(job.templates, ['engine_asan', 'afl'])
+    six.assertCountEqual(self, job.templates, ['engine_asan', 'afl'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds-afl/lib1/lib1-address-([0-9]+).zip\n'
@@ -482,7 +486,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
 
     libfuzzer = data_types.Fuzzer.query(
         data_types.Fuzzer.name == 'libFuzzer').get()
-    self.assertItemsEqual(libfuzzer.jobs, [
+    six.assertCountEqual(self, libfuzzer.jobs, [
         'libfuzzer_asan_lib1',
         'libfuzzer_asan_lib3',
         'libfuzzer_asan_i386_lib3',
@@ -496,7 +500,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     ])
 
     afl = data_types.Fuzzer.query(data_types.Fuzzer.name == 'afl').get()
-    self.assertItemsEqual(afl.jobs, [
+    six.assertCountEqual(self, afl.jobs, [
         'afl_asan_lib1',
         'afl_asan_lib6',
     ])
@@ -1298,7 +1302,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
 
     mappings = data_types.FuzzerJob.query()
     tags_fuzzers_and_jobs = [(m.platform, m.fuzzer, m.job) for m in mappings]
-    self.assertItemsEqual(tags_fuzzers_and_jobs, [
+    six.assertCountEqual(self, tags_fuzzers_and_jobs, [
         ('LIB1_LINUX', 'afl', 'afl_asan_lib1'),
         ('LIB1_LINUX', 'libFuzzer', 'libfuzzer_asan_lib1'),
         ('LIB3_LINUX', 'libFuzzer', 'libfuzzer_asan_lib3'),
@@ -1319,7 +1323,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         for entity in data_types.ExternalUserPermission.query()
     ]
 
-    self.assertItemsEqual(all_permissions, [{
+    six.assertCountEqual(self, all_permissions, [{
         'entity_kind': 1,
         'is_prefix': False,
         'auto_cc': 1,
@@ -1505,11 +1509,11 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         'projects/clusterfuzz-external/topics/jobs-lib5-linux',
         'projects/clusterfuzz-external/topics/jobs-lib6-linux',
     ]
-    self.assertItemsEqual(expected_topics,
-                          list(pubsub_client.list_topics('projects/' + app_id)))
+    six.assertCountEqual(self, expected_topics,
+                         list(pubsub_client.list_topics('projects/' + app_id)))
 
     for i, topic in enumerate(expected_topics[2:]):
-      self.assertItemsEqual([
+      six.assertCountEqual(self, [
           'projects/clusterfuzz-external/subscriptions/'
           'jobs-lib{}-linux'.format(i + 1),
       ], pubsub_client.list_topic_subscriptions(topic))
@@ -1652,7 +1656,8 @@ class GenericProjectSetupTest(unittest.TestCase):
         'BOOL_VAR = True\n'
         'INT_VAR = 0\n'
         'STRING_VAR = VAL\n', job.environment_string)
-    self.assertItemsEqual(['engine_asan', 'libfuzzer', 'prune'], job.templates)
+    six.assertCountEqual(self, ['engine_asan', 'libfuzzer', 'prune'],
+                         job.templates)
 
     job = data_types.Job.query(
         data_types.Job.name == 'honggfuzz_asan_a-b').get()
@@ -1664,20 +1669,20 @@ class GenericProjectSetupTest(unittest.TestCase):
         'BOOL_VAR = True\n'
         'INT_VAR = 0\n'
         'STRING_VAR = VAL\n', job.environment_string)
-    self.assertItemsEqual(['engine_asan', 'honggfuzz'], job.templates)
+    six.assertCountEqual(self, ['engine_asan', 'honggfuzz'], job.templates)
 
     libfuzzer = data_types.Fuzzer.query(
         data_types.Fuzzer.name == 'libFuzzer').get()
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'libfuzzer_asan_a-b',
         'old_unmanaged',
     ], libfuzzer.jobs)
 
     afl = data_types.Fuzzer.query(data_types.Fuzzer.name == 'afl').get()
-    self.assertItemsEqual([], afl.jobs)
+    six.assertCountEqual(self, [], afl.jobs)
 
     honggfuzz = data_types.Fuzzer.query(
         data_types.Fuzzer.name == 'honggfuzz').get()
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'honggfuzz_asan_a-b',
     ], honggfuzz.jobs)

--- a/src/python/tests/appengine/handlers/cron/sync_admins_test.py
+++ b/src/python/tests/appengine/handlers/cron/sync_admins_test.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+import six
 import webapp2
 import webtest
 
@@ -85,7 +86,7 @@ class SyncAdminsTest(unittest.TestCase):
     """Test syncing admins."""
     self.app.get('/sync-admins')
     admins = data_types.Admin.query()
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'user1@email.com',
         'user2@email.com',
         'user3@email.com',

--- a/src/python/tests/appengine/libs/issue_filer_test.py
+++ b/src/python/tests/appengine/libs/issue_filer_test.py
@@ -19,8 +19,10 @@ from builtins import object
 import datetime
 import mock
 import os
-import parameterized
 import unittest
+
+import parameterized
+import six
 
 from datastore import data_types
 from libs.issue_management import issue_filer
@@ -339,7 +341,7 @@ class IssueFilerTests(unittest.TestCase):
     self.mock.get.return_value = CHROMIUM_POLICY
     issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
     issue_filer.file_issue(self.testcase5, issue_tracker)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'ClusterFuzz',
         'Reproducible',
         'Pri-1',
@@ -348,7 +350,7 @@ class IssueFilerTests(unittest.TestCase):
         'label1',
         'label2',
     ], issue_tracker._itm.last_issue.labels)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'component1',
         'component2',
     ], issue_tracker._itm.last_issue.components)
@@ -358,7 +360,8 @@ class IssueFilerTests(unittest.TestCase):
     self.mock.get.return_value = CHROMIUM_POLICY
     issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
     issue_filer.file_issue(self.testcase6, issue_tracker)
-    self.assertItemsEqual(
+    six.assertCountEqual(
+        self,
         ['ClusterFuzz', 'Reproducible', 'Pri-1', 'Stability-Crash', 'Type-Bug'],
         issue_tracker._itm.last_issue.labels)
 
@@ -605,8 +608,9 @@ class UpdateImpactTest(unittest.TestCase):
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual(['Security_Impact-Stable'], mock_issue.labels.added)
-    self.assertItemsEqual([], mock_issue.labels.removed)
+    six.assertCountEqual(self, ['Security_Impact-Stable'],
+                         mock_issue.labels.added)
+    six.assertCountEqual(self, [], mock_issue.labels.removed)
 
   def test_update_impact_stable(self):
     """Tests updating impact to Stable."""
@@ -616,8 +620,9 @@ class UpdateImpactTest(unittest.TestCase):
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual(['Security_Impact-Stable'], mock_issue.labels.added)
-    self.assertItemsEqual([], mock_issue.labels.removed)
+    six.assertCountEqual(self, ['Security_Impact-Stable'],
+                         mock_issue.labels.added)
+    six.assertCountEqual(self, [], mock_issue.labels.removed)
 
   def test_update_impact_beta(self):
     """Tests updating impact to Beta."""
@@ -627,8 +632,9 @@ class UpdateImpactTest(unittest.TestCase):
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual(['Security_Impact-Beta'], mock_issue.labels.added)
-    self.assertItemsEqual([], mock_issue.labels.removed)
+    six.assertCountEqual(self, ['Security_Impact-Beta'],
+                         mock_issue.labels.added)
+    six.assertCountEqual(self, [], mock_issue.labels.removed)
 
   def test_update_impact_head(self):
     """Tests updating impact to Head."""
@@ -637,8 +643,9 @@ class UpdateImpactTest(unittest.TestCase):
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual(['Security_Impact-Head'], mock_issue.labels.added)
-    self.assertItemsEqual([], mock_issue.labels.removed)
+    six.assertCountEqual(self, ['Security_Impact-Head'],
+                         mock_issue.labels.added)
+    six.assertCountEqual(self, [], mock_issue.labels.removed)
 
   def test_no_impact_for_unreproducible_testcase(self):
     """Tests no impact for unreproducible testcase on trunk and which also
@@ -649,16 +656,16 @@ class UpdateImpactTest(unittest.TestCase):
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual([], mock_issue.labels.added)
-    self.assertItemsEqual([], mock_issue.labels.removed)
+    six.assertCountEqual(self, [], mock_issue.labels.added)
+    six.assertCountEqual(self, [], mock_issue.labels.removed)
 
   def test_no_impact_if_not_set(self):
     """Tests no impact if the impact flag is not set."""
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual([], mock_issue.labels.added)
-    self.assertItemsEqual([], mock_issue.labels.removed)
+    six.assertCountEqual(self, [], mock_issue.labels.added)
+    six.assertCountEqual(self, [], mock_issue.labels.removed)
 
   def test_replace_impact(self):
     """Tests replacing impact."""
@@ -669,8 +676,10 @@ class UpdateImpactTest(unittest.TestCase):
     mock_issue.labels.reset_tracking()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual(['Security_Impact-Head'], mock_issue.labels.added)
-    self.assertItemsEqual(['Security_Impact-Beta'], mock_issue.labels.removed)
+    six.assertCountEqual(self, ['Security_Impact-Head'],
+                         mock_issue.labels.added)
+    six.assertCountEqual(self, ['Security_Impact-Beta'],
+                         mock_issue.labels.removed)
 
   def test_replace_same_impact(self):
     """Tests replacing same impact."""
@@ -681,8 +690,8 @@ class UpdateImpactTest(unittest.TestCase):
     mock_issue.labels.reset_tracking()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual([], mock_issue.labels.added)
-    self.assertItemsEqual([], mock_issue.labels.removed)
+    six.assertCountEqual(self, [], mock_issue.labels.added)
+    six.assertCountEqual(self, [], mock_issue.labels.removed)
 
   def test_component_add_label(self):
     """Test that we set labels for component builds."""
@@ -700,5 +709,6 @@ class UpdateImpactTest(unittest.TestCase):
     self.testcase.is_impact_set_flag = True
     mock_issue = self._make_mock_issue()
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    self.assertItemsEqual(['Security_Impact-Stable'], mock_issue.labels.added)
-    self.assertItemsEqual([], mock_issue.labels.removed)
+    six.assertCountEqual(self, ['Security_Impact-Stable'],
+                         mock_issue.labels.added)
+    six.assertCountEqual(self, [], mock_issue.labels.removed)

--- a/src/python/tests/appengine/libs/issue_management/issue_tracker_test.py
+++ b/src/python/tests/appengine/libs/issue_management/issue_tracker_test.py
@@ -18,6 +18,8 @@ from builtins import str
 import mock
 import unittest
 
+import six
+
 from libs.issue_management.issue_tracker import IssueTracker
 from libs.issue_management.issue_tracker import LabelStore
 
@@ -28,69 +30,69 @@ class LabelStoreTest(unittest.TestCase):
   def test_init_and_iter(self):
     """Test initializing and iterating LabelStore."""
     store = LabelStore(['label1', 'label2'])
-    self.assertItemsEqual([], store.added)
-    self.assertItemsEqual([], store.removed)
-    self.assertItemsEqual(['label1', 'label2'], list(store))
+    six.assertCountEqual(self, [], store.added)
+    six.assertCountEqual(self, [], store.removed)
+    six.assertCountEqual(self, ['label1', 'label2'], list(store))
 
   def test_add(self):
     """Test adding items."""
     store = LabelStore()
     store.add('laBel1')
-    self.assertItemsEqual(['laBel1'], store)
-    self.assertItemsEqual(['laBel1'], store.added)
-    self.assertItemsEqual([], store.removed)
+    six.assertCountEqual(self, ['laBel1'], store)
+    six.assertCountEqual(self, ['laBel1'], store.added)
+    six.assertCountEqual(self, [], store.removed)
 
     store.add('label2')
-    self.assertItemsEqual(['laBel1', 'label2'], store)
-    self.assertItemsEqual(['laBel1', 'label2'], store.added)
-    self.assertItemsEqual([], store.removed)
+    six.assertCountEqual(self, ['laBel1', 'label2'], store)
+    six.assertCountEqual(self, ['laBel1', 'label2'], store.added)
+    six.assertCountEqual(self, [], store.removed)
 
     store.add('labEl2')
-    self.assertItemsEqual(['laBel1', 'labEl2'], store)
-    self.assertItemsEqual(['laBel1', 'labEl2'], store.added)
-    self.assertItemsEqual([], store.removed)
+    six.assertCountEqual(self, ['laBel1', 'labEl2'], store)
+    six.assertCountEqual(self, ['laBel1', 'labEl2'], store.added)
+    six.assertCountEqual(self, [], store.removed)
 
   def test_remove(self):
     """Test removing items."""
     store = LabelStore(['laBel1', 'label2', 'Label3'])
     store.remove('Label1')
-    self.assertItemsEqual(['label2', 'Label3'], store)
-    self.assertItemsEqual([], store.added)
-    self.assertItemsEqual(['Label1'], store.removed)
+    six.assertCountEqual(self, ['label2', 'Label3'], store)
+    six.assertCountEqual(self, [], store.added)
+    six.assertCountEqual(self, ['Label1'], store.removed)
 
     store.remove('Label2')
-    self.assertItemsEqual(['Label3'], store)
-    self.assertItemsEqual([], store.added)
-    self.assertItemsEqual(['Label1', 'Label2'], store.removed)
+    six.assertCountEqual(self, ['Label3'], store)
+    six.assertCountEqual(self, [], store.added)
+    six.assertCountEqual(self, ['Label1', 'Label2'], store.removed)
 
     store.remove('LaBel2')
-    self.assertItemsEqual(['Label3'], store)
-    self.assertItemsEqual([], store.added)
-    self.assertItemsEqual(['Label1', 'Label2'], store.removed)
+    six.assertCountEqual(self, ['Label3'], store)
+    six.assertCountEqual(self, [], store.added)
+    six.assertCountEqual(self, ['Label1', 'Label2'], store.removed)
 
     store.remove('Label4')
-    self.assertItemsEqual(['Label3'], store)
-    self.assertItemsEqual([], store.added)
-    self.assertItemsEqual(['Label1', 'Label2'], store.removed)
+    six.assertCountEqual(self, ['Label3'], store)
+    six.assertCountEqual(self, [], store.added)
+    six.assertCountEqual(self, ['Label1', 'Label2'], store.removed)
 
   def test_add_and_remove(self):
     """Test both adding and removing."""
     store = LabelStore(['laBel1', 'label2', 'Label3'])
     store.remove('Label1')
-    self.assertItemsEqual(['label2', 'Label3'], store)
-    self.assertItemsEqual([], store.added)
-    self.assertItemsEqual(['Label1'], store.removed)
+    six.assertCountEqual(self, ['label2', 'Label3'], store)
+    six.assertCountEqual(self, [], store.added)
+    six.assertCountEqual(self, ['Label1'], store.removed)
 
     store.add('label1')
-    self.assertItemsEqual(['label1', 'label2', 'Label3'], store)
-    self.assertItemsEqual([], store.added)
-    self.assertItemsEqual([], store.removed)
+    six.assertCountEqual(self, ['label1', 'label2', 'Label3'], store)
+    six.assertCountEqual(self, [], store.added)
+    six.assertCountEqual(self, [], store.removed)
 
     store.remove('Label1')
     store.add('label4')
-    self.assertItemsEqual(['label2', 'Label3', 'label4'], store)
-    self.assertItemsEqual(['label4'], store.added)
-    self.assertItemsEqual(['Label1'], store.removed)
+    six.assertCountEqual(self, ['label2', 'Label3', 'label4'], store)
+    six.assertCountEqual(self, ['label4'], store.added)
+    six.assertCountEqual(self, ['Label1'], store.removed)
 
   def test_reset(self):
     """Test reset."""
@@ -100,14 +102,14 @@ class LabelStoreTest(unittest.TestCase):
     store.remove('label1')
 
     store.reset_tracking()
-    self.assertItemsEqual([], store.added)
-    self.assertItemsEqual([], store.removed)
+    six.assertCountEqual(self, [], store.added)
+    six.assertCountEqual(self, [], store.removed)
 
   def test_remove_by_prefix(self):
     """Test remove_by_prefix."""
     store = LabelStore(['p-0', 'P-1', 'Q-2'])
     store.remove_by_prefix('p-')
-    self.assertItemsEqual(['Q-2'], store)
+    six.assertCountEqual(self, ['Q-2'], store)
 
   def test_in(self):
     """Test in operator."""

--- a/src/python/tests/appengine/libs/issue_management/jira/jira_test.py
+++ b/src/python/tests/appengine/libs/issue_management/jira/jira_test.py
@@ -18,6 +18,8 @@ from dateutil import tz
 import datetime
 import unittest
 
+import six
+
 from libs.issue_management import jira
 from libs.issue_management.jira import Issue
 from libs.issue_management.jira import issue_tracker_manager
@@ -111,15 +113,15 @@ class JiraTests(unittest.TestCase):
     self.assertEqual('reporter', issue.reporter)
     self.assertEqual('NOT STARTED', issue.status)
 
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'label1',
         'label2',
     ], issue.labels)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'A>B',
         'C>D',
     ], issue.components)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'cc@cc.com',
     ], issue.ccs)
 
@@ -136,7 +138,7 @@ class JiraTests(unittest.TestCase):
     issue = self.issue_tracker.get_issue('VSEC-3112')
     issue.labels.add('Label3')
     issue.labels.remove('laBel1')
-    self.assertItemsEqual(['label2', 'Label3'], issue.labels)
+    six.assertCountEqual(self, ['label2', 'Label3'], issue.labels)
 
   def test_modify_components(self):
     """Test modifying components."""
@@ -144,14 +146,14 @@ class JiraTests(unittest.TestCase):
     issue = self.issue_tracker.get_issue('VSEC-3112')
     issue.components.add('Y>Z')
     issue.components.remove('a>B')
-    self.assertItemsEqual(['C>D', 'Y>Z'], issue.components)
+    six.assertCountEqual(self, ['C>D', 'Y>Z'], issue.components)
 
   def test_find_issues(self):
     """Test find_issues."""
     issue = self.mock_issue
     self.mock.get_issues.return_value = [self.jira_issue]
     issues = self.issue_tracker.find_issues(keywords=['body'], only_open=True)
-    self.assertItemsEqual(['VSEC-3112'], [issue.id for issue in issues])
+    six.assertCountEqual(self, ['VSEC-3112'], [issue.id for issue in issues])
 
   def test_issue_url(self):
     """Test issue_url."""

--- a/src/python/tests/appengine/libs/issue_management/monorail/monorail_test.py
+++ b/src/python/tests/appengine/libs/issue_management/monorail/monorail_test.py
@@ -17,6 +17,8 @@ import datetime
 import mock
 import unittest
 
+import six
+
 from libs.issue_management import monorail
 from libs.issue_management.monorail import issue_tracker_manager
 from libs.issue_management.monorail.comment import Comment as MonorailComment
@@ -119,15 +121,15 @@ class MonorailTests(unittest.TestCase):
     self.assertEqual('New', issue.status)
     self.assertIsNone(issue.merged_into)
 
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'label1',
         'label2',
     ], issue.labels)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'A>B',
         'C>D',
     ], issue.components)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'cc@cc.com',
     ], issue.ccs)
 
@@ -160,15 +162,15 @@ class MonorailTests(unittest.TestCase):
     self.assertEqual('New', monorail_issue.status)
     self.assertEqual('comment', monorail_issue.comment)
 
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'label1',
         'label2',
     ], monorail_issue.labels)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'A>B',
         'C>D',
     ], monorail_issue.components)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'cc@cc.com',
     ], monorail_issue.cc)
 
@@ -182,45 +184,45 @@ class MonorailTests(unittest.TestCase):
     self.assertEqual('comment', actions[0].comment)
     self.assertEqual('owner', actions[0].assignee)
     self.assertEqual('status', actions[0].status)
-    self.assertItemsEqual(['cc@cc.com'], actions[0].ccs.added)
-    self.assertItemsEqual(['removed@cc.com'], actions[0].ccs.removed)
-    self.assertItemsEqual(['label1'], actions[0].labels.added)
-    self.assertItemsEqual(['label0'], actions[0].labels.removed)
-    self.assertItemsEqual(['A>B'], actions[0].components.added)
-    self.assertItemsEqual(['E>F'], actions[0].components.removed)
+    six.assertCountEqual(self, ['cc@cc.com'], actions[0].ccs.added)
+    six.assertCountEqual(self, ['removed@cc.com'], actions[0].ccs.removed)
+    six.assertCountEqual(self, ['label1'], actions[0].labels.added)
+    six.assertCountEqual(self, ['label0'], actions[0].labels.removed)
+    six.assertCountEqual(self, ['A>B'], actions[0].components.added)
+    six.assertCountEqual(self, ['E>F'], actions[0].components.removed)
 
     self.assertIsNone(actions[1].title)
     self.assertEqual('comment', actions[1].comment)
     self.assertIsNone(actions[1].assignee)
     self.assertIsNone(actions[1].status)
-    self.assertItemsEqual([], actions[1].ccs.added)
-    self.assertItemsEqual([], actions[1].ccs.removed)
-    self.assertItemsEqual([], actions[1].labels.added)
-    self.assertItemsEqual([], actions[1].labels.removed)
-    self.assertItemsEqual([], actions[1].components.added)
-    self.assertItemsEqual([], actions[1].components.removed)
+    six.assertCountEqual(self, [], actions[1].ccs.added)
+    six.assertCountEqual(self, [], actions[1].ccs.removed)
+    six.assertCountEqual(self, [], actions[1].labels.added)
+    six.assertCountEqual(self, [], actions[1].labels.removed)
+    six.assertCountEqual(self, [], actions[1].components.added)
+    six.assertCountEqual(self, [], actions[1].components.removed)
 
   def test_modify_labels(self):
     """Test modifying labels."""
     issue = self.issue_tracker.get_issue(1337)
     issue.labels.add('Label3')
     issue.labels.remove('laBel1')
-    self.assertItemsEqual(['label2', 'Label3'], issue.labels)
+    six.assertCountEqual(self, ['label2', 'Label3'], issue.labels)
     issue.save()
 
-    self.assertItemsEqual(['label2', 'Label3', '-laBel1'],
-                          self.itm.last_issue.labels)
+    six.assertCountEqual(self, ['label2', 'Label3', '-laBel1'],
+                         self.itm.last_issue.labels)
 
   def test_modify_components(self):
     """Test modifying labels."""
     issue = self.issue_tracker.get_issue(1337)
     issue.components.add('Y>Z')
     issue.components.remove('a>B')
-    self.assertItemsEqual(['C>D', 'Y>Z'], issue.components)
+    six.assertCountEqual(self, ['C>D', 'Y>Z'], issue.components)
     issue.save()
 
-    self.assertItemsEqual(['-a>B', 'C>D', 'Y>Z'],
-                          self.itm.last_issue.components)
+    six.assertCountEqual(self, ['-a>B', 'C>D', 'Y>Z'],
+                         self.itm.last_issue.components)
 
   def test_get_original_issue(self):
     """Test get_original_issue."""
@@ -240,7 +242,7 @@ class MonorailTests(unittest.TestCase):
     ]
     issues = self.issue_tracker.find_issues(
         keywords=['one', 'two'], only_open=True)
-    self.assertItemsEqual([1, 2], [issue.id for issue in issues])
+    six.assertCountEqual(self, [1, 2], [issue.id for issue in issues])
 
     self.mock.get_issues.assert_has_calls([
         mock.call(mock.ANY, '"one" "two"', can='open'),
@@ -248,7 +250,7 @@ class MonorailTests(unittest.TestCase):
 
     issues = self.issue_tracker.find_issues(
         keywords=['one', 'two'], only_open=False)
-    self.assertItemsEqual([1, 2], [issue.id for issue in issues])
+    six.assertCountEqual(self, [1, 2], [issue.id for issue in issues])
 
     self.mock.get_issues.assert_has_calls([
         mock.call(mock.ANY, '"one" "two"', can='all'),

--- a/src/python/tests/appengine/libs/query/datastore_query_test.py
+++ b/src/python/tests/appengine/libs/query/datastore_query_test.py
@@ -19,6 +19,7 @@ import mock
 import unittest
 
 from google.cloud import ndb
+import six
 
 from libs.query import datastore_query
 from tests.test_libs import test_utils
@@ -241,13 +242,13 @@ class QueryMockTest(unittest.TestCase):
     query.fetch_page(page=1, page_size=2, projection=['tokens'], more_limit=4)
 
     self.assertIsInstance(self.queries[0][-1].filters, ndb.AND)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         ('tokens', '=', 'a'),
         ('boolean_value', '=', True),
     ], [f.__getnewargs__() for f in self.queries[0][-1].filters])
 
     self.assertIsInstance(self.queries[1][-1].filters, ndb.AND)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         ('tokens', '=', 'b'),
         ('boolean_value', '=', True),
     ], [f.__getnewargs__() for f in self.queries[1][-1].filters])
@@ -258,7 +259,7 @@ class QueryMockTest(unittest.TestCase):
     for item in [f.__getnewargs__() for f in self.queries[2][-1].filters]:
       expected.append((item[0], item[1], repr(item[2])))
 
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         ('__key__', '=',
          '<Key(\'TestDatastoreModel\', 0), project=test-clusterfuzz>'),
         ('__key__', '=',

--- a/src/python/tests/core/bot/fuzzers/builtin_fuzzers_test.py
+++ b/src/python/tests/core/bot/fuzzers/builtin_fuzzers_test.py
@@ -19,6 +19,7 @@ import os
 import unittest
 
 from pyfakefs import fake_filesystem_unittest
+import six
 
 from bot.fuzzers import builtin
 from bot.fuzzers import builtin_fuzzers
@@ -111,7 +112,7 @@ class BuiltinFuzzersSetupTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(('/input', '/output', 4), self.mock.run.call_args[0][1:])
 
     self.assertFalse(error_occurred)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         '/output/fuzz-0',
         '/output/fuzz-1',
         '/output/fuzz-2',

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -24,6 +24,7 @@ import unittest
 import mock
 import parameterized
 import pyfakefs.fake_filesystem_unittest as fake_fs_unittest
+import six
 
 from bot.fuzzers import engine_common
 from bot.fuzzers import libfuzzer
@@ -99,7 +100,7 @@ class PrepareTest(fake_fs_unittest.TestCase):
     engine_impl = engine.LibFuzzerEngine()
     options = engine_impl.prepare('/corpus_dir', '/path/target', '/path')
     self.assertEqual('/corpus_dir', options.corpus_dir)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         '-max_len=31337', '-timeout=11', '-rss_limit_mb=2560', '-arg1',
         '-dict=/path/blah.dict'
     ], options.arguments)
@@ -108,8 +109,8 @@ class PrepareTest(fake_fs_unittest.TestCase):
         'corpus_subset': 20,
         'fork': 2
     }, options.strategies)
-    self.assertItemsEqual(['/new_corpus_dir', '/corpus_dir'],
-                          options.fuzz_corpus_dirs)
+    six.assertCountEqual(self, ['/new_corpus_dir', '/corpus_dir'],
+                         options.fuzz_corpus_dirs)
     self.assertDictEqual({'extra_env': '1'}, options.extra_env)
     self.assertFalse(options.use_dataflow_tracing)
     self.assertTrue(options.is_mutations_run)
@@ -127,8 +128,8 @@ class PrepareTest(fake_fs_unittest.TestCase):
 
     engine_impl = engine.LibFuzzerEngine()
     options = engine_impl.prepare('/corpus_dir', '/path/target', '/path')
-    self.assertItemsEqual(
-        ['-max_len=31337', '-timeout=11', '-rss_limit_mb=2560', '-arg1'],
+    six.assertCountEqual(
+        self, ['-max_len=31337', '-timeout=11', '-rss_limit_mb=2560', '-arg1'],
         options.arguments)
 
   def test_prepare_auto_add_dict(self):
@@ -139,7 +140,7 @@ class PrepareTest(fake_fs_unittest.TestCase):
 
     engine_impl = engine.LibFuzzerEngine()
     options = engine_impl.prepare('/corpus_dir', '/path/target', '/path')
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         '-max_len=31337', '-timeout=11', '-rss_limit_mb=2560', '-arg1',
         '-dict=/path/target.dict'
     ], options.arguments)
@@ -160,7 +161,7 @@ class PickStrategiesTest(fake_fs_unittest.TestCase):
     strategy_pool = set_strategy_pool([strategy.RANDOM_MAX_LENGTH_STRATEGY])
     strategy_info = libfuzzer.pick_strategies(strategy_pool, '/path/target',
                                               '/path/corpus', ['-max_len=100'])
-    self.assertItemsEqual([], strategy_info.arguments)
+    six.assertCountEqual(self, [], strategy_info.arguments)
 
   def test_max_length_strategy_without_override(self):
     """Tests max length strategy without override."""
@@ -168,7 +169,7 @@ class PickStrategiesTest(fake_fs_unittest.TestCase):
     strategy_pool = set_strategy_pool([strategy.RANDOM_MAX_LENGTH_STRATEGY])
     strategy_info = libfuzzer.pick_strategies(strategy_pool, '/path/target',
                                               '/path/corpus', [])
-    self.assertItemsEqual(['-max_len=1337'], strategy_info.arguments)
+    six.assertCountEqual(self, ['-max_len=1337'], strategy_info.arguments)
 
 
 class FuzzTest(fake_fs_unittest.TestCase):
@@ -253,7 +254,7 @@ class FuzzTest(fake_fs_unittest.TestCase):
     self.assertEqual('/fake/crash-1e15825e6f0b2240a5af75d84214adda1b6b5340',
                      crash.input_path)
     self.assertEqual(fuzz_output, crash.stacktrace)
-    self.assertItemsEqual(['-arg=1', '-timeout=60'], crash.reproduce_args)
+    six.assertCountEqual(self, ['-arg=1', '-timeout=60'], crash.reproduce_args)
     self.assertEqual(2, crash.crash_time)
 
     self.mock.fuzz.assert_called_with(

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
@@ -25,6 +25,8 @@ import shutil
 import tempfile
 import unittest
 
+import six
+
 from bot.fuzzers.libFuzzer import engine as libFuzzer_engine
 from bot.tasks import commands
 from bot.tasks import corpus_pruning_task
@@ -170,7 +172,7 @@ class CorpusPruningTest(unittest.TestCase, BaseTest):
 
     corpus = os.listdir(self.corpus_dir)
     self.assertEqual(4, len(corpus))
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         '39e0574a4abfd646565a3e436c548eeb1684fb57',
         '7d157d7c000ae27db146575c08ce30df893d3a64',
         '31836aeaab22dc49555a97edb4c753881432e01d',
@@ -293,14 +295,14 @@ class CorpusPruningTestFuchsia(unittest.TestCase, BaseTest):
         'libfuzzer_asan_fuchsia')
     corpus = os.listdir(self.corpus_dir)
     self.assertEqual(2, len(corpus))
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         '31836aeaab22dc49555a97edb4c753881432e01d',
         '7cf184f4c67ad58283ecb19349720b0cae756829'
     ], corpus)
     quarantine = os.listdir(self.quarantine_dir)
     self.assertEqual(1, len(quarantine))
-    self.assertItemsEqual(['crash-7a8dc3985d2a90fb6e62e94910fc11d31949c348'],
-                          quarantine)
+    six.assertCountEqual(
+        self, ['crash-7a8dc3985d2a90fb6e62e94910fc11d31949c348'], quarantine)
 
 
 class CorpusPruningTestUntrusted(
@@ -423,7 +425,7 @@ class CorpusPruningTestUntrusted(
     os.mkdir(corpus_dir)
     self.corpus.rsync_to_disk(corpus_dir)
 
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         '39e0574a4abfd646565a3e436c548eeb1684fb57',
         '7d157d7c000ae27db146575c08ce30df893d3a64',
         '31836aeaab22dc49555a97edb4c753881432e01d',
@@ -434,8 +436,9 @@ class CorpusPruningTestUntrusted(
     os.mkdir(quarantine_dir)
     self.quarantine_corpus.rsync_to_disk(quarantine_dir)
 
-    self.assertItemsEqual(['crash-7acd6a2b3fe3c5ec97fa37e5a980c106367491fa'],
-                          os.listdir(quarantine_dir))
+    six.assertCountEqual(self,
+                         ['crash-7acd6a2b3fe3c5ec97fa37e5a980c106367491fa'],
+                         os.listdir(quarantine_dir))
 
     testcases = list(data_types.Testcase.query())
     self.assertEqual(1, len(testcases))

--- a/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -20,6 +20,8 @@ import six
 import subprocess
 import tempfile
 
+import six
+
 from base import utils
 from bot import testcase_manager
 from bot.tasks import setup
@@ -177,13 +179,13 @@ class UntrustedRunnerIntegrationTest(
     with open(os.path.join(fuzz_inputs, 'c', 'c'), 'w') as f:
       f.write('')
 
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         os.path.join(fuzz_inputs, 'a'),
         os.path.join(fuzz_inputs, 'b'),
         os.path.join(fuzz_inputs, 'c'),
     ], file_host.list_files(fuzz_inputs))
 
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         os.path.join(fuzz_inputs, 'a'),
         os.path.join(fuzz_inputs, 'b'),
         os.path.join(fuzz_inputs, 'c', 'c'),
@@ -433,7 +435,7 @@ class UntrustedRunnerIntegrationTest(
     file_list, input_directory, testcase_file_path = (
         setup.setup_testcase(testcase, job_type))
 
-    self.assertItemsEqual(file_list, [
+    six.assertCountEqual(self, file_list, [
         testcase.absolute_path,
     ])
     self.assertEqual(input_directory, fuzz_inputs)
@@ -482,8 +484,8 @@ class UntrustedRunnerIntegrationTest(
 
     try:
       self.assertTrue(corpus.rsync_to_disk(test_corpus_directory))
-      self.assertItemsEqual(
-          os.listdir(test_corpus_directory), ['123', '456', 'abc'])
+      six.assertCountEqual(self, os.listdir(test_corpus_directory),
+                           ['123', '456', 'abc'])
     finally:
       if os.path.exists(test_corpus_directory):
         shutil.rmtree(test_corpus_directory, ignore_errors=True)
@@ -530,7 +532,7 @@ class UntrustedRunnerIntegrationTest(
                                          'core', 'bot', 'untrusted_runner',
                                          'test_data', 'test_build')
     fuzz_target_paths = file_host.get_fuzz_targets(worker_test_build_dir)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         os.path.join(worker_test_build_dir, 'do_stuff_fuzzer'),
         os.path.join(worker_test_build_dir, 'target'),
     ], fuzz_target_paths)

--- a/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -16,7 +16,6 @@
 import filecmp
 import os
 import shutil
-import six
 import subprocess
 import tempfile
 

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -27,6 +27,7 @@ import types
 import unittest
 
 from pyfakefs import fake_filesystem_unittest
+import six
 
 from base import errors
 from base import utils
@@ -219,7 +220,7 @@ class FuchsiaBuildTest(unittest.TestCase):
 
     # pylint: disable=protected-access
     targets = build._get_fuzz_targets_from_dir(build.build_dir)
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         'example_fuzzers/baz_fuzzer',
         'example_fuzzers/overflow_fuzzer',
         'example_fuzzers/trap_fuzzer',
@@ -1906,7 +1907,7 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
 
     targets_list = build_manager._get_targets_list(
         os.environ['FUZZ_TARGET_BUILD_BUCKET_PATH'])
-    self.assertItemsEqual(['target1', 'target3'], targets_list)
+    six.assertCountEqual(self, ['target1', 'target3'], targets_list)
 
 
 class GetPrimaryBucketPathTest(unittest.TestCase):

--- a/src/python/tests/core/google_cloud_utils/pubsub_test.py
+++ b/src/python/tests/core/google_cloud_utils/pubsub_test.py
@@ -17,6 +17,8 @@ from builtins import range
 import time
 import unittest
 
+import six
+
 from google_cloud_utils import pubsub
 from tests.test_libs import helpers
 from tests.test_libs import test_utils
@@ -77,7 +79,7 @@ class PubSubTest(unittest.TestCase):
     time.sleep(ACK_DEADLINE + ACK_DEADLINE_WINDOW)
     messages = self.client.pull_from_subscription(self.subscription)
     self.assertEqual(2, len(messages))
-    self.assertItemsEqual([
+    six.assertCountEqual(self, [
         {
             'data': 'MTIz',
         },
@@ -135,14 +137,14 @@ class PubSubTest(unittest.TestCase):
     expected.append('projects/fake-project/topics/test-topic')
 
     topics = list(self.client.list_topics('projects/' + PROJECT_NAME))
-    self.assertItemsEqual(expected, topics)
+    six.assertCountEqual(self, expected, topics)
 
     # Note: Page size appears to be ignored by the emulator. Even when creating
     # large amounts of topics to force paging, the nextPageToken returned is
     # buggy and results in infinite loops.
     topics = list(
         self.client.list_topics('projects/' + PROJECT_NAME, page_size=1))
-    self.assertItemsEqual(expected, topics)
+    six.assertCountEqual(self, expected, topics)
 
   def test_list_topic_subscriptions(self):
     """Test listing topic subscriptions."""
@@ -155,14 +157,14 @@ class PubSubTest(unittest.TestCase):
     expected.append('projects/fake-project/subscriptions/subscription')
 
     subscriptions = list(self.client.list_topic_subscriptions(self.topic))
-    self.assertItemsEqual(expected, subscriptions)
+    six.assertCountEqual(self, expected, subscriptions)
 
     # Note: Page size appears to be ignored by the emulator. Even when creating
     # large amounts of topics to force paging, the nextPageToken returned is
     # buggy and results in infinite loops.
     subscriptions = list(
         self.client.list_topic_subscriptions(self.topic, page_size=1))
-    self.assertItemsEqual(expected, subscriptions)
+    six.assertCountEqual(self, expected, subscriptions)
 
   def test_get_topic(self):
     """Test getting a topic."""

--- a/src/python/tests/core/google_cloud_utils/storage_test.py
+++ b/src/python/tests/core/google_cloud_utils/storage_test.py
@@ -17,6 +17,7 @@ import os
 import unittest
 
 from pyfakefs import fake_filesystem_unittest
+import six
 
 from base import utils
 from google_cloud_utils import storage
@@ -110,7 +111,7 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
         contents='{"key":"value"}').st_mtime = mtime_seconds
 
     result = list(self.provider.list_blobs('gs://test-bucket'))
-    self.assertItemsEqual([{
+    six.assertCountEqual(self, [{
         'bucket': 'test-bucket',
         'name': 'a',
         'updated': mtime,
@@ -139,7 +140,7 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
     }], result)
 
     result = list(self.provider.list_blobs('gs://test-bucket/b'))
-    self.assertItemsEqual([{
+    six.assertCountEqual(self, [{
         'bucket': 'test-bucket',
         'name': 'b/c',
         'updated': mtime,
@@ -156,7 +157,7 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
     }], result)
 
     result = list(self.provider.list_blobs('gs://test-bucket/b/d'))
-    self.assertItemsEqual([{
+    six.assertCountEqual(self, [{
         'bucket': 'test-bucket',
         'name': 'b/d/e',
         'updated': mtime,
@@ -166,7 +167,7 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
 
     result = list(
         self.provider.list_blobs('gs://test-bucket/', recursive=False))
-    self.assertItemsEqual([{
+    six.assertCountEqual(self, [{
         'bucket': 'test-bucket',
         'name': 'a',
         'updated': mtime,

--- a/src/python/tests/core/metrics/fuzzer_stats_test.py
+++ b/src/python/tests/core/metrics/fuzzer_stats_test.py
@@ -20,6 +20,8 @@ import os
 import re
 import unittest
 
+import six
+
 from bot.tasks import fuzz_task
 from datastore import data_types
 from metrics import fuzzer_stats
@@ -141,7 +143,8 @@ class FuzzerStatsTest(unittest.TestCase):
             'upload.json'),
     ]
 
-    self.assertItemsEqual(self.mock.write_data.call_args_list, expected_calls)
+    six.assertCountEqual(self, self.mock.write_data.call_args_list,
+                         expected_calls)
 
   def test_upload_job_run(self):
     """Tests uploading of JobRun."""


### PR DESCRIPTION
Python 3 renamed assertItemsEqual to the very misleadingly named
assertCountEqual and broke compatiblity. Use six.assertCountEqual.

https://six.readthedocs.io/#six.assertCountEqual