### PR TITLE
Fix launcher rebase to worker root.

### DIFF
--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -547,9 +547,8 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
 
   # Setup environment variable for launcher script path.
   if fuzzer.launcher_script:
-    fuzzer_launcher_path = shell.get_execute_command(
-        os.path.join(fuzzer_directory, fuzzer.launcher_script),
-        is_blackbox_fuzzer=True)
+    fuzzer_launcher_path = os.path.join(fuzzer_directory,
+                                        fuzzer.launcher_script)
     environment.set_value('LAUNCHER_PATH', fuzzer_launcher_path)
 
     # For launcher script usecase, we need the entire fuzzer directory on the

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -918,10 +918,6 @@ def get_command_line_for_application(file_to_run='',
     file_to_run = file_host.rebase_to_worker_root(file_to_run)
     launcher = file_host.rebase_to_worker_root(launcher)
 
-  # Add interpreter for launcher script.
-  if launcher:
-    launcher = shell.get_execute_command(launcher, is_blackbox_fuzzer=True)
-
   # Default case.
   testcase_path = file_to_run
   testcase_filename = os.path.basename(testcase_path)
@@ -944,7 +940,9 @@ def get_command_line_for_application(file_to_run='',
       # have app_name == launcher. In this case don't prepend launcher to
       # command - just use app_name.
       if os.path.basename(launcher) != app_name:
-        command += launcher + ' '
+        launcher_with_interpreter = shell.get_execute_command(
+            launcher, is_blackbox_fuzzer=True)
+        command += launcher_with_interpreter + ' '
     elif plt in ['ANDROID']:
       # Android-specific testcase path fixup for fuzzers that don't rely on
       # launcher scripts.

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -912,11 +912,15 @@ def get_command_line_for_application(file_to_run='',
   # Start creating the command line.
   command = ''
 
+  # Rebase the file_to_run and launcher paths to the worker's root.
   if environment.is_trusted_host():
-    # Rebase the file_to_run and launcher paths to the worker's root.
     from bot.untrusted_runner import file_host
     file_to_run = file_host.rebase_to_worker_root(file_to_run)
     launcher = file_host.rebase_to_worker_root(launcher)
+
+  # Add interpreter for launcher script.
+  if launcher:
+    launcher = shell.get_execute_command(launcher, is_blackbox_fuzzer=True)
 
   # Default case.
   testcase_path = file_to_run

--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -307,7 +307,10 @@ def run_process(cmdline,
 
     # If the process is still running, then terminate it.
     if not process_status.finished:
-      if launcher and cmdline.startswith(launcher):
+      launcher_with_interpreter = shell.get_execute_command(
+          launcher, is_blackbox_fuzzer=True) if launcher else None
+      if (launcher_with_interpreter and
+          cmdline.startswith(launcher_with_interpreter)):
         # If this was a launcher script, we KILL all child processes created
         # except for APP_NAME.
         # It is expected that, if the launcher script terminated normally, it

--- a/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/python/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -16,10 +16,10 @@
 import filecmp
 import os
 import shutil
-import subprocess
-import tempfile
-
 import six
+import subprocess
+import sys
+import tempfile
 
 from base import utils
 from bot import testcase_manager
@@ -466,8 +466,9 @@ class UntrustedRunnerIntegrationTest(
     command_line = testcase_manager.get_command_line_for_application(
         file_to_run)
     self.assertEqual(
-        command_line, '%s %s %s %s' % (worker_launcher_path, app_path,
-                                       worker_file_to_run, worker_file_to_run))
+        command_line,
+        '%s %s %s %s %s' % (sys.executable, worker_launcher_path, app_path,
+                            worker_file_to_run, worker_file_to_run))
 
   def test_corpus_sync(self):
     """Test syncing corpus."""


### PR DESCRIPTION
Rebase has to happen on direct path and not one with interpreter.
Add interpreter path (e.g. python) at the point of command line
calculation.

Fixes exception
```
AssertionError: Bad relative path ../../../../../usr/local/bin/python3.7 /mnt/scratch0/bots/oss-fuzz-linux-zone1-host-high-end-1fr1-7/clusterfuzz/bot/inputs/fuzzers/graphicsfuzz_spirv_fuzzer/spirv_launcher.py
```