### PR TITLE
Support multiple project setup configurations.

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -933,7 +933,7 @@ class Handler(base_handler.Handler):
           BUILD_BUCKET_PATH_TEMPLATE,
           REVISION_URL,
           setup_config.get('build_type'),
-          config_suffix=setup_config.get('suffix', ''),
+          config_suffix=setup_config.get('job_suffix', ''),
           segregate_projects=setup_config.get('segregate_projects', False),
           engine_build_buckets={
               'libfuzzer': bucket_config.get('libfuzzer'),

--- a/src/python/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/python/tests/appengine/handlers/cron/project_setup_test.py
@@ -1656,7 +1656,7 @@ class GenericProjectSetupTest(unittest.TestCase):
             },
             {
                 'source': 'gs://bucket-dbg/projects.json',
-                'suffix': '_dbg',
+                'job_suffix': '_dbg',
                 'build_type': 'FUZZ_TARGET_BUILD_BUCKET_PATH',
                 'build_buckets': {
                     'afl': 'clusterfuzz-builds-afl-dbg',


### PR DESCRIPTION
- Make the project_setup section of project.yaml be a list instead.
- Add a config_suffix option as well to append to job names.