### PR TITLE
Fix type of security flag in bisection pubsub message.

### DIFF
--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -295,5 +295,5 @@ def request_bisection(testcase, bisect_type):
               'crash_type':
                   testcase.crash_type,
               'security':
-                  testcase.security_flag,
+                  str(testcase.security_flag),
           }))

--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Common functions for task creation for test cases."""
 
+from builtins import str
+
 from base import tasks
 from base import utils
 from build_management import build_manager

--- a/src/python/tests/core/bot/tasks/task_creation_test.py
+++ b/src/python/tests/core/bot/tasks/task_creation_test.py
@@ -72,7 +72,7 @@ class RequestBisectionTest(unittest.TestCase):
     self.assertEqual(b'reproducer', message.data)
     self.assertDictEqual({
         'crash_type': 'crash-type',
-        'security': True,
+        'security': 'True',
         'fuzz_target': 'target',
         'new_commit': 'new',
         'old_commit': 'old',


### PR DESCRIPTION
Attribute values have to be strings.