### PR TITLE
Fix an exception when running Antlr under Python 3.

### DIFF
--- a/src/python/base/utils.py
+++ b/src/python/base/utils.py
@@ -99,14 +99,20 @@ def utc_datetime_to_timestamp(dt):
   return (dt - datetime.datetime.utcfromtimestamp(0)).total_seconds()
 
 
-# TODO(mbarbella): Clean up call-sites and delete this function. Any usage is
-# potentially indicative of poor tracking of encodings.
 def decode_to_unicode(obj):
   """Decode object to unicode encoding."""
   if not hasattr(obj, 'decode'):
     return obj
 
   return obj.decode('utf-8', errors='ignore')
+
+
+def encode_as_unicode(obj):
+  """Encode a string as unicode, or leave bytes as they are."""
+  if not hasattr(obj, 'encode'):
+    return obj
+
+  return obj.encode('utf-8')
 
 
 @retry.wrap(

--- a/src/python/bot/minimizer/errors.py
+++ b/src/python/bot/minimizer/errors.py
@@ -33,3 +33,8 @@ class TokenizationFailureError(Exception):
 
   def __init__(self, minimization_type):
     Exception.__init__(self, 'Unable to perform ' + minimization_type + '.')
+
+
+class AntlrDecodeError(Exception):
+  """Raised when Antlr can't minimize input because it is not unicode."""
+  pass

--- a/src/python/bot/minimizer/minimizer.py
+++ b/src/python/bot/minimizer/minimizer.py
@@ -38,11 +38,6 @@ MAX_MERGE_BATCH_SIZE = 32
 PROGRESS_REPORT_INTERVAL = 300
 
 
-class AntlrDecodeError(Exception):
-  """Raised when Antlr can't minimize input because it is not unicode."""
-  pass
-
-
 class DummyLock(object):
   """Dummy to replace threading.Lock for single-threaded tests."""
 
@@ -156,7 +151,7 @@ class Testcase(object):
       try:
         self.tokens = minimizer.tokenizer(data)
       except UnicodeDecodeError:
-        raise AntlrDecodeError
+        raise errors.AntlrDecodeError
     else:
       self.tokens = data
 

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -34,6 +34,7 @@ from bot.fuzzers import engine_common
 from bot.fuzzers.libFuzzer.engine import LibFuzzerEngine
 from bot.minimizer import basic_minimizers
 from bot.minimizer import delta_minimizer
+from bot.minimizer import errors as minimizer_errors
 from bot.minimizer import html_minimizer
 from bot.minimizer import js_minimizer
 from bot.minimizer import minimizer
@@ -1078,7 +1079,7 @@ def do_js_minimization(test_function, get_temp_file, data, deadline, threads,
   try:
     for _ in range(2):
       data = current_minimizer.minimize(data)
-  except minimizer.AntlrDecodeError:
+  except minimizer_errors.AntlrDecodeError:
     data = do_line_minimization(test_function, get_temp_file, data, deadline,
                                 threads, cleanup_interval, delete_temp_files)
 
@@ -1403,7 +1404,7 @@ def do_html_minimization(test_function, get_temp_file, data, deadline, threads,
       progress_report_function=functools.partial(logs.log))
   try:
     return current_minimizer.minimize(data)
-  except minimizer.AntlrDecodeError:
+  except minimizer_errors.AntlrDecodeError:
     return do_line_minimization(test_function, get_temp_file, data, deadline,
                                 threads, cleanup_interval, delete_temp_files)
 

--- a/src/python/bot/tokenizer/antlr_tokenizer.py
+++ b/src/python/bot/tokenizer/antlr_tokenizer.py
@@ -16,6 +16,7 @@
 from builtins import object
 import antlr4
 
+from base import utils
 from bot.minimizer import errors
 
 
@@ -50,4 +51,7 @@ class AntlrTokenizer(object):
 
   def combine(self, tokens):
     """Token combiner passed to minimizer"""
-    return ''.join(tokens)
+    # This tokenizer must handle either bytes or str inputs. Antlr works with
+    # strings, but the tokenizer validation step uses the original data, which
+    # is always raw bytes.
+    return b''.join(utils.encode_as_unicode(t) for t in tokens)

--- a/src/python/bot/tokenizer/antlr_tokenizer.py
+++ b/src/python/bot/tokenizer/antlr_tokenizer.py
@@ -42,7 +42,7 @@ class AntlrTokenizer(object):
     try:
       lexer_input = antlr4.InputStream(data.decode('utf-8'))
     except UnicodeDecodeError:
-      raise errors.TokenizationFailureError('Antlr Tokenizer')
+      raise errors.AntlrDecodeError
 
     stream = antlr4.CommonTokenStream(self._lexer(lexer_input))
     end = self.fill(stream)

--- a/src/python/bot/tokenizer/antlr_tokenizer.py
+++ b/src/python/bot/tokenizer/antlr_tokenizer.py
@@ -16,6 +16,8 @@
 from builtins import object
 import antlr4
 
+from bot.minimizer import errors
+
 
 class AntlrTokenizer(object):
   """Tokenizer. Takes an Antlr Lexer created using
@@ -35,11 +37,14 @@ class AntlrTokenizer(object):
 
   def tokenize(self, data):
     """Takes in a file and uses the antlr lexer to return a list of tokens"""
-    lexer_input = antlr4.InputStream(data)
+    # Antlr expects a string, but test cases are not necessarily valid utf-8.
+    try:
+      lexer_input = antlr4.InputStream(data.decode('utf-8'))
+    except UnicodeDecodeError:
+      raise errors.TokenizationFailureError('Antlr Tokenizer')
+
     stream = antlr4.CommonTokenStream(self._lexer(lexer_input))
-
     end = self.fill(stream)
-
     tokens = stream.getTokens(0, end)
     return [token.text for token in tokens]
 

--- a/src/python/tests/core/bot/minimizer/js_minimizer_test.py
+++ b/src/python/tests/core/bot/minimizer/js_minimizer_test.py
@@ -44,7 +44,7 @@ class JSMinimizerTest(unittest.TestCase):
     """No need to prepare anything, because tests wont be run. Just save what
       tests would have been run to validate that the correct tokens will be
       removed."""
-    text = b''
+    text = ''
     for index in hypothesis:
       text += testcase.tokens[index]
 
@@ -69,7 +69,7 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'if(boolean) {}', self._hypotheses_tested)
+    self.assertIn('if(boolean) {}', self._hypotheses_tested)
 
   def test_try_catch_hypothesis(self):
     """Test that the minimizer successfully removes all of the try/catch
@@ -78,7 +78,7 @@ class JSMinimizerTest(unittest.TestCase):
     data = b'try{ crash() } catch(e){ }'
     self._minimizer.minimize(data)
 
-    self.assertIn(b'try{} catch(e){ }', self._hypotheses_tested)
+    self.assertIn('try{} catch(e){ }', self._hypotheses_tested)
 
   def test_handle_if_else(self):
     """Make sure the minimizer runs all of the other hypothesis cleanly on
@@ -87,8 +87,8 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'if(boolean) {}', self._hypotheses_tested)
-    self.assertIn(b'if(boolean) {} else { do_something_else }',
+    self.assertIn('if(boolean) {}', self._hypotheses_tested)
+    self.assertIn('if(boolean) {} else { do_something_else }',
                   self._hypotheses_tested)
     self.assertIn("if(boolean) {crash} else {}", self._hypotheses_tested)
 
@@ -98,7 +98,7 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'function name(param1, param2){}', self._hypotheses_tested)
+    self.assertIn('function name(param1, param2){}', self._hypotheses_tested)
 
   def test_handle_bracket_with_new_line(self):
     """Test for try/catch with extra whitespace."""
@@ -106,8 +106,8 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'try{}', self._hypotheses_tested)
-    self.assertIn(b'try{}\ncatch(e){\n\n}', self._hypotheses_tested)
+    self.assertIn('try{}', self._hypotheses_tested)
+    self.assertIn('try{}\ncatch(e){\n\n}', self._hypotheses_tested)
 
   def test_handle_function_with_new_lines(self):
     """Test for functions with extra whitespace."""
@@ -115,7 +115,7 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'function name(param1,\n\t\tparam2){}',
+    self.assertIn('function name(param1,\n\t\tparam2){}',
                   self._hypotheses_tested)
 
   def test_remove_outer_paren(self):
@@ -126,7 +126,7 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'assertTrue()', self._hypotheses_tested)
+    self.assertIn('assertTrue()', self._hypotheses_tested)
 
   def test_remove_inside_paren(self):
     """Test that minimizer removes everything between the parentheses.
@@ -135,7 +135,7 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'junk, more_junk', self._hypotheses_tested)
+    self.assertIn('junk, more_junk', self._hypotheses_tested)
 
   def test_remove_paren_to_start_of_line(self):
     """Tests that the minimizer will remove the whole line (including setting
@@ -146,7 +146,7 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'leftover_junk = (function(){\n})', self._hypotheses_tested)
+    self.assertIn('leftover_junk = (function(){\n})', self._hypotheses_tested)
 
   def test_remove_paren_with_attached_brackets(self):
     """Test that the minimizer removes the whole line and following brackets
@@ -156,7 +156,7 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'(function(global) { })(this)', self._hypotheses_tested)
+    self.assertIn('(function(global) { })(this)', self._hypotheses_tested)
 
   def test_remove_left_of_comma(self):
     """Test the minimizer removes the comma and token left of the comma
@@ -165,7 +165,7 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b'whatever,', self._hypotheses_tested)
+    self.assertIn('whatever,', self._hypotheses_tested)
 
   def test_remove_right_of_comma(self):
     """Test the minimizer removes the comma and right of the comma.
