### PR TITLE
Fix BuildNotFoundError due to stale last_progression_max.

### DIFF
--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -252,6 +252,16 @@ def find_fixed_range(testcase_id, job_type):
   # if it timed out.
   min_revision = testcase.get_metadata('last_progression_min')
   max_revision = testcase.get_metadata('last_progression_max')
+
+  if min_revision or max_revision:
+    # Clear these to avoid using them in next run. If this run fails, then we
+    # should try next run without them to see it succeeds. If this run succeeds,
+    # we should still clear them to avoid capping max revision in next run.
+    testcase = data_handler.get_testcase_by_id(testcase_id)
+    testcase.delete_metadata('last_progression_min', update_testcase=False)
+    testcase.delete_metadata('last_progression_max', update_testcase=False)
+    testcase.put()
+
   last_tested_revision = testcase.get_metadata('last_tested_crash_revision')
   known_crash_revision = last_tested_revision or testcase.crash_revision
   if not min_revision:

--- a/src/python/bot/tasks/regression_task.py
+++ b/src/python/bot/tasks/regression_task.py
@@ -254,16 +254,6 @@ def find_regression_range(testcase_id, job_type):
   # Pick up where left off in a previous run if necessary.
   min_revision = testcase.get_metadata('last_regression_min')
   max_revision = testcase.get_metadata('last_regression_max')
-
-  if min_revision or max_revision:
-    # Clear these to avoid using them in next run. If this run fails, then we
-    # should try next run without them to see it succeeds. If this run succeeds,
-    # we should still clear them to avoid capping max revision in next run.
-    testcase = data_handler.get_testcase_by_id(testcase_id)
-    testcase.delete_metadata('last_regression_min', update_testcase=False)
-    testcase.delete_metadata('last_regression_max', update_testcase=False)
-    testcase.put()
-
   first_run = not min_revision and not max_revision
   if not min_revision:
     min_revision = revisions.get_first_revision_in_list(revision_list)

--- a/src/python/bot/tasks/regression_task.py
+++ b/src/python/bot/tasks/regression_task.py
@@ -254,6 +254,16 @@ def find_regression_range(testcase_id, job_type):
   # Pick up where left off in a previous run if necessary.
   min_revision = testcase.get_metadata('last_regression_min')
   max_revision = testcase.get_metadata('last_regression_max')
+
+  if min_revision or max_revision:
+    # Clear these to avoid using them in next run. If this run fails, then we
+    # should try next run without them to see it succeeds. If this run succeeds,
+    # we should still clear them to avoid capping max revision in next run.
+    testcase = data_handler.get_testcase_by_id(testcase_id)
+    testcase.delete_metadata('last_regression_min', update_testcase=False)
+    testcase.delete_metadata('last_regression_max', update_testcase=False)
+    testcase.put()
+
   first_run = not min_revision and not max_revision
   if not min_revision:
     min_revision = revisions.get_first_revision_in_list(revision_list)


### PR DESCRIPTION
last_progression_max was stuck on testcase forever. This causes
progression task to run on stale revisions. On google instance,
when builds had log rotation, this caused exceptions to occur.