### PR TITLE
Filter out more testcases when requesting bisects.

### DIFF
--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -211,7 +211,7 @@ def _save_fixed_range(testcase_id, min_revision, max_revision,
   _write_to_bigquery(testcase, min_revision, max_revision)
 
   # If there is a fine grained bisection service available, request it.
-  task_creation.request_bisection(testcase, 'fixed')
+  task_creation.request_bisection(testcase)
 
   _store_testcase_for_regression_testing(testcase, testcase_file_path)
 

--- a/src/python/bot/tasks/regression_task.py
+++ b/src/python/bot/tasks/regression_task.py
@@ -83,9 +83,6 @@ def save_regression_range(testcase_id, regression_range_start,
   # Get blame information using the regression range result.
   task_creation.create_blame_task_if_needed(testcase)
 
-  # If there is a fine grained bisection service available, request it.
-  task_creation.request_bisection(testcase, 'regressed')
-
 
 def _testcase_reproduces_in_revision(testcase,
                                      testcase_file_path,

--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -232,6 +232,9 @@ def create_tasks(testcase):
 
 def _get_commits(commit_range, job_type):
   """Get commits from range."""
+  if not commit_range or commit_range == 'NA':
+    return None, None
+
   start, end = revisions.get_start_and_end_revision(commit_range)
   components = revisions.get_component_range_list(start, end, job_type)
 
@@ -247,16 +250,33 @@ def _get_commits(commit_range, job_type):
   return old_commit, new_commit
 
 
-def request_bisection(testcase, bisect_type):
+def request_bisection(testcase):
   """Request precise bisection."""
   pubsub_topic = local_config.ProjectConfig().get('bisect_service.pubsub_topic')
   if not pubsub_topic:
+    return
+
+  # Only request bisects for reproducible security bugs with a bug filed, found
+  # by engine fuzzers.
+  if not testcase.security_flag:
+    return
+
+  if testcase.one_time_crasher_flag:
+    return
+
+  if not testcase.bug_information:
     return
 
   target = testcase.get_fuzz_target()
   if not target:
     return
 
+  _make_bisection_request(pubsub_topic, testcase, target, 'regressed')
+  _make_bisection_request(pubsub_topic, testcase, target, 'fixed')
+
+
+def _make_bisection_request(pubsub_topic, testcase, target, bisect_type):
+  """Make a bisection request to the external bisection service."""
   if bisect_type == 'fixed':
     old_commit, new_commit = _get_commits(testcase.fixed, testcase.job_type)
   elif bisect_type == 'regressed':
@@ -264,6 +284,9 @@ def request_bisection(testcase, bisect_type):
                                           testcase.job_type)
   else:
     raise ValueError('Invalid bisection type: ' + bisect_type)
+
+  if not old_commit or not new_commit:
+    return
 
   reproducer = blobs.read_key(testcase.minimized_keys or testcase.fuzzed_keys)
   pubsub_client = pubsub.PubSubClient()

--- a/src/python/tests/core/bot/tasks/task_creation_test.py
+++ b/src/python/tests/core/bot/tasks/task_creation_test.py
@@ -63,47 +63,78 @@ class RequestBisectionTest(unittest.TestCase):
         }
     })
 
-  def _test(self, sanitizer, bisect_type):
-    task_creation.request_bisection(self.testcase, bisect_type)
-    publish_call = self.mock.publish.call_args[0]
-    topic = publish_call[1]
-    message = publish_call[2]
-    self.assertEqual('/projects/project/topics/topic', topic)
-    self.assertEqual(b'reproducer', message.data)
-    self.assertDictEqual({
-        'crash_type': 'crash-type',
-        'security': 'True',
-        'fuzz_target': 'target',
-        'new_commit': 'new',
-        'old_commit': 'old',
-        'project_name': 'proj',
-        'sanitizer': sanitizer,
-        'testcase_id': 1,
-        'issue_id': '1337',
-        'type': bisect_type,
-    }, message.attributes)
+  def _test(self, sanitizer):
+    """Test task publication."""
+    task_creation.request_bisection(self.testcase)
+    publish_calls = self.mock.publish.call_args_list
+    bisect_types = ('regressed', 'fixed')
 
