### PR TITLE
Fix an exception with non-unicode stack traces in testcase details.

### DIFF
--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -560,7 +560,7 @@ def get_stacktrace(testcase, stack_attribute='crash_stacktrace'):
   # For App Engine, we can't write to local file, so use blobs.read_key instead.
   if environment.is_running_on_app_engine():
     key = result[len(data_types.BLOBSTORE_STACK_PREFIX):]
-    return str(blobs.read_key(key), errors='replace')
+    return str(blobs.read_key(key), 'utf-8', errors='replace')
 
   key = result[len(data_types.BLOBSTORE_STACK_PREFIX):]
   tmpdir = environment.get_value('BOT_TMPDIR')


### PR DESCRIPTION
PTAL. This doesn't seem to be working on staging due to what looks like an unrelated problem (stale exception trace issue I mentioned on chat), but from a quick test I'm guessing this should work:

```
>>> from builtins import str
>>> str(b'\xca', errors='replace')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/dist-packages/future/types/newstr.py", line 102, in __new__
    return super(newstr, cls).__new__(cls, value)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xca in position 0: ordinal not in range(128)
>>> str(b'\xca', 'utf-8', errors='replace')
'\ufffd'
>>>
```