### PR TITLE
Fix improperly tokenized testcases causing minimization result to not reproduce error.

### DIFF
--- a/src/python/bot/minimizer/chunk_minimizer.py
+++ b/src/python/bot/minimizer/chunk_minimizer.py
@@ -19,6 +19,7 @@ import functools
 
 from . import minimizer
 from . import utils
+from metrics import logs
 
 
 class ChunkMinimizer(minimizer.Minimizer):
@@ -32,6 +33,12 @@ class ChunkMinimizer(minimizer.Minimizer):
   def _execute(self, data):
     """Minimize |data| using the algorithm from CF (but backwards)."""
     testcase = minimizer.Testcase(data, self)
+    if testcase.get_current_testcase_data() != data:
+      logs.log_error(
+          "Unable to perform Chunk Minimization. Tokenized data did not match \
+          original data.")
+      testcase.failed = True
+      return testcase
 
     for lines_to_remove in self.chunk_sizes:
       remaining_tokens = testcase.get_required_token_indices()

--- a/src/python/bot/minimizer/chunk_minimizer.py
+++ b/src/python/bot/minimizer/chunk_minimizer.py
@@ -17,9 +17,9 @@ from __future__ import absolute_import
 from builtins import range
 import functools
 
+from. import errors
 from . import minimizer
 from . import utils
-from metrics import logs
 
 
 class ChunkMinimizer(minimizer.Minimizer):
@@ -34,11 +34,7 @@ class ChunkMinimizer(minimizer.Minimizer):
     """Minimize |data| using the algorithm from CF (but backwards)."""
     testcase = minimizer.Testcase(data, self)
     if testcase.get_current_testcase_data() != data:
-      logs.log_error(
-          "Unable to perform Chunk Minimization. Tokenized data did not match \
-          original data.")
-      testcase.failed = True
-      return testcase
+      raise errors.TokenizationFailureError("JSMinimizer")
 
     for lines_to_remove in self.chunk_sizes:
       remaining_tokens = testcase.get_required_token_indices()

--- a/src/python/bot/minimizer/chunk_minimizer.py
+++ b/src/python/bot/minimizer/chunk_minimizer.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from builtins import range
 import functools
 
-from. import errors
+from . import errors
 from . import minimizer
 from . import utils
 

--- a/src/python/bot/minimizer/delta_minimizer.py
+++ b/src/python/bot/minimizer/delta_minimizer.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 from builtins import range
 
-from. import  errors
+from . import errors
 from . import minimizer
 from . import utils
 

--- a/src/python/bot/minimizer/delta_minimizer.py
+++ b/src/python/bot/minimizer/delta_minimizer.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 
 from builtins import range
 
+from. import  errors
 from . import minimizer
 from . import utils
-from metrics import logs
 
 
 class DeltaTestcase(minimizer.Testcase):
@@ -47,11 +47,7 @@ class DeltaMinimizer(minimizer.Minimizer):
     """Prepare tests for delta minimization and process."""
     testcase = DeltaTestcase(data, self)
     if testcase.get_current_testcase_data() != data:
-      logs.log_error(
-          "Unable to perform Delta Minimization. Tokenized data did not match \
-          original data.")
-      testcase.failed = True
-      return testcase
+      raise errors.TokenizationFailureError("JSMinimizer")
 
     tokens = testcase.tokens
 

--- a/src/python/bot/minimizer/delta_minimizer.py
+++ b/src/python/bot/minimizer/delta_minimizer.py
@@ -18,6 +18,7 @@ from builtins import range
 
 from . import minimizer
 from . import utils
+from metrics import logs
 
 
 class DeltaTestcase(minimizer.Testcase):
@@ -45,6 +46,13 @@ class DeltaMinimizer(minimizer.Minimizer):
   def _execute(self, data):
     """Prepare tests for delta minimization and process."""
     testcase = DeltaTestcase(data, self)
