### PR TITLE
Properly handle bytes objects passed to utils.decode_to_unicode.

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -108,7 +108,11 @@ def decode_to_unicode(obj, encoding='utf-8'):
     try:
       obj = str(obj, encoding)
     except:
-      obj = str(''.join(char for char in obj if ord(char) < 128), encoding)
+      obj = str(
+          ''.join(
+              char for char in obj
+              if (char if isinstance(char, int) else ord(char)) < 128),
+          encoding)
 
   return obj
 


### PR DESCRIPTION
If we pass a bytes to this function, instead of iterating over 1-character strings we'll be iterating over the integer values. This makes the ord() call unnecessary.