### PR TITLE
Store past crashes in corpus regressions folder, test in pruning task.

### DIFF
--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -216,7 +216,9 @@ class Context(object):
     self.merge_tmp_dir = self._create_temp_corpus_directory('merge_workdir')
 
     self.corpus = corpus_manager.FuzzTargetCorpus(
-        self.fuzz_target.engine, self.fuzz_target.project_qualified_name())
+        self.fuzz_target.engine,
+        self.fuzz_target.project_qualified_name(),
+        include_regressions=True)
     self.quarantine_corpus = corpus_manager.FuzzTargetCorpus(
         self.fuzz_target.engine,
         self.fuzz_target.project_qualified_name(),
@@ -445,7 +447,7 @@ class CorpusPruner(object):
       unit_name = os.path.basename(unit_path)
       if unit_name.startswith('timeout-') or unit_name.startswith('oom-'):
         # Don't waste time re-running timeout or oom testcases.
-        unit_path = self._quarantine_unit(unit_path, quarantine_corpus_path)
+        self._quarantine_unit(unit_path, quarantine_corpus_path)
         num_bad_units += 1
         continue
 
@@ -453,7 +455,7 @@ class CorpusPruner(object):
         result = self._run_single_unit(unit_path)
       except TimeoutError:
         # Slow unit. Quarantine it.
-        unit_path = self._quarantine_unit(unit_path, quarantine_corpus_path)
+        self._quarantine_unit(unit_path, quarantine_corpus_path)
         num_bad_units += 1
         continue
 

--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -234,9 +234,13 @@ def _store_testcase_for_regression_testing(testcase, testcase_file_path):
   regression_testcase_url = os.path.join(
       corpus.get_regressions_corpus_gcs_url(),
       os.path.basename(testcase_file_path))
-  storage.copy_file_to(testcase_file_path, regression_testcase_url)
-  logs.log('Successfully stored testcase for regression testing: ' +
-           regression_testcase_url)
+
+  if storage.copy_file_to(testcase_file_path, regression_testcase_url):
+    logs.log('Successfully stored testcase for regression testing: ' +
+             regression_testcase_url)
+  else:
+    logs.log_error('Failed to store testcase for regression testing: ' +
+                   regression_testcase_url)
 
 
 def find_fixed_range(testcase_id, job_type):

--- a/src/python/tests/core/bot/tasks/progression_task_test.py
+++ b/src/python/tests/core/bot/tasks/progression_task_test.py
@@ -20,7 +20,6 @@ import unittest
 from base import errors
 from bot.tasks import progression_task
 from datastore import data_types
-from system import environment
 from tests.test_libs import helpers
 from tests.test_libs import test_utils
 

--- a/src/python/tests/core/bot/tasks/progression_task_test.py
+++ b/src/python/tests/core/bot/tasks/progression_task_test.py
@@ -20,6 +20,7 @@ import unittest
 from base import errors
 from bot.tasks import progression_task
 from datastore import data_types
+from system import environment
 from tests.test_libs import helpers
 from tests.test_libs import test_utils
 
@@ -139,9 +140,12 @@ class StoreTestcaseForRegressionTesting(unittest.TestCase):
   """Test _store_testcase_for_regression_testing."""
 
   def setUp(self):
+    helpers.patch_environ(self)
     helpers.patch(self, [
         'google_cloud_utils.storage.copy_file_to',
     ])
+
+    os.environ['CORPUS_BUCKET'] = 'corpus'
 
     fuzz_target = data_types.FuzzTarget(id='libFuzzer_test_project_test_fuzzer')
     fuzz_target.binary = 'test_fuzzer'
@@ -190,9 +194,9 @@ class StoreTestcaseForRegressionTesting(unittest.TestCase):
 
   def test_testcase_stored(self):
     """Test that a testcase is stored for regression testing."""
+    corpus_bucket = environment.get_value('CORPUS_BUCKET')
     progression_task._store_testcase_for_regression_testing(  # pylint: disable=protected-access
         self.testcase, self.testcase_file_path)
     self.mock.copy_file_to.assert_called_with(
         '/testcase',
-        'gs://test-corpus-bucket/libFuzzer/test_project_test_fuzzer_regressions'
-        '/testcase')
+        'gs://corpus/libFuzzer/test_project_test_fuzzer_regressions/testcase')

--- a/src/python/tests/core/bot/tasks/progression_task_test.py
+++ b/src/python/tests/core/bot/tasks/progression_task_test.py
@@ -194,7 +194,6 @@ class StoreTestcaseForRegressionTesting(unittest.TestCase):
 
   def test_testcase_stored(self):
     """Test that a testcase is stored for regression testing."""
-    corpus_bucket = environment.get_value('CORPUS_BUCKET')
     progression_task._store_testcase_for_regression_testing(  # pylint: disable=protected-access
         self.testcase, self.testcase_file_path)
     self.mock.copy_file_to.assert_called_with(

--- a/src/python/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/python/tests/core/fuzzing/corpus_manager_test.py
@@ -217,6 +217,22 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
     """Test rsync_to_disk."""
     corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'fuzzer')
     self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
+    self.assertEqual(self.mock.Popen.call_args[0][0], [
+        '/gsutil_path/gsutil',
+        '-m',
+        '-q',
+        'rsync',
+        '-r',
+        '-d',
+        'gs://bucket/libFuzzer/fuzzer/',
+        '/dir',
+    ])
+
+  def test_rsync_to_disk_with_regressions(self):
+    """Test rsync_to_disk, with regressions set."""
+    corpus = corpus_manager.FuzzTargetCorpus(
+        'libFuzzer', 'fuzzer', include_regressions=True)
+    self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
 
     commands = [call_arg[0][0] for call_arg in self.mock.Popen.call_args_list]
 
@@ -237,7 +253,7 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
             '-q',
             'rsync',
             '-r',
-            'gs://bucket/libFuzzer/fuzzer_static/',
+            'gs://bucket/libFuzzer/fuzzer_regressions/',
             '/dir',
         ],
     ])


### PR DESCRIPTION
Also, remove _static urls which are unused and just increase unnecessary storage calls.