### PR TITLE
Fix an exception in run_process logging.

### DIFF
--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -349,7 +349,7 @@ def run_process(cmdline,
 
   logs.log(
       'Process (%s) ended, exit code (%s), output (%s).' %
-      (str(cmdline), str(return_code), output),
+      (repr(cmdline), str(return_code), output),
       level=logging.DEBUG)
 
   return return_code, round(time.time() - start_time, 1), output


### PR DESCRIPTION
Use repr instead of str for logging the command, as it looks like it can
contain binary/non-utf8 characters.