### PR TITLE
Fix exception when stacktrace is not generated for Honggfuzz crashes.

### DIFF
--- a/src/python/bot/fuzzers/honggfuzz/engine.py
+++ b/src/python/bot/fuzzers/honggfuzz/engine.py
@@ -167,7 +167,7 @@ class HonggfuzzEngine(engine.Engine):
       reproducer_path = _get_reproducer_path(line)
       if reproducer_path:
         crashes.append(
-            engine.Crash(reproducer_path, sanitizer_stacktrace, [],
+            engine.Crash(reproducer_path, sanitizer_stacktrace or '', [],
                          int(fuzz_result.time_executed)))
         continue
 


### PR DESCRIPTION
Should fix
```
AttributeError: 'NoneType' object has no attribute 'splitlines'
at process_stacktrace (/mnt/scratch0/clusterfuzz/src/python/crash_analysis/stack_parsing/stack_symbolizer.py:489)
at symbolize_stacktrace (/mnt/scratch0/clusterfuzz/src/python/crash_analysis/stack_parsing/stack_symbolizer.py:636)
at get_crash_data (/mnt/scratch0/clusterfuzz/src/python/crash_analysis/stack_parsing/stack_analyzer.py:1149)
at __init__ (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:202)
at from_engine_crash (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:174)
at do_engine_fuzzing (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1605)
at run (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1863)
at execute_task (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1943)
at run_command (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:204)
at process_command (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:378)
at wrapper (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:150)
at task_loop (/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py:99)
```

Use an empty stack when not available instead of None.