### PR TITLE
Update ml-with-gpu image to use Python 3 pip.

### DIFF
--- a/docker/ml-with-gpu/Dockerfile
+++ b/docker/ml-with-gpu/Dockerfile
@@ -38,10 +38,10 @@ RUN wget https://storage.googleapis.com/clusterfuzz-data/cudnn/7.1.4_cuda9.0/lib
 
 # Replace TensorFlow CPU version with GPU version. Also the version number
 # needs to match cuda and cuDNN version above.
-RUN pip2 uninstall tensorflow -y && \
-    pip2 uninstall tensorboard -y && \
-    pip2 install mock==2.0.0 && \
-    pip2 install tensorflow-gpu==1.8.0
+RUN python3.7 -m pip uninstall tensorflow -y && \
+    python3.7 -m pip uninstall tensorboard -y && \
+    python3.7 -m pip install mock==2.0.0 && \
+    python3.7 -m pip install tensorflow-gpu==1.15.2
 
 WORKDIR $INSTALL_DIRECTORY
 


### PR DESCRIPTION
To match chromium/ml-with-gpu

We no longer install Python 2 dependencies.