### PR TITLE
Catch all exceptions from corpus pruning tasks.

### DIFF
--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -593,7 +593,7 @@ def do_corpus_pruning(context, last_execution_failed, revision):
   if environment.is_trusted_host():
     from bot.untrusted_runner import tasks_host
     return tasks_host.do_corpus_pruning(context, last_execution_failed,
-                                        revision)
+                                          revision)
 
   build_manager.setup_build(revision=revision)
   build_directory = environment.get_value('BUILD_DIR')
@@ -949,7 +949,7 @@ def execute_task(full_fuzzer_name, job_type):
     _record_cross_pollination_stats(result.cross_pollination_stats)
     _save_coverage_information(context, result)
     _process_corpus_crashes(context, result)
-  except CorpusPruningException:
+  except Exception:
     logs.log_error('Corpus pruning failed.')
     data_handler.update_task_status(task_name, data_types.TaskState.ERROR)
     return

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -593,7 +593,7 @@ def do_corpus_pruning(context, last_execution_failed, revision):
   if environment.is_trusted_host():
     from bot.untrusted_runner import tasks_host
     return tasks_host.do_corpus_pruning(context, last_execution_failed,
-                                          revision)
+                                        revision)
 
   build_manager.setup_build(revision=revision)
   build_directory = environment.get_value('BUILD_DIR')


### PR DESCRIPTION
This catches exceptions that come over grpc channel from OSS-Fuzz
worker bots for the same CorpusPruningException. This helps to mark
last execution failed properly instead of task failure.