### PR TITLE
Fix some Python 2 development issues.

### DIFF
--- a/src/local/butler/appengine.py
+++ b/src/local/butler/appengine.py
@@ -142,7 +142,11 @@ def symlink_dirs():
   local_gcs_symlink_path = os.path.join(SRC_DIR_PY, 'local_gcs')
   common.remove_symlink(local_gcs_symlink_path)
 
-  _, output = common.execute('bazel run //local:create_gopath', cwd='src')
+  # TODO(ochang): Remove extra_environments once migrated to Python 3.
+  _, output = common.execute(
+      'bazel run //local:create_gopath',
+      cwd='src',
+      extra_environments={'PYTHONPATH': ''})
   os.environ['GOPATH'] = output.decode('utf-8').splitlines()[-1]
 
 

--- a/src/local/butler/run_server.py
+++ b/src/local/butler/run_server.py
@@ -131,6 +131,7 @@ def start_cron_threads():
 def execute(args):
   """Run the server."""
   os.environ['LOCAL_DEVELOPMENT'] = 'True'
+  os.environ['CLOUDSDK_PYTHON'] = 'python2'
   common.kill_leftover_emulators()
 
   if not args.skip_install_deps:


### PR DESCRIPTION
- Unset PYTHONPATH when running //local:create_gopath to prevent
Py2/Py3 third_party issues.
- Force gcloud to use python 2 in `run_server` for similar issues.