+    if testcase.get_current_testcase_data() != data:
+      logs.log_error(
+          "Unable to perform Delta Minimization. Tokenized data did not match \
+          original data.")
+      testcase.failed = True
+      return testcase
+
     tokens = testcase.tokens
 
     step = max(1, len(tokens) // self.max_threads)

--- a/src/python/bot/minimizer/errors.py
+++ b/src/python/bot/minimizer/errors.py
@@ -28,7 +28,8 @@ class NoCommandError(Exception):
   def __init__(self):
     Exception.__init__(self, 'Attempting to run with no command configured.')
 
+
 class TokenizationFailureError(Exception):
+
   def __init__(self, minimization_type):
     Exception.__init__(self, 'Unable to perform ' + minimization_type + '.')
-    

--- a/src/python/bot/minimizer/errors.py
+++ b/src/python/bot/minimizer/errors.py
@@ -27,3 +27,8 @@ class NoCommandError(Exception):
 
   def __init__(self):
     Exception.__init__(self, 'Attempting to run with no command configured.')
+
+class TokenizationFailureError(Exception):
+  def __init__(self, minimization_type):
+    Exception.__init__(self, 'Unable to perform ' + minimization_type + '.')
+    

--- a/src/python/bot/minimizer/js_minimizer.py
+++ b/src/python/bot/minimizer/js_minimizer.py
@@ -17,12 +17,12 @@ from __future__ import absolute_import
 from builtins import range
 
 from . import delta_minimizer
+from . import errors
 from . import minimizer
 from . import utils
 
 from bot.tokenizer.antlr_tokenizer import AntlrTokenizer
 from bot.tokenizer.grammars.JavaScriptLexer import JavaScriptLexer
-from metrics import logs
 
 
 def step_back_while(cur_index, condition):
@@ -38,11 +38,7 @@ class JSMinimizer(minimizer.Minimizer):
   def _execute(self, data):
     testcase = minimizer.Testcase(data, self)
     if testcase.get_current_testcase_data() != data:
-      logs.log_error(
-          "Unable to perform JSMinimization. Tokenized data did not match \
-          original data.")
-      testcase.failed = True
-      return testcase
+      raise errors.TokenizationFailureError("JSMinimizer")
 
     brace_stack = []
     paren_stack = []

--- a/src/python/bot/minimizer/js_minimizer.py
+++ b/src/python/bot/minimizer/js_minimizer.py
@@ -22,6 +22,7 @@ from . import utils
 
 from bot.tokenizer.antlr_tokenizer import AntlrTokenizer
 from bot.tokenizer.grammars.JavaScriptLexer import JavaScriptLexer
+from metrics import logs
 
 
 def step_back_while(cur_index, condition):
@@ -36,6 +37,12 @@ class JSMinimizer(minimizer.Minimizer):
 
   def _execute(self, data):
     testcase = minimizer.Testcase(data, self)
+    if testcase.get_current_testcase_data() != data:
+      logs.log_error(
+          "Unable to perform JSMinimization. Tokenized data did not match \
+          original data.")
+      testcase.failed = True
+      return testcase
 
     brace_stack = []
     paren_stack = []

--- a/src/python/bot/minimizer/minimizer.py
+++ b/src/python/bot/minimizer/minimizer.py
@@ -167,6 +167,8 @@ class Testcase(object):
     self.last_progress_report_time = 0
     self.runs_since_last_cleanup = 0
     self.runs_executed = 0
+    self.failed = False
+    self.original_data = data
 
     if minimizer.max_threads > 1:
       self.test_queue = TestQueue(
@@ -481,6 +483,9 @@ class Testcase(object):
     """Get the result of minimization."""
     # Done with minimization, output log one more time
     self._report_progress(is_final_progress_report=True)
+    if self.failed:
+      return self.original_data
+
     if not self.minimizer.tokenize:
       return self.get_required_tokens()
     return self.get_current_testcase_data()

--- a/src/python/bot/minimizer/minimizer.py
+++ b/src/python/bot/minimizer/minimizer.py
@@ -28,7 +28,6 @@ import tempfile
 import threading
 import time
 
-
 from . import errors
 
 DEFAULT_CLEANUP_INTERVAL = 20


### PR DESCRIPTION
This should stop any round of minimization where the tokenizer has failed. It logs when the tokenizer fails so that we can continue to amend the grammar as we see common missed tokens.