### PR TITLE
Don't create bucket from empty data bundle attribute in fuzzers.

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -684,6 +684,7 @@ class ProjectSetup(object):
     data_bundles = set([
         fuzzer_entity.data_bundle_name
         for fuzzer_entity in six.itervalues(self._fuzzer_entities)
+        if fuzzer_entity.data_bundle_name
     ])
     for data_bundle in data_bundles:
       # Workers also need to be able to set up these global bundles.


### PR DESCRIPTION
Fixes
```
LogError: Failed to get IAM policies for -corpus.clusterfuzz-external.appspot.com: <HttpError 400 when requesting https://storage.googleapis.com/storage/v1/b/-corpus.clusterfuzz-external.appspot.com/iam?alt=json returned "Invalid Value"> Traceback (most recent call last): File "python/google_cloud_utils/storage.py", line 667, in get_bucket_iam_policy iam_policy = storage.buckets().getIamPolicy(bucket=bucket_name).execute() File "third_party/googleapiclient/_helpers.py", line 130, in positional_wrapper return wrapped(*args, **kwargs) File "third_party/googleapiclient/http.py", line 842, in execute raise HttpError(resp, content, uri=self.uri) googleapiclient.errors.HttpError: <HttpError 400 when requesting https://storage.googleapis.com/storage/v1/b/-corpus.clusterfuzz-external.appspot.com/iam?alt=json returned "Invalid Value">
```