### PR TITLE
Move builtin fuzzers corpora to local data bundles directory.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -18,6 +18,7 @@ disable=
   fixme,
   global-statement,
   import-error,
+  import-outside-toplevel,
   locally-disabled,
   misplaced-comparison-constant,
   multiple-imports,

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -604,6 +604,13 @@ def get_data_bundle_directory(fuzzer_name):
     logs.log_error('Unable to find fuzzer %s.' % fuzzer_name)
     return None
 
+  # Store corpora for built-in fuzzers like libFuzzer in the same directory
+  # as other local data bundles. This makes it easy to clear them when we run
+  # out of disk space.
+  local_data_bundles_directory = environment.get_value('DATA_BUNDLES_DIR')
+  if fuzzer.builtin:
+    return local_data_bundles_directory
+
   # Check if we have a fuzzer-specific data bundle. Use it to calculate the
   # data directory we will fetch our testcases from.
   data_bundle = data_types.DataBundle.query(
@@ -613,7 +620,6 @@ def get_data_bundle_directory(fuzzer_name):
     # have their own data bundle.
     return environment.get_value('FUZZ_DATA')
 
-  local_data_bundles_directory = environment.get_value('DATA_BUNDLES_DIR')
   local_data_bundle_directory = os.path.join(local_data_bundles_directory,
                                              data_bundle.name)
 

--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -331,12 +331,12 @@ def run():
     # Update heartbeat with current time.
     data_handler.update_heartbeat()
 
-    # Download new layout tests once per day.
-    update_tests_if_needed()
-
     # Check overall free disk space. If we are running too low, clear all
     # data directories like builds, fuzzers, data bundles, etc.
     shell.clear_data_directories_on_low_disk_space()
+
+    # Download new layout tests once per day.
+    update_tests_if_needed()
   except Exception:
     logs.log_error('Error occurred while running update task.')
 

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -495,7 +495,7 @@ def reset_usb():
     return True
 
   # App Engine does not let us import this.
-  import fcntl  # pylint: disable=import-outside-toplevel
+  import fcntl
 
   # We need to get latest device path since it could be changed in reboots or
   # adb root restarts.


### PR DESCRIPTION
This makes it easy to implement a corpus eviction strategy
when we run out of disk space.