### PR TITLE
Fix honggfuzz for Python 3.

### DIFF
--- a/src/python/bot/fuzzers/honggfuzz/engine.py
+++ b/src/python/bot/fuzzers/honggfuzz/engine.py
@@ -19,6 +19,7 @@ import glob
 import os
 import re
 
+from base import utils
 from bot.fuzzers import dictionary_manager
 from bot.fuzzers import engine
 from metrics import logs
@@ -58,7 +59,7 @@ def _get_runner():
     raise HonggfuzzError('honggfuzz not found in build')
 
   os.chmod(honggfuzz_path, 0o755)
-  return new_process.ProcessRunner(honggfuzz_path)
+  return new_process.UnicodeProcessRunner(honggfuzz_path)
 
 
 def _find_sanitizer_stacktrace(reproducers_dir):
@@ -66,7 +67,7 @@ def _find_sanitizer_stacktrace(reproducers_dir):
   for stacktrace_path in glob.glob(
       os.path.join(reproducers_dir, _HF_SANITIZER_LOG_PREFIX + '*')):
     with open(stacktrace_path, 'rb') as f:
-      return f.read()
+      return utils.decode_to_unicode(f.read())
 
   return None
 
@@ -191,7 +192,7 @@ class HonggfuzzEngine(engine.Engine):
       A ReproduceResult.
     """
     os.chmod(target_path, 0o775)
-    runner = new_process.ProcessRunner(target_path)
+    runner = new_process.UnicodeProcessRunner(target_path)
     with open(input_path) as f:
       result = runner.run_and_wait(timeout=max_time, stdin=f)
 

--- a/src/python/system/new_process.py
+++ b/src/python/system/new_process.py
@@ -359,3 +359,15 @@ class ProcessRunner(object):
     result.command = process.command
 
     return result
+
+
+class UnicodeProcessRunner(ProcessRunner):
+  """ProcessRunner which always returns unicode output."""
+
+  def run_and_wait(self, *args, **kwargs):
+    """Overridden run_and_wait which always decodes the output."""
+    result = ProcessRunner.run_and_wait(self, *args, **kwargs)
+    if result.output is not None:
+      result.output = utils.decode_to_unicode(result.output)
+
+    return result

--- a/src/python/system/new_process.py
+++ b/src/python/system/new_process.py
@@ -364,7 +364,7 @@ class ProcessRunner(object):
 class UnicodeProcessRunner(ProcessRunner):
   """ProcessRunner which always returns unicode output."""
 
-  def run_and_wait(self, *args, **kwargs):
+  def run_and_wait(self, *args, **kwargs):  # pylint: disable=arguments-differ
     """Overridden run_and_wait which always decodes the output."""
     result = ProcessRunner.run_and_wait(self, *args, **kwargs)
     if result.output is not None:

--- a/src/python/tests/core/bot/fuzzers/honggfuzz/honggfuzz_engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/honggfuzz/honggfuzz_engine_test.py
@@ -159,7 +159,7 @@ class IntegrationTest(unittest.TestCase):
     self.assertIn('ERROR: AddressSanitizer: heap-use-after-free',
                   crash.stacktrace)
 
-    with open(crash.input_path) as f:
-      self.assertEqual('A', f.read()[0])
+    with open(crash.input_path, 'rb') as f:
+      self.assertEqual(b'A', f.read()[:1])
 
     self.assert_has_stats(results)


### PR DESCRIPTION
- Introduce UnicodeProcessRunner, which always returns unicode decoded
  output.