### PR TITLE
[fuchsia] Drop sanitizer suffixes from Zircon fuzzer names

### DIFF
--- a/src/python/platforms/fuchsia/util/fuzzer.py
+++ b/src/python/platforms/fuchsia/util/fuzzer.py
@@ -153,8 +153,11 @@ class Fuzzer(object):
                                           self.tgt)
     self._foreground = foreground
 
+    # Required for backwards compatibility with older builds where Zircon
+    # fuzzers had a sanitizer suffix
     if pkg == 'zircon_fuzzers' and sanitizer:
-      self.tgt += '.' + sanitizer
+      if (pkg, tgt) not in self.host.fuzzers:
+        self.tgt += '.' + sanitizer
 
   def __str__(self):
     return self.pkg + '/' + self.tgt


### PR DESCRIPTION
Due to build changes on the Fuchsia side, Zircon fuzzers no longer end
in e.g. '.asan', so we need to stop appending it unless required for
backwards compatibility with older builds. Prior to this fix, newer
builds were failing to run Zircon fuzzers because the name was now
wrong.