### PR TITLE
Batch FuzzerJob entities to reduce Datastore read ops.

### DIFF
--- a/configs/test/gae/prod3/cron.yaml
+++ b/configs/test/gae/prod3/cron.yaml
@@ -55,6 +55,11 @@ cron:
     schedule: every day 03:00
     target: cron-service
 
+  - description: Batch FuzzerJobs.
+    url: /batch-fuzzer-jobs
+    schedule: every 30 minutes
+    target: cron-service
+
   - description: Adjust strategy selection weights based on strategy stats.
     url: /fuzz-strategy-selection
     schedule: every day 05:00

--- a/configs/test/gae/prod3/cron.yaml
+++ b/configs/test/gae/prod3/cron.yaml
@@ -13,16 +13,15 @@
 # limitations under the License.
 
 cron:
-  # Run fuzzer coverage task right before the corpus pruning task.
-  - description: Obtain code coverage information from the coverage GCS bucket.
-    url: /fuzzer-coverage
-    schedule: every day 18:30
-    target: cron-service
-
   # Python crons start here.
   - description: Backup
     url: /backup
     schedule: every day 01:47
+    target: cron-service
+
+  - description: Batch FuzzerJobs.
+    url: /batch-fuzzer-jobs
+    schedule: every 30 minutes
     target: cron-service
 
   - description: Build crash stats.
@@ -40,6 +39,12 @@ cron:
     schedule: every day 03:00
     target: cron-service
 
+  # Run fuzzer coverage task right before the corpus pruning task.
+  - description: Obtain code coverage information from the coverage GCS bucket.
+    url: /fuzzer-coverage
+    schedule: every day 18:30
+    target: cron-service
+
   - description: Exercise cache on the fuzzer stats page.
     url: /fuzzer-stats/cache
     schedule: every 7 minutes
@@ -53,11 +58,6 @@ cron:
   - description: Adjust target and job weights based on fuzzer stats.
     url: /fuzzer-and-job-weights
     schedule: every day 03:00
-    target: cron-service
-
-  - description: Batch FuzzerJobs.
-    url: /batch-fuzzer-jobs
-    schedule: every 30 minutes
     target: cron-service
 
   - description: Adjust strategy selection weights based on strategy stats.

