### PR TITLE
Exception fixes

### DIFF
--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -418,6 +418,9 @@ def upload_testcase(testcase_path, log_time):
   if not fuzz_logs_bucket:
     return
 
+  if not os.path.exists(testcase_path):
+    return
+
   with open(testcase_path, 'rb') as file_handle:
     testcase_contents = file_handle.read()
 

--- a/src/python/metrics/logs.py
+++ b/src/python/metrics/logs.py
@@ -338,8 +338,14 @@ def _add_appengine_trace(extras):
     return
 
   import webapp2
-  request = webapp2.get_request()
-  if not request:
+
+  try:
+    request = webapp2.get_request()
+    if not request:
+      return
+  except Exception:
+    # FIXME: Find a way to add traces in threads. Skip adding for now, as
+    # otherwise, we hit an exception "Request global variable is not set".
     return
 
   trace_header = request.headers.get('X-Cloud-Trace-Context')


### PR DESCRIPTION
1. Skip adding traces in threads for now. Unblocks manage-vms cron on
chromium.
```
Traceback (most recent call last):
  File "third_party/webapp2.py", line 604, in dispatch
    return method(*args, **kwargs)
  File "/srv/libs/handler.py", line 96, in wrapper
    return func(self)
  File "/srv/handlers/cron/manage_vms.py", line 714, in get
    manager.update_clusters()
  File "/srv/handlers/cron/manage_vms.py", line 198, in update_clusters
    self.finish_updates()
  File "/srv/handlers/cron/manage_vms.py", line 183, in finish_updates
    update.result()
  File "/opt/python3.7/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/opt/python3.7/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/opt/python3.7/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/handlers/cron/manage_vms.py", line 224, in update_cluster
    if instance_template.exists():
  File "/srv/handlers/cron/helpers/bot_manager.py", line 109, in exists
    self.get()
  File "/srv/handlers/cron/helpers/bot_manager.py", line 283, in get
    result_proc=self._identity)
  File "python/base/retry.py", line 102, in _wrapper
    if not handle_retry(num_try, exception=e):
  File "python/base/retry.py", line 79, in handle_retry
    total=tries)
  File "python/metrics/logs.py", line 422, in log_error
    emit(logging.ERROR, message, exc_info=sys.exc_info(), **extras)
  File "python/metrics/logs.py", line 384, in emit
    _add_appengine_trace(all_extras)
  File "python/metrics/logs.py", line 341, in _add_appengine_trace
    request = webapp2.get_request()
  File "third_party/webapp2.py", line 1757, in get_request
    assert getattr(_local, 'request', None) is not None, _get_request_error
AssertionError: Request global variable is not set."
```

2. Don't exception in upload testcase when it does not exist. We would
later log_error in archive_testcase_and_dependencies_in_gcs. This is expected on google
instance where we can run out of FDs on borg.
```
IOError: [Errno 2] No such file or directory: u'/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-da39a3ee5e6b4b0d3255bfef95601890afd80709'
at upload_testcase (/mnt/scratch0/clusterfuzz/src/python/bot/testcase_manager.py:421)
at do_engine_fuzzing (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1613)
at run (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1881)
at execute_task (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/fuzz_task.py:1961)
at run_command (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:204)
at process_command (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:378)
at wrapper (/mnt/scratch0/clusterfuzz/src/python/bot/tasks/commands.py:150)
at task_loop (/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py:99)
```