### PR TITLE
Uninstall python-openssl in chromium/base.

### DIFF
--- a/docker/chromium/base/Dockerfile
+++ b/docker/chromium/base/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
         xvfb && \
     # 16.04's pyOpenSSL (installed by install-build-deps.sh) is too old for
     # Google Cloud SDK.
+    sudo apt-get remove -y python-openssl && \
     sudo pip install pyOpenSSL==19.0.0
 
 # Needed for older versions of Chrome.


### PR DESCRIPTION
Otherwise we get an exception when running pip.