### PR TITLE
Extend crash comparer to catch some cases of shifting frames.

### DIFF
--- a/src/python/crash_analysis/crash_comparer.py
+++ b/src/python/crash_analysis/crash_comparer.py
@@ -53,9 +53,20 @@ def _similarity_ratio(string_1, string_2):
       1.0 * length_sum)
 
 
+def count_same_frames(first_frames, second_frames):
+  """Count number of frames which are the same (disregarding order)."""
+  same_count = 0
+  for frame in first_frames:
+    if frame in second_frames:
+      same_count += 1
+
+  return same_count
+
+
 class CrashComparer(object):
   """Compares two crash results."""
   COMPARE_THRESHOLD = 0.8
+  SAME_FRAMES_THRESHOLD = 2
 
   def __init__(self, crash_state_1, crash_state_2, compare_threshold=None):
     self.crash_state_1 = crash_state_1
@@ -81,6 +92,10 @@ class CrashComparer(object):
     # stacktrace.
     crash_state_lines_1 = self.crash_state_1.splitlines()
     crash_state_lines_2 = self.crash_state_2.splitlines()
+
+    if (count_same_frames(crash_state_lines_1, crash_state_lines_2) >=
+        self.SAME_FRAMES_THRESHOLD):
+      return True
 
     lines_compared = 0
     similarity_ratio_sum = 0.0

--- a/src/python/crash_analysis/crash_comparer.py
+++ b/src/python/crash_analysis/crash_comparer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Functions for helping in crash comparison."""
+# pylint: disable=consider-using-enumerate
 from __future__ import division
 from builtins import object
 from builtins import range
@@ -22,9 +23,9 @@ def _levenshtein_distance(string_1, string_2):
   based on Wikipedia article and code by Christopher P. Matthews."""
   if string_1 == string_2:
     return 0
-  elif not string_1:
+  if not string_1:
     return len(string_2)
-  elif not string_2:
+  if not string_2:
     return len(string_1)
 
   v0 = list(range(len(string_2) + 1))

--- a/src/python/crash_analysis/crash_comparer.py
+++ b/src/python/crash_analysis/crash_comparer.py
@@ -53,14 +53,21 @@ def _similarity_ratio(string_1, string_2):
       1.0 * length_sum)
 
 
-def count_same_frames(first_frames, second_frames):
-  """Count number of frames which are the same (disregarding order)."""
-  same_count = 0
-  for frame in first_frames:
-    if frame in second_frames:
-      same_count += 1
+def longest_common_subsequence(first_frames, second_frames):
+  """Count number of frames which are the same (taking into account order)."""
+  first_len = len(first_frames)
+  second_len = len(second_frames)
 
-  return same_count
+  solution = [[0 for _ in range(second_len + 1)] for _ in range(first_len + 1)]
+
+  for i in range(1, first_len + 1):
+    for j in range(1, second_len + 1):
+      if first_frames[i - 1] == second_frames[j - 1]:
+        solution[i][j] = solution[i - 1][j - 1] + 1
+      else:
+        solution[i][j] = max(solution[i - 1][j], solution[i][j - 1])
+
+  return solution[first_len][second_len]
 
 
 class CrashComparer(object):
@@ -93,7 +100,7 @@ class CrashComparer(object):
     crash_state_lines_1 = self.crash_state_1.splitlines()
     crash_state_lines_2 = self.crash_state_2.splitlines()
 
