### PR TITLE
Revert "Use mmap for utils.search_bytes_in_file."

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -28,7 +28,6 @@ import functools
 import gc
 import hashlib
 import inspect
-import mmap
 import os
 import random
 import requests
@@ -627,12 +626,17 @@ def restart_machine():
     os.system('sudo shutdown -r now')
 
 
-def search_bytes_in_file(search_bytes, file_handle):
-  """Helper to search for bytes in a large binary file without memory
+def search_string_in_file(search_string, file_handle):
+  """Helper to search for a string in a large binary file without memory
   issues.
   """
-  memory_mapped = mmap.mmap(file_handle.fileno(), 0, access=mmap.ACCESS_READ)
-  return memory_mapped.find(search_bytes) != -1
+  # TODO(aarya): This is too brittle and will fail if we have a very large line.
+  search_string = search_string.encode('utf-8')
+  for line in file_handle:
+    if search_string in line:
+      return True
+
+  return False
 
 
 def string_hash(obj):

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -353,8 +353,8 @@ def is_lpm_fuzz_target(fuzzer_path):
   """Returns True if |fuzzer_path| is a libprotobuf-mutator based fuzz
   target."""
   # TODO(metzman): Use this function to disable running LPM targets with AFL.
-  with open(fuzzer_path, 'rb') as file_handle:
-    return utils.search_bytes_in_file(b'TestOneProtoInput', file_handle)
+  with open(fuzzer_path) as file_handle:
+    return utils.search_string_in_file('TestOneProtoInput', file_handle)
 
 
 def get_issue_owners(fuzz_target_path):

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -39,7 +39,7 @@ from system import shell
 ENGINE_ERROR_MESSAGE = 'libFuzzer: engine encountered an error'
 DICT_PARSING_FAILED_REGEX = re.compile(
     r'ParseDictionaryFile: error in line (\d+)')
-MULTISTEP_MERGE_SUPPORT_TOKEN = b'fuzz target overwrites its const input'
+MULTISTEP_MERGE_SUPPORT_TOKEN = 'fuzz target overwrites its const input'
 
 
 def _project_qualified_fuzzer_name(target_path):
@@ -59,8 +59,8 @@ def _is_multistep_merge_supported(target_path):
   # multi step merge: https://github.com/llvm/llvm-project/commit/f054067.
   if os.path.exists(target_path):
     with open(target_path, 'rb') as file_handle:
-      return utils.search_bytes_in_file(MULTISTEP_MERGE_SUPPORT_TOKEN,
-                                        file_handle)
+      return utils.search_string_in_file(MULTISTEP_MERGE_SUPPORT_TOKEN,
+                                         file_handle)
 
   return False
 

--- a/src/python/bot/fuzzers/utils.py
+++ b/src/python/bot/fuzzers/utils.py
@@ -26,7 +26,7 @@ from system import environment
 from system import shell
 
 ALLOWED_FUZZ_TARGET_EXTENSIONS = ['', '.exe', '.par']
-FUZZ_TARGET_SEARCH_BYTES = b'LLVMFuzzerTestOneInput'
+FUZZ_TARGET_SEARCH_STRING = 'LLVMFuzzerTestOneInput'
 VALID_TARGET_NAME = re.compile(r'^[a-zA-Z0-9_-]+$')
 
 
@@ -65,8 +65,8 @@ def is_fuzz_target_local(file_path, file_handle=None):
 
   # TODO(metzman): Bound this call so we don't read forever if something went
   # wrong.
-  result = utils.search_bytes_in_file(FUZZ_TARGET_SEARCH_BYTES,
-                                      local_file_handle)
+  result = utils.search_string_in_file(FUZZ_TARGET_SEARCH_STRING,
+                                       local_file_handle)
 
   if not file_handle:
     # If this local file handle is owned by our function, close it now.

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -150,11 +150,7 @@ class PickStrategiesTest(fake_fs_unittest.TestCase):
   """pick_strategies tests."""
 
   def setUp(self):
-    test_helpers.patch(self, [
-        'bot.fuzzers.engine_common.is_lpm_fuzz_target',
-        'random.SystemRandom.randint',
-    ])
-    self.mock.is_lpm_fuzz_target.return_value = False
+    test_helpers.patch(self, ['random.SystemRandom.randint'])
 
     test_utils.set_up_pyfakefs(self)
     self.fs.create_dir('/path/corpus')


### PR DESCRIPTION
`Reverts` google/clusterfuzz#1489. Doesn't work for archive file handles.