### PR TITLE
Only run path patcher on Python 2.

### DIFF
--- a/src/python/system/path_patcher.py
+++ b/src/python/system/path_patcher.py
@@ -139,6 +139,11 @@ def patch():
   if not _is_windows():
     return
 
+  # TODO(mbarbella): Verify that this is no longer necessary in Python 3 and
+  # remove it completely after transitioning.
+  if sys.version_info.major != 2:
+    return
+
   if _ORIGINAL_MAP:
     return
 
@@ -156,6 +161,9 @@ def patch():
 def unpatch():
   """Restore the methods to their original implementations."""
   if not _is_windows():
+    return
+
+  if sys.version_info.major != 2:
     return
 
   for obj, attr in list(_ORIGINAL_MAP):

--- a/src/python/system/path_patcher.py
+++ b/src/python/system/path_patcher.py
@@ -139,8 +139,7 @@ def patch():
   if not _is_windows():
     return
 
-  # TODO(mbarbella): Verify that this is no longer necessary in Python 3 and
-  # remove it completely after transitioning.
+  # TODO(mbarbella): Remove this file after fully transitioning to Python 3.
   if sys.version_info.major != 2:
     return
 

--- a/src/python/tests/core/system/path_patcher_test.py
+++ b/src/python/tests/core/system/path_patcher_test.py
@@ -24,6 +24,7 @@ import unittest
 
 from system import path_patcher
 from tests.test_libs import helpers
+from tests.test_libs import test_utils
 
 
 class MockedBuffer(object):
@@ -33,6 +34,7 @@ class MockedBuffer(object):
     self.value = value
 
 
+@test_utils.python2_only
 class MetadataTest(unittest.TestCase):
   """Metadata test."""
 
@@ -87,6 +89,7 @@ class MetadataTest(unittest.TestCase):
         self.assertNotEqual(file, type(file_handle))
 
 
+@test_utils.python2_only
 class PatcherTest(object):
   """Patcher tests."""
 
@@ -188,6 +191,7 @@ class PatcherTest(object):
     self.underlying_mock.assert_has_calls([self.expected_call(self.path)])
 
 
+@test_utils.python2_only
 class ListdirTest(PatcherTest, unittest.TestCase):
   """Listdir test."""
 
@@ -204,6 +208,7 @@ class ListdirTest(PatcherTest, unittest.TestCase):
     return mock.call(path)
 
 
+@test_utils.python2_only
 class StatTest(PatcherTest, unittest.TestCase):
   """Stat test."""
 
@@ -220,6 +225,7 @@ class StatTest(PatcherTest, unittest.TestCase):
     return mock.call(path)
 
 
+@test_utils.python2_only
 class MakedirsTest(PatcherTest, unittest.TestCase):
   """Makedirs test."""
 
@@ -236,6 +242,7 @@ class MakedirsTest(PatcherTest, unittest.TestCase):
     return mock.call(path)
 
 
+@test_utils.python2_only
 class FileTest(PatcherTest, unittest.TestCase):
   """File test."""
 
@@ -264,6 +271,7 @@ class FileTest(PatcherTest, unittest.TestCase):
     return mock.call(path, 'wb')
 
 
+@test_utils.python2_only
 class OpenTest(PatcherTest, unittest.TestCase):
   """Open test."""
 
@@ -280,6 +288,7 @@ class OpenTest(PatcherTest, unittest.TestCase):
     return mock.call(path, 'wb')
 
 
+@test_utils.python2_only
 class OsPathExistsTest(PatcherTest, unittest.TestCase):
   """os.path.exists test."""
 
@@ -296,6 +305,7 @@ class OsPathExistsTest(PatcherTest, unittest.TestCase):
     return mock.call(path)
 
 
+@test_utils.python2_only
 class OsPathIsfileTest(PatcherTest, unittest.TestCase):
   """os.path.isfile test."""
 
@@ -312,6 +322,7 @@ class OsPathIsfileTest(PatcherTest, unittest.TestCase):
     return mock.call(path)
 
 
+@test_utils.python2_only
 class OsPathIsdirTest(PatcherTest, unittest.TestCase):
   """os.path.isdir test."""
 
@@ -328,6 +339,7 @@ class OsPathIsdirTest(PatcherTest, unittest.TestCase):
     return mock.call(path)
 
 
+@test_utils.python2_only
 class OsMkdirTest(PatcherTest, unittest.TestCase):
   """mkdir test."""
 

--- a/src/python/tests/test_libs/test_utils.py
+++ b/src/python/tests/test_libs/test_utils.py
@@ -132,8 +132,9 @@ def reproduce_tool(func):
 # TODO(mbarbella): Remove this and all users after fully migrating to Python 3.
 def python2_only(func):
   """Tests which can only run on Python 2."""
-  return unittest.skipIf(
-    sys.version_info.major != 2, 'Skipping Python 2-only test.')(func)
+  return unittest.skipIf(sys.version_info.major != 2,
+                         'Skipping Python 2-only test.')(
+                             func)
 
 
 def android_device_required(func):

--- a/src/python/tests/test_libs/test_utils.py
+++ b/src/python/tests/test_libs/test_utils.py
@@ -28,6 +28,7 @@ import shutil
 import six
 import socket
 import subprocess
+import sys
 import tempfile
 import threading
 import unittest
@@ -121,11 +122,18 @@ def slow(func):
 
 
 def reproduce_tool(func):
-  """Slow tests which are skipped during presubmit."""
+  """Tests for the test case reproduction script."""
   return unittest.skipIf(
       not environment.get_value('REPRODUCE_TOOL_TESTS', False),
       'Skipping reproduce tool tests.')(
           func)
+
+
+# TODO(mbarbella): Remove this and all users after fully migrating to Python 3.
+def python2_only(func):
+  """Tests which can only run on Python 2."""
+  return unittest.skipIf(
+    sys.version_info.major != 2, 'Skipping Python 2-only test.')(func)
 
 
 def android_device_required(func):


### PR DESCRIPTION
It relies on some builtins that are not available in Python 3, and it's
not clear that it's necessary. Similar functionality will be added if it
turns out we still need something like this after staging Python 3 on
Windows.