### PR TITLE
Speculative fix for a JSON serialization error in manage_vms.

### DIFF
--- a/src/appengine/handlers/cron/manage_vms.py
+++ b/src/appengine/handlers/cron/manage_vms.py
@@ -96,10 +96,10 @@ def get_template_body(gce_project,
   if tls_cert:
     template_body['properties']['metadata']['items'].extend([{
         'key': 'tls-cert',
-        'value': tls_cert.cert_contents,
+        'value': tls_cert.cert_contents.decode('utf-8'),
     }, {
         'key': 'tls-key',
-        'value': tls_cert.key_contents,
+        'value': tls_cert.key_contents.decode('utf-8'),
     }])
 
   return template_body

--- a/src/python/tests/appengine/handlers/cron/manage_vms_test.py
+++ b/src/python/tests/appengine/handlers/cron/manage_vms_test.py
@@ -282,10 +282,10 @@ def expected_instance_template(gce_project_name,
   if tls_cert:
     expected['properties']['metadata']['items'].extend([{
         'key': 'tls-cert',
-        'value': project_name.encode() + b'_cert',
+        'value': project_name + '_cert',
     }, {
         'key': 'tls-key',
-        'value': project_name.encode() + b'_key',
+        'value': project_name + '_key',
     }])
 
   return expected


### PR DESCRIPTION
PTAL. This assumes that ndb blob properties are interpreted as bytes. It didn't seem that any of the other fields could have been bytes, which led to a JSON serialization error later.