### PR TITLE
Fix all App Engine tests running under Python 3.

### DIFF
--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -107,9 +107,13 @@ def run_one_test_parallel(args):
     test_modules, suppress_output = args
     suite = unittest.loader.TestLoader().loadTestsFromNames(test_modules)
 
-    # We use BufferedWriter as a hack to accept both unicode and str write
-    # arguments.
-    stream = io.BufferedWriter(io.BytesIO())
+    if sys.version_info.major == 2:
+      # We use BufferedWriter as a hack to accept both unicode and str write
+      # arguments.
+      # TODO(ochang): Remove this once migrated to Python 3.
+      stream = io.BufferedWriter(io.BytesIO())
+    else:
+      stream = io.StringIO()
 
     # Verbosity=0 since we cannot see real-time test execution order when tests
     # are executed in parallel.
@@ -120,9 +124,14 @@ def run_one_test_parallel(args):
     print('Done running', tests)
 
     stream.flush()
-    return TestResult(stream.raw.getvalue(), len(result.errors),
-                      len(result.failures), len(result.skipped),
-                      result.testsRun)
+    if sys.version_info.major == 2:
+      # TODO(ochang): Remove this once migrated to Python 3.
+      value = stream.raw.getvalue()
+    else:
+      value = stream.getvalue()
+
+    return TestResult(value, len(result.errors), len(result.failures),
+                      len(result.skipped), result.testsRun)
   except BaseException:
     # Print exception traceback here, as it will be lost otherwise.
     traceback.print_exc()

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1498,7 +1498,7 @@ def parse_log_stats(log_lines):
   log_stats = {}
 
   # Parse libFuzzer generated stats (`-print_final_stats=1`).
-  stats_regex = re.compile(br'stat::([A-Za-z_]+):\s*([^\s]+)')
+  stats_regex = re.compile(r'stat::([A-Za-z_]+):\s*([^\s]+)')
   for line in log_lines:
     match = stats_regex.match(line)
     if not match:

--- a/src/python/tests/appengine/handlers/cron/manage_vms_test.py
+++ b/src/python/tests/appengine/handlers/cron/manage_vms_test.py
@@ -282,10 +282,10 @@ def expected_instance_template(gce_project_name,
   if tls_cert:
     expected['properties']['metadata']['items'].extend([{
         'key': 'tls-cert',
-        'value': project_name + '_cert',
+        'value': project_name.encode() + b'_cert',
     }, {
         'key': 'tls-key',
-        'value': project_name + '_key',
+        'value': project_name.encode() + b'_key',
     }])
 
   return expected

--- a/src/python/tests/appengine/handlers/performance_report/performance_analyzer_test.py
+++ b/src/python/tests/appengine/handlers/performance_report/performance_analyzer_test.py
@@ -44,7 +44,8 @@ def _get_stats_from_log(log_path,
   if arguments is None:
     arguments = []
 
-  log_lines = utils.read_data_from_file(log_path, eval_data=False).splitlines()
+  log_lines = utils.decode_to_unicode(
+      utils.read_data_from_file(log_path, eval_data=False)).splitlines()
   stats = libfuzzer.parse_log_stats(log_lines)
   stats.update(
       performance_stats.parse_performance_features(log_lines, strategies,


### PR DESCRIPTION
- Make multithreaded unit tests work.
- Fix performance analyzer tests to pass unicode (str) stacktraces. This
  matches behaviour in production.
- Fix one last str/bytes issue in manage_vms_test.