### PR TITLE
Suppress unwanted warnings in googleapiclient.

### DIFF
--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """server.py initialises the appengine server for ClusterFuzz."""
 from __future__ import absolute_import
-import logging
 
 from webapp2_extras import routes
 import webapp2
@@ -79,6 +78,7 @@ from handlers.testcase_detail import remove_issue
 from handlers.testcase_detail import testcase_variants
 from handlers.testcase_detail import update_from_trunk
 from handlers.testcase_detail import update_issue
+from metrics import logs
 
 _is_chromium = utils.is_chromium()
 _is_oss_fuzz = utils.is_oss_fuzz()
@@ -224,7 +224,7 @@ _ROUTES = [
     ('/viewer', viewer.Handler),
 ]
 
-logging.getLogger().setLevel(logging.INFO)
+logs.configure('appengine')
 
 config = local_config.GAEConfig()
 main_domain = config.get('domains.main')

--- a/src/python/metrics/logs.py
+++ b/src/python/metrics/logs.py
@@ -63,6 +63,12 @@ def _console_logging_enabled():
   return bool(os.getenv('LOG_TO_CONSOLE'))
 
 
+def _suppress_warnings():
+  """Suppress unwanted warnings."""
+  # See https://github.com/googleapis/google-api-python-client/issues/299
+  logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
+
+
 def set_logger(logger):
   """Set the logger."""
   global _logger
@@ -276,6 +282,8 @@ def get_logger():
   """Return logger. We need this method because we need to mock logger."""
   if _logger:
     return _logger
+
+  _suppress_warnings()
 
   if _is_running_on_app_engine():
     # Running on App Engine.

--- a/src/python/metrics/logs.py
+++ b/src/python/metrics/logs.py
@@ -95,6 +95,7 @@ def get_handler_config(filename, backup_count):
 def get_logging_config_dict(name):
   """Get config dict for the logger `name`."""
   logging_handler = {
+      'appengine': get_handler_config('bot/logs/appengine.log', 1),
       'run_bot': get_handler_config('bot/logs/bot.log', 3),
       'run': get_handler_config('bot/logs/run.log', 1),
       'run_heartbeat': get_handler_config('bot/logs/run_heartbeat.log', 1),

--- a/src/python/metrics/logs.py
+++ b/src/python/metrics/logs.py
@@ -63,7 +63,7 @@ def _console_logging_enabled():
   return bool(os.getenv('LOG_TO_CONSOLE'))
 
 
-def _suppress_warnings():
+def suppress_unwanted_warnings():
   """Suppress unwanted warnings."""
   # See https://github.com/googleapis/google-api-python-client/issues/299
   logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
@@ -255,7 +255,10 @@ def configure(name, extras=None):
   """Set logger. See the list of loggers in bot/config/logging.yaml.
   Also configures the process to log any uncaught exceptions as an error.
   |extras| will be included by emit() in log messages."""
+  suppress_unwanted_warnings()
+
   if _is_running_on_app_engine():
+    logging.getLogger().setLevel(logging.INFO)
     return
 
   if _console_logging_enabled():
@@ -282,8 +285,6 @@ def get_logger():
   """Return logger. We need this method because we need to mock logger."""
   if _logger:
     return _logger
-
-  _suppress_warnings()
 
   if _is_running_on_app_engine():
     # Running on App Engine.

--- a/src/python/tests/core/metrics/logs_test.py
+++ b/src/python/tests/core/metrics/logs_test.py
@@ -253,6 +253,7 @@ class ConfigureTest(unittest.TestCase):
         'logging.config.dictConfig',
         'logging.getLogger',
         'metrics.logs._is_running_on_app_engine',
+        'metrics.logs.suppress_unwanted_warnings',
     ])
 
   def test_configure(self):


### PR DESCRIPTION
Should fix warnings like
```
ImportError: file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth
```