### PR TITLE
disabled stats collection for cross pollination on oss fuzz

### DIFF
--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -528,8 +528,9 @@ def record_cross_pollination_stats(
   """Log stats about cross pollination in BigQuery."""
   # BigQuery not available in local development.This is necessary because the
   # untrusted runner is in a separate process and can't be easily mocked.
-  if environment.get_value('LOCAL_DEVELOPMENT') or environment.get_value(
-      'PY_UNITTESTS'):
+  # TODO(mpherman): Find a way to collect these stats for OSS Fuzz.
+  if environment.is_untrusted_worker() or environment.get_value(
+      'LOCAL_DEVELOPMENT') or environment.get_value('PY_UNITTESTS'):
     return
 
   if not pruner_stats or not pollinator_stats:

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -526,11 +526,13 @@ def record_cross_pollination_stats(
     pruner_stats, pollinator_stats, project_qualified_name, sources, tags,
     initial_corpus_size, minimized_corpus_size_units):
   """Log stats about cross pollination in BigQuery."""
+  # TODO(mpherman): Find a way to collect these stats for OSS Fuzz.
+  if environment.is_untrusted_worker():
+    return
   # BigQuery not available in local development.This is necessary because the
   # untrusted runner is in a separate process and can't be easily mocked.
-  # TODO(mpherman): Find a way to collect these stats for OSS Fuzz.
-  if environment.is_untrusted_worker() or environment.get_value(
-      'LOCAL_DEVELOPMENT') or environment.get_value('PY_UNITTESTS'):
+  if environment.get_value('LOCAL_DEVELOPMENT') or environment.get_value(
+      'PY_UNITTESTS'):
     return
 
   if not pruner_stats or not pollinator_stats:


### PR DESCRIPTION
Untrusted runners do not have access to the BigQuery table so these stats can't be collected on OSS-fuzz @oliverchang do you know of any way around this?