--- a/src/appengine/handlers/cron/batch_fuzzer_jobs.py
+++ b/src/appengine/handlers/cron/batch_fuzzer_jobs.py
@@ -1,0 +1,55 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A cron handler that batches FuzzerJobs."""
+
+import datetime
+import json
+import logging
+import time
+
+from datastore import data_types
+from handlers import base_handler
+from libs import handler
+
+FUZZER_JOB_BATCH_SIZE = 10000
+
+
+def batch_fuzzer_jobs():
+  """Batch FuzzerJobs for reduced Datastore read ops by bots."""
+  platforms = [
+      item.platform for item in data_types.FuzzerJob.query(
+      projection=[data_types.FuzzerJob.platform], distinct=True)]
+
+  for platform in platforms:
+    fuzzer_jobs = list(data_types.FuzzerJob.query(data_types.FuzzerJob.platform
+                                                  == platform))
+    fuzzer_jobs.sort(key=lambda item: item.job)
+
+    for i in range(0, len(fuzzer_jobs), FUZZER_JOB_BATCH_SIZE):
+      key_id = platform + '-' + str(i // FUZZER_JOB_BATCH_SIZE)
+      end = min(i + FUZZER_JOB_BATCH_SIZE, len(fuzzer_jobs))
+
+      batched = data_types.FuzzerJobs(id=key_id, platform=platform)
+      batched.platform = platform
+      batched.fuzzer_jobs = fuzzer_jobs[i:end]
+      batched.put()
+
+
+class Handler(base_handler.Handler):
+  """Handler for building data_types.CrashsStats2."""
+
+  @handler.check_cron()
+  def get(self):
+    """Process a GET request from a cronjob."""
+    batch_fuzzer_jobs()

--- a/src/appengine/handlers/cron/batch_fuzzer_jobs.py
+++ b/src/appengine/handlers/cron/batch_fuzzer_jobs.py
@@ -13,11 +13,6 @@
 # limitations under the License.
 """A cron handler that batches FuzzerJobs."""
 
-import datetime
-import json
-import logging
-import time
-
 from datastore import data_types
 from handlers import base_handler
 from libs import handler

--- a/src/appengine/handlers/cron/batch_fuzzer_jobs.py
+++ b/src/appengine/handlers/cron/batch_fuzzer_jobs.py
@@ -29,11 +29,12 @@ def batch_fuzzer_jobs():
   """Batch FuzzerJobs for reduced Datastore read ops by bots."""
   platforms = [
       item.platform for item in data_types.FuzzerJob.query(
-      projection=[data_types.FuzzerJob.platform], distinct=True)]
+          projection=[data_types.FuzzerJob.platform], distinct=True)
+  ]
 
   for platform in platforms:
-    fuzzer_jobs = list(data_types.FuzzerJob.query(data_types.FuzzerJob.platform
-                                                  == platform))
+    fuzzer_jobs = list(
+        data_types.FuzzerJob.query(data_types.FuzzerJob.platform == platform))
     fuzzer_jobs.sort(key=lambda item: item.job)
 
     for i in range(0, len(fuzzer_jobs), FUZZER_JOB_BATCH_SIZE):

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -42,6 +42,7 @@ from handlers import testcase_list
 from handlers import upload_testcase
 from handlers import viewer
 from handlers.cron import backup
+from handlers.cron import batch_fuzzer_jobs
 from handlers.cron import build_crash_stats
 from handlers.cron import cleanup
 from handlers.cron import corpus_backup
@@ -126,6 +127,7 @@ base_handler.add_menu('Documentation', '/docs')
 # We need to separate routes for cron to avoid redirection.
 _CRON_ROUTES = [
     ('/backup', backup.Handler),
+    ('/batch-fuzzer-jobs', batch_fuzzer_jobs.Handler),
     ('/build-crash-stats', build_crash_stats.Handler),
     ('/cleanup', cleanup.Handler),
     ('/corpus-backup/make-public', corpus_backup.MakePublicHandler),

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -1417,6 +1417,13 @@ class FuzzerJob(Model):
     return self.weight * self.multiplier
 
 
+class FuzzerJobs(Model):
+  """(Batched) mappings between a fuzzer and jobs with additional metadata for
+  selection."""
+  platform = ndb.StringProperty()
+  fuzzer_jobs = ndb.LocalStructuredProperty(FuzzerJob, repeated=True)
+
+
 class OssFuzzBuildFailure(Model):
   """Represents build failure."""
   # Project name.

--- a/src/python/fuzzing/fuzzer_selection.py
+++ b/src/python/fuzzing/fuzzer_selection.py
@@ -80,10 +80,13 @@ def get_fuzz_task_payload(platform=None):
     queue_override = environment.get_value('QUEUE_OVERRIDE')
     platform = queue_override if queue_override else environment.platform()
 
-  query = data_types.FuzzerJob.query()
-  query = query.filter(data_types.FuzzerJob.platform == platform)
+  query = data_types.FuzzerJobs.query()
+  query = query.filter(data_types.FuzzerJobs.platform == platform)
 
-  mappings = list(ndb_utils.get_all_from_query(query))
+  mappings = []
+  for fuzzer_jobs in query:
+    mappings.extend(fuzzer_jobs.fuzzer_jobs)
+
   if not mappings:
     return None, None
 

--- a/src/python/fuzzing/fuzzer_selection.py
+++ b/src/python/fuzzing/fuzzer_selection.py
@@ -80,12 +80,17 @@ def get_fuzz_task_payload(platform=None):
     queue_override = environment.get_value('QUEUE_OVERRIDE')
     platform = queue_override if queue_override else environment.platform()
 
-  query = data_types.FuzzerJobs.query()
-  query = query.filter(data_types.FuzzerJobs.platform == platform)
+  if environment.is_local_development():
+    query = data_types.FuzzerJob.query()
+    query = query.filter(data_types.FuzzerJobs.platform == platform)
+    mappings = list(ndb_utils.get_all_from_query(query))
+  else:
+    query = data_types.FuzzerJobs.query()
+    query = query.filter(data_types.FuzzerJobs.platform == platform)
 
-  mappings = []
-  for fuzzer_jobs in query:
-    mappings.extend(fuzzer_jobs.fuzzer_jobs)
+    mappings = []
+    for entity in query:
+      mappings.extend(entity.fuzzer_jobs)
 
   if not mappings:
     return None, None

--- a/src/python/tests/appengine/handlers/cron/batch_fuzzer_jobs_test.py
+++ b/src/python/tests/appengine/handlers/cron/batch_fuzzer_jobs_test.py
@@ -41,4 +41,5 @@ class TestBatchingFuzzerJobs(unittest.TestCase):
 
       self.assertEqual(self.total_fuzzer_jobs, len(all_fuzzer_jobs))
       for i in range(self.total_fuzzer_jobs):
-        self.assertEqual('libfuzzer_asan_{}_{:06d}'.format(platform, i), all_fuzzer_jobs[i].job)
+        self.assertEqual('libfuzzer_asan_{}_{:06d}'.format(platform, i),
+                         all_fuzzer_jobs[i].job)

--- a/src/python/tests/appengine/handlers/cron/batch_fuzzer_jobs_test.py
+++ b/src/python/tests/appengine/handlers/cron/batch_fuzzer_jobs_test.py
@@ -1,0 +1,44 @@
+# Lint as: python3
+"""Tests for batch_fuzzer_jobs."""
+
+import unittest
+
+from google.cloud import ndb
+
+from datastore import data_types
+from handlers.cron import batch_fuzzer_jobs
+from tests.test_libs import helpers as test_helpers
+from tests.test_libs import test_utils
+
+
+@test_utils.with_cloud_emulators('datastore')
+class TestBatchingFuzzerJobs(unittest.TestCase):
+  """Test batching FuzzerJob entitites."""
+
+  def setUp(self):
+    self.total_fuzzer_jobs = 12000
+    self.platforms = ['LINUX', 'WINDOWS']
+    fuzzer_jobs = []
+    for platform in self.platforms:
+      for i in range(self.total_fuzzer_jobs):
+        fuzzer_job = data_types.FuzzerJob(
+            fuzzer='libFuzzer',
+            job='libfuzzer_asan_{}_{:06d}'.format(platform, i),
+            platform=platform)
+        fuzzer_jobs.append(fuzzer_job)
+
+    ndb.put_multi(fuzzer_jobs)
+
+  def test_batch(self):
+    """Test batching."""
+    batch_fuzzer_jobs.batch_fuzzer_jobs()
+    for platform in self.platforms:
+      all_fuzzer_jobs = []
+      for i in range(2):
+        key = ndb.Key(data_types.FuzzerJobs, platform + '-' + str(i))
+        fuzzer_jobs = key.get()
+        all_fuzzer_jobs.extend(fuzzer_jobs.fuzzer_jobs)
+
+      self.assertEqual(self.total_fuzzer_jobs, len(all_fuzzer_jobs))
+      for i in range(self.total_fuzzer_jobs):
+        self.assertEqual('libfuzzer_asan_{}_{:06d}'.format(platform, i), all_fuzzer_jobs[i].job)

--- a/src/python/tests/appengine/handlers/cron/batch_fuzzer_jobs_test.py
+++ b/src/python/tests/appengine/handlers/cron/batch_fuzzer_jobs_test.py
@@ -7,7 +7,6 @@ from google.cloud import ndb
 
 from datastore import data_types
 from handlers.cron import batch_fuzzer_jobs
-from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils
 
 

--- a/src/python/tests/appengine/handlers/cron/batch_fuzzer_jobs_test.py
+++ b/src/python/tests/appengine/handlers/cron/batch_fuzzer_jobs_test.py
@@ -1,4 +1,16 @@
-# Lint as: python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Tests for batch_fuzzer_jobs."""
 
 import unittest
