### PR TITLE
Remove log_error on tokenization fail

### DIFF
--- a/src/python/bot/minimizer/minimizer.py
+++ b/src/python/bot/minimizer/minimizer.py
@@ -572,7 +572,8 @@ class Minimizer(object):
       # that had been done up to that point.
       testcase = error.testcase
     except errors.TokenizationFailureError:
-      logs.log_error('Tokenized data did not match original data.')
+      logs.log('Tokenized data did not match original data. Defaulting to line'
+               'minimization.')
       # In situation where the tokenizer does not work, we still want to use
       # the token combiner. This will not change the data unless
       # token combiner changes the data such as appending extra data to the


### PR DESCRIPTION
Let me know if any other changes need to be made to stop TokenizationFailureError from being recorded. 