### PR TITLE
Bump TensorFlow for Python2 from 1.8.0 to 1.15.0 (#1386, #1387).

### DIFF
--- a/docker/base/requirements.txt
+++ b/docker/base/requirements.txt
@@ -1,7 +1,7 @@
 crcmod==1.7
 future==0.17.1
 psutil==5.6.6
-tensorflow==1.8.0
+tensorflow==1.15.0
 numpy==1.16.4
 
 # The following are added by pip freeze.

--- a/src/local/requirements.txt
+++ b/src/local/requirements.txt
@@ -7,4 +7,4 @@ nodeenv==1.0.0
 paramiko==2.6.0
 protobuf==3.6.1
 psutil==5.6.6
-tensorflow==1.8.0
+tensorflow==1.15.0


### PR DESCRIPTION
1.15.2 is not available for Python2.

Not attempting to upgrade `tensorflow-gpu` package that is installed in Dockerfile for `ml-with-gpu` bots, as there is no tested combination of CUDA and cuDNN versions, and it's likely going to break, as even 1.13 or 1.14 seem to need a newer CUDA and cuDNN: https://www.tensorflow.org/install/source#tested_build_configurations

The real solution will be https://github.com/google/clusterfuzz/issues/1540

In the meantime, GPU bots should be working, if we invoke use interpreter for model generation. If bots break, we'll have to live with it until switching to py3.