### PR TITLE
Fix a unicode exception in the HTML minimizer.

### DIFF
--- a/src/python/bot/minimizer/html_minimizer.py
+++ b/src/python/bot/minimizer/html_minimizer.py
@@ -190,7 +190,8 @@ class HTMLMinimizer(minimizer.Minimizer):  # pylint:disable=abstract-method
   @staticmethod
   def combine_worker_tokens(tokens, prefix=b'', suffix=b''):
     """Combine tokens for a worker minimizer."""
-    return prefix + b''.join(tokens) + suffix
+    # The Antlr tokenizer decodes the bytes objects we originally pass to it.
+    return prefix + b''.join([t.encode('utf-8') for t in tokens] + suffix
 
   @staticmethod
   def combine_tokens(tokens):

--- a/src/python/bot/minimizer/html_minimizer.py
+++ b/src/python/bot/minimizer/html_minimizer.py
@@ -191,7 +191,7 @@ class HTMLMinimizer(minimizer.Minimizer):  # pylint:disable=abstract-method
   def combine_worker_tokens(tokens, prefix=b'', suffix=b''):
     """Combine tokens for a worker minimizer."""
     # The Antlr tokenizer decodes the bytes objects we originally pass to it.
-    return prefix + b''.join([t.encode('utf-8') for t in tokens] + suffix
+    return prefix + b''.join([t.encode('utf-8') for t in tokens]) + suffix
 
   @staticmethod
   def combine_tokens(tokens):

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1292,8 +1292,7 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
       reproduced = False
       for _ in range(MINIMIZE_SANITIZER_OPTIONS_RETRIES):
         crash_result = _run_libfuzzer_testcase(testcase, testcase_file_path)
-        if (crash_result.is_crash() and
-            crash_result.is_security_issue() ==
+        if (crash_result.is_crash() and crash_result.is_security_issue() ==
             initial_crash_result.is_security_issue() and
             crash_result.get_type() == initial_crash_result.get_type() and
             crash_result.get_state() == initial_crash_result.get_state()):

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -1292,7 +1292,7 @@ def do_libfuzzer_minimization(testcase, testcase_file_path):
       reproduced = False
       for _ in range(MINIMIZE_SANITIZER_OPTIONS_RETRIES):
         crash_result = _run_libfuzzer_testcase(testcase, testcase_file_path)
-        if (crash_result.is_crash() and \
+        if (crash_result.is_crash() and
             crash_result.is_security_issue() ==
             initial_crash_result.is_security_issue() and
             crash_result.get_type() == initial_crash_result.get_type() and


### PR DESCRIPTION
The combine_worker_functions function was not actually properly
converting the tokens to a bytes object. |tokens| were unicode objects
since Antlr converts the bytes we pass to it to unicode, which caused
the entire string to be treated as unicode. If the suffix contained
invalid utf-8, we'd hit a UnicodeDecodeError here.