### PR TITLE
Fix all AFL integration tests for Python 3.

### DIFF
--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -1513,9 +1513,8 @@ def main(argv):
     command = engine_common.strip_minijail_command(command,
                                                    runner.afl_fuzz_path)
   # Print info for the fuzzer logs.
-  print(
-      engine_common.get_log_header(command, BOT_NAME,
-                                   fuzz_result.time_executed))
+  print(engine_common.get_log_header(command, BOT_NAME,
+                                     fuzz_result.time_executed))
 
   print(fuzz_result.output)
   runner.strategies.print_strategies()

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -530,7 +530,7 @@ class AflRunnerCommon(object):
   HANG_LOG_MESSAGE = 'Testcase {0} in corpus causes a hang, retrying without it'
 
   SHOWMAP_FILENAME = 'afl_showmap_output'
-  SHOWMAP_REGEX = re.compile(r'(?P<guard>\d{6}):(?P<hit_count>\d+)\n')
+  SHOWMAP_REGEX = re.compile(br'(?P<guard>\d{6}):(?P<hit_count>\d+)\n')
 
   def __init__(self,
                target_path,
@@ -1171,7 +1171,7 @@ class AflRunnerCommon(object):
     return new_units_generated, new_units_added, corpus_size
 
 
-class AflRunner(AflRunnerCommon, new_process.ProcessRunner):
+class AflRunner(AflRunnerCommon, new_process.UnicodeProcessRunner):
   """Afl runner."""
 
   def __init__(self,
@@ -1186,7 +1186,7 @@ class AflRunner(AflRunnerCommon, new_process.ProcessRunner):
     new_process.ProcessRunner.__init__(self, self.afl_fuzz_path)
 
 
-class MinijailAflRunner(AflRunnerCommon,
+class MinijailAflRunner(AflRunnerCommon, new_process.UnicodeProcessRunnerMixin,
                         engine_common.MinijailEngineFuzzerRunner):
   """Minijail AFL runner."""
 
@@ -1513,8 +1513,9 @@ def main(argv):
     command = engine_common.strip_minijail_command(command,
                                                    runner.afl_fuzz_path)
   # Print info for the fuzzer logs.
-  print(engine_common.get_log_header(command, BOT_NAME,
-                                     fuzz_result.time_executed))
+  print(
+      engine_common.get_log_header(command, BOT_NAME,
+                                   fuzz_result.time_executed))
 
   print(fuzz_result.output)
   runner.strategies.print_strategies()

--- a/src/python/system/new_process.py
+++ b/src/python/system/new_process.py
@@ -361,7 +361,19 @@ class ProcessRunner(object):
     return result
 
 
-class UnicodeProcessRunner(ProcessRunner):
+class UnicodeProcessRunnerMixin(object):
+  """Mixin for process runner subclasses to output unicode output."""
+
+  def run_and_wait(self, *args, **kwargs):  # pylint: disable=arguments-differ
+    """Overridden run_and_wait which always decodes the output."""
+    result = ProcessRunner.run_and_wait(self, *args, **kwargs)
+    if result.output is not None:
+      result.output = utils.decode_to_unicode(result.output)
+
+    return result
+
+
+class UnicodeProcessRunner(UnicodeProcessRunnerMixin, ProcessRunner):
   """ProcessRunner which always returns unicode output."""
 
   def run_and_wait(self, *args, **kwargs):  # pylint: disable=arguments-differ

--- a/src/python/system/new_process.py
+++ b/src/python/system/new_process.py
@@ -375,11 +375,3 @@ class UnicodeProcessRunnerMixin(object):
 
 class UnicodeProcessRunner(UnicodeProcessRunnerMixin, ProcessRunner):
   """ProcessRunner which always returns unicode output."""
-
-  def run_and_wait(self, *args, **kwargs):  # pylint: disable=arguments-differ
-    """Overridden run_and_wait which always decodes the output."""
-    result = ProcessRunner.run_and_wait(self, *args, **kwargs)
-    if result.output is not None:
-      result.output = utils.decode_to_unicode(result.output)
-
-    return result

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -324,8 +324,8 @@ class TestLauncher(BaseLauncherTest):
 
     # Testcase should've been copied back.
     self.assertGreaterEqual(os.path.getsize(testcase_path), 3)
-    with open(testcase_path) as f:
-      self.assertEqual(f.read()[:3], 'ABC')
+    with open(testcase_path, 'rb') as f:
+      self.assertEqual(f.read()[:3], b'ABC')
 
   @no_errors
   @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')
@@ -364,7 +364,7 @@ def _run_with_sudo(command):
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.STDOUT)
-  popen.communicate(input=SUDO_PASSWORD + '\n')
+  popen.communicate(input=(SUDO_PASSWORD + '\n').encode())
   assert popen.returncode == 0
 
 
@@ -435,8 +435,8 @@ class TestLauncherMinijail(BaseLauncherTest):
 
     # Testcase should've been copied back.
     self.assertGreaterEqual(os.path.getsize(testcase_path), 3)
-    with open(testcase_path) as f:
-      self.assertEqual(f.read()[:3], 'ABC')
+    with open(testcase_path, 'rb') as f:
+      self.assertEqual(f.read()[:3], b'ABC')
 
   @no_errors
   @mock.patch('bot.fuzzers.afl.launcher.get_fuzz_timeout')

--- a/src/python/tests/test_libs/test_utils.py
+++ b/src/python/tests/test_libs/test_utils.py
@@ -380,4 +380,4 @@ if sys.version_info.major == 2:
       self.flush()
       return self.raw.getvalue()
 else:
-  MockStdout = io.StringIO
+  MockStdout = io.StringIO  # pylint: disable=invalid-name

--- a/src/python/tests/test_libs/test_utils.py
+++ b/src/python/tests/test_libs/test_utils.py
@@ -367,12 +367,17 @@ def supported_platforms(*platforms):
   return decorator
 
 
-class MockStdout(io.BufferedWriter):
-  """Mock stdout."""
+# TODO(ochang): Remove once migrated to Python 3.
+if sys.version_info.major == 2:
 
-  def __init__(self):
-    super(MockStdout, self).__init__(io.BytesIO())
+  class MockStdout(io.BufferedWriter):
+    """Mock stdout."""
 
-  def getvalue(self):
-    self.flush()
-    return self.raw.getvalue()
+    def __init__(self):
+      super(MockStdout, self).__init__(io.BytesIO())
+
+    def getvalue(self):
+      self.flush()
+      return self.raw.getvalue()
+else:
+  MockStdout = io.StringIO


### PR DESCRIPTION
Use UnicodeProcessRunner for AFL runners.