### PR TITLE
Fix broken golang parsing with memory sanitizer.

### DIFF
--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -97,7 +97,7 @@ CHROME_MAC_STACK_FRAME_REGEX = re.compile(
     r'([^/\\]+)\s*\+\s*'  # fun (6)
     r'(\d+)')  # off[dec] (7)
 MSAN_TSAN_REGEX = re.compile(
-    r'.*(ThreadSanitizer|MemorySanitizer):[ ]*([^(:]+)')
+    r'.*(ThreadSanitizer|MemorySanitizer):\s+(?!ABRT)(?!ILL)([^(:]+)')
 FATAL_ERROR_CHECK_FAILURE = re.compile(
     r'#\s+(Check failed: |RepresentationChangerError: node #\d+:)?(.*)')
 FATAL_ERROR_DCHECK_FAILURE = re.compile(r'#\s+(Debug check failed: )(.*)')

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_index_out_of_range_with_msan.txt
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/golang_panic_runtime_error_index_out_of_range_with_msan.txt
@@ -1,0 +1,26 @@
+panic: runtime error: index out of range
+goroutine 108 [running]:
+net/http.(*conn).serve.func1(0xc420115a40)
+  /syzkaller/go/src/net/http/server.go:1726 +0xd0
+panic(0xc30720, 0x144ca60)
+  /syzkaller/go/src/runtime/panic.go:502 +0x229
+main.(*Manager).httpPrio(0xc4201dab60, 0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /syzkaller/gopath/src/github.com/google/syzkaller/syz-manager/html.go:298 +0x5f4
+main.(*Manager).(main.httpPrio)-fm(0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /syzkaller/gopath/src/github.com/google/syzkaller/syz-manager/html.go:37 +0x48
+net/http.HandlerFunc.ServeHTTP(0xc420272400, 0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /syzkaller/go/src/net/http/server.go:1947 +0x44
+net/http.(*ServeMux).ServeHTTP(0x2e82ba0, 0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /syzkaller/go/src/net/http/server.go:2337 +0x130
+net/http.serverHandler.ServeHTTP(0xc4203ac000, 0xf2dac0, 0xc4211800e0, 0xc4203bc200)
+  /syzkaller/go/src/net/http/server.go:2694 +0xbc
+net/http.(*conn).serve(0xc420115a40, 0xf2e540, 0xc420134800)
+  /syzkaller/go/src/net/http/server.go:1830 +0x651
+created by net/http.(*Server).Serve
+  /syzkaller/go/src/net/http/server.go:2795 +0x27b
+MemorySanitizer:DEADLYSIGNAL
+==682278==ERROR: MemorySanitizer: ABRT on unknown address 0x0539000a6926 (pc 0x55a0c2ff2761 bp 0x00c0000527e8 sp 0x00c0000527d0 T682278)
+    #0 0x55a0c2ff2761 in runtime.raise /syzkaller/go/gc/src/runtime/sys_linux_amd64.s:165
+MemorySanitizer can not provide additional info.
+SUMMARY: MemorySanitizer: ABRT (/fuzzer+0x1116761)
+==682278==ABORTING

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2652,6 +2652,22 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_golang_panic_runtime_error_index_out_of_range_with_msan(self):
+    """Test golang stacktrace with panic caused by index out of range
+    with memory sanitizer."""
+    data = self._read_test_data(
+        'golang_panic_runtime_error_index_out_of_range_with_msan.txt')
+    expected_type = 'Index out of range'
+    expected_address = ''
+    expected_state = ('http.(*conn).serve.func1\n'
+                      'http.HandlerFunc.ServeHTTP\n'
+                      'http.(*ServeMux).ServeHTTP\n')
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_golang_panic_runtime_error_slice_bounds_out_of_range(self):
     """Test golang stacktrace with panic caused by slice bounds out of range."""
     data = self._read_test_data(


### PR DESCRIPTION
Don't parse ABRT and ILL with MSan,TSan specific regex, leave
them for the generic sanitizer regex where we do check for python
and golang parsed stacks.