### PR TITLE
[fuchsia] Update example fuzzer excludelist

### DIFF
--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -73,9 +73,11 @@ class Fuzzer(object):
     """ Returns whether or not a given pkg/tgt pair is an example fuzzer.
     (Helper function to prevent us from wasting cycles on example fuzzers in
     production). """
-    # We want to remove the noop-fuzzer regardless of the extension.
+    # Strip any sanitizer extensions
     tgt = os.path.splitext(tgt)[0]
-    return pkg == 'example_fuzzers' or tgt == 'noop-fuzzer'
+    return (pkg == 'example_fuzzers' and tgt != 'oom_fuzzer') \
+        or (pkg == 'zircon_fuzzers' and tgt == 'noop-fuzzer') \
+        or (pkg == 'go_fuzzers' and tgt == 'basic_fuzzer')
 
   @classmethod
   def filter(cls, fuzzers, name, sanitizer=None, example_fuzzers=True):

--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -75,9 +75,9 @@ class Fuzzer(object):
     production). """
     # Strip any sanitizer extensions
     tgt = os.path.splitext(tgt)[0]
-    return (pkg == 'example_fuzzers' and tgt != 'oom_fuzzer') \
-        or (pkg == 'zircon_fuzzers' and tgt == 'noop-fuzzer') \
-        or (pkg == 'go_fuzzers' and tgt == 'basic_fuzzer')
+    return ((pkg == 'example_fuzzers' and tgt != 'oom_fuzzer') or
+            (pkg == 'zircon_fuzzers' and tgt == 'noop-fuzzer') or
+            (pkg == 'go_fuzzers' and tgt == 'basic_fuzzer'))
 
   @classmethod
   def filter(cls, fuzzers, name, sanitizer=None, example_fuzzers=True):


### PR DESCRIPTION
An example fuzzer that intentionally OOMs was added so we can test that
ClusterFuzz is correctly catching OOMs on Fuchsia, but it was excluded
since we normally avoid running examples. This lets it run temporarily.

Additionally, this change disables a test Go fuzzer that isn't under the
examples package.