### PR TITLE
Generalize python 3 deployment.

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -169,8 +169,6 @@ def main():
   parser_deploy.add_argument(
       '--staging', action='store_true', help='Deploy to staging.')
   parser_deploy.add_argument(
-      '--staging3', action='store_true', help='Deploy to staging (Python 3).')
-  parser_deploy.add_argument(
       '--prod', action='store_true', help='Deploy to production.')
   parser_deploy.add_argument(
       '--targets', nargs='*', default=['appengine', 'zips'])

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -319,7 +319,8 @@ def _staging_deployment_helper(deploy_go, python3=False):
 def _prod_deployment_helper(config_dir,
                             package_zip_paths,
                             deploy_go=True,
-                            deploy_appengine=True):
+                            deploy_appengine=True,
+                            python3=False):
   """Helper for production deployment."""
   config = local_config.Config()
   deployment_bucket = config.get('project.deployment.bucket')
@@ -329,7 +330,12 @@ def _prod_deployment_helper(config_dir,
   project = gae_config.get('application_id')
 
   print('Deploying %s to prod.' % project)
-  yaml_paths = gae_deployment.get_absolute_path('prod')
+  if python3:
+    path = 'prod3'
+  else:
+    path = 'prod'
+
+  yaml_paths = gae_deployment.get_absolute_path(path)
   yaml_paths = appengine.filter_yaml_paths(yaml_paths, deploy_go)
 
   if deploy_appengine:
@@ -379,7 +385,7 @@ def execute(args):
   # Build templates before deployment.
   appengine.build_templates()
 
-  if not is_ci and not (args.staging or args.staging3):
+  if not is_ci and not args.staging:
     if is_diff_origin_master():
       if args.force:
         print('You are not on origin/master. --force is used. Continue.')
@@ -391,7 +397,7 @@ def execute(args):
         print('You are not on origin/master. Please fix or use --force.')
         sys.exit(1)
 
-  if args.staging or args.staging3:
+  if args.staging:
     revision = common.compute_staging_revision()
     platforms = ['linux']  # No other platforms required.
   elif args.prod:
@@ -406,11 +412,13 @@ def execute(args):
   deploy_zips = 'zips' in args.targets
   deploy_appengine = 'appengine' in args.targets
 
+  is_python_3 = sys.version_info.major == 3
   package_zip_paths = []
   if deploy_zips:
     for platform_name in platforms:
       package_zip_paths.append(
-          package.package(revision, platform_name=platform_name))
+          package.package(
+              revision, platform_name=platform_name, python3=is_python3))
   else:
     # package.package calls these, so only set these up if we're not packaging,
     # since they can be fairly slow.
@@ -428,12 +436,14 @@ def execute(args):
 
   deploy_go = args.with_go
   if args.staging:
-    _staging_deployment_helper(deploy_go, python3=False)
-  elif args.staging3:
-    _staging_deployment_helper(deploy_go, python3=True)
+    _staging_deployment_helper(deploy_go, python3=is_python_3)
   else:
-    _prod_deployment_helper(args.config_dir, package_zip_paths, deploy_go,
-                            deploy_appengine)
+    _prod_deployment_helper(
+        args.config_dir,
+        package_zip_paths,
+        deploy_go,
+        deploy_appengine,
+        python3=is_python_3)
 
   with open(constants.PACKAGE_TARGET_MANIFEST_PATH) as f:
     print('Source updated to %s' % f.read())

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -412,7 +412,7 @@ def execute(args):
   deploy_zips = 'zips' in args.targets
   deploy_appengine = 'appengine' in args.targets
 
-  is_python_3 = sys.version_info.major == 3
+  is_python3 = sys.version_info.major == 3
   package_zip_paths = []
   if deploy_zips:
     for platform_name in platforms:
@@ -436,14 +436,14 @@ def execute(args):
 
   deploy_go = args.with_go
   if args.staging:
