### PR TITLE
honggfuzz_engine: Make honggfuzz not delete *SAN report files.

### DIFF
--- a/src/python/bot/fuzzers/honggfuzz/engine.py
+++ b/src/python/bot/fuzzers/honggfuzz/engine.py
@@ -37,6 +37,7 @@ _DEFAULT_ARGUMENTS = [
     '-z',  # use clang instrumentation
     '-P',  # persistent mode
     '-S',  # enable sanitizers
+    '--sanitizers_del_report=false',  # keep ASAN log files around for parsing
     '--rlimit_rss',
     str(_RSS_LIMIT),
     '--timeout',


### PR DESCRIPTION
Currently honggfuzz doesn't touch *SAN log/report files if these are
produced, but I intend to change that behavior in the future (delete by
default). Set a flag for honggfuzz, which will prevent deleting those,
so clusterfuzz can use those report-files for its own crash analysis.