### PR TITLE
Fix Android libFuzzer tests after python 3 migration.

### DIFF
--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1091,21 +1091,21 @@ class AndroidLibFuzzerRunner(new_process.UnicodeProcessRunner, LibFuzzerCommon):
 
   def _copy_local_directories_to_device(self, local_directories):
     """Copies local directories to device."""
-    for local_directory in set(local_directories):
+    for local_directory in sorted(set(local_directories)):
       self._copy_local_directory_to_device(local_directory)
 
   def _copy_local_directory_to_device(self, local_directory):
     """Copy local directory to device."""
     device_directory = self._get_device_path(local_directory)
-    android.adb.remove_directory(device_directory)
+    android.adb.remove_directory(device_directory, recreate=True)
     android.adb.copy_local_directory_to_remote(local_directory,
                                                device_directory)
 
   def _copy_local_directories_from_device(self, local_directories):
     """Copies directories from device to local."""
-    for local_directory in set(local_directories):
+    for local_directory in sorted(set(local_directories)):
       device_directory = self._get_device_path(local_directory)
-      shell.remove_directory(local_directory)
+      shell.remove_directory(local_directory, recreate=True)
       android.adb.copy_remote_directory_to_local(device_directory,
                                                  local_directory)
 
@@ -1357,7 +1357,7 @@ def get_runner(fuzzer_path, temp_dir=None, use_minijail=None, use_unshare=None):
   elif is_android:
     runner = AndroidLibFuzzerRunner(fuzzer_path, build_dir)
   elif use_unshare:
-    runner = UnshareLibFuzzerRunner(fuzzer_path)
+    runner = UnshareLibFuzzerRunner(fuzzer_path)  # pylint: disable=too-many-function-args
   else:
     runner = LibFuzzerRunner(fuzzer_path)
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -909,7 +909,6 @@ class MinijailIntegrationTests(IntegrationTests):
 
   def test_exit_failure_logged(self):
     """Exit failure is not logged in minijail."""
-    pass
 
   @parameterized.parameterized.expand(['1', '77', '27'])
   def test_exit_target_bug_not_logged(self, exit_code):
@@ -980,7 +979,7 @@ class IntegrationTestsFuchsia(BaseIntegrationTest):
     build_manager.setup_build()
 
     _, corpus_path = setup_testcase_and_corpus('aaaa', 'fuchsia_corpus')
-    num_files_original = len([corpfile for corpfile in os.listdir(corpus_path)])
+    num_files_original = len(os.listdir(corpus_path))
     engine_impl = engine.LibFuzzerEngine()
 
     self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(20.0)
@@ -994,10 +993,7 @@ class IntegrationTestsFuchsia(BaseIntegrationTest):
     # Check that the command was invoked with a corpus argument.
     self.assertIn('data/corpus/new', results.command)
     # Check that new units were added to the corpus.
-    num_files_new = len([
-        corpfile
-        for corpfile in os.listdir(os.path.join(TEMP_DIR, 'temp-1337/new'))
-    ])
+    num_files_new = len(os.listdir(os.path.join(TEMP_DIR, 'temp-1337/new')))
     self.assertGreater(num_files_new, num_files_original)
 
   @unittest.skipIf(
@@ -1279,8 +1275,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     test_helpers.patch(self, [
         'bot.fuzzers.dictionary_manager.DictionaryManager.'
         'parse_recommended_dictionary_from_log_lines',
-        'bot.fuzzers.dictionary_manager.DictionaryManager.'
-        'update_recommended_dictionary',
     ])
 
     self.mock.parse_recommended_dictionary_from_log_lines.return_value = set([


### PR DESCRIPTION
Also, fix a bug from directory removal, we need to recreate
directory on removal as otherwise empty directory is not created
on copy from host/device.