### PR TITLE
Capturing syzkaller crashes into appengine

### DIFF
--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -72,7 +72,8 @@ LABELS_FILE_EXTENSION = '.labels'
 COMPONENTS_FILE_EXTENSION = '.components'
 
 # Header format for logs.
-LOG_HEADER_FORMAT = ('Command: {command}\n' 'Bot: {bot}\n' 'Time ran: {time}\n')
+LOG_HEADER_FORMAT = (
+    'Command: {command}\n' + 'Bot: {bot}\n' + 'Time ran: {time}\n')
 
 # Number of radamsa mutations.
 RADAMSA_MUTATIONS = 2000
@@ -100,9 +101,9 @@ def select_generator(strategy_pool, fuzzer_path):
   # These generators don't produce testcases that LPM fuzzers can use.
   if (environment.platform() == 'WINDOWS' or is_lpm_fuzz_target(fuzzer_path)):
     return Generator.NONE
-  elif strategy_pool.do_strategy(strategy.CORPUS_MUTATION_ML_RNN_STRATEGY):
+  if strategy_pool.do_strategy(strategy.CORPUS_MUTATION_ML_RNN_STRATEGY):
     return Generator.ML_RNN
-  elif strategy_pool.do_strategy(strategy.CORPUS_MUTATION_RADAMSA_STRATEGY):
+  if strategy_pool.do_strategy(strategy.CORPUS_MUTATION_RADAMSA_STRATEGY):
     return Generator.RADAMSA
 
   return Generator.NONE
@@ -293,6 +294,9 @@ def find_fuzzer_path(build_directory, fuzzer_name):
   if environment.platform() == 'FUCHSIA':
     # Fuchsia targets are not on disk.
     return fuzzer_name
+
+  if environment.platform() == 'ANDROID_KERNEL':
+    return os.path.join(build_directory, 'syzkaller', 'bin', 'syz-manager')
 
   # TODO(ochang): This is necessary for legacy testcases, which include the
   # project prefix in arguments. Remove this in the near future.

--- a/src/python/bot/fuzzers/syzkaller/constants.py
+++ b/src/python/bot/fuzzers/syzkaller/constants.py
@@ -14,12 +14,9 @@
 """Constants that are meaningful to syzkaller.
 Should not have any dependancies.
 """
-
-# Regex to find testcase path from a crash.
-KASAN_CRASH_TESTCASE_REGEX = (r'.*Test unit written to\s*'
-                              r'(Read|Write) of .*')
-
 SYZKALLER_WORK_FOLDER = '/tmp/syzkaller'
+
+SYZ_REPRO = 'syz-repro'
 
 VMLINUX_FOLDER = '/tmp/syzkaller/vmlinux'
 

--- a/src/python/bot/fuzzers/syzkaller/engine.py
+++ b/src/python/bot/fuzzers/syzkaller/engine.py
@@ -16,6 +16,7 @@
 from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from bot.fuzzers import utils as fuzzer_utils
+from bot.fuzzers.syzkaller import constants
 from bot.fuzzers.syzkaller import runner
 from metrics import profiler
 from system import environment
@@ -46,6 +47,21 @@ class SyzkallerEngine(engine.Engine):
   def name(self):
     return 'syzkaller'
 
+  def prepare_binary_path(self):
+    """Prepares the path for the syzkaller binary
+
+    Returns:
+      The full path of the binary
+    """
+    syzkaller_path = os.path.join(
+        environment.get_value('BUILD_DIR'), 'syzkaller')
+    if not os.path.exists(syzkaller_path):
+      raise SyzkallerError('syzkaller not found in build')
+    binary_folder = os.path.join(syzkaller_path, BIN_FOLDER_PATH)
+    for filename in os.listdir(binary_folder):
+      os.chmod(os.path.join(binary_folder, filename), 0o755)
+    return binary_folder
+
   def prepare(self, corpus_dir, target_path, unused_build_dir):
     """Prepare for a fuzzing session, by generating options and making
     syzkaller binaries executable.
@@ -56,20 +72,15 @@ class SyzkallerEngine(engine.Engine):
       build_dir: Path to the build directory.
 
     Returns:
-      A FuzzOptions object.
-    """
-    syzkaller_path = os.path.join(
-        environment.get_value('BUILD_DIR'), 'syzkaller')
-    if not os.path.exists(syzkaller_path):
-      raise SyzkallerError('syzkaller not found in build')
-    binary_full_path = os.path.join(syzkaller_path, BIN_FOLDER_PATH)
-    for filename in os.listdir(binary_full_path):
-      os.chmod(os.path.join(binary_full_path, filename), 0o755)
-
-    # TODO(hzawawy): Add strategies here
-
-    arguments = runner.get_arguments(target_path)
-    return SyzkallerOptions(corpus_dir, arguments, None, None, None)
+      A FuzzOptions object."""
+    self.prepare_binary_path()
+    config = runner.get_config()
+    return SyzkallerOptions(
+        corpus_dir,
+        config,
+        strategies={},
+        fuzz_corpus_dirs=None,
+        extra_env=None)
 
   def _create_temp_corpus_dir(self, name):
     """Create temporary corpus directory."""
@@ -100,6 +111,7 @@ class SyzkallerEngine(engine.Engine):
 
   def reproduce(self, target_path, input_path, arguments, max_time):
     """Reproduce a crash given an input.
