### PR TITLE
Fixed Linting Issues in src/appengine

### DIFF
--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -64,13 +64,13 @@ class JsonEncoder(json.JSONEncoder):
       dict_obj = obj.to_dict()
       dict_obj['id'] = obj.key.id()
       return dict_obj
-    elif isinstance(obj, datetime.datetime):
+    if isinstance(obj, datetime.datetime):
       return int((obj - self._EPOCH).total_seconds())
-    elif hasattr(obj, 'to_dict'):
+    if hasattr(obj, 'to_dict'):
       return obj.to_dict()
-    elif isinstance(obj, cgi.FieldStorage):
+    if isinstance(obj, cgi.FieldStorage):
       return str(obj)
-    elif isinstance(obj, bytes):
+    if isinstance(obj, bytes):
       return obj.decode('utf-8')
 
     return json.JSONEncoder.default(self, obj)
@@ -243,7 +243,7 @@ class Handler(webapp2.RequestHandler):
           self.response.headers.get('Content-Type')):
         self.render_json(values, status)
       else:
-        if status == 403 or status == 401:
+        if status in (403, 401):
           self.render_forbidden(str(exception))
         else:
           self.render('error.html', values, status)

--- a/src/appengine/handlers/cron/manage_vms.py
+++ b/src/appengine/handlers/cron/manage_vms.py
@@ -374,7 +374,7 @@ class OssFuzzClustersManager(ClustersManager):
       available_cpus -= cpus_allocated
 
     if available_cpus:
-      logging.warn('%d CPUs are not being used.', available_cpus)
+      logging.warning('%d CPUs are not being used.', available_cpus)
 
     return cpu_count
 
@@ -394,7 +394,7 @@ class OssFuzzClustersManager(ClustersManager):
     #   order).
     # This should ensure that a worker is reassigned only if it was
     # reimaged/new.
-    current_worker_names = set([worker.name for worker in worker_instances])
+    current_worker_names = {worker.name for worker in worker_instances}
     previous_assigned_workers = set()
 
     new_assignments = []
@@ -505,7 +505,7 @@ class OssFuzzClustersManager(ClustersManager):
       service_account = project.service_account
       tls_cert = ndb.Key(data_types.WorkerTlsCert, project.name).get()
       if not tls_cert:
-        logging.warn('TLS certs not set up yet for %s.', project.name)
+        logging.warning('TLS certs not set up yet for %s.', project.name)
         return
 
     cluster_info = project_info.get_cluster_info(cluster.name)

--- a/src/appengine/handlers/fuzzer_stats.py
+++ b/src/appengine/handlers/fuzzer_stats.py
@@ -19,7 +19,7 @@ standard_library.install_aliases()
 from builtins import object
 from builtins import str
 
-import cgi
+import html
 import datetime
 import re
 import six
@@ -73,7 +73,7 @@ class BuiltinField(object):
 def _bigquery_type_to_charts_type(typename):
   """Convert bigquery type to charts type."""
   typename = typename.lower()
-  if typename == 'integer' or typename == 'float':
+  if typename in ('integer', 'float'):
     return 'number'
 
   if typename == 'timestamp':
@@ -84,7 +84,7 @@ def _bigquery_type_to_charts_type(typename):
 
 def _python_type_to_charts_type(type_value):
   """Convert bigquery type to charts type."""
-  if type_value == int or type_value == float or type_value == float:
+  if type_value in (int, float):
     return 'number'
 
   if type_value == datetime.date:
@@ -150,13 +150,13 @@ def _parse_group_by(group_by):
   """Parse group_by value."""
   if group_by == 'by-day':
     return fuzzer_stats.QueryGroupBy.GROUP_BY_DAY
-  elif group_by == 'by-time':
+  if group_by == 'by-time':
     return fuzzer_stats.QueryGroupBy.GROUP_BY_TIME
-  elif group_by == 'by-revision':
+  if group_by == 'by-revision':
     return fuzzer_stats.QueryGroupBy.GROUP_BY_REVISION
-  elif group_by == 'by-job':
+  if group_by == 'by-job':
     return fuzzer_stats.QueryGroupBy.GROUP_BY_JOB
-  elif group_by == 'by-fuzzer':
+  if group_by == 'by-fuzzer':
     return fuzzer_stats.QueryGroupBy.GROUP_BY_FUZZER
 
   return None
