### PR TITLE
Make build setup result checking more strict in corpus pruning.

### DIFF
--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -595,9 +595,9 @@ def do_corpus_pruning(context, last_execution_failed, revision):
     return tasks_host.do_corpus_pruning(context, last_execution_failed,
                                         revision)
 
-  build_manager.setup_build(revision=revision)
+  build_setup_result = build_manager.setup_build(revision=revision)
   build_directory = environment.get_value('BUILD_DIR')
-  if not build_directory:
+  if not build_setup_result or not build_directory:
     raise CorpusPruningException('Failed to setup build.')
 
   start_time = datetime.datetime.utcnow()

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -595,11 +595,10 @@ def do_corpus_pruning(context, last_execution_failed, revision):
     return tasks_host.do_corpus_pruning(context, last_execution_failed,
                                         revision)
 
-  build_setup_result = build_manager.setup_build(revision=revision)
-  build_directory = environment.get_value('BUILD_DIR')
-  if not build_setup_result or not build_directory:
+  if not build_manager.setup_build(revision=revision):
     raise CorpusPruningException('Failed to setup build.')
 
+  build_directory = environment.get_value('BUILD_DIR')
   start_time = datetime.datetime.utcnow()
   runner = Runner(build_directory, context)
   pruner = CorpusPruner(runner)

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
@@ -119,6 +119,7 @@ class BaseTest(object):
 
   def _mock_setup_build(self, revision=None):
     os.environ['BUILD_DIR'] = os.path.join(TEST_DIR, 'build')
+    return True
 
   def _mock_rsync_to_disk(self, _, sync_dir, timeout=None, delete=None):
     """Mock rsync_to_disk."""


### PR DESCRIPTION
Otherwise we may proceed even if the build actually failed to be set up
(e.g. a broken build on Fuchsia).