### PR TITLE
Fixed Linting issues in src/local (#1824)

### DIFF
--- a/src/local/butler/guard.py
+++ b/src/local/butler/guard.py
@@ -21,11 +21,6 @@ def check_virtualenv():
   if sys.version_info.major != 3:
     raise RuntimeError('Python 2 is no longer supported!')
 
-  root_path = os.path.realpath(
-      os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-
-  del root_path  # unused by check_virtualenv
-
   is_in_virtualenv = bool(os.getenv('VIRTUAL_ENV'))
 
   if not is_in_virtualenv:

--- a/src/local/butler/guard.py
+++ b/src/local/butler/guard.py
@@ -23,6 +23,9 @@ def check_virtualenv():
 
   root_path = os.path.realpath(
       os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+  del root_path  # unused by check_virtualenv
+
   is_in_virtualenv = bool(os.getenv('VIRTUAL_ENV'))
 
   if not is_in_virtualenv:

--- a/src/local/butler/remote.py
+++ b/src/local/butler/remote.py
@@ -33,19 +33,18 @@ def _get_handler_ctor(args):
   """Get a Handler class given arguments."""
   if 'linux' in args.instance_name:
     return linux.Handler
-  elif 'windows' in args.instance_name:
+  if 'windows' in args.instance_name:
     return windows.Handler
-  elif 'golo' in args.instance_name:
+  if 'golo' in args.instance_name:
     return mac.Handler
-  elif 'android-build' in args.instance_name:
+  if 'android-build' in args.instance_name:
     return android_chrome_lab.Handler
-  else:
-    raise NotImplementedError('Unsupported platform.')
+  raise NotImplementedError('Unsupported platform.')
 
 
 def _args_to_dict(args, method):
   """Convert args to dict that is compatible with the method's argument."""
-  arg_names = inspect.getargspec(method).args[1:]
+  arg_names = inspect.getfullargspec(method).args[1:]
   args_dict = {
       k: v
       for k, v in six.iteritems(vars(args))

--- a/src/local/butler/reproduce_tool/errors.py
+++ b/src/local/butler/reproduce_tool/errors.py
@@ -16,9 +16,7 @@
 
 class ReproduceToolError(Exception):
   """Base class for reproduce tool exceptions."""
-  pass
 
 
 class ReproduceToolUnrecoverableError(ReproduceToolError):
   """Unrecoverable errors."""
-  pass


### PR DESCRIPTION
Hi, This PR is to fix linting issues in src/local as described by #1824.
These are the issues that were fixed:

************* Module src.local.butler.guard
butler/guard.py:24:2: W0612: Unused variable 'root_path' (unused-variable)
************* Module src.local.butler.remote
butler/remote.py:34:2: R1705: Unnecessary "elif" after "return" (no-else-return)
butler/remote.py:48:14: W1505: Using deprecated method getargspec() (deprecated-method)
************* Module src.local.butler.reproduce_tool.errors
butler/reproduce_tool/errors.py:19:2: W0107: Unnecessary pass statement (unnecessary-pass)
butler/reproduce_tool/errors.py:24:2: W0107: Unnecessary pass statement (unnecessary-pass)

Please check and if there are any improvements, please let me know.