### PR TITLE
Fix Attribute error in record cross pollination stats. 

### DIFF
--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -563,9 +563,9 @@ def _record_cross_pollination_stats(stats):
       'feature_coverage': stats.feature_coverage
   }
 
-  # BigQuery not available in local development.This is necessary because the
+  # BigQuery not available in local development. This is necessary because the
   # untrusted runner is in a separate process and can't be easily mocked.
-  # Check here instead of earlier to test for attribute errors above.
+  # Check here instead of earlier to test as much of the function as we can.
   if environment.get_value('LOCAL_DEVELOPMENT') or environment.get_value(
       'PY_UNITTESTS'):
     return

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -549,11 +549,6 @@ def _record_cross_pollination_stats(stats):
   # If no stats were gathered due to a timeout or lack of corpus, return.
   if not stats:
     return
-  # BigQuery not available in local development.This is necessary because the
-  # untrusted runner is in a separate process and can't be easily mocked.
-  if environment.get_value('LOCAL_DEVELOPMENT') or environment.get_value(
-      'PY_UNITTESTS'):
-    return
 
   bigquery_row = {
       'project_qualified_name': stats.project_qualified_name,
@@ -567,6 +562,13 @@ def _record_cross_pollination_stats(stats):
       'initial_feature_coverage': stats.initial_feature_coverage,
       'feature_coverage': stats.feature_coverage
   }
+
+  # BigQuery not available in local development.This is necessary because the
+  # untrusted runner is in a separate process and can't be easily mocked.
+  # Check here instead of earlier to test for attribute errors above.
+  if environment.get_value('LOCAL_DEVELOPMENT') or environment.get_value(
+      'PY_UNITTESTS'):
+    return
 
   client = big_query.Client(
       dataset_id='main', table_id='cross_pollination_statistics')

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -561,10 +561,10 @@ def _record_cross_pollination_stats(stats):
       'sources': stats.sources,
       'tags': stats.tags if stats.tags else '',
       'initial_corpus_size': stats.initial_corpus_size,
-      'corpus_size': stats.minimized_corpus_size_units,
+      'corpus_size': stats.corpus_size,
       'initial_edge_coverage': stats.initial_edge_coverage,
       'edge_coverage': stats.edge_coverage,
-      'initial_feature_coverage': stats.initial_feature_coverate,
+      'initial_feature_coverage': stats.initial_feature_coverage,
       'feature_coverage': stats.feature_coverage
   }
 


### PR DESCRIPTION
There was a check that was stopping this method from running during local development and py_unittest so we did not catch these errors. I moved the check to just before the bigquery call so that the function could at least be tested up to that point. 