### PR TITLE
Simplify utils.decode_to_unicode.

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -104,17 +104,10 @@ def utc_datetime_to_timestamp(dt):
 # potentially indicative of poor tracking of encodings.
 def decode_to_unicode(obj, encoding='utf-8'):
   """Decode object to unicode encoding."""
-  if isinstance(obj, basestring) and not isinstance(obj, str):
-    try:
-      obj = str(obj, encoding)
-    except:
-      obj = str(
-          ''.join(
-              char for char in obj
-              if (char if isinstance(char, int) else ord(char)) < 128),
-          encoding)
+  if not hasattr(obj, 'decode'):
+    return obj
 
-  return obj
+  return obj.decode(encoding, errors='ignore')
 
 
 @retry.wrap(

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -101,12 +101,12 @@ def utc_datetime_to_timestamp(dt):
 
 # TODO(mbarbella): Clean up call-sites and delete this function. Any usage is
 # potentially indicative of poor tracking of encodings.
-def decode_to_unicode(obj, encoding='utf-8'):
+def decode_to_unicode(obj):
   """Decode object to unicode encoding."""
   if not hasattr(obj, 'decode'):
     return obj
 
-  return obj.decode(encoding, errors='ignore')
+  return obj.decode('utf-8', errors='ignore')
 
 
 @retry.wrap(

--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -17,7 +17,6 @@ from builtins import map
 from builtins import range
 from builtins import str
 from future import utils as future_utils
-from past.builtins import basestring
 
 from future import standard_library
 standard_library.install_aliases()


### PR DESCRIPTION
The previous implementation also had a bug, as ''.join did not work for
bytes in Python 3.