@@ -195,7 +195,7 @@ def _parse_stats_column_descriptions(stats_column_descriptions):
   try:
     result = yaml.safe_load(stats_column_descriptions)
     for key, value in six.iteritems(result):
-      result[key] = cgi.escape(value)
+      result[key] = html.escape(value)
 
     return result
   except yaml.parser.ParserError:
@@ -444,7 +444,7 @@ class LoadFiltersHandler(base_handler.Handler):
 
       jobs_list = sorted(external_users.allowed_jobs_for_user(user_email))
       projects_list = sorted(
-          set([data_handler.get_project_name(job) for job in jobs_list]))
+          {data_handler.get_project_name(job) for job in jobs_list})
 
     result = {
         'projects': projects_list,

--- a/src/appengine/handlers/fuzzer_stats.py
+++ b/src/appengine/handlers/fuzzer_stats.py
@@ -19,8 +19,8 @@ standard_library.install_aliases()
 from builtins import object
 from builtins import str
 
-import html
 import datetime
+import html
 import re
 import six
 import urllib.parse

--- a/src/appengine/handlers/testcase_detail/testcase_variants.py
+++ b/src/appengine/handlers/testcase_detail/testcase_variants.py
@@ -27,11 +27,11 @@ class Handler(base_handler.Handler):
       """Return status for display."""
       if status == data_types.TestcaseVariantStatus.PENDING:
         return 'Pending'
-      elif status == data_types.TestcaseVariantStatus.REPRODUCIBLE:
+      if status == data_types.TestcaseVariantStatus.REPRODUCIBLE:
         return 'Reproducible'
-      elif status == data_types.TestcaseVariantStatus.FLAKY:
+      if status == data_types.TestcaseVariantStatus.FLAKY:
         return 'Flaky'
-      elif status == data_types.TestcaseVariantStatus.UNREPRODUCIBLE:
+      if status == data_types.TestcaseVariantStatus.UNREPRODUCIBLE:
         return 'Unreproducible'
 
       return 'Unknown'

--- a/src/appengine/libs/filters.py
+++ b/src/appengine/libs/filters.py
@@ -58,10 +58,9 @@ def get_boolean(value):
   """Convert yes/no to boolean or raise Exception."""
   if value == 'yes':
     return True
-  elif value == 'no':
+  if value == 'no':
     return False
-  else:
-    raise ValueError("The value must be 'yes' or 'no'.")
+  raise ValueError("The value must be 'yes' or 'no'.")
 
 
 def get_string(value):

--- a/src/appengine/libs/filters.py
+++ b/src/appengine/libs/filters.py
@@ -50,8 +50,7 @@ def extract_keyword_field(keyword, field):
     elif value.startswith("'") and value.endswith("'"):
       value = value.strip("'")
     return re.sub(regex, ' ', keyword), value
-  else:
-    return keyword, None
+  return keyword, None
 
 
 def get_boolean(value):

--- a/src/appengine/libs/helpers.py
+++ b/src/appengine/libs/helpers.py
@@ -31,7 +31,6 @@ TTL_IN_SECONDS = 15 * 60
 
 class _DoNotCatchException(Exception):
   """Serve as a dummy exception to avoid catching any exception."""
-  pass
 
 
 class EarlyExitException(Exception):
@@ -145,8 +144,7 @@ def get_or_exit(fn,
 
   if non_empty_fn(result):
     return result
-  else:
-    raise EarlyExitException(not_found_message, 404)
+  raise EarlyExitException(not_found_message, 404)
 
 
 def get_user_email():

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -113,7 +113,7 @@ class Issue(issue_tracker.Issue):
     """The issue component list."""
     return self._components
 
-  def save(self):
+  def save(self, new_comment=None, notify=True): # pylint: disable=unused-argument
     """Save the issue."""
     for added in self._components.added:
       self.components.add(added)
@@ -134,6 +134,14 @@ class Issue(issue_tracker.Issue):
     self._labels.reset_tracking()
 
     self.itm.save(self)
+
+  def actions(self):
+    # To prevent abstract exception.
+    return
+
+  def merged_into(self):
+    # To prevent abstract exception.
+    return
 
 
 class IssueTracker(issue_tracker.IssueTracker):
@@ -171,6 +179,10 @@ class IssueTracker(issue_tracker.IssueTracker):
     config = db_config.get()
     url = config.jira_url + '/browse/' + str(issue_id)
     return url
+
+  def find_issues_url(self, keywords=None, only_open=None): # pylint: disable=unused-argument
+    # To prevent abstract exception.
+    return
 
 
 def _get_issue_tracker_manager_for_project(project_name):

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -113,7 +113,7 @@ class Issue(issue_tracker.Issue):
     """The issue component list."""
     return self._components
 
-  def save(self, new_comment=None, notify=True): # pylint: disable=unused-argument
+  def save(self, new_comment=None, notify=True):  # pylint: disable=unused-argument
     """Save the issue."""
     for added in self._components.added:
       self.components.add(added)
@@ -180,7 +180,7 @@ class IssueTracker(issue_tracker.IssueTracker):
     url = config.jira_url + '/browse/' + str(issue_id)
     return url
 
-  def find_issues_url(self, keywords=None, only_open=None): # pylint: disable=unused-argument
+  def find_issues_url(self, keywords=None, only_open=None):  # pylint: disable=unused-argument
     # To prevent abstract exception.
     return
 

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -113,6 +113,7 @@ class Issue(issue_tracker.Issue):
     """The issue component list."""
     return self._components
 
+  # FIXME: Add support for new_comment and notify arguments
   def save(self, new_comment=None, notify=True):  # pylint: disable=unused-argument
     """Save the issue."""
     for added in self._components.added:
@@ -136,12 +137,10 @@ class Issue(issue_tracker.Issue):
     self.itm.save(self)
 
   def actions(self):
-    # To prevent abstract exception.
-    return
+    pass
 
   def merged_into(self):
-    # To prevent abstract exception.
-    return
+    pass
 
 
 class IssueTracker(issue_tracker.IssueTracker):
@@ -180,9 +179,9 @@ class IssueTracker(issue_tracker.IssueTracker):
     url = config.jira_url + '/browse/' + str(issue_id)
     return url
 
+  # FIXME: Add support for keywords and only_open arguments
   def find_issues_url(self, keywords=None, only_open=None):  # pylint: disable=unused-argument
-    # To prevent abstract exception.
-    return
+    pass
 
 
 def _get_issue_tracker_manager_for_project(project_name):

--- a/src/appengine/libs/issue_management/monorail/__init__.py
+++ b/src/appengine/libs/issue_management/monorail/__init__.py
@@ -19,7 +19,7 @@ from builtins import object
 import urllib.parse
 
 from libs.issue_management import issue_tracker
-from libs.issue_management.monorail.issue import ChangeList as ChangeList
+from libs.issue_management.monorail.issue import ChangeList
 from libs.issue_management.monorail.issue import Issue as MonorailIssue
 from libs.issue_management.monorail.issue_tracker_manager import (
     IssueTrackerManager)

--- a/src/appengine/libs/issue_management/monorail/credential_storage.py
+++ b/src/appengine/libs/issue_management/monorail/credential_storage.py
@@ -23,6 +23,7 @@ class CredentialStorage(Storage):
   """Instead of reading a file, just parse a config entry."""
 
   def locked_get(self):
+    """ TODO ADD DOC-STRING"""
     content = db_config.get_value('client_credentials')
     if not content:
       return None
@@ -35,7 +36,7 @@ class CredentialStorage(Storage):
 
     return credentials
 
-  def locked_put(self, credentials):  # pylint: disable=unused_argument
+  def locked_put(self, credentials): # pylint: disable=unused-argument
     # To prevent abstract exception.
     return
 

--- a/src/appengine/libs/issue_management/monorail/credential_storage.py
+++ b/src/appengine/libs/issue_management/monorail/credential_storage.py
@@ -23,7 +23,7 @@ class CredentialStorage(Storage):
   """Instead of reading a file, just parse a config entry."""
 
   def locked_get(self):
-    """ TODO ADD DOC-STRING"""
+    """Return Credentials."""
     content = db_config.get_value('client_credentials')
     if not content:
       return None
@@ -37,9 +37,7 @@ class CredentialStorage(Storage):
     return credentials
 
   def locked_put(self, credentials):  # pylint: disable=unused-argument
-    # To prevent abstract exception.
-    return
+    pass
 
   def locked_delete(self):
-    # To prevent abstract exception.
-    return
+    pass

--- a/src/appengine/libs/issue_management/monorail/credential_storage.py
+++ b/src/appengine/libs/issue_management/monorail/credential_storage.py
@@ -36,7 +36,7 @@ class CredentialStorage(Storage):
 
     return credentials
 
-  def locked_put(self, credentials): # pylint: disable=unused-argument
+  def locked_put(self, credentials):  # pylint: disable=unused-argument
     # To prevent abstract exception.
     return
 

--- a/src/appengine/libs/query/datastore_query.py
+++ b/src/appengine/libs/query/datastore_query.py
@@ -193,7 +193,7 @@ class _KeyQuery(object):
               projection=None,
               limit=more_limit))
 
