### PR TITLE
Use mmap for utils.search_bytes_in_file.

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -627,12 +627,12 @@ def restart_machine():
     os.system('sudo shutdown -r now')
 
 
-def search_bytes_in_file(search_string, file_handle):
-  """Helper to search for a string in a large binary file without memory
+def search_bytes_in_file(search_bytes, file_handle):
+  """Helper to search for bytes in a large binary file without memory
   issues.
   """
   memory_mapped = mmap.mmap(file_handle.fileno(), 0, access=mmap.ACCESS_READ)
-  return memory_mapped.find(search_string) != -1
+  return memory_mapped.find(search_bytes) != -1
 
 
 def string_hash(obj):

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -28,6 +28,7 @@ import functools
 import gc
 import hashlib
 import inspect
+import mmap
 import os
 import random
 import requests
@@ -626,17 +627,12 @@ def restart_machine():
     os.system('sudo shutdown -r now')
 
 
-def search_string_in_file(search_string, file_handle):
+def search_bytes_in_file(search_string, file_handle):
   """Helper to search for a string in a large binary file without memory
   issues.
   """
-  # TODO(aarya): This is too brittle and will fail if we have a very large line.
-  search_string = search_string.encode('utf-8')
-  for line in file_handle:
-    if search_string in line:
-      return True
-
-  return False
+  memory_mapped = mmap.mmap(file_handle.fileno(), 0, access=mmap.ACCESS_READ)
+  return memory_mapped.find(search_string) != -1
 
 
 def string_hash(obj):

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -353,8 +353,8 @@ def is_lpm_fuzz_target(fuzzer_path):
   """Returns True if |fuzzer_path| is a libprotobuf-mutator based fuzz
   target."""
   # TODO(metzman): Use this function to disable running LPM targets with AFL.
-  with open(fuzzer_path) as file_handle:
-    return utils.search_string_in_file('TestOneProtoInput', file_handle)
+  with open(fuzzer_path, 'rb') as file_handle:
+    return utils.search_bytes_in_file(b'TestOneProtoInput', file_handle)
 
 
 def get_issue_owners(fuzz_target_path):

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -39,7 +39,7 @@ from system import shell
 ENGINE_ERROR_MESSAGE = 'libFuzzer: engine encountered an error'
 DICT_PARSING_FAILED_REGEX = re.compile(
     r'ParseDictionaryFile: error in line (\d+)')
-MULTISTEP_MERGE_SUPPORT_TOKEN = 'fuzz target overwrites its const input'
+MULTISTEP_MERGE_SUPPORT_TOKEN = b'fuzz target overwrites its const input'
 
 
 def _project_qualified_fuzzer_name(target_path):
@@ -59,8 +59,8 @@ def _is_multistep_merge_supported(target_path):
   # multi step merge: https://github.com/llvm/llvm-project/commit/f054067.
   if os.path.exists(target_path):
     with open(target_path, 'rb') as file_handle:
-      return utils.search_string_in_file(MULTISTEP_MERGE_SUPPORT_TOKEN,
-                                         file_handle)
+      return utils.search_bytes_in_file(MULTISTEP_MERGE_SUPPORT_TOKEN,
+                                        file_handle)
 
   return False
 

--- a/src/python/bot/fuzzers/utils.py
+++ b/src/python/bot/fuzzers/utils.py
@@ -26,7 +26,7 @@ from system import environment
 from system import shell
 
 ALLOWED_FUZZ_TARGET_EXTENSIONS = ['', '.exe', '.par']
-FUZZ_TARGET_SEARCH_STRING = 'LLVMFuzzerTestOneInput'
+FUZZ_TARGET_SEARCH_BYTES = b'LLVMFuzzerTestOneInput'
 VALID_TARGET_NAME = re.compile(r'^[a-zA-Z0-9_-]+$')
 
 
@@ -65,8 +65,8 @@ def is_fuzz_target_local(file_path, file_handle=None):
 
   # TODO(metzman): Bound this call so we don't read forever if something went
   # wrong.
-  result = utils.search_string_in_file(FUZZ_TARGET_SEARCH_STRING,
-                                       local_file_handle)
+  result = utils.search_bytes_in_file(FUZZ_TARGET_SEARCH_BYTES,
+                                      local_file_handle)
 
   if not file_handle:
     # If this local file handle is owned by our function, close it now.

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -150,7 +150,11 @@ class PickStrategiesTest(fake_fs_unittest.TestCase):
   """pick_strategies tests."""
 
   def setUp(self):
-    test_helpers.patch(self, ['random.SystemRandom.randint'])
+    test_helpers.patch(self, [
+        'bot.fuzzers.engine_common.is_lpm_fuzz_target',
+        'random.SystemRandom.randint',
+    ])
+    self.mock.is_lpm_fuzz_target.return_value = False
 
     test_utils.set_up_pyfakefs(self)
     self.fs.create_dir('/path/corpus')

--- a/src/python/tests/core/bot/fuzzers/utils_test.py
+++ b/src/python/tests/core/bot/fuzzers/utils_test.py
@@ -97,3 +97,10 @@ class IsFuzzTargetLocalTest(unittest.TestCase):
     path = self._create_file(
         'a_fuzzer', contents=b'anything\nLLVMFuzzerTestOneInput')
     self.assertTrue(utils.is_fuzz_target_local(path))
+
+  def test_file_handle(self):
+    """Test with a file handle."""
+    path = self._create_file(
+        'abc', contents=b'anything\nLLVMFuzzerTestOneInput')
+    with open(path, 'rb') as f:
+      self.assertTrue(utils.is_fuzz_target_local('name', f))

--- a/src/python/tests/core/bot/fuzzers/utils_test.py
+++ b/src/python/tests/core/bot/fuzzers/utils_test.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for fuzzers.utils."""
-from pyfakefs import fake_filesystem_unittest
+
+import os
+import shutil
+import tempfile
+import unittest
 
 from bot.fuzzers import utils
 from system import environment