-    if (count_same_frames(crash_state_lines_1, crash_state_lines_2) >=
+    if (longest_common_subsequence(crash_state_lines_1, crash_state_lines_2) >=
         self.SAME_FRAMES_THRESHOLD):
       return True
 

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -336,6 +336,7 @@ STACK_FRAME_IGNORE_REGEXES = [
     # Function names (exact match).
     r'^abort$',
     r'^exit$',
+    r'^pthread\_create$'
     r'^pthread\_kill$',
     r'^raise$',
     r'^tgkill$',
@@ -408,6 +409,7 @@ STACK_FRAME_IGNORE_REGEXES = [
     r'^alloc\:\:',
     r'^android\.app\.ActivityManagerProxy\.',
     r'^android\.os\.Parcel\.',
+    r'^art\:\:Thread\:\:CreateNativeThread'
     r'^asan\_',
     r'^calloc',
     r'^check\_memory\_region',

--- a/src/python/tests/core/crash_analysis/crash_comparer_test.py
+++ b/src/python/tests/core/crash_analysis/crash_comparer_test.py
@@ -67,3 +67,9 @@ class CrashComparerTest(unittest.TestCase):
                      'base::debug::DebugBreak\n'
                      'gpu::gles2::GLES2Util::GLFaceTargetToTextureTarget\n')
     self.is_similar_helper(crash_state_1, crash_state_2, False)
+
+  def test_is_similar_shifted(self):
+    """Test similar when frames have shifted slightly."""
+    crash_state_1 = ('first\n' 'second\n' 'third\n')
+    crash_state_2 = ('second\n' 'third\n' 'fourth\n')
+    self.is_similar_helper(crash_state_1, crash_state_2, True)

--- a/src/python/tests/core/crash_analysis/crash_comparer_test.py
+++ b/src/python/tests/core/crash_analysis/crash_comparer_test.py
@@ -73,3 +73,15 @@ class CrashComparerTest(unittest.TestCase):
     crash_state_1 = ('first\n' 'second\n' 'third\n')
     crash_state_2 = ('second\n' 'third\n' 'fourth\n')
     self.is_similar_helper(crash_state_1, crash_state_2, True)
+
+  def test_only_one_frame_matching(self):
+    """Test not similar when 1/3 frames match."""
+    crash_state_1 = ('first\n' 'second\n' 'third\n')
+    crash_state_2 = ('second\n' 'fourth\n' 'fifth\n')
+    self.is_similar_helper(crash_state_1, crash_state_2, False)
+
+  def test_is_same_frames_wrong_order(self):
+    """Test not similar when some frames match but the order doesn't match."""
+    crash_state_1 = ('first\n' 'second\n' 'third\n')
+    crash_state_2 = ('second\n' 'first\n' 'fourth\n')
+    self.is_similar_helper(crash_state_1, crash_state_2, False)

--- a/src/python/tests/core/crash_analysis/crash_comparer_test.py
+++ b/src/python/tests/core/crash_analysis/crash_comparer_test.py
@@ -70,18 +70,36 @@ class CrashComparerTest(unittest.TestCase):
 
   def test_is_similar_shifted(self):
     """Test similar when frames have shifted slightly."""
-    crash_state_1 = ('first\n' 'second\n' 'third\n')
-    crash_state_2 = ('second\n' 'third\n' 'fourth\n')
+    crash_state_1 = 'first\nsecond\nthird\n'
+    crash_state_2 = 'second\nthird\nfourth\n'
+    self.is_similar_helper(crash_state_1, crash_state_2, True)
+
+    crash_state_2 = 'first\nthird\nfourth'
+    self.is_similar_helper(crash_state_1, crash_state_2, True)
+
+    crash_state_2 = 'first\nsecond\nfourth'
+    self.is_similar_helper(crash_state_1, crash_state_2, True)
+
+    crash_state_2 = 'first\nthird'
+    self.is_similar_helper(crash_state_1, crash_state_2, True)
+
+    crash_state_2 = 'other\nsecond\nthird'
     self.is_similar_helper(crash_state_1, crash_state_2, True)
 
   def test_only_one_frame_matching(self):
     """Test not similar when 1/3 frames match."""
-    crash_state_1 = ('first\n' 'second\n' 'third\n')
-    crash_state_2 = ('second\n' 'fourth\n' 'fifth\n')
+    crash_state_1 = 'first\nsecond\nthird\n'
+    crash_state_2 = 'second\nfourth\nfifth\n'
+    self.is_similar_helper(crash_state_1, crash_state_2, False)
+
+    crash_state_2 = 'first\nfourth\nfifth\n'
     self.is_similar_helper(crash_state_1, crash_state_2, False)
 
   def test_is_same_frames_wrong_order(self):
     """Test not similar when some frames match but the order doesn't match."""
-    crash_state_1 = ('first\n' 'second\n' 'third\n')
-    crash_state_2 = ('second\n' 'first\n' 'fourth\n')
+    crash_state_1 = 'first\nsecond\nthird\n'
+    crash_state_2 = 'second\nfirst\nfourth\n'
+    self.is_similar_helper(crash_state_1, crash_state_2, False)
+
+    crash_state_2 = 'third\nsecond\nfirst\n'
     self.is_similar_helper(crash_state_1, crash_state_2, False)


### PR DESCRIPTION
If 2 out of 3 frames match (in the same order), consider the crash similar. This can catch
cases where a function is inlined in one build but not in another.