+       Example: ./syz-repro -config my.cfg crash-qemu-1-1455745459265726910
 
     Args:
       target_path: Path to the target.
@@ -110,7 +122,15 @@ class SyzkallerEngine(engine.Engine):
     Returns:
       A ReproduceResult.
     """
-    raise NotImplementedError
+    binary_path = self.prepare_binary_path()
+    syzkaller_runner = runner.get_runner(
+        os.path.join(binary_path, constants.SYZ_REPRO))
+    repro_args = runner.get_config()
+    repro_args.extend(input_path)
+    result = syzkaller_runner.repro(max_time, repro_args=repro_args)
+
+    return engine.ReproduceResult(result.command, result.return_code,
+                                  result.time_executed, result.output)
 
   def minimize_corpus(self, target_path, arguments, input_dirs, output_dir,
                       unused_reproducers_dir, unused_max_time):

--- a/src/python/bot/fuzzers/syzkaller/runner.py
+++ b/src/python/bot/fuzzers/syzkaller/runner.py
@@ -112,8 +112,8 @@ class AndroidSyzkallerRunner(new_process.ProcessRunner):
       for file in files:
         # Each crash typically have 2 files: reportN and logN. Similar crashes
         # are grouped together in subfolders. unique_crash puts together the
-        # subfolder name (without './' (hence the [2:])) and reportN.
-        unique_crash = subdir[len('./'):] + file
+        # subfolder name and reportN.
+        unique_crash = os.path.join(subdir, file)
         if fnmatch.fnmatch(file, 'report*') and unique_crash not in visited:
           visited.add(unique_crash)
           log_lines = utils.read_data_from_file(

--- a/src/python/bot/fuzzers/syzkaller/runner.py
+++ b/src/python/bot/fuzzers/syzkaller/runner.py
@@ -84,7 +84,6 @@ class AndroidSyzkallerRunner(new_process.ProcessRunner):
     """
     logs.log('Running Syzkaller testcase.')
     additional_args = copy.copy(repro_args)
-    repro_timeout = 30
     result = self.run_and_wait(additional_args, timeout=repro_timeout)
     logs.log('Syzkaller testcase stopped.')
     return engine.ReproduceResult(result.command, result.return_code,
@@ -104,7 +103,6 @@ class AndroidSyzkallerRunner(new_process.ProcessRunner):
     """
     logs.log('Running Syzkaller!')
     additional_args = copy.copy(additional_args)
-    fuzz_timeout = 30
     fuzz_result = self.run_and_wait(additional_args, timeout=fuzz_timeout)
     logs.log('Syzkaller Stopped! Fuzzing timed out: {}'.format(fuzz_timeout))
     fuzz_logs = ''

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1458,7 +1458,7 @@ class FuzzingSession(object):
         logs.log_error(
             'Fuzzer %s does not have an executable path.' % fuzzer_name)
         error_occurred = True
-        return error_occurred, None, None, None, None
+        return error_occurred, None, None, None
 
       # Get the fuzzer executable and chdir to its base directory. This helps to
       # prevent referencing every file using __file__.
@@ -1907,7 +1907,7 @@ class FuzzingSession(object):
     platform_id = environment.get_platform_id()
 
     # For Android, bring back device to a good state before analyzing crashes.
-    if platform == 'ANDROID' and crashes:
+    if (platform in ('ANDROID', 'ANDROID-KERNEL')) and crashes:
       # Remove this variable so that application is fully shutdown before every
       # re-run of testcase. This is critical for reproducibility.
       environment.remove_key('CHILD_PROCESS_TERMINATION_PATTERN')

--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -175,7 +175,7 @@ def run_platform_init_scripts():
   plt = environment.platform()
   if plt in ('ANDROID', 'ANDROID_KERNEL'):
     android_init.run()
-  if plt == 'CHROMEOS':
+  elif plt == 'CHROMEOS':
     chromeos_init.run()
   elif plt == 'FUCHSIA':
     fuchsia_init.run()

--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -175,7 +175,7 @@ def run_platform_init_scripts():
   plt = environment.platform()
   if plt in ('ANDROID', 'ANDROID_KERNEL'):
     android_init.run()
-  elif plt == 'CHROMEOS':
+  if plt == 'CHROMEOS':
     chromeos_init.run()
   elif plt == 'FUCHSIA':
     fuchsia_init.run()

--- a/src/python/platforms/android/settings.py
+++ b/src/python/platforms/android/settings.py
@@ -132,6 +132,8 @@ def get_sanitizer_tool_name():
   build_flavor = get_build_flavor()
   if 'hwasan' in build_flavor:
     return 'hwasan'
+  if 'kasan' in build_flavor:
+    return 'kasan'
   if 'asan' in build_flavor:
     return 'asan'
 
@@ -155,7 +157,7 @@ def is_google_device():
   if product_brand is None:
     return None
 
-  return product_brand == 'google' or product_brand == 'generic'
+  return product_brand in ('google', 'generic')
 
 
 def set_content_setting(table, key, value):


### PR DESCRIPTION
This PR is a replacement of 1777. The change is a follow up on the initial work to add syzkaller as a fuzzing engine on clusterfuzz. This change captures crashes and upload them as testcases to appengine. It is tested by adding a new syzkaller job, associating it with syzkaller fuzzer, and running it locally, crashes showed up on http://0.0.0.0:9000/testcases