### PR TITLE
Remove explicit gc for ndb cleanup.

### DIFF
--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -21,7 +21,6 @@ standard_library.install_aliases()
 import base64
 import cgi
 import datetime
-import gc
 import json
 import logging
 import os

--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -284,13 +284,6 @@ class Handler(webapp2.RequestHandler):
       with ndb_init.context():
         super(Handler, self).dispatch()
 
-      # App Engine Python 2 does not like it when there are threads still alive
-      # at the end of a request. In particular, NDB and gRPC may create threads
-      # which aren't automatically stopped at this point due to reference
-      # cycles. Garbage collect here to get rid of them.
-      # TODO(ochang): Check if this is still needed for Python 3 GAE.
-      gc.collect()
-
     # Replace header values with Python 2-style strings after dispatching. There
     # is an explicit type check against str that causes issues with newstr here.
     for key, value in self.response.headers.items():


### PR DESCRIPTION
This may no longer be necessary due to the Python 3 migration.