### PR TITLE
Revert "Fix Python 3 bots to use pipenv run, as python3.7 is not inherited."

### DIFF
--- a/docker/chromium/base3/Dockerfile
+++ b/docker/chromium/base3/Dockerfile
@@ -14,4 +14,4 @@
 FROM gcr.io/clusterfuzz-images/chromium/base
 
 ENV DEPLOYMENT_ZIP "linux-3.zip"
-ENV RUN_CMD "pipenv run python $ROOT_DIR/src/python/bot/startup/run.py"
+ENV RUN_CMD "python3.7 $ROOT_DIR/src/python/bot/startup/run.py"

--- a/docker/oss-fuzz/host3/Dockerfile
+++ b/docker/oss-fuzz/host3/Dockerfile
@@ -14,4 +14,4 @@
 FROM gcr.io/clusterfuzz-images/oss-fuzz/host
 
 ENV DEPLOYMENT_ZIP "linux-3.zip"
-ENV RUN_CMD "pipenv run python /data/start_host.py"
+ENV RUN_CMD "python3.7 /data/start_host.py"

--- a/docker/oss-fuzz/worker3/Dockerfile
+++ b/docker/oss-fuzz/worker3/Dockerfile
@@ -14,4 +14,4 @@
 FROM gcr.io/clusterfuzz-images/oss-fuzz/worker
 
 ENV DEPLOYMENT_ZIP "linux-3.zip"
-ENV RUN_CMD "pipenv run python $ROOT_DIR/src/python/bot/startup/run.py"
+ENV RUN_CMD "python3.7 $ROOT_DIR/src/python/bot/startup/run.py"


### PR DESCRIPTION
Reverts google/clusterfuzz#1644