-  def test_request_bisection_regressed(self):
-    """Basic regressed test."""
-    self.testcase.job_type = 'libfuzzer_asan_proj'
-    self._test('address', 'regressed')
-    self.testcase.job_type = 'libfuzzer_msan_proj'
-    self._test('memory', 'regressed')
-    self.testcase.job_type = 'libfuzzer_ubsan_proj'
-    self._test('undefined', 'regressed')
+    self.assertEqual(2, len(publish_calls))
+    for bisect_type, publish_call in zip(bisect_types, publish_calls):
+      topic = publish_call[0][1]
+      message = publish_call[0][2]
+      self.assertEqual('/projects/project/topics/topic', topic)
+      self.assertEqual(b'reproducer', message.data)
+      self.assertDictEqual({
+          'crash_type': 'crash-type',
+          'security': 'True',
+          'fuzz_target': 'target',
+          'new_commit': 'new',
+          'old_commit': 'old',
+          'project_name': 'proj',
+          'sanitizer': sanitizer,
+          'testcase_id': 1,
+          'issue_id': '1337',
+          'type': bisect_type,
+      }, message.attributes)
 
-  def test_request_bisection_fixed(self):
-    """Basic fixed test."""
+  def test_request_bisection_asan(self):
+    """Basic regressed test (asan)."""
     self.testcase.job_type = 'libfuzzer_asan_proj'
-    self._test('address', 'fixed')
+    self._test('address')
+
+  def test_request_bisection_msan(self):
+    """Basic regressed test (asan)."""
     self.testcase.job_type = 'libfuzzer_msan_proj'
-    self._test('memory', 'fixed')
+    self._test('memory')
+
+  def test_request_bisection_ubsan(self):
+    """Basic regressed test (ubsan)."""
     self.testcase.job_type = 'libfuzzer_ubsan_proj'
-    self._test('undefined', 'fixed')
+    self._test('undefined')
 
   def test_request_bisection_blackbox(self):
     """Test request bisection for blackbox."""
     self.testcase.job_type = 'blackbox'
     self.testcase.overridden_fuzzer_name = None
-    task_creation.request_bisection(self.testcase, 'regressed')
+    task_creation.request_bisection(self.testcase)
+    self.assertEqual(0, self.mock.publish.call_count)
+
+  def test_request_bisection_non_security(self):
+    """Test request bisection for non-security testcases."""
+    self.testcase.job_type = 'libfuzzer_asan_proj'
+    self.testcase.security_flag = False
+    task_creation.request_bisection(self.testcase)
+    self.assertEqual(0, self.mock.publish.call_count)
+
+  def test_request_bisection_flaky(self):
+    """Test request bisection for flaky testcases."""
+    self.testcase.job_type = 'libfuzzer_asan_proj'
+    self.testcase.one_time_crasher_flag = True
+    task_creation.request_bisection(self.testcase)
+    self.assertEqual(0, self.mock.publish.call_count)
+
+  def test_request_bisection_no_bug(self):
+    """Test request bisection for testcases with no bug attached."""
+    self.testcase.job_type = 'libfuzzer_asan_proj'
+    self.testcase.bug_information = ''
+    task_creation.request_bisection(self.testcase)
+    self.assertEqual(0, self.mock.publish.call_count)
+
+  def test_request_bisection_invalid_range(self):
+    """Test request bisection for testcases with no bug attached."""
+    self.testcase.job_type = 'libfuzzer_asan_proj'
+    self.testcase.regression = 'NA'
+    self.testcase.fixed = 'NA'
+    task_creation.request_bisection(self.testcase)
     self.assertEqual(0, self.mock.publish.call_count)


### PR DESCRIPTION
To reduce load, only request bisects for testcases which are
reproducible security bugs with a bug filed.

As a result, requests for both regressed and fixed are moved to the
completion of progression_task, as this information isn't available when
regression_task completes.