### PR TITLE
OSS-Fuzz: double REMINDER_INTERVAL in the build status cron.

### DIFF
--- a/src/appengine/handlers/cron/oss_fuzz_build_status.py
+++ b/src/appengine/handlers/cron/oss_fuzz_build_status.py
@@ -54,7 +54,9 @@ NO_BUILDS_THRESHOLD = datetime.timedelta(days=2)
 MIN_CONSECUTIVE_BUILD_FAILURES = 2
 
 # Number of failures after the last reminder/initial filing to send a reminder.
-REMINDER_INTERVAL = 3
+# This used to be 3 days, but now we may have up to two failures a day since
+# https://github.com/google/oss-fuzz/pull/3585 was landed.
+REMINDER_INTERVAL = 6
 
 
 class OssFuzzBuildStatusException(Exception):

--- a/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
+++ b/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
@@ -520,7 +520,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         project_name='proj0',
         last_checked_timestamp=datetime.datetime(2018, 1, 31),
         issue_id='1',
-        consecutive_failures=4,
+        consecutive_failures=7,
         build_type='fuzzing').put()
     data_types.OssFuzzProject(
         id='proj1', name='proj1', ccs=['a@user.com']).put()
@@ -529,7 +529,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         project_name='proj1',
         last_checked_timestamp=datetime.datetime(2018, 1, 31),
         issue_id='2',
-        consecutive_failures=6,
+        consecutive_failures=3,
         build_type='fuzzing').put()
 
     self.itm.issues[1] = Issue()

--- a/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
+++ b/src/python/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
@@ -529,7 +529,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         project_name='proj1',
         last_checked_timestamp=datetime.datetime(2018, 1, 31),
         issue_id='2',
-        consecutive_failures=3,
+        consecutive_failures=6,
         build_type='fuzzing').put()
 
     self.itm.issues[1] = Issue()


### PR DESCRIPTION
After https://github.com/google/oss-fuzz/pull/3585 we will have up to two failures every day instead of just one.

Discussed in https://github.com/google/oss-fuzz/pull/3585#issuecomment-610049558