### PR TITLE
Fix log spam due to exception.

### DIFF
--- a/src/appengine/libs/issue_management/issue_tracker.py
+++ b/src/appengine/libs/issue_management/issue_tracker.py
@@ -293,6 +293,9 @@ class IssueTracker(object):
     seen_issue_ids = []
     while True:
       original_issue = self.get_issue(original_issue_id)
+      if not original_issue:
+        return None
+
       seen_issue_ids.append(original_issue_id)
 
       if not original_issue.merged_into:


### PR DESCRIPTION
if not original_issue.merged_into:
AttributeError: 'NoneType' object has no attribute 'merged_into'

Happens on issue tracker where some issues might be inaccessible.