### PR TITLE
Remove unused default_args in AndroidSyzkallerRunner.

### DIFF
--- a/src/python/bot/fuzzers/syzkaller/runner.py
+++ b/src/python/bot/fuzzers/syzkaller/runner.py
@@ -58,22 +58,21 @@ def get_config():
 
 def get_runner(fuzzer_path):
   """Return a syzkaller runner object."""
-  build_dir = environment.get_value('BUILD_DIR')
-  return AndroidSyzkallerRunner(fuzzer_path, build_dir)
+  return AndroidSyzkallerRunner(fuzzer_path)
 
 
 class AndroidSyzkallerRunner(new_process.ProcessRunner):
   """Syzkaller runner."""
 
-  def __init__(self, executable_path, default_args=None):
+  def __init__(self, executable_path):
     """Inits the AndroidSyzkallerRunner.
 
     Args:
       executable_path: Path to the fuzzer executable.
       default_args: Default arguments to always pass to the fuzzer.
     """
-    super(AndroidSyzkallerRunner, self).__init__(
-        executable_path=executable_path, default_args=default_args)
+    super(AndroidSyzkallerRunner,
+          self).__init__(executable_path=executable_path)
 
   def get_command(self, additional_args=None):
     """Process.get_command override."""

--- a/src/python/bot/fuzzers/syzkaller/runner.py
+++ b/src/python/bot/fuzzers/syzkaller/runner.py
@@ -61,7 +61,7 @@ def get_runner(fuzzer_path):
   return AndroidSyzkallerRunner(fuzzer_path)
 
 
-class AndroidSyzkallerRunner(new_process.ProcessRunner):
+class AndroidSyzkallerRunner(new_process.UnicodeProcessRunner):
   """Syzkaller runner."""
 
   def __init__(self, executable_path):


### PR DESCRIPTION
Fixes regression from
https://github.com/google/clusterfuzz/commit/00e0263a3c62af1a8d5673d120388fbcb73e629f#diff-0060724aa427ae4a3e04a3abd9c99893