### PR TITLE
Fix for Datastore emulator did not get ready in time in py_unittest

### DIFF
--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -218,6 +218,7 @@ def execute(args):
   """Run Python unit tests. For unittests involved appengine, sys.path needs
   certain modification."""
   os.environ['PY_UNITTESTS'] = 'True'
+  os.environ['CLOUDSDK_PYTHON'] = 'python2'
 
   if os.getenv('INTEGRATION') or os.getenv('UNTRUSTED_RUNNER_TESTS'):
     # Set up per-user buckets used by integration tests.


### PR DESCRIPTION
Noticed the same problem happening in py_unittest that was happening in run_server. Looked at @oliverchangs  PR and applied the same fix. 