@@ -28,6 +40,9 @@ class TestBatchingFuzzerJobs(unittest.TestCase):
 
     ndb.put_multi(fuzzer_jobs)
 
+    # Should be removed.
+    data_types.FuzzerJobs(id='LINUX-2', platform='LINUX').put()
+
   def test_batch(self):
     """Test batching."""
     batch_fuzzer_jobs.batch_fuzzer_jobs()
@@ -42,3 +57,5 @@ class TestBatchingFuzzerJobs(unittest.TestCase):
       for i in range(self.total_fuzzer_jobs):
         self.assertEqual('libfuzzer_asan_{}_{:06d}'.format(platform, i),
                          all_fuzzer_jobs[i].job)
+
+    self.assertIsNone(ndb.Key(data_types.FuzzerJobs, 'LINUX-2').get())

--- a/src/python/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/python/tests/core/fuzzing/fuzzer_selection_test.py
@@ -152,6 +152,9 @@ class GetFuzzTaskPayloadTest(unittest.TestCase):
     windows_mapping.platform = 'windows'
     windows_mapping.put()
 
+    data_types.FuzzerJobs(
+        platform='windows', fuzzer_jobs=[windows_mapping]).put()
+
     self.assertEqual(
         (None, None), fuzzer_selection.get_fuzz_task_payload(platform='linux'))
 
@@ -160,6 +163,8 @@ class GetFuzzTaskPayloadTest(unittest.TestCase):
     linux_mapping.job = 'job_2'
     linux_mapping.platform = 'linux'
     linux_mapping.put()
+
+    data_types.FuzzerJobs(platform='linux', fuzzer_jobs=[linux_mapping]).put()
 
     argument, job = fuzzer_selection.get_fuzz_task_payload('linux')
     self.assertEqual(('right_fuzzer', 'job_2'), (argument, job))

--- a/src/python/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/python/tests/core/fuzzing/fuzzer_selection_test.py
@@ -16,6 +16,8 @@
 import os
 import unittest
 
+import parameterized
+
 from datastore import data_types
 from datastore import ndb_utils
 from fuzzing import fuzzer_selection
@@ -133,6 +135,7 @@ class GetFuzzTaskPayloadTest(unittest.TestCase):
   """Tests for the get_fuzz_task_payload function."""
 
   def setUp(self):
+    test_helpers.patch_environ(self)
     test_helpers.patch(self, [
         'base.utils.random_weighted_choice',
     ])
@@ -144,8 +147,10 @@ class GetFuzzTaskPayloadTest(unittest.TestCase):
     self.assertEqual(
         (None, None), fuzzer_selection.get_fuzz_task_payload(platform='linux'))
 
-  def test_platform_restriction(self):
+  @parameterized.parameterized.expand([('False',), ('True',)])
+  def test_platform_restriction(self, local_development):
     """Ensure that we can find a task with a valid platform."""
+    os.environ['LOCAL_DEVELOPMENT'] = local_development
     windows_mapping = data_types.FuzzerJob()
     windows_mapping.fuzzer = 'wrong_fuzzer'
     windows_mapping.job = 'job_1'


### PR DESCRIPTION
Batch FuzzerJobs in a cron, and have bots read the batched version
instead.

Fixes #1844