### PR TITLE
Set minimum logging level for AppEngine to INFO.

### DIFF
--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """server.py initialises the appengine server for ClusterFuzz."""
 from __future__ import absolute_import
+import logging
 
 from webapp2_extras import routes
 import webapp2
@@ -222,6 +223,8 @@ _ROUTES = [
     ('/report-bug', help_redirector.ReportBugHandler),
     ('/viewer', viewer.Handler),
 ]
+
+logging.getLogger().setLevel(logging.INFO)
 
 config = local_config.GAEConfig()
 main_domain = config.get('domains.main')

--- a/src/python/metrics/logs.py
+++ b/src/python/metrics/logs.py
@@ -250,7 +250,6 @@ def configure(name, extras=None):
   Also configures the process to log any uncaught exceptions as an error.
   |extras| will be included by emit() in log messages."""
   if _is_running_on_app_engine():
-    logging.getLogger().setLevel(logging.INFO)
     return
 
   if _console_logging_enabled():

--- a/src/python/metrics/logs.py
+++ b/src/python/metrics/logs.py
@@ -250,6 +250,7 @@ def configure(name, extras=None):
   Also configures the process to log any uncaught exceptions as an error.
   |extras| will be included by emit() in log messages."""
   if _is_running_on_app_engine():
+    logging.getLogger().setLevel(logging.INFO)
     return
 
   if _console_logging_enabled():


### PR DESCRIPTION
This avoid the noise from datastore api debug logs.