@@ -174,4 +174,4 @@ class JSMinimizerTest(unittest.TestCase):
 
     self._minimizer.minimize(data)
 
-    self.assertIn(b', whatever', self._hypotheses_tested)
+    self.assertIn(', whatever', self._hypotheses_tested)

--- a/src/python/tests/core/bot/minimizer/js_minimizer_test.py
+++ b/src/python/tests/core/bot/minimizer/js_minimizer_test.py
@@ -44,7 +44,7 @@ class JSMinimizerTest(unittest.TestCase):
     """No need to prepare anything, because tests wont be run. Just save what
       tests would have been run to validate that the correct tokens will be
       removed."""
-    text = ''
+    text = b''
     for index in hypothesis:
       text += testcase.tokens[index]
 
@@ -55,7 +55,7 @@ class JSMinimizerTest(unittest.TestCase):
 
   def test_minimize_empty_string(self):
     """Minimizer does not break on empty data."""
-    data = ''
+    data = b''
 
     self._minimizer.minimize(data)
 
@@ -65,113 +65,113 @@ class JSMinimizerTest(unittest.TestCase):
     """Test that the minimizer successfully removes all of the if statement
       syntax when it hits a bracket.
       e.g.: if (statement_that_evaluates_to_true) { crash() } -> crash()."""
