### PR TITLE
Add a config flag to consider all authenticated users privileged.

### DIFF
--- a/configs/test/gae/auth.yaml
+++ b/configs/test/gae/auth.yaml
@@ -31,3 +31,7 @@ whitelisted_cors_urls:
 #  - https?://(.*-dot-)?test-client-site-staging.appspot.com
 #  - https?://(.*-dot-)?test-client-site.appspot.com
 
+# All users are privileged. This should not be used in the majority of cases,
+# and only be turned on when access to the web interface is tightly controlled
+# (e.g. via IAP).
+all_users_privileged: False

--- a/src/appengine/libs/access.py
+++ b/src/appengine/libs/access.py
@@ -29,6 +29,9 @@ from libs.issue_management import issue_tracker_utils
 
 def _is_privileged_user(email):
   """Check if an email is in the privileged users list."""
+  if local_config.AuthConfig().get('all_users_privileged'):
+    return True
+
   privileged_user_emails = (db_config.get_value('privileged_users') or
                             '').splitlines()
   return any(

--- a/src/python/tests/appengine/libs/access_test.py
+++ b/src/python/tests/appengine/libs/access_test.py
@@ -24,6 +24,7 @@ from libs.issue_management import monorail
 from libs.issue_management.monorail import issue
 from libs.issue_management.monorail import issue_tracker_manager
 from tests.test_libs import helpers as test_helpers
+from tests.test_libs import mock_config
 from tests.test_libs import test_utils
 
 
@@ -75,6 +76,14 @@ class IsPrivilegedUserTest(unittest.TestCase):
     self.mock.get_value.return_value = self._FAKE_CONFIG
     self.assertTrue(access._is_privileged_user('test@test.com'))
     self.mock.get_value.assert_has_calls([mock.call('privileged_users')])
+
+  def test_all_users_privileged(self):
+    """Test when all_users_privileged is set."""
+    test_helpers.patch(self, ['config.local_config.AuthConfig'])
+    self.mock.AuthConfig.return_value = mock_config.MockConfig({
+        'all_users_privileged': True,
+    })
+    self.assertTrue(access._is_privileged_user('a@user.com'))
 
 
 class IsDomainAllowedTest(unittest.TestCase):


### PR DESCRIPTION
This should only be used in cases where e.g. IAP is used.