### PR TITLE
Fix exception with no cross pollination stats in untrusted runner.

### DIFF
--- a/src/python/bot/untrusted_runner/tasks_impl.py
+++ b/src/python/bot/untrusted_runner/tasks_impl.py
@@ -52,18 +52,22 @@ def prune_corpus(request, _):
   result = corpus_pruning_task.do_corpus_pruning(
       context, request.last_execution_failed, request.revision)
 
-  result_stats = result.cross_pollination_stats
-  cross_pollination_stats = untrusted_runner_pb2.CrossPollinationStats(
-      project_qualified_name=result_stats.project_qualified_name,
-      method=result_stats.method,
-      sources=result_stats.sources,
-      tags=result_stats.tags,
-      initial_corpus_size=result_stats.initial_corpus_size,
-      corpus_size=result_stats.corpus_size,
-      initial_edge_coverage=result_stats.initial_edge_coverage,
-      edge_coverage=result_stats.edge_coverage,
-      initial_feature_coverage=result_stats.initial_feature_coverage,
-      feature_coverage=result_stats.feature_coverage)
+  cross_pollination_stats = None
+  if result.cross_pollination_stats:
+    cross_pollination_stats = untrusted_runner_pb2.CrossPollinationStats(
+        project_qualified_name=result.cross_pollination_stats.
+        project_qualified_name,
+        method=result.cross_pollination_stats.method,
+        sources=result.cross_pollination_stats.sources,
+        tags=result.cross_pollination_stats.tags,
+        initial_corpus_size=result.cross_pollination_stats.initial_corpus_size,
+        corpus_size=result.cross_pollination_stats.corpus_size,
+        initial_edge_coverage=result.cross_pollination_stats.
+        initial_edge_coverage,
+        edge_coverage=result.cross_pollination_stats.edge_coverage,
+        initial_feature_coverage=result.cross_pollination_stats.
+        initial_feature_coverage,
+        feature_coverage=result.cross_pollination_stats.feature_coverage)
 
   # Intentionally skip edge and function coverage values as those would come
   # from fuzzer coverage cron task (see src/go/server/cron/coverage.go).


### PR DESCRIPTION
Should fix exception

```
AttributeError: 'NoneType' object has no attribute 'project_qualified_name'
at prune_corpus (/mnt/scratch0/clusterfuzz/src/python/bot/untrusted_runner/tasks_impl.py:57)
at PruneCorpus (/mnt/scratch0/clusterfuzz/src/python/bot/untrusted_runner/untrusted.py:190)
at wrapper (/mnt/scratch0/clusterfuzz/src/python/bot/untrusted_runner/untrusted.py:84)
at _call_behavior (/mnt/scratch0/clusterfuzz/src/third_party/grpc/_server.py:389)
```