### PR TITLE
Remove redundant fuzzer entity query call in fuzz task.

### DIFF
--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1821,9 +1821,8 @@ class FuzzingSession(object):
 
     # Ensure that that the fuzzer still exists.
     logs.log('Setting up fuzzer and data bundles.')
-    fuzzer = data_types.Fuzzer.query(
-        data_types.Fuzzer.name == self.fuzzer_name).get()
-    if not fuzzer or not setup.update_fuzzer_and_data_bundles(self.fuzzer_name):
+    fuzzer = setup.update_fuzzer_and_data_bundles(self.fuzzer_name)
+    if not fuzzer:
       _track_fuzzer_run_result(self.fuzzer_name, 0, 0,
                                FuzzErrorCode.FUZZER_SETUP_FAILED)
       logs.log_error('Unable to setup fuzzer %s.' % self.fuzzer_name)

--- a/src/python/bot/tasks/setup.py
+++ b/src/python/bot/tasks/setup.py
@@ -499,13 +499,13 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
     # Clear the old fuzzer directory if it exists.
     if not shell.remove_directory(fuzzer_directory, recreate=True):
       logs.log_error('Failed to clear fuzzer directory.')
-      return False
+      return None
 
     # Copy the archive to local disk and unpack it.
     archive_path = os.path.join(fuzzer_directory, fuzzer.filename)
     if not blobs.read_blob_to_disk(fuzzer.blobstore_key, archive_path):
       logs.log_error('Failed to copy fuzzer archive.')
-      return False
+      return None
 
     try:
       archive.unpack(archive_path, fuzzer_directory)
@@ -515,7 +515,7 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
       logs.log_error(error_message)
       fuzzer_logs.upload_script_log(
           'Fatal error: ' + error_message, fuzzer_name=fuzzer_name)
-      return False
+      return None
 
     fuzzer_path = os.path.join(fuzzer_directory, fuzzer.executable_path)
     if not os.path.exists(fuzzer_path):
@@ -524,7 +524,7 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
       logs.log_error(error_message)
       fuzzer_logs.upload_script_log(
           'Fatal error: ' + error_message, fuzzer_name=fuzzer_name)
-      return False
+      return None
 
     # Make fuzzer executable.
     os.chmod(fuzzer_path, 0o750)
@@ -544,7 +544,7 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
           data_types.DataBundle.name == fuzzer.data_bundle_name))
   for data_bundle in data_bundles:
     if not update_data_bundle(fuzzer, data_bundle):
-      return False
+      return None
 
   # Setup environment variable for launcher script path.
   if fuzzer.launcher_script:
@@ -561,7 +561,7 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
       file_host.copy_directory_to_worker(
           fuzzer_directory, worker_fuzzer_directory, replace=True)
 
-  return True
+  return fuzzer
 
 
 def _is_search_index_data_bundle(data_bundle_name):


### PR DESCRIPTION
Make setup.update_fuzzer_and_data_bundles return a fuzzer entity
on success and None on failure. This helps to remove a redundant
fuzzer entity query call.