### PR TITLE
[fuchsia] Add runtime snapshot information to qemu failure logs

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -48,6 +48,7 @@ from platforms.fuchsia.util.host import Host
 from system import environment
 from system import minijail
 from system import new_process
+from system import process_handler
 from system import shell
 
 # Maximum length of a random chosen length for `-max_len`.
@@ -526,7 +527,9 @@ class FuchsiaQemuLibFuzzerRunner(new_process.ProcessRunner, LibFuzzerCommon):
 
   def _restart_qemu(self):
     """Restart QEMU."""
-    logs.log_warn('Connection to fuzzing VM lost. Restarting.')
+    logs.log_warn(
+        'Connection to fuzzing VM lost. Restarting.',
+        processes=process_handler.get_runtime_snapshot())
     stop_qemu()
 
     # Do this after the stop, to make sure everything is flushed

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -35,12 +35,6 @@ from system import environment
 from system import new_process
 from system import process_handler
 
-# Import will fail on AppEngine
-try:
-  import psutil
-except ImportError:
-  pass
-
 _QEMU_WAIT_SECONDS = 60
 
 
@@ -220,20 +214,6 @@ def start_qemu():
 
 def stop_qemu():
   """Stop qemu."""
-
-  # Report whether qemu is running, for diagnostics
-  found = False
-  for process in psutil.process_iter():
-    try:
-      if process.name() == 'qemu-system-x86_64':
-        found = True
-        break
-    except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
-      continue
-
-  if not found:
-    logs.log_warn('qemu stop requested, but it was not running.')
-
   process_handler.terminate_processes_matching_names('qemu-system-x86_64')
 
 

--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -35,6 +35,12 @@ from system import environment
 from system import new_process
 from system import process_handler
 
+# Import will fail on AppEngine
+try:
+  import psutil
+except ImportError:
+  pass
+
 _QEMU_WAIT_SECONDS = 60
 
 
@@ -214,6 +220,20 @@ def start_qemu():
 
 def stop_qemu():
   """Stop qemu."""
+
+  # Report whether qemu is running, for diagnostics
+  found = False
+  for process in psutil.process_iter():
+    try:
+      if process.name() == 'qemu-system-x86_64':
+        found = True
+        break
+    except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+      continue
+
+  if not found:
+    logs.log_warn('qemu stop requested, but it was not running.')
+
   process_handler.terminate_processes_matching_names('qemu-system-x86_64')
 
 


### PR DESCRIPTION
A warning will now be logged if stop_qemu is called but qemu isn't
running.  This will help to narrow down causes of connection failures.