### PR TITLE
Set multiprocessing start method to 'spawn'. …

### DIFF
--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -37,6 +37,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import object
 import os
+import multiprocessing
 import time
 import traceback
 
@@ -189,6 +190,7 @@ def main():
 
 
 if __name__ == '__main__':
+  multiprocessing.set_start_method('spawn')
   try:
     with ndb_init.context():
       main()

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -190,7 +190,10 @@ def main():
 
 
 if __name__ == '__main__':
-  multiprocessing.set_start_method('spawn')
+  if sys.version_info.major == 3:
+    # TODO(ochang): Remove check once all migrated to Python 3.
+    multiprocessing.set_start_method('spawn')
+
   try:
     with ndb_init.context():
       main()


### PR DESCRIPTION
This makes things consistent across our platforms and may prevent fork
issues with gRPC (#1750)