@@ -20,65 +24,77 @@ from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils
 
 
-class IsFuzzTargetLocalTest(fake_filesystem_unittest.TestCase):
+class IsFuzzTargetLocalTest(unittest.TestCase):
   """is_fuzz_target_local tests."""
 
   def setUp(self):
     test_helpers.patch_environ(self)
-    test_utils.set_up_pyfakefs(self)
+    self.temp_dir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+  def _create_file(self, name, contents=b''):
+    path = os.path.join(self.temp_dir, name)
+    with open(path, 'wb') as f:
+      f.write(contents)
+
+    return path
 
   def test_not_a_fuzzer_invalid_name(self):
-    self.fs.create_file('/abc$_fuzzer', contents='anything')
-    self.assertFalse(utils.is_fuzz_target_local('/abc$_fuzzer'))
+    path = self._create_file('abc$_fuzzer', contents=b'anything')
+    self.assertFalse(utils.is_fuzz_target_local(path))
 
   def test_not_a_fuzzer_without_extension(self):
-    self.fs.create_file('/abc', contents='anything')
-    self.assertFalse(utils.is_fuzz_target_local('/abc'))
+    path = self._create_file('abc', contents=b'anything')
+    self.assertFalse(utils.is_fuzz_target_local(path))
 
   def test_not_a_fuzzer_with_extension(self):
-    self.fs.create_file('/abc.dict', contents='anything')
-    self.assertFalse(utils.is_fuzz_target_local('/abc.dict'))
+    path = self._create_file('abc.dict', contents=b'anything')
+    self.assertFalse(utils.is_fuzz_target_local(path))
 
   def test_not_a_fuzzer_with_extension_and_suffix(self):
-    self.fs.create_file('/abc_fuzzer.dict', contents='anything')
-    self.assertFalse(utils.is_fuzz_target_local('/abc_fuzzer.dict'))
+    path = self._create_file('abc_fuzzer.dict', contents=b'anything')
+    self.assertFalse(utils.is_fuzz_target_local(path))
 
   def test_fuzzer_posix(self):
