### PR TITLE
Fix startup crash empty testcase creation for OSS-Fuzz.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -155,9 +155,9 @@ class LibFuzzerEngine(engine.Engine):
         strategy_info.extra_env, strategy_info.use_dataflow_tracing,
         strategy_info.is_mutations_run)
 
-  def _create_empty_testcase_file(self):
+  def _create_empty_testcase_file(self, reproducers_dir):
     """Create an empty testcase file in temporary directory."""
-    _, path = tempfile.mkstemp(dir=fuzzer_utils.get_temp_dir())
+    _, path = tempfile.mkstemp(dir=reproducers_dir)
     return path
 
   def _create_temp_corpus_dir(self, name):
@@ -284,7 +284,8 @@ class LibFuzzerEngine(engine.Engine):
     # libFuzzer, this is most likely a startup crash. Use an empty testcase to
     # to store it as a crash.
     if not crash_testcase_file_path and fuzz_result.return_code:
-      crash_testcase_file_path = self._create_empty_testcase_file()
+      crash_testcase_file_path = self._create_empty_testcase_file(
+          reproducers_dir)
 
     # Parse stats information based on libFuzzer output.
     parsed_stats = libfuzzer.parse_log_stats(log_lines)

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -804,8 +804,7 @@ class IntegrationTests(BaseIntegrationTest):
     self.assertEqual(1, self.mock.log_error.call_count)
 
     self.assertEqual(1, len(results.crashes))
-    self.assertEqual(fuzzer_utils.get_temp_dir(),
-                     os.path.dirname(results.crashes[0].input_path))
+    self.assertEqual(TEMP_DIR, os.path.dirname(results.crashes[0].input_path))
     self.assertEqual(0, os.path.getsize(results.crashes[0].input_path))
 
   @parameterized.parameterized.expand(['77', '27'])
@@ -830,8 +829,7 @@ class IntegrationTests(BaseIntegrationTest):
     results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
 
     self.assertEqual(1, len(results.crashes))
-    self.assertEqual(fuzzer_utils.get_temp_dir(),
-                     os.path.dirname(results.crashes[0].input_path))
+    self.assertEqual(TEMP_DIR, os.path.dirname(results.crashes[0].input_path))
     self.assertEqual(0, os.path.getsize(results.crashes[0].input_path))
 
   def test_fuzz_invalid_dict(self):
@@ -914,8 +912,7 @@ class MinijailIntegrationTests(IntegrationTests):
     results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
 
     self.assertEqual(1, len(results.crashes))
-    self.assertEqual(fuzzer_utils.get_temp_dir(),
-                     os.path.dirname(results.crashes[0].input_path))
+    self.assertEqual(TEMP_DIR, os.path.dirname(results.crashes[0].input_path))
     self.assertEqual(0, os.path.getsize(results.crashes[0].input_path))
 
 


### PR DESCRIPTION
Create the empty testcase in `reproducers_dir` instead, which is
guaranteed to be pulled back to the host.