### PR TITLE
Move pyOpenSSL from appengine to general requirements.txt

### DIFF
--- a/src/appengine/requirements.txt
+++ b/src/appengine/requirements.txt
@@ -2,7 +2,6 @@ firebase-admin==2.16.0
 Jinja2==2.11.1
 jira==2.0.0
 PyJWT==1.7.1
-pyOpenSSL==19.1.0
 requests-toolbelt==0.9.1
 sendgrid==6.0.4
 webapp2==3.0.0b1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,6 +20,7 @@ lxml==4.5.0
 mozprocess==1.1.0
 oauth2client==4.1.3
 protobuf==3.11.3
+pyOpenSSL==19.1.0
 python-dateutil==2.8.1
 pytz==2018.5
 PyYAML==5.1


### PR DESCRIPTION
This is needed for fetch_artifact on bots.