### PR TITLE
Fix UnicodeDecodeError in process_handler.

### DIFF
--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -22,7 +22,6 @@ standard_library.install_aliases()
 
 import copy
 import datetime
-import logging
 import os
 import queue
 import subprocess

--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -178,8 +178,6 @@ def run_process(cmdline,
   else:
     gesture_start_time = timeout // 2
 
-  logs.log('Process (%s) started.' % str(cmdline), level=logging.DEBUG)
-
   if plt == 'ANDROID':
     # Clear the log upfront.
     android.logger.clear_log()
@@ -347,10 +345,11 @@ def run_process(cmdline,
       output += utils.get_line_seperator('Memory Statistics')
       output += ps_output
 
-  logs.log(
-      'Process (%s) ended, exit code (%s), output (%s).' %
-      (repr(cmdline), str(return_code), output),
-      level=logging.DEBUG)
+  if return_code:
+    logs.log_warn(
+        'Process (%s) ended with exit code (%s).' % (repr(cmdline),
+                                                     str(return_code)),
+        output=output)
 
   return return_code, round(time.time() - start_time, 1), output
 


### PR DESCRIPTION
- Fix exception on chromium instance
UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 10924: invalid start byte
at run_process (/home/chrome-bot/bots/usb-1-4.4.3/clusterfuzz/src/python/system/process_handler.py:352)
at run_testcase (/home/chrome-bot/bots/usb-1-4.4.3/clusterfuzz/src/python/bot/testcase_manager.py:331)

- DEBUG log level is not enabled (minimum is INFO), so log with
WARNING for non-zero return code.