### PR TITLE
Some small fixes for Python 3 core unittests.

### DIFF
--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -18,8 +18,9 @@ from __future__ import print_function
 # instead of the default 'ascii' encoding. This must happen before any
 # other imports.
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if sys.version_info.major == 2:
+  reload(sys)
+  sys.setdefaultencoding('utf-8')
 
 # Before other modules import os, we patch path-related methods, so they are
 # compatible with windows.

--- a/src/python/bot/startup/run_heartbeat.py
+++ b/src/python/bot/startup/run_heartbeat.py
@@ -20,8 +20,9 @@ from builtins import str
 # instead of the default 'ascii' encoding. This must happen before any
 # other imports.
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if sys.version_info.major == 2:
+  reload(sys)
+  sys.setdefaultencoding('utf-8')
 
 # Before any other imports, we must fix the path. Some libraries might expect
 # to be able to import dependencies directly, but we must store these in

--- a/src/python/bot/tokenizer/grammars/JavaScriptLexer.py
+++ b/src/python/bot/tokenizer/grammars/JavaScriptLexer.py
@@ -14,6 +14,7 @@
 """Translation from Java code for JavaScriptBaseLexer made to work with
 JavaScriptLexer"""
 
+from __future__ import absolute_import
 from __future__ import print_function
 
 from builtins import str
@@ -21,7 +22,8 @@ from builtins import str
 from antlr4 import *
 from io import StringIO
 import sys
-from JavaScriptBaseLexer import JavaScriptBaseLexer
+
+from .JavaScriptBaseLexer import JavaScriptBaseLexer
 
 
 def serializedATN():

--- a/src/python/tests/core/local/butler/deploy_test.py
+++ b/src/python/tests/core/local/butler/deploy_test.py
@@ -83,19 +83,19 @@ class DeployTest(fake_filesystem_unittest.TestCase):
     """Mock execute."""
     if 'app deploy' in command:
       if self.deploy_failure_count == 0:
-        return (0, 'ok')
+        return (0, b'ok')
 
       self.deploy_failure_count -= 1
-      return (1, 'failure')
+      return (1, b'failure')
 
     if 'app describe' in command:
-      return (0, 'us-central')
+      return (0, b'us-central')
 
     if 'describe redis-instance' in command:
-      return (0, 'redis-ip')
+      return (0, b'redis-ip')
 
     if 'describe' in command:
-      return (1, '')
+      return (1, b'')
 
     if 'versions list' in command:
       return (0,
@@ -136,9 +136,9 @@ class DeployTest(fake_filesystem_unittest.TestCase):
                       },
                       'traffic_split': 1.0,
                   },
-              ]))
+              ]).encode())
 
-    return (0, '')
+    return (0, b'')
 
   def test_app(self):
     """Test deploy app."""
@@ -427,9 +427,9 @@ class GetRemoteShaTest(unittest.TestCase):
   def test_get(self):
     """Test get_remote_sha."""
     self.mock.execute.return_value = (
-        0, 'cbb7f93c7ddc1c3a3c98f45ebf5c3490a0c38e95        refs/heads/master')
+        0, b'cbb7f93c7ddc1c3a3c98f45ebf5c3490a0c38e95        refs/heads/master')
 
-    self.assertEqual('cbb7f93c7ddc1c3a3c98f45ebf5c3490a0c38e95',
+    self.assertEqual(b'cbb7f93c7ddc1c3a3c98f45ebf5c3490a0c38e95',
                      deploy.get_remote_sha())
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
-antlr4-python2-runtime==4.7.2
+antlr4-python2-runtime==4.7.2; python_version < '3.0'
+antlr4-python3-runtime==4.7.2; python_version >= '3.0'
 # TODO(aarya): Remove backports.lzma after python 3 migration.
 backports.lzma==0.0.13; sys_platform != 'win32'
 configparser==3.7.4


### PR DESCRIPTION
- Install antlr4-python3-runtime for Python 3 environments.
- Fix a relative import in grammars/JavaScriptLexer.py.
- Fix deploy_test encoding issues.
- Don't use sys.setdefaultencoding on Python 3. It's removed and the
  default is utf-8 in Python 3.