### PR TITLE
Builds for fuzzers with launcher need to run on trusted host.

### DIFF
--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -1250,7 +1250,11 @@ def setup_regular_build(revision,
   base_build_dir = _base_build_dir(bucket_path)
 
   build_class = RegularBuild
-  if environment.is_trusted_host():
+
+  # Testcases are run on the trusted host when launcher is used. Otherwise,
+  # set up the build on the untrusted worker bot.
+  launcher = environment.get_value('LAUNCHER_PATH')
+  if environment.is_trusted_host() and not launcher:
     from bot.untrusted_runner import build_setup_host
     build_class = build_setup_host.RemoteRegularBuild
   elif environment.platform() == 'FUCHSIA':


### PR DESCRIPTION
This should fix exception
```
Exception occurred when running command: /usr/local/bin/python3.7 /mnt/scratch0/bots/oss-fuzz-linux-zone1-host-high-end-1p1w-5/clusterfuzz/bot/inputs/fuzzers/graphicsfuzz_spirv_fuzzer/spirv_launcher.py /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds-no-engine_graphicsfuzz-spirv_6d5a4ff25b1b5152c6ed7f433ee38aff2a08c2f5/revisions/glslangValidator /mnt/scratch0/bots/oss-fuzz-linux-zone1-host-high-end-1p1w-5/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-36.frag.
Traceback (most recent call last):
  File "/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-high-end-1p1w-5/clusterfuzz/src/python/system/process_handler.py", line 200, in run_process
    start_process(process_handle)
  File "/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-high-end-1p1w-5/clusterfuzz/src/python/system/process_handler.py", line 95, in start_process
    process_handle.run()
  File "/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-high-end-1p1w-5/clusterfuzz/src/third_party/mozprocess/processhandler.py", line 811, in run
    self.proc = self.Process([self.cmd] + self.args, **args)
  File "/mnt/scratch0/bots/oss-fuzz-linux-zone1-host-high-end-1p1w-5/clusterfuzz/src/third_party/mozprocess/processhandler.py", line 123, in __init__
    universal_newlines, startupinfo, creationflags)
  File "/usr/local/lib/python3.7/subprocess.py", line 800, in __init__
    restore_signals, start_new_session)
  File "/usr/local/lib/python3.7/subprocess.py", line 1551, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds-no-engine_graphicsfuzz-spirv_6d5a4ff25b1b5152c6ed7f433ee38aff2a08c2f5/revisions': '/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds-no-engine_graphicsfuzz-spirv_6d5a4ff25b1b5152c6ed7f433ee38aff2a08c2f5/revisions'
```