### PR TITLE
[fuchsia] Only initialize the global qemu log path when necessary

### DIFF
--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -122,7 +122,8 @@ class QemuProcess(object):
     self.logfile = None
 
     if not QemuProcess.LOG_PATH:
-      QemuProcess.LOG_PATH = os.path.join(tempfile.gettempdir(), 'fuchsia-qemu-log')
+      QemuProcess.LOG_PATH = os.path.join(tempfile.gettempdir(),
+                                          'fuchsia-qemu-log')
 
   def create(self):
     """Configures a QEMU process which can subsequently be `run`.

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -111,13 +111,18 @@ class QemuProcess(object):
   of Fuchsia QEMU processes."""
 
   # For now, use a system-global log path so we don't need to pass a tempfile
-  # path around everywhere
-  LOG_PATH = os.path.join(tempfile.gettempdir(), 'fuchsia-qemu-log')
+  # path around everywhere. We use a class constant so it can be accessed
+  # without an instance, but defer initialization until the constructor so that
+  # it isn't run in non-Fuchsia contexts.
+  LOG_PATH = None
 
   def __init__(self):
     self.process_runner = None
     self.popen = None
     self.logfile = None
+
+    if not QemuProcess.LOG_PATH:
+      QemuProcess.LOG_PATH = os.path.join(tempfile.gettempdir(), 'fuchsia-qemu-log')
 
   def create(self):
     """Configures a QEMU process which can subsequently be `run`.


### PR DESCRIPTION
This change is to address some "No usable temporary directory found"
errors that were being thrown. This may not address the root cause (e.g.
lack of disk space/permission issues) but will at least avoid extra
errors for non-Fuchsia bots.