### PR TITLE
fuchsia: Return symbolizer output as a string

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -663,7 +663,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.UnicodeProcessRunner,
     # craft one by hand here.
     fuzzer_process_result = new_process.ProcessResult()
     fuzzer_process_result.return_code = 0
-    fuzzer_process_result.output = symbolized_output
+    fuzzer_process_result.output = str(symbolized_output)
     fuzzer_process_result.time_executed = 0
     fuzzer_process_result.command = self.fuzzer.last_fuzz_cmd
     return fuzzer_process_result


### PR DESCRIPTION
Python3 if more opinionated about regex type matching than Python2. The
output of the FuchsiaQemuLiFuzzerRunner's fuzz() result needs to be a
string to be handled properly downstream.