### PR TITLE
Enforce max_len in corpus pruning task (follow up #1616).

### DIFF
--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -84,8 +84,8 @@ RSS_LIMIT_MB_FLAG = '-rss_limit_mb=%d'
 # Flag to enforce length limit for a single corpus element.
 MAX_LEN_FLAG = '-max_len=%d'
 
-# Flag to disable leak checking.
-DISABLE_LEAK_CHECK_FLAG = '-detect_leaks=0'
+# Flag to control memory leaks detection.
+DETECT_LEAKS_FLAG = '-detect_leaks=%d'
 
 # Flag to do value profile during merges.
 USE_VALUE_PROFILE_FLAG = '-use_value_profile=%d'
@@ -343,6 +343,7 @@ class Runner(object):
     """Get default libFuzzer options."""
     rss_limit = RSS_LIMIT
     max_len = engine_common.CORPUS_INPUT_SIZE_LIMIT
+    detect_leaks = 1
     arguments = [TIMEOUT_FLAG]
 
     if self.fuzzer_options:
@@ -363,11 +364,14 @@ class Runner(object):
 
       # Some targets might falsely report leaks all the time, so allow this to
       # be disabled.
-      detect_leaks = libfuzzer_arguments.get('detect_leaks', default='1')
-      arguments.append('-detect_leaks=%s' % detect_leaks)
+      custom_detect_leaks = libfuzzer_arguments.get(
+          'detect_leaks', constructor=int)
+      if custom_detect_leaks is not None:
+        detect_leaks = custom_detect_leaks
 
     arguments.append(RSS_LIMIT_MB_FLAG % rss_limit)
     arguments.append(MAX_LEN_FLAG % max_len)
+    arguments.append(DETECT_LEAKS_FLAG % detect_leaks)
 
     corpus_size = shell.get_directory_file_count(
         self.context.initial_corpus_path)

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -347,12 +347,10 @@ class Runner(object):
     arguments = [TIMEOUT_FLAG]
 
     if self.fuzzer_options:
-      # Default values from above can be custom for a particular fuzz target.
+      # Default values from above can be customized for a given fuzz target.
       libfuzzer_arguments = self.fuzzer_options.get_engine_arguments(
           'libfuzzer')
 
-      # Allow some flags to be used from .options file for single unit testing.
-      # Allow specifying a lower rss_limit.
       custom_rss_limit = libfuzzer_arguments.get(
           'rss_limit_mb', constructor=int)
       if custom_rss_limit and custom_rss_limit < rss_limit:

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -81,6 +81,9 @@ MAX_QUARANTINE_UNITS_TO_RESTORE = 128
 RSS_LIMIT = 2560
 RSS_LIMIT_MB_FLAG = '-rss_limit_mb=%d'
 
+# Flag to enforce length limit for a single corpus element.
+MAX_LEN_FLAG = '-max_len=%d'
+
 # Flag to disable leak checking.
 DISABLE_LEAK_CHECK_FLAG = '-detect_leaks=0'
 
@@ -338,25 +341,33 @@ class Runner(object):
 
   def get_libfuzzer_flags(self):
     """Get default libFuzzer options."""
+    rss_limit = RSS_LIMIT
+    max_len = engine_common.CORPUS_INPUT_SIZE_LIMIT
+    arguments = [TIMEOUT_FLAG]
+
     if self.fuzzer_options:
+      # Default values from above can be custom for a particular fuzz target.
       libfuzzer_arguments = self.fuzzer_options.get_engine_arguments(
           'libfuzzer')
 
       # Allow some flags to be used from .options file for single unit testing.
       # Allow specifying a lower rss_limit.
-      rss_limit = libfuzzer_arguments.get('rss_limit_mb', constructor=int)
-      if not rss_limit or rss_limit > RSS_LIMIT:
-        rss_limit = RSS_LIMIT
+      custom_rss_limit = libfuzzer_arguments.get(
+          'rss_limit_mb', constructor=int)
+      if custom_rss_limit and custom_rss_limit < rss_limit:
+        rss_limit = custom_rss_limit
+
+      custom_max_len = libfuzzer_arguments.get('max_len', constructor=int)
+      if custom_max_len and custom_max_len < max_len:
+        max_len = custom_max_len
 
       # Some targets might falsely report leaks all the time, so allow this to
       # be disabled.
       detect_leaks = libfuzzer_arguments.get('detect_leaks', default='1')
-      arguments = [
-          RSS_LIMIT_MB_FLAG % rss_limit,
-          '-detect_leaks=%s' % detect_leaks, TIMEOUT_FLAG
-      ]
-    else:
-      arguments = [RSS_LIMIT_MB_FLAG % RSS_LIMIT, TIMEOUT_FLAG]
+      arguments.append('-detect_leaks=%s' % detect_leaks)
+
+    arguments.append(RSS_LIMIT_MB_FLAG % rss_limit)
+    arguments.append(MAX_LEN_FLAG % max_len)
 
     corpus_size = shell.get_directory_file_count(
         self.context.initial_corpus_path)

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_data/build/test_get_libfuzzer_flags.options
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_data/build/test_get_libfuzzer_flags.options
@@ -3,7 +3,7 @@
 # Valid value expected to be used.
 max_len=1337
 
-# Valid value that is not ued by get_libfuzzer_flags.
+# Valid value that is not used by get_libfuzzer_flags.
 timeout=10
 
 # Large value to be ignored as it exceeds the default.
@@ -11,3 +11,6 @@ rss_limit_mb=31337
 
 # Arbitrary option to be ignored, as get_libfuzzer_flags doesn't use all flags.
 close_mask_fd=1
+
+# Valid value that is allowed and should be used.
+detect_leaks=0

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_data/build/test_get_libfuzzer_flags.options
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_data/build/test_get_libfuzzer_flags.options
@@ -1,0 +1,13 @@
+[libfuzzer]
+
+# Valid value expected to be used.
+max_len=1337
+
+# Valid value that is not ued by get_libfuzzer_flags.
+timeout=10
+
+# Large value to be ignored as it exceeds the default.
+rss_limit_mb=31337
+
+# Arbitrary option to be ignored, as get_libfuzzer_flags doesn't use all flags.
+close_mask_fd=1

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
@@ -255,7 +255,7 @@ class CorpusPruningTest(unittest.TestCase, BaseTest):
         os.path.join(self.build_dir, 'test_get_libfuzzer_flags.options'))
     flags = runner.get_libfuzzer_flags()
     expected_custom_flags = [
-        '-timeout=5', '-rss_limit_mb=2560', '-max_len=1337', '-detect_leaks=1',
+        '-timeout=5', '-rss_limit_mb=2560', '-max_len=1337', '-detect_leaks=0',
         '-use_value_profile=1'
     ]
     self.assertCountEqual(flags, expected_custom_flags)


### PR DESCRIPTION
Otherwise the large elements living in GCS (or added there manually) will remain.