### PR TITLE
install_deps_linux: use glogin instead of prodaccess.

### DIFF
--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -61,7 +61,7 @@ if [ ! $only_reproduce ]; then
   sudo apt-get install -y apt-transport-https software-properties-common
 
   if [ "$distro_codename" == "rodete" ]; then
-    prodaccess || glogin
+    glogin
     sudo glinux-add-repo docker-ce-"$distro_codename"
   else
     curl -fsSL https://download.docker.com/linux/${distro_id,,}/gpg | \

--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -61,7 +61,7 @@ if [ ! $only_reproduce ]; then
   sudo apt-get install -y apt-transport-https software-properties-common
 
   if [ "$distro_codename" == "rodete" ]; then
-    prodaccess
+    prodaccess || glogin
     sudo glinux-add-repo docker-ce-"$distro_codename"
   else
     curl -fsSL https://download.docker.com/linux/${distro_id,,}/gpg | \


### PR DESCRIPTION
`glogin` provides less capabilities but is sufficient enough for our use case.