### PR TITLE
Fix TypeError exception in leak_blacklist.py

### DIFF
--- a/src/python/fuzzing/leak_blacklist.py
+++ b/src/python/fuzzing/leak_blacklist.py
@@ -33,14 +33,14 @@ STACK_START_REGEX = re.compile(r'^ *#0 ')
 BLANK_LINE_REGEX = re.compile(r'^\s*$')
 
 LSAN_TOOL_NAME = 'lsan'
-LSAN_SUPPRESSION_LINE = b'leak:{function}\n'
-LSAN_HEADER_COMMENT = b'# This is a LSAN suppressions file.\n'
+LSAN_SUPPRESSION_LINE = 'leak:{function}\n'
+LSAN_HEADER_COMMENT = '# This is a LSAN suppressions file.\n'
 
 
 def create_empty_local_blacklist():
   """Creates an empty local blacklist."""
   lsan_suppressions_path = get_local_blacklist_file_path()
-  with open(lsan_suppressions_path, 'wb') as local_blacklist:
+  with open(lsan_suppressions_path, 'w') as local_blacklist:
     # Insert comment on top to avoid parsing errors on empty file.
     local_blacklist.write(LSAN_HEADER_COMMENT)
 

--- a/src/python/fuzzing/leak_blacklist.py
+++ b/src/python/fuzzing/leak_blacklist.py
@@ -73,9 +73,8 @@ def copy_global_to_local_blacklist(excluded_testcase=None):
       get_leak_function_for_blacklist(excluded_testcase)
       if excluded_testcase else None)
 
-  # The local suppressions file should always have a comment on top
-  # to prevent parsing errors.
   with open(lsan_suppressions_path, 'w') as local_blacklist:
+    # Insert comment on top to avoid parsing errors on empty file.
     local_blacklist.write(LSAN_HEADER_COMMENT)
 
     # Copy global blacklist into local blacklist.

--- a/src/python/fuzzing/leak_blacklist.py
+++ b/src/python/fuzzing/leak_blacklist.py
@@ -33,7 +33,8 @@ STACK_START_REGEX = re.compile(r'^ *#0 ')
 BLANK_LINE_REGEX = re.compile(r'^\s*$')
 
 LSAN_TOOL_NAME = 'lsan'
-LSAN_SUPPRESSION_LINE = 'leak:{function}\n'
+LSAN_SUPPRESSION_LINE = b'leak:{function}\n'
+LSAN_HEADER_COMMENT = b'# This is a LSAN suppressions file.\n'
 
 
 def create_empty_local_blacklist():
@@ -41,7 +42,7 @@ def create_empty_local_blacklist():
   lsan_suppressions_path = get_local_blacklist_file_path()
   with open(lsan_suppressions_path, 'wb') as local_blacklist:
     # Insert comment on top to avoid parsing errors on empty file.
-    local_blacklist.write('# This is a LSAN suppressions file.\n')
+    local_blacklist.write(LSAN_HEADER_COMMENT)
 
 
 def cleanup_global_blacklist():
@@ -75,7 +76,7 @@ def copy_global_to_local_blacklist(excluded_testcase=None):
   # The local suppressions file should always have a comment on top
   # to prevent parsing errors.
   with open(lsan_suppressions_path, 'w') as local_blacklist:
-    local_blacklist.write('# This is a LSAN suppressions file.\n')
+    local_blacklist.write(LSAN_HEADER_COMMENT)
 
     # Copy global blacklist into local blacklist.
     global_blacklists = data_types.Blacklist.query(


### PR DESCRIPTION
Fixes:
```
TypeError: a bytes-like object is required, not 'str'
at create_empty_local_blacklist (/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-3-qq49-8/clusterfuzz/src/python/fuzzing/leak_blacklist.py:44)
at execute_task (/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-3-qq49-8/clusterfuzz/src/python/bot/tasks/analyze_task.py:108)
at run_command (/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-3-qq49-8/clusterfuzz/src/python/bot/tasks/commands.py:204)
at process_command (/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-3-qq49-8/clusterfuzz/src/python/bot/tasks/commands.py:378)
at wrapper (/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-3-qq49-8/clusterfuzz/src/python/bot/tasks/commands.py:150)
at task_loop (/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-3-qq49-8/clusterfuzz/src/python/bot/startup/run_bot.py:99)
```