### PR TITLE
Make launcher script work on OSS-Fuzz.

### DIFF
--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -552,6 +552,15 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
         is_blackbox_fuzzer=True)
     environment.set_value('LAUNCHER_PATH', fuzzer_launcher_path)
 
+    # For launcher script usecase, we need the entire fuzzer directory on the
+    # worker.
+    if environment.is_trusted_host():
+      from bot.untrusted_runner import file_host
+      worker_fuzzer_directory = file_host.rebase_to_worker_root(
+          fuzzer_directory)
+      file_host.copy_directory_to_worker(
+          fuzzer_directory, worker_fuzzer_directory, replace=True)
+
   return True
 
 

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -888,6 +888,7 @@ def get_command_line_for_application(file_to_run='',
   fuzzer_directory = environment.get_value('FUZZER_DIR')
   extension_argument = environment.get_value('EXTENSION_ARG')
   input_directory = environment.get_value('INPUT_DIR')
+  launcher = environment.get_value('LAUNCHER_PATH')
   plt = environment.platform()
   root_directory = environment.get_value('ROOT_DIR')
   temp_directory = environment.get_value('BOT_TMPDIR')
@@ -911,12 +912,11 @@ def get_command_line_for_application(file_to_run='',
   # Start creating the command line.
   command = ''
 
-  launcher = environment.get_value('LAUNCHER_PATH')
-  if environment.is_trusted_host() and not launcher:
-    # Rebase the file_to_run path to the worker's root (unless we're running
-    # under a launcher, which runs on the host).
+  if environment.is_trusted_host():
+    # Rebase the file_to_run and launcher paths to the worker's root.
     from bot.untrusted_runner import file_host
     file_to_run = file_host.rebase_to_worker_root(file_to_run)
+    launcher = file_host.rebase_to_worker_root(launcher)
 
   # Default case.
   testcase_path = file_to_run

--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -126,10 +126,7 @@ def run_process(cmdline,
                 testcase_run=True,
                 ignore_children=True):
   """Executes a process with a given command line and other parameters."""
-  # FIXME(mbarbella): Using LAUNCHER_PATH here is error prone. It forces us to
-  # do certain operations before fuzzer setup (e.g. bad build check).
-  launcher = environment.get_value('LAUNCHER_PATH')
-  if environment.is_trusted_host() and testcase_run and not launcher:
+  if environment.is_trusted_host() and testcase_run:
     from bot.untrusted_runner import remote_process_host
     return remote_process_host.run_process(
         cmdline, current_working_directory, timeout, need_shell, gestures,
@@ -141,6 +138,9 @@ def run_process(cmdline,
   if env_copy:
     os.environ.update(env_copy)
 
+  # FIXME(mbarbella): Using LAUNCHER_PATH here is error prone. It forces us to
+  # do certain operations before fuzzer setup (e.g. bad build check).
+  launcher = environment.get_value('LAUNCHER_PATH')
   # This is used when running scripts on native linux OS and not on the device.
   # E.g. running a fuzzer to generate testcases or launcher script.
   plt = environment.platform()

--- a/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -459,13 +459,15 @@ class UntrustedRunnerIntegrationTest(
         '%s %s %s' % (app_path, worker_file_to_run,
                       utils.file_path_to_file_url(worker_file_to_run)))
 
-    launcher_path = '/path/to/launcher'
+    launcher_path = os.path.join(os.environ['FUZZERS_DIR'], 'test',
+                                 'launcher.py')
     os.environ['LAUNCHER_PATH'] = launcher_path
+    worker_launcher_path = file_host.rebase_to_worker_root(launcher_path)
     command_line = testcase_manager.get_command_line_for_application(
         file_to_run)
     self.assertEqual(
-        command_line,
-        '%s %s %s %s' % (launcher_path, app_path, file_to_run, file_to_run))
+        command_line, '%s %s %s %s' % (worker_launcher_path, app_path,
+                                       worker_file_to_run, worker_file_to_run))
 
   def test_corpus_sync(self):
     """Test syncing corpus."""


### PR DESCRIPTION
Sync fuzzer directory on untrusted worker if we have a launcher
script specified. Also, make sure it executes on the untrusted
worker with correct rebased paths.