-    self.fs.create_file('/abc_fuzzer', contents='anything')
-    self.assertTrue(utils.is_fuzz_target_local('/abc_fuzzer'))
+    path = self._create_file('abc_fuzzer', contents=b'anything')
+    self.assertTrue(utils.is_fuzz_target_local(path))
 
   def test_fuzzer_win(self):
-    self.fs.create_file('/abc_fuzzer.exe', contents='anything')
-    self.assertTrue(utils.is_fuzz_target_local('/abc_fuzzer.exe'))
+    path = self._create_file('abc_fuzzer.exe', contents=b'anything')
+    self.assertTrue(utils.is_fuzz_target_local(path))
 
   def test_fuzzer_py(self):
-    self.fs.create_file('/abc_fuzzer.par', contents='anything')
-    self.assertTrue(utils.is_fuzz_target_local('/abc_fuzzer.par'))
+    path = self._create_file('abc_fuzzer.par', contents=b'anything')
+    self.assertTrue(utils.is_fuzz_target_local(path))
 
   def test_fuzzer_not_exist(self):
     self.assertFalse(utils.is_fuzz_target_local('/not_exist_fuzzer'))
 
   def test_fuzzer_without_suffix(self):
-    self.fs.create_file('/abc', contents='anything\nLLVMFuzzerTestOneInput')
-    self.assertTrue(utils.is_fuzz_target_local('/abc'))
+    path = self._create_file(
+        'abc', contents=b'anything\nLLVMFuzzerTestOneInput')
+    self.assertTrue(utils.is_fuzz_target_local(path))
 
   def test_fuzzer_with_name_regex_match(self):
     environment.set_value('FUZZER_NAME_REGEX', '.*_custom$')
-    self.fs.create_file('/a_custom', contents='anything')
-    self.assertTrue(utils.is_fuzz_target_local('/a_custom'))
+    path = self._create_file('a_custom', contents=b'anything')
+    self.assertTrue(utils.is_fuzz_target_local(path))
 
   def test_fuzzer_with_file_string_and_without_name_regex_match(self):
     environment.set_value('FUZZER_NAME_REGEX', '.*_custom$')
-    self.fs.create_file('/nomatch', contents='anything\nLLVMFuzzerTestOneInput')
-    self.assertFalse(utils.is_fuzz_target_local('/nomatch'))
+    path = self._create_file(
+        'nomatch', contents=b'anything\nLLVMFuzzerTestOneInput')
+    self.assertFalse(utils.is_fuzz_target_local(path))
 
   def test_fuzzer_without_file_string_and_without_name_regex_match(self):
     environment.set_value('FUZZER_NAME_REGEX', '.*_custom$')
-    self.fs.create_file('/nomatch', contents='anything')
-    self.assertFalse(utils.is_fuzz_target_local('/nomatch'))
+    path = self._create_file('nomatch', contents=b'anything')
+    self.assertFalse(utils.is_fuzz_target_local(path))
 
   def test_fuzzer_with_fuzzer_name_and_without_name_regex_match(self):
     environment.set_value('FUZZER_NAME_REGEX', '.*_custom$')
-    self.fs.create_file(
-        '/a_fuzzer', contents='anything\nLLVMFuzzerTestOneInput')
-    self.assertTrue(utils.is_fuzz_target_local('/a_fuzzer'))
+    path = self._create_file(
+        'a_fuzzer', contents=b'anything\nLLVMFuzzerTestOneInput')
+    self.assertTrue(utils.is_fuzz_target_local(path))

--- a/src/python/tests/core/bot/fuzzers/utils_test.py
+++ b/src/python/tests/core/bot/fuzzers/utils_test.py
@@ -21,7 +21,6 @@ import unittest
 from bot.fuzzers import utils
 from system import environment
 from tests.test_libs import helpers as test_helpers
-from tests.test_libs import test_utils
 
 
 class IsFuzzTargetLocalTest(unittest.TestCase):


### PR DESCRIPTION
Renamed from utils.search_strings_in_file, and use mmap instead of attempting
to read the file line by line.

This also fixes a Python 3 exception.