### PR TITLE
Dataflow strategy: do not report an error if there are no traces for a target (#1346).

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1645,7 +1645,7 @@ def pick_strategies(strategy_pool, fuzzer_path, corpus_directory,
       arguments.append('%s%s' % (constants.FOCUS_FUNCTION_FLAG, 'auto'))
       fuzzing_strategies.append(strategy.DATAFLOW_TRACING_STRATEGY.name)
     else:
-      logs.log_error(
+      logs.log_warn(
           'Dataflow trace is not found in dataflow build, skipping strategy.')
       use_dataflow_tracing = False
 


### PR DESCRIPTION
This typically occurs when there is a recently added fuzz target or corpus backup is missing for some other reason, which is either not an error or should be caught and reported in some other place.