### PR TITLE
OSS-Fuzz build failures: be explicit about Monorail not being monitored.

### DIFF
--- a/src/appengine/handlers/cron/oss_fuzz_build_status.py
+++ b/src/appengine/handlers/cron/oss_fuzz_build_status.py
@@ -69,7 +69,8 @@ def _get_issue_body(project_name, build_id, build_type):
               'To reproduce locally, please see: '
               'https://google.github.io/oss-fuzz/advanced-topics/reproducing'
               '#reproducing-build-failures\n\n'
-              'If you have any questions, please file a bug on '
+              '<b>This bug tracker is not being monitored by OSS-Fuzz team.</b>'
+              ' If you have any questions, please create an issue at '
               'https://github.com/google/oss-fuzz/issues/new.\n\n'
               '**This bug will be automatically closed within a '
               'day once it is fixed.**')

--- a/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
+++ b/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
@@ -337,7 +337,8 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         'To reproduce locally, please see: '
         'https://google.github.io/oss-fuzz/advanced-topics/reproducing'
         '#reproducing-build-failures\n\n'
-        'If you have any questions, please file a bug on '
+        '<b>This bug tracker is not being monitored by OSS-Fuzz team.</b> '
+        'If you have any questions, please create an issue at '
         'https://github.com/google/oss-fuzz/issues/new.\n\n'
         '**This bug will be automatically closed within a '
         'day once it is fixed.**', issue.body)
@@ -358,7 +359,8 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         'To reproduce locally, please see: '
         'https://google.github.io/oss-fuzz/advanced-topics/reproducing'
         '#reproducing-build-failures\n\n'
-        'If you have any questions, please file a bug on '
+        '<b>This bug tracker is not being monitored by OSS-Fuzz team.</b> '
+        'If you have any questions, please create an issue at '
         'https://github.com/google/oss-fuzz/issues/new.\n\n'
         '**This bug will be automatically closed within a '
         'day once it is fixed.**', issue.body)


### PR DESCRIPTION
Turns out it's not so clear in build failure issues, e.g. https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20619