### PR TITLE
search_bytes_in_file: Don't mmap if file handle size is 0.

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -631,6 +631,15 @@ def search_bytes_in_file(search_bytes, file_handle):
   """Helper to search for bytes in a large binary file without memory
   issues.
   """
+  old_pos = file_handle.tell()
+  file_handle.seek(0, os.SEEK_END)
+  file_size = file_handle.tell()
+  file_handle.seek(old_pos, os.SEEK_SET)
+
+  if file_size == 0:
+    # Avoid mapping 0 sized files, as they do not work on Windows.
+    return False
+
   memory_mapped = mmap.mmap(file_handle.fileno(), 0, access=mmap.ACCESS_READ)
   return memory_mapped.find(search_bytes) != -1
 

--- a/src/python/tests/core/base/utils_test.py
+++ b/src/python/tests/core/base/utils_test.py
@@ -16,7 +16,9 @@ from builtins import object
 import datetime
 import mock
 import os
+import shutil
 import sys
+import tempfile
 import time
 import unittest
 
@@ -473,3 +475,54 @@ class ServiceAccountEmailTest(unittest.TestCase):
     os.environ['APPLICATION_ID'] = 'domain.com:project-id'
     self.assertEqual('project-id.domain.com@appspot.gserviceaccount.com',
                      utils.service_account_email())
+
+
+class SearchBytesInFileTest(unittest.TestCase):
+  """Tests search_bytes_in_file."""
+
+  def setUp(self):
+    self.temp_dir = tempfile.mkdtemp()
+    self.test_path = os.path.join(self.temp_dir, 'file')
+    with open(self.test_path, 'wb') as f:
+      f.write(b'A' * 16 + b'B' * 16 + b'C' + b'D' * 16)
+
+  def tearDown(self):
+    shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+  def test_exists(self):
+    """Test exists."""
+    with open(self.test_path, 'rb') as f:
+      self.assertTrue(utils.search_bytes_in_file(b'A', f))
+      self.assertTrue(utils.search_bytes_in_file(b'B', f))
+      self.assertTrue(utils.search_bytes_in_file(b'C', f))
+      self.assertTrue(utils.search_bytes_in_file(b'D', f))
+
+      self.assertTrue(utils.search_bytes_in_file(b'A' * 16, f))
+      self.assertTrue(utils.search_bytes_in_file(b'B' * 16, f))
+      self.assertTrue(utils.search_bytes_in_file(b'D' * 16, f))
+
+  def test_not_exists(self):
+    """Test not exists."""
+    with open(self.test_path, 'rb') as f:
+      self.assertFalse(utils.search_bytes_in_file(b'A' * 17, f))
+      self.assertFalse(utils.search_bytes_in_file(b'B' * 17, f))
+      self.assertFalse(utils.search_bytes_in_file(b'C' * 2, f))
+      self.assertFalse(utils.search_bytes_in_file(b'D' * 17, f))
+      self.assertFalse(utils.search_bytes_in_file(b'ABCD', f))
+
+  def test_zero_sized(self):
+    """Test zero sized file."""
+    helpers.patch(self, [
+        'mmap.mmap',
+    ])
+
+    with open(self.test_path, 'wb') as f:
+      f.write(b'')
+
+    with open(self.test_path, 'rb') as f:
+      self.assertFalse(utils.search_bytes_in_file(b'A', f))
+      self.assertFalse(utils.search_bytes_in_file(b'B', f))
+      self.assertFalse(utils.search_bytes_in_file(b'C', f))
+
+    # mmap should not be called at all.
+    self.assertEqual(0, self.mock.mmap.call_count)


### PR DESCRIPTION
Windows doesn't allow mmaping empty files.