### PR TITLE
Fix uses of storage.write_data for Python 3.

### DIFF
--- a/src/python/bot/fuzzers/dictionary_manager.py
+++ b/src/python/bot/fuzzers/dictionary_manager.py
@@ -221,7 +221,7 @@ class DictionaryManager(object):
     if current_content != old_content:
       return False, current_content
 
-    storage.write_data(new_content, self.gcs_path)
+    storage.write_data(new_content.encode('utf-8'), self.gcs_path)
     return True, old_content
 
   def download_recommended_dictionary_from_gcs(self, local_dict_path):
@@ -341,7 +341,8 @@ class DictionaryManager(object):
     """
     # If the dictionary does not already exist, then directly update it.
     if not storage.exists(self.gcs_path):
-      storage.write_data('\n'.join(new_dictionary), self.gcs_path)
+      storage.write_data('\n'.join(new_dictionary).encode('utf-8'),
+                         self.gcs_path)
       return len(new_dictionary)
 
     # Read current version of the dictionary.

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -829,7 +829,8 @@ def prepare_log_for_upload(symbolized_output, return_code):
           app_revision=app_revision, component_revisions=component_revisions))
   return_code_header = 'Return code: %s\n\n' % return_code
 
-  return revisions_header + return_code_header + symbolized_output
+  result = revisions_header + return_code_header + symbolized_output
+  return result.encode('utf-8')
 
 
 def upload_log(log, log_time):

--- a/src/python/fuzzing/coverage_uploader.py
+++ b/src/python/fuzzing/coverage_uploader.py
@@ -89,7 +89,8 @@ def upload_testcases_if_needed(fuzzer_name, testcase_list, testcase_directory,
   gcs_base_url += utils.string_hash(identifier)
 
   list_gcs_url = gcs_base_url + '/' + LIST_FILE_BASENAME
-  if not storage.write_data('\n'.join(files_list), list_gcs_url):
+  if not storage.write_data('\n'.join(files_list).encode('utf-8'),
+                            list_gcs_url):
     return
 
   if has_testcases_in_testcase_directory:

--- a/src/python/google_cloud_utils/storage.py
+++ b/src/python/google_cloud_utils/storage.py
@@ -386,7 +386,7 @@ class FileSystemProvider(StorageProvider):
 
     fs_metadata_path = self.convert_path_for_write(remote_path,
                                                    self.METADATA_DIR)
-    with open(fs_metadata_path, 'wb') as f:
+    with open(fs_metadata_path, 'w') as f:
       json.dump(metadata, f)
 
   def convert_path(self, remote_path, directory=OBJECTS_DIR):

--- a/src/python/metrics/fuzzer_stats.py
+++ b/src/python/metrics/fuzzer_stats.py
@@ -1065,7 +1065,7 @@ def upload_stats(stats_list, filename=None):
     day_path = 'gs:/' + get_gcs_stats_path(
         kind, fuzzer_or_engine_name, timestamp=timestamp) + filename
 
-    if not storage.write_data(upload_data, day_path):
+    if not storage.write_data(upload_data.encode('utf-8'), day_path):
       logs.log_error('Failed to upload FuzzerRun.')
 
 

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1410,12 +1410,12 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
 
     log_time = datetime.datetime(1970, 1, 1, 0, 0)
     log_call = mock.call(
-        'Component revisions (build r1):\n'
-        'component: rev\n\n'
-        'Return code: 1\n\n'
-        'Command: cmd\nBot: None\nTime ran: 42.0\n\n'
-        'logs\n'
-        'cf::fuzzing_strategies: strategy_1:1,strategy_2:50', log_time)
+        b'Component revisions (build r1):\n'
+        b'component: rev\n\n'
+        b'Return code: 1\n\n'
+        b'Command: cmd\nBot: None\nTime ran: 42.0\n\n'
+        b'logs\n'
+        b'cf::fuzzing_strategies: strategy_1:1,strategy_2:50', log_time)
     self.mock.upload_log.assert_has_calls([log_call, log_call])
     self.mock.upload_testcase.assert_has_calls([
         mock.call('/input', log_time),

--- a/src/python/tests/core/bot/testcase_manager_test.py
+++ b/src/python/tests/core/bot/testcase_manager_test.py
@@ -125,9 +125,9 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
 
     # Date and time below is derived from 1472846341 timestamp value.
     self.mock.write_data.assert_called_once_with(
-        'Component revisions (build r123):\n'
-        'Component: REVISION\nComponent2: REVISION2\n\n'
-        'Return code: 1\n\nfake output',
+        b'Component revisions (build r123):\n'
+        b'Component: REVISION\nComponent2: REVISION2\n\n'
+        b'Return code: 1\n\nfake output',
         'gs://fake-gcs-logs/fuzzer/job/2016-09-02/19:59:01:017923.log')
 
   def test_upload_without_timestamp(self):
@@ -146,9 +146,9 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
     log_time = testcase_manager._get_testcase_time(self.testcase_path)
     testcase_manager.upload_log(log, log_time)
     self.mock.write_data.assert_called_once_with(
-        'Component revisions (build r123):\n'
-        'Component: REVISION\nComponent2: REVISION2\n\n'
-        'Return code: None\n\nNo output!',
+        b'Component revisions (build r123):\n'
+        b'Component: REVISION\nComponent2: REVISION2\n\n'
+        b'Return code: None\n\nNo output!',
         'gs://fake-gcs-logs/fuzzer/job/2017-05-15/16:10:28:374119.log')
 
   def test_upload_without_component_revisions(self):
@@ -173,9 +173,9 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
 
     # Date and time below is derived from 1472846341 timestamp value.
     self.mock.write_data.assert_called_once_with(
-        'Component revisions (build r123):\n'
-        'Not available.\n\n'
-        'Return code: 1\n\nfake output',
+        b'Component revisions (build r123):\n'
+        b'Not available.\n\n'
+        b'Return code: 1\n\nfake output',
         'gs://fake-gcs-logs/fuzzer/job/2016-09-02/19:59:01:017923.log')
 
 

--- a/src/python/tests/core/fuzzing/coverage_uploader_test.py
+++ b/src/python/tests/core/fuzzing/coverage_uploader_test.py
@@ -82,7 +82,7 @@ class UploadTestsToCloudStorageTest(fake_filesystem_unittest.TestCase):
                                                  '/testcases', '/data')
 
     self.mock.write_data.assert_called_with(
-        'a/file1.txt\nfile2.txt\nf/g/file4.txt',
+        b'a/file1.txt\nfile2.txt\nf/g/file4.txt',
         'gs://test-coverage-testcases/2018-11-01/test_fuzzer/'
         '5b680a295e1f3a81160a0bd71ca2abbcb8d19521/file_list.txt')
     self.assertEquals(
@@ -110,7 +110,8 @@ class UploadTestsToCloudStorageTest(fake_filesystem_unittest.TestCase):
     coverage_uploader.upload_testcases_if_needed('test_fuzzer', files,
                                                  '/testcases', '/data')
 
-    filtered_files_list = '\n'.join(['file%s' % i for i in range(1000)])
+    filtered_files_list = '\n'.join(
+        ['file%s' % i for i in range(1000)]).encode('utf-8')
     self.mock.write_data.assert_called_with(
         filtered_files_list,
         'gs://test-coverage-testcases/2018-11-01/test_fuzzer/'

--- a/src/python/tests/core/google_cloud_utils/storage_test.py
+++ b/src/python/tests/core/google_cloud_utils/storage_test.py
@@ -221,7 +221,7 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
     """Test copy_blob."""
     self.fs.create_dir('/local/test-bucket')
     self.provider.write_data(
-        'a', 'gs://test-bucket/subdir/a', metadata={'key': 'value'})
+        b'a', 'gs://test-bucket/subdir/a', metadata={'key': 'value'})
     with open('/local/test-bucket/objects/subdir/a') as f:
       self.assertEqual('a', f.read())
 


### PR DESCRIPTION
storage.write_data should accept bytes, but we were passing strings in
some cases.