-    data = "if(boolean) { crash }"
+    data = b'if(boolean) { crash }'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("if(boolean) {}", self._hypotheses_tested)
+    self.assertIn(b'if(boolean) {}', self._hypotheses_tested)
 
   def test_try_catch_hypothesis(self):
     """Test that the minimizer successfully removes all of the try/catch
       syntax when it hits a bracket.
       e.g.: try { crash() } catch(e) {} -> crash()."""
-    data = "try{ crash() } catch(e){ }"
+    data = b'try{ crash() } catch(e){ }'
     self._minimizer.minimize(data)
 
-    self.assertIn("try{} catch(e){ }", self._hypotheses_tested)
+    self.assertIn(b'try{} catch(e){ }', self._hypotheses_tested)
 
   def test_handle_if_else(self):
     """Make sure the minimizer runs all of the other hypothesis cleanly on
       if else."""
-    data = "if(boolean) {crash} else { do_something_else }"
+    data = b'if(boolean) {crash} else { do_something_else }'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("if(boolean) {}", self._hypotheses_tested)
-    self.assertIn("if(boolean) {} else { do_something_else }",
+    self.assertIn(b'if(boolean) {}', self._hypotheses_tested)
+    self.assertIn(b'if(boolean) {} else { do_something_else }',
                   self._hypotheses_tested)
     self.assertIn("if(boolean) {crash} else {}", self._hypotheses_tested)
 
   def test_remove_function_call(self):
     """Test that it removes functions calls effectively."""
-    data = "function name(param1, param2){ stuff inside function }"
+    data = b'function name(param1, param2){ stuff inside function }'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("function name(param1, param2){}", self._hypotheses_tested)
+    self.assertIn(b'function name(param1, param2){}', self._hypotheses_tested)
 
   def test_handle_bracket_with_new_line(self):
     """Test for try/catch with extra whitespace."""
-    data = """try{\n\tcrash()\n}\ncatch(e){\n\n}"""
+    data = b'try{\n\tcrash()\n}\ncatch(e){\n\n}'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("try{}", self._hypotheses_tested)
-    self.assertIn("try{}\ncatch(e){\n\n}", self._hypotheses_tested)
+    self.assertIn(b'try{}', self._hypotheses_tested)
+    self.assertIn(b'try{}\ncatch(e){\n\n}', self._hypotheses_tested)
 
   def test_handle_function_with_new_lines(self):
     """Test for functions with extra whitespace."""
-    data = "function name(param1,\n\t\tparam2){\n\tstuff inside function\n}"
+    data = b'function name(param1,\n\t\tparam2){\n\tstuff inside function\n}'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("function name(param1,\n\t\tparam2){}",
+    self.assertIn(b'function name(param1,\n\t\tparam2){}',
                   self._hypotheses_tested)
 
   def test_remove_outer_paren(self):
     """Test that the minimizer successfully removes all of the outer parens
       to check for nested parens.
       e.g.: assertTrue(crash()); -> crash()."""
-    data = "assertTrue(crash());"
+    data = b'assertTrue(crash());'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("assertTrue()", self._hypotheses_tested)
+    self.assertIn(b'assertTrue()', self._hypotheses_tested)
 
   def test_remove_inside_paren(self):
     """Test that minimizer removes everything between the parentheses.
       e.g.: crash(junk, more_junk) -> crash()."""
-    data = "crash(junk, more_junk)"
+    data = b'crash(junk, more_junk)'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("junk, more_junk", self._hypotheses_tested)
+    self.assertIn(b'junk, more_junk', self._hypotheses_tested)
 
   def test_remove_paren_to_start_of_line(self):
     """Tests that the minimizer will remove the whole line (including setting
       vars) when there are parens.
       e.g.: leftover_junk = (function() {
              });."""
-    data = "leftover_junk = (function(){\n})"
+    data = b'leftover_junk = (function(){\n})'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("leftover_junk = (function(){\n})", self._hypotheses_tested)
+    self.assertIn(b'leftover_junk = (function(){\n})', self._hypotheses_tested)
 
   def test_remove_paren_with_attached_brackets(self):
     """Test that the minimizer removes the whole line and following brackets
       when there are parens.
       e.g.: (function(global) { })(this);."""
-    data = "(function(global) { })(this)"
+    data = b'(function(global) { })(this)'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("(function(global) { })(this)", self._hypotheses_tested)
+    self.assertIn(b'(function(global) { })(this)', self._hypotheses_tested)
 
   def test_remove_left_of_comma(self):
     """Test the minimizer removes the comma and token left of the comma
       e.g.: f(whatever, crash()) -> f(crash())."""
-    data = "f(whatever, crash())"
+    data = b'f(whatever, crash())'
 
     self._minimizer.minimize(data)
 
-    self.assertIn("whatever,", self._hypotheses_tested)
+    self.assertIn(b'whatever,', self._hypotheses_tested)
 
   def test_remove_right_of_comma(self):
     """Test the minimizer removes the comma and right of the comma.
       e.g.: f(crash(),whatever) -> f(crash())."""
-    data = "f(crash(), whatever)"
+    data = b'f(crash(), whatever)'
 
     self._minimizer.minimize(data)
 
-    self.assertIn(", whatever", self._hypotheses_tested)
+    self.assertIn(b', whatever', self._hypotheses_tested)

--- a/src/python/tests/core/bot/tokenizer/antlr_tokenizer_test.py
+++ b/src/python/tests/core/bot/tokenizer/antlr_tokenizer_test.py
@@ -24,7 +24,7 @@ class AntlrTokenizerTest(unittest.TestCase):
   def test_empty_list_on_empty_data(self):
     """Test Tokenizer works on empty list"""
     tokenizer = AntlrTokenizer(JavaScriptLexer)
-    data = ""
+    data = b''
 
     tokens = tokenizer.tokenize(data)
 
@@ -33,7 +33,7 @@ class AntlrTokenizerTest(unittest.TestCase):
   def test_tokenize_simple_js_file(self):
     """Test tokenizer works with sample JS"""
     tokenizer = AntlrTokenizer(JavaScriptLexer)
-    txt = """async function process(array) {
+    txt = b"""async function process(array) {
           for await (let i of array) {
               doSomething(i);
             }
@@ -51,7 +51,7 @@ class AntlrTokenizerTest(unittest.TestCase):
   def test_combine_same_as_orig(self):
     """Tests the token combiner"""
     tokenizer = AntlrTokenizer(JavaScriptLexer)
-    txt = """async function process(array) {
+    txt = b"""async function process(array) {
           for await (let i of array) {
               doSomething(i);
             }
@@ -64,7 +64,7 @@ class AntlrTokenizerTest(unittest.TestCase):
   def test_tokenizes_malformed_without_error(self):
     """Tests tokenizer doesnt error on garbage input"""
     tokenizer = AntlrTokenizer(JavaScriptLexer)
-    txt = "aasdfj1  1jhsdf9 1 3@ 1 + => adj 193"
+    txt = b'aasdfj1  1jhsdf9 1 3@ 1 + => adj 193'
 
     tokens = tokenizer.tokenize(txt)
     self.assertEqual(tokens, [


### PR DESCRIPTION
Mitchel, would you mind taking a look at this? I think we may have had some other check in place to deal with Antlr failing to handle invalid utf-8, but this seems like a cleaner way to handle it which also fixes an issue we're seeing when running with Python 3. If there was another check, I'd like to remove it.