### PR TITLE
Use google.cloud.logging for logging on App Engine.

### DIFF
--- a/src/local/butler/run_server3.py
+++ b/src/local/butler/run_server3.py
@@ -176,7 +176,7 @@ def execute(args):
   os.environ['LOCAL_GCS_SERVER_HOST'] = constants.LOCAL_GCS_SERVER_HOST
   os.environ['DATASTORE_EMULATOR_HOST'] = constants.DATASTORE_EMULATOR_HOST
   os.environ['PUBSUB_EMULATOR_HOST'] = constants.PUBSUB_EMULATOR_HOST
-  os.environ['GAE_ENV'] = 'True'
+  os.environ['GAE_ENV'] = 'dev'
   try:
     cron_server = common.execute_async(
         'gunicorn -b :{port} main:app'.format(port=constants.CRON_SERVICE_PORT),

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -658,7 +658,8 @@ def is_running_on_app_engine():
 
 def is_running_on_app_engine_development():
   """Return True if running on the local development appengine server."""
-  return os.getenv('SERVER_SOFTWARE', '').startswith('Development/')
+  return (os.getenv('GAE_ENV') == 'dev' or
+          os.getenv('SERVER_SOFTWARE', '').startswith('Development/'))
 
 
 def parse_environment_definition(environment_string):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,9 @@ future==0.17.1
 google-api-python-client==1.7.4
 google-auth==1.8.1
 google-auth-oauthlib==0.2.0
+google-cloud-core==1.3.0
 google-cloud-datastore==1.7.0
+google-cloud-logging==1.15.0
 google-cloud-monitoring==0.30.1
 google-cloud-ndb==1.0.0
 google-cloud-profiler==1.0.3


### PR DESCRIPTION
- Install google.cloud.logging handler to root logger. This is necessary for severity logging to work.
- Also attach trace information to each log to allow correlating logs with requests.