### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/configs/test/gce/android-init.bash
+++ b/configs/test/gce/android-init.bash
@@ -46,7 +46,7 @@ PYTHONPATH="$PYTHONPATH:$ROOT_DIR/src"
 curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
 
 echo "Installing dependencies."
-apt-get update && apt-get install -y \
+apt-get update && apt-get --no-install-recommends install -y \
   autofs \
   apt-transport-https \
   build-essential \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -21,7 +21,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get autoremove -y && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         apt-transport-https \
         build-essential \
         curl \
@@ -53,7 +53,7 @@ RUN curl -sS https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.b
 RUN CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -  && \
-    apt-get update && apt-get install -y google-cloud-sdk
+    apt-get update && apt-get --no-install-recommends install -y google-cloud-sdk
 
 # Only upgrade python packages used by fuzzers and infrastructure.
 COPY requirements.txt .

--- a/docker/chromium/base/Dockerfile
+++ b/docker/chromium/base/Dockerfile
@@ -22,7 +22,7 @@ RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula selec
     /tmp/install-build-deps.sh --backwards-compatible --no-prompt --no-chromeos-fonts --syms
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         autofs \
         dbus-x11 \
         blackbox \

--- a/docker/chromium/builder/Dockerfile
+++ b/docker/chromium/builder/Dockerfile
@@ -22,7 +22,7 @@ ENV EXTRA_PATH "/data/depot_tools"
 ENV WAIT_TIME 7200
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         git \
         subversion \
         zip

--- a/docker/chromium/ml-with-gpu/Dockerfile
+++ b/docker/chromium/ml-with-gpu/Dockerfile
@@ -26,7 +26,7 @@ RUN wget https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cud
     dpkg -i cuda.deb && \
     apt-key add /var/cuda-repo-9-0-local/7fa2af80.pub && \
     apt-get update && \
-    apt-get install -y cuda
+    apt-get --no-install-recommends install -y cuda
 
 # From (requires registration) https://docs.nvidia.com/deeplearning/sdk/cudnn-install/#installlinux-deb
 RUN wget https://storage.googleapis.com/clusterfuzz-data/cudnn/7.1.4_cuda9.0/libcudnn7_7.1.4.18-1%2Bcuda9.0_amd64.deb && \

--- a/docker/chromium/tests-syncer/Dockerfile
+++ b/docker/chromium/tests-syncer/Dockerfile
@@ -23,7 +23,7 @@ ENV TESTS_ARCHIVE_NAME "web_tests.zip"
 ENV TESTS_DIR /home/$USER/tests
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         git \
         subversion \
         zip

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
 
 # TOOD(ochang):Also need libnss3 libfreetype6 libfontconfig1 libgconf-2-4 xvfb for chrome-driver.
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         git \
         golang-go \
         google-cloud-sdk-app-engine-go \
@@ -34,14 +34,14 @@ RUN apt-get update && \
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
     curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
     apt-get update && \
-    apt-get install -y bazel
+    apt-get --no-install-recommends install -y bazel
 
 RUN npm install -g bower polymer-bundler
 
 # Install latest Chrome stable, needed for chromedriver testing.
 RUN curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    apt-get update && apt-get install -y google-chrome-stable
+    apt-get update && apt-get --no-install-recommends install -y google-chrome-stable
 
 # Container Builder mount.
 VOLUME /workspace

--- a/docker/fuchsia/Dockerfile
+++ b/docker/fuchsia/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 FROM gcr.io/clusterfuzz-images/base
 
-RUN apt-get update && apt-get install -y openssh-client
+RUN apt-get update && apt-get --no-install-recommends install -y openssh-client
 
 ENV OS_OVERRIDE FUCHSIA
 ENV QUEUE_OVERRIDE FUCHSIA

--- a/docker/ml-with-gpu/Dockerfile
+++ b/docker/ml-with-gpu/Dockerfile
@@ -26,7 +26,7 @@ RUN wget https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cud
     dpkg -i cuda.deb && \
     apt-key add /var/cuda-repo-9-0-local/7fa2af80.pub && \
     apt-get update && \
-    apt-get install -y cuda
+    apt-get --no-install-recommends install -y cuda
 
 # From (requires registration) https://docs.nvidia.com/deeplearning/sdk/cudnn-install/#installlinux-deb
 RUN wget https://storage.googleapis.com/clusterfuzz-data/cudnn/7.1.4_cuda9.0/libcudnn7_7.1.4.18-1%2Bcuda9.0_amd64.deb && \

--- a/docker/oss-fuzz/worker/Dockerfile
+++ b/docker/oss-fuzz/worker/Dockerfile
@@ -13,5 +13,5 @@
 # limitations under the License.
 FROM gcr.io/clusterfuzz-images/oss-fuzz/base
 
-RUN apt-get install -y libc6-i386 lib32gcc1
+RUN apt-get --no-install-recommends install -y libc6-i386 lib32gcc1
 ENV UNTRUSTED_WORKER True

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Prerequisites
 ```bash
-sudo apt install ruby bundler
+sudo apt-get --no-install-recommends install ruby bundler
 bundle install --path vendor/bundle
 ```
 

--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -58,7 +58,7 @@ fi
 
 if [ ! $only_reproduce ]; then
   # Prerequisite for add-apt-repository.
-  sudo apt-get install -y apt-transport-https software-properties-common
+  sudo apt-get --no-install-recommends install -y apt-transport-https software-properties-common
 
   if [ "$distro_codename" == "rodete" ]; then
     prodaccess
@@ -92,7 +92,7 @@ if [ ! $only_reproduce ]; then
 
   # Install apt-get packages.
   sudo apt-get update
-  sudo apt-get install -y \
+  sudo apt-get --no-install-recommends install -y \
       bazel \
       docker-ce \
       google-cloud-sdk \
@@ -114,12 +114,12 @@ if [ ! $only_reproduce ]; then
           sudo make install && \
           sudo rm -rf /tmp/patchelf-*)
   else
-      sudo apt-get install -y patchelf
+      sudo apt-get --no-install-recommends install -y patchelf
   fi
 fi
 
 # Install other packages that we depend on unconditionally.
-sudo apt-get install -y \
+sudo apt-get --no-install-recommends install -y \
     blackbox \
     python-pip \
     python-virtualenv \
@@ -138,7 +138,7 @@ if gcloud components install --quiet beta; then
 else
   # Either Cloud SDK component manager is disabled (default on GCE), or google-cloud-sdk package is
   # installed via apt-get.
-  sudo apt-get install -y \
+  sudo apt-get --no-install-recommends install -y \
       google-cloud-sdk-app-engine-go \
       google-cloud-sdk-app-engine-python \
       google-cloud-sdk-app-engine-python-extras \
@@ -149,7 +149,7 @@ fi
 
 # Setup virtualenv.
 if [[ -n "$PY3" ]]; then
-  sudo apt-get install -y pipenv
+  sudo apt-get --no-install-recommends install -y pipenv
   pipenv sync --python 3.7
   pipenv sync --dev
   source "$(pipenv --venv)/bin/activate"


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>