### PR TITLE
Set bucket IAM policy: log a warning when group email is used.

### DIFF
--- a/src/python/google_cloud_utils/storage.py
+++ b/src/python/google_cloud_utils/storage.py
@@ -692,10 +692,14 @@ def set_bucket_iam_policy(client, bucket_name, iam_policy):
     return client.buckets().setIamPolicy(
         bucket=bucket_name, body=filtered_iam_policy).execute()
   except HttpError as e:
-    if _get_error_reason(e) == 'Invalid argument':
+    error_reason = _get_error_reason(e)
+    if error_reason == 'Invalid argument':
       # Expected error for non-Google emails or groups. Warn about these.
       logs.log_warn('Invalid Google email or group being added to bucket %s.' %
                     bucket_name)
+    elif 'is of type "group"' in error_reason:
+      logs.log_warn('Failed to set IAM policy for %s bucket for a group: %s.' %
+                    (bucket_name, error_reason))
     else:
       logs.log_error('Failed to set IAM policies for bucket %s.' % bucket_name)
 

--- a/src/python/google_cloud_utils/storage.py
+++ b/src/python/google_cloud_utils/storage.py
@@ -697,7 +697,7 @@ def set_bucket_iam_policy(client, bucket_name, iam_policy):
       # Expected error for non-Google emails or groups. Warn about these.
       logs.log_warn('Invalid Google email or group being added to bucket %s.' %
                     bucket_name)
-    elif 'is of type "group"' in error_reason:
+    elif error_reason and 'is of type "group"' in error_reason:
       logs.log_warn('Failed to set IAM policy for %s bucket for a group: %s.' %
                     (bucket_name, error_reason))
     else:


### PR DESCRIPTION
To suppress errors like https://console.cloud.google.com/logs/viewer?expandAll=false&project=clusterfuzz-external&organizationId=433637338589&minLogLevel=0&timestamp=2020-02-18T22%3A15%3A59.670000000Z&customFacets&limitCustomFacetWidth=true&dateRangeStart=2020-02-18T21%3A16%3A01.537Z&dateRangeEnd=2020-02-18T22%3A16%3A01.537Z&interval=PT1H&scrollTimestamp=2020-02-18T21%3A22%3A00.217564000Z&advancedFilter=resource.type%3D%22gae_app%22%0Aresource.labels.module_id%3D%22cron-service%22%0Aresource.labels.zone%3D%22us17%22%0Aresource.labels.project_id%3D%22clusterfuzz-external%22%0Aresource.labels.version_id%3D%2220200214t205622%22%0Atimestamp%3D%222020-02-18T21%3A22%3A00.217564000Z%22%0AinsertId%3D%225e4c58fa00093fb5f7f63b4e%22

```
HttpError: <HttpError 400 when requesting https://storage.googleapis.com/storage/v1/b/oak-backup.clusterfuzz-external.appspot.com/iam?alt=json returned "Account project-oak-team@google.com is of type "group". Please set the type prefix to be "group:".">
```

Alternative options:

- Re-try setting the policy using `group:` prefix instead of `user:` -- I haven't realized a nice way to implement this
- Ban group accounts in OSS-Fuzz project.yaml -- I don't think it's possible to enforce