### PR TITLE
Shrink corpus by both size and count in corpus pruning task.

### DIFF
--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1319,7 +1319,7 @@ def run_engine_fuzzer(engine_impl, target_name, sync_corpus_directory,
   _add_issue_metadata_from_environment(fuzzer_metadata)
 
   # Cleanup fuzzer temporary artifacts (e.g. mutations dir, merge dirs. etc).
-  shell.remove_directory(fuzzer_utils.get_temp_dir())
+  fuzzer_utils.cleanup()
 
   return result, fuzzer_metadata, options.strategies
 

--- a/src/python/google_cloud_utils/storage.py
+++ b/src/python/google_cloud_utils/storage.py
@@ -853,9 +853,19 @@ def write_data(data, cloud_storage_file_path, metadata=None):
 @retry.wrap(
     retries=DEFAULT_FAIL_RETRIES,
     delay=DEFAULT_FAIL_WAIT,
+    function='google_cloud_utils.storage.get_blobs')
+def get_blobs(cloud_storage_path, recursive=True):
+  """Return blobs under the given cloud storage path."""
+  for blob in _provider().list_blobs(cloud_storage_path, recursive=recursive):
+    yield blob
+
+
+@retry.wrap(
+    retries=DEFAULT_FAIL_RETRIES,
+    delay=DEFAULT_FAIL_WAIT,
     function='google_cloud_utils.storage.list_blobs')
 def list_blobs(cloud_storage_path, recursive=True):
-  """Return list of blobs under the given cloud storage path."""
+  """Return blob names under the given cloud storage path."""
   for blob in _provider().list_blobs(cloud_storage_path, recursive=recursive):
     yield blob['name']
 


### PR DESCRIPTION
This prevents corpus pruning failures on google instances since
10k file limit does not prevent large overall size which will
fail to sync on disk (due to limited free space).

Also, dont raise exception on cross pollinated corpus merge.