-    _staging_deployment_helper(deploy_go, python3=is_python_3)
+    _staging_deployment_helper(deploy_go, python3=is_python3)
   else:
     _prod_deployment_helper(
         args.config_dir,
         package_zip_paths,
         deploy_go,
         deploy_appengine,
-        python3=is_python_3)
+        python3=is_python3)
 
   with open(constants.PACKAGE_TARGET_MANIFEST_PATH) as f:
     print('Source updated to %s' % f.read())

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -91,7 +91,7 @@ def _deploy_app_prod(project,
                      package_zip_paths,
                      deploy_appengine=True):
   """Deploy app in production."""
-  if deploy_appengine and yaml_paths:
+  if deploy_appengine:
     services = _get_services(yaml_paths)
     rebased_yaml_paths = appengine.copy_yamls_and_preprocess(
         yaml_paths, _additional_app_env_vars(project))
@@ -337,8 +337,10 @@ def _prod_deployment_helper(config_dir,
 
   yaml_paths = gae_deployment.get_absolute_path(path, default=[])
   yaml_paths = appengine.filter_yaml_paths(yaml_paths, deploy_go)
+  if not yaml_paths:
+    deploy_appengine = False
 
-  if yaml_paths and deploy_appengine:
+  if deploy_appengine:
     _update_pubsub_queues(project)
     _update_alerts(project)
     _update_bigquery(project)
@@ -351,7 +353,7 @@ def _prod_deployment_helper(config_dir,
       package_zip_paths,
       deploy_appengine=deploy_appengine)
 
-  if yaml_paths and deploy_appengine:
+  if deploy_appengine:
     common.execute('python butler.py run setup --config-dir {config_dir} '
                    '--non-dry-run'.format(config_dir=config_dir))
   print('Production deployment finished.')

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -91,7 +91,7 @@ def _deploy_app_prod(project,
                      package_zip_paths,
                      deploy_appengine=True):
   """Deploy app in production."""
-  if deploy_appengine:
+  if deploy_appengine and yaml_paths:
     services = _get_services(yaml_paths)
     rebased_yaml_paths = appengine.copy_yamls_and_preprocess(
         yaml_paths, _additional_app_env_vars(project))
@@ -335,10 +335,10 @@ def _prod_deployment_helper(config_dir,
   else:
     path = 'prod'
 
-  yaml_paths = gae_deployment.get_absolute_path(path)
+  yaml_paths = gae_deployment.get_absolute_path(path, default=[])
   yaml_paths = appengine.filter_yaml_paths(yaml_paths, deploy_go)
 
-  if deploy_appengine:
+  if yaml_paths and deploy_appengine:
     _update_pubsub_queues(project)
     _update_alerts(project)
     _update_bigquery(project)

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -351,7 +351,7 @@ def _prod_deployment_helper(config_dir,
       package_zip_paths,
       deploy_appengine=deploy_appengine)
 
-  if deploy_appengine:
+  if yaml_paths and deploy_appengine:
     common.execute('python butler.py run setup --config-dir {config_dir} '
                    '--non-dry-run'.format(config_dir=config_dir))
   print('Production deployment finished.')

--- a/src/local/butler/package.py
+++ b/src/local/butler/package.py
@@ -71,7 +71,8 @@ def _get_files(path):
 def package(revision,
             target_zip_dir=constants.PACKAGE_TARGET_ZIP_DIRECTORY,
             target_manifest_path=constants.PACKAGE_TARGET_MANIFEST_PATH,
-            platform_name=None):
+            platform_name=None,
+            python3=False):
   """Prepare clusterfuzz-source.zip."""
   is_ci = os.getenv('TEST_BOT_ENVIRONMENT')
   if not is_ci and common.is_git_dirty():
@@ -96,7 +97,10 @@ def package(revision,
 
   target_zip_name = constants.LEGACY_ZIP_NAME
   if platform_name:
-    target_zip_name = platform_name + '.zip'
+    if python3:
+      target_zip_name = platform_name + '-3.zip'
+    else:
+      target_zip_name = platform_name + '.zip'
 
   target_zip_path = os.path.join(target_zip_dir, target_zip_name)
   _clear_zip(target_zip_path)


### PR DESCRIPTION
- Automatically figure out whether we're deploying Python 2 or 3 based
  on environment.
- Prepare for production App Engine deployment via the prod3 config dir.
- Prepare for zip deployment in the form of e.g. linux-3.zip
- Skip deployment of prod/prod3 if it's not specified, to allow for gradual migration.