### PR TITLE
Fix chromium bad build exceptions.

### DIFF
--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -37,7 +37,7 @@ from src.python.config import local_config
 APPENGINE_TEST_DIRECTORY = os.path.join('src', 'python', 'tests', 'appengine')
 CORE_TEST_DIRECTORY = os.path.join('src', 'python', 'tests', 'core')
 SLOW_TEST_THRESHOLD = 2  # In seconds.
-TESTS_TIMEOUT = 12 * 60  # In seconds.
+TESTS_TIMEOUT = 15 * 60  # In seconds.
 
 
 class TrackedTestResult(unittest.TextTestResult):

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -667,7 +667,8 @@ class Build(BaseBuild):
       os.system('rm %s' % symbolic_link_target)
       os.system('ln -s %s %s' % (app_directory, symbolic_link_target))
 
-    if utils.is_chromium():
+    # Use deterministic fonts when available. See crbug.com/822737.
+    if utils.is_chromium() and self.revision >= 635076:
       environment.set_value('FONTCONFIG_SYSROOT', app_directory)
 
     if environment.platform() != 'ANDROID':


### PR DESCRIPTION
Don't set FONTCONFIG_SYSROOT before fix revision r635076. Otherwise,
this causes a startup crash and build detected as a bad build (when it is not).

Check failed: InitDefaultFont(). Could not find the default font