-    keys = set([item.key.id() for item in items])
+    keys = {item.key.id() for item in items}
     for run in more_runs:
       for key in run.result:
         keys.add(key)


### PR DESCRIPTION
Fixing Linting issues as mentioned in #1824. This PR Fixes all Linting issues in appengine.

These are the fixed issues:
************* Module src.appengine.handlers.base_handler
handlers/base_handler.py:63:4: R1705: Unnecessary "elif" after "return" (no-else-return)
handlers/base_handler.py:246:11: R1714: Consider merging these comparisons with "in" to 'status in (403, 401)' (consider-using-in)
************* Module src.appengine.handlers.fuzzer_stats
handlers/fuzzer_stats.py:76:5: R1714: Consider merging these comparisons with "in" to "typename in ('integer', 'float')" (consider-using-in)
handlers/fuzzer_stats.py:87:5: R1714: Consider merging these comparisons with "in" to 'type_value in (int, float)' (consider-using-in)
handlers/fuzzer_stats.py:151:2: R1705: Unnecessary "elif" after "return" (no-else-return)
handlers/fuzzer_stats.py:198:20: W1505: Using deprecated method escape() (deprecated-method)
handlers/fuzzer_stats.py:447:10: R1718: Consider using a set comprehension (consider-using-set-comprehension)
************* Module src.appengine.handlers.cron.manage_vms
handlers/cron/manage_vms.py:377:6: W1505: Using deprecated method warn() (deprecated-method)
handlers/cron/manage_vms.py:397:27: R1718: Consider using a set comprehension (consider-using-set-comprehension)
handlers/cron/manage_vms.py:508:8: W1505: Using deprecated method warn() (deprecated-method)
************* Module src.appengine.handlers.testcase_detail.testcase_variants
handlers/testcase_detail/testcase_variants.py:28:6: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module src.appengine.libs.filters
libs/filters.py:59:2: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module src.appengine.libs.helpers
libs/helpers.py:34:2: W0107: Unnecessary pass statement (unnecessary-pass)
libs/helpers.py:146:2: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module src.appengine.libs.issue_management.jira
libs/issue_management/jira/__init__.py:25:0: W0223: Method 'actions' is abstract in class 'Issue' but is not overridden (abstract-method)
libs/issue_management/jira/__init__.py:25:0: W0223: Method 'merged_into' is abstract in class 'Issue' but is not overridden (abstract-method)
libs/issue_management/jira/__init__.py:116:2: W0221: Parameters differ from overridden 'save' method (arguments-differ)
libs/issue_management/jira/__init__.py:139:0: W0223: Method 'find_issues_url' is abstract in class 'IssueTracker' but is not overridden (abstract-method)
************* Module src.appengine.libs.issue_management.monorail
libs/issue_management/monorail/__init__.py:22:0: C0414: Import alias does not rename original package (useless-import-alias)
************* Module src.appengine.libs.issue_management.monorail.credential_storage
libs/issue_management/monorail/credential_storage.py:25:2: C0111: Missing method docstring (missing-docstring)
libs/issue_management/monorail/credential_storage.py:38:23: W0613: Unused argument 'credentials' (unused-argument)
************* Module src.appengine.libs.query.datastore_query
libs/query/datastore_query.py:196:11: R1718: Consider using a set comprehension (consider-using-set-comprehension)

These issues are not fixed as @oliverchang mentioned that `appengine_config.py` will be deleted.
************* Module src.appengine.appengine_config
appengine_config.py:52:2: E0602: Undefined variable 'reload' (undefined-variable)
appengine_config.py:66:0: E0602: Undefined variable 'reload' (undefined-variable)

Please let me know if there are any changes required. Also, should I fix linting issues in other parts of the database and add it to this PR or make different PRs for different parts of codebase?