### PR TITLE
Use default strategy pool when there are no probabilities for the given engine.

### DIFF
--- a/src/python/bot/fuzzers/strategy_selection.py
+++ b/src/python/bot/fuzzers/strategy_selection.py
@@ -136,6 +136,11 @@ def generate_weighted_strategy_pool(strategy_list, use_generator, engine_name):
       if elem['engine'] == engine_name
   ]
 
+  if not distribution_tuples:
+    logs.log_warn('Tried to generate a weighted strategy pool, but do not have '
+                  'strategy probabilities for %s fuzzing engine.' % engine_name)
+    return generate_default_strategy_pool(strategy_list, use_generator)
+
   strategy_selection = utils.random_weighted_choice(distribution_tuples,
                                                     'probability')
   strategy_name = strategy_selection.strategy_name


### PR DESCRIPTION
Should fix https://console.cloud.google.com/errors/CP7JlYGF9o7V0AE?time=P1D&project=google.com:clusterfuzz

