### PR TITLE
Added Pagination support to Jobs Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+## Next
+- Next version requires new DB migrations due to addition of search keywords in Jobs.
+- To perform migrations, please use:
+```
+python butler.py run -c=path/to/config --non-dry-run migration.jobs_keywords
+```
+
 ## Version 2.0.2
 - Improved Syzkaller support.
 - Support narrower bisection for regression/fix ranges.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Change Log
 - Next version requires new DB migrations due to addition of search keywords in Jobs.
 - To perform migrations, please use:
 ```
-python butler.py run -c=path/to/config --non-dry-run migration.jobs_keywords
+python butler.py run -c path/to/config --non-dry-run migration.jobs_keywords
 ```
 
 ## Version 2.0.2

--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -56,9 +56,10 @@ def get_queues():
   queues.sort(key=lambda q: q['display_name'])
   return queues
 
+
 def get_results(this):
   """Get results for the jobs page."""
-  params = {k: v for k, v in this.request.iterparams()}
+  params = {k: v for k, v in this.request.iterparams()}  # pylint: disable=unnecessary-comprehension
 
   query = datastore_query.Query(data_types.Job)
 
@@ -102,18 +103,19 @@ class Handler(base_handler.Handler):
 
     result, params = get_results(self)
 
-    self.render('jobs.html', {
-        'result': result,
-        'templates': templates,
-        'fieldValues': {
-            'csrf_token': form.generate_csrf_token(),
-            'queues': queues,
-            'update_job_url': '/update-job',
-            'update_job_template_url': '/update-job-template',
-            'upload_info': gcs.prepare_blob_upload()._asdict(),
-        },
-        'params': params,
-    })
+    self.render(
+        'jobs.html', {
+            'result': result,
+            'templates': templates,
+            'fieldValues': {
+                'csrf_token': form.generate_csrf_token(),
+                'queues': queues,
+                'update_job_url': '/update-job',
+                'update_job_template_url': '/update-job-template',
+                'upload_info': gcs.prepare_blob_upload()._asdict(),
+            },
+            'params': params,
+        })
 
 
 class UpdateJob(base_handler.GcsUploadHandler):

--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -55,10 +55,11 @@ def get_queues():
 
 def get_results(this):
   """Get results for the jobs page."""
-  params = dict(this.request.iterparams())
+
   # Return jobs sorted alphabetically by name
   query = datastore_query.Query(data_types.Job)
   query.order('name', is_desc=False)
+  params = dict(this.request.iterparams())
   filters.add(query, params, FILTERS)
 
   page = helpers.cast(

--- a/src/appengine/index.yaml
+++ b/src/appengine/index.yaml
@@ -550,3 +550,8 @@ indexes:
   properties:
     - name: project
     - name: name
+
+- kind: Job
+  properties:
+    - name: keywords
+    - name: name

--- a/src/appengine/private/components/jobs/jobs.html
+++ b/src/appengine/private/components/jobs/jobs.html
@@ -183,9 +183,9 @@
     <div class="section">
       <div class="title">Existing jobs</div>
       <div class="body">
-        <paper-input class="search-box" label="Enter search string here" type="search" value="{{params.q}}" on-keyup="searchButtonTapped">
+        <paper-input class="search-box" label="Enter search string here" type="text" value="{{params.q}}" on-input="searchInputTimeout" on-keyup="searchButtonPressed">
           <iron-icon icon="icons:search" slot="prefix"></iron-icon>
-          <iron-icon icon="icons:help-outline" title="Search with keywords in job name or its environment string." slot="suffix"></iron-icon>
+          <iron-icon icon="icons:help-outline" title="Search with keywords in job name or project name." slot="suffix"></iron-icon>
         </paper-input>
       </div>
     </div>
@@ -362,21 +362,23 @@
         this.$.paginatedList.save();
       }
       
-      searchButtonTapped(ev) {
+      searchInputTimeout(ev) {
         let self = this;
         let thisId = ++self.submitId;
+        setTimeout(
+            () => {
+              if (self.submitId == thisId) {
+                self.resetPageAndSearch();
+              }
+            },
+            600
+        );
+      }
 
+      searchButtonPressed(ev) {
+        let self = this;
         if (ev.keyCode == 13) {
           self.resetPageAndSearch();
-        } else {
-          setTimeout(
-              () => {
-                if (self.submitId == thisId) {
-                  self.resetPageAndSearch();
-                }
-              },
-              600
-          );
         }
       }
       

--- a/src/appengine/private/components/jobs/jobs.html
+++ b/src/appengine/private/components/jobs/jobs.html
@@ -22,6 +22,7 @@
 <link rel="import" href="../../bower_components/paper-input/paper-textarea.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../../bower_components/paper-listbox/paper-listbox.html">
+<link rel="import" href="../common/paginated-list/paginated-list.html">
 
 <link rel="import" href="delete-job-dialog.html">
 
@@ -45,6 +46,10 @@
         font-size: 12px;
         color: var(--paper-input-container-color);
       }
+      
+      .paginatedList {
+        margin-bottom: 10px;
+      }
 
       paper-textarea {
         --iron-autogrow-textarea: {
@@ -56,6 +61,20 @@
         --paper-input-container-input-color: var(--primary-text-color);
       }
     </style>
+    <iron-ajax
+      id="ajax"
+      url="/jobs/load"
+      method="POST"
+      content-type="application/json"
+      body="[[ajaxParams]]"
+      loading="{{loading}}"
+      last-request="{{request}}"
+      last-error="{{error}}"
+      last-response="{{response}}"
+      on-error="handleError"
+      on-request="handleRequest"
+      on-response="handleResponse"
+      debounce-duration="500"></iron-ajax>
 
     <delete-job-dialog id="deleteJobDialog" field-values="[[fieldValues]]" job="[[toDelete]]">
     </delete-job-dialog>
@@ -164,54 +183,74 @@
     <div class="section">
       <div class="title">Existing jobs</div>
       <div class="body">
-        <paper-input class="search-box" label="Enter search string here" value="{{jobSearchString::input}}">
+        <paper-input class="search-box" label="Enter search string here" type="search" value="{{params.q}}" on-keyup="searchButtonTapped">
           <iron-icon icon="icons:search" slot="prefix"></iron-icon>
           <iron-icon icon="icons:help-outline" title="Search with keywords in job name or its environment string." slot="suffix"></iron-icon>
         </paper-input>
-        <template is="dom-repeat" items="[[jobs]]" initial-count="20" filter="[[computeFilter(jobSearchString)]]">
-          <iron-form id="form_[[index]]" allow-redirect>
-            <form action="[[fieldValues.update_job_url]]" method="post">
-              <input type="hidden" name="csrf_token" value="[[fieldValues.csrf_token]]" />
-              <input type="hidden" name="upload_key" id="upload_key_[[index]]" />
-              <div class="container flex">
-                <div class="left">
-                  <paper-input label="Name" name="name" value="[[item.name]]" readonly></paper-input>
-
-                  <paper-dropdown-menu label="Platform" name="platform" no-animations="true" noink>
-                    <paper-listbox selected="[[item.platform]]" attr-for-selected="value" slot="dropdown-content" class="dropdown-content">
-                      <template is="dom-repeat" items="[[fieldValues.queues]]">
-                        <paper-item label="[[item.name]]" value="[[item.name]]">[[item.display_name]]</paper-item>
-                      </template>
-                    </paper-listbox>
-                  </paper-dropdown-menu>
-
-                  <paper-input label="Description (optional)" name="description" value="[[item.description]]"></paper-input>
-
-                  <paper-textarea label="Templates (optional)" name="templates" value="[[getTemplatesString(item.templates)]]"></paper-textarea>
-                  <br/>
-
-                  <div class="label">
-                    Custom Build (optional)
-                  </div>
-                  <template is="dom-if" if="[[item.custom_binary_key]]">
-                    <a href="/download/[[item.custom_binary_key]]">[[item.custom_binary_filename]]</a>
-                  </template>
-                  <paper-input type="file" id="file_[[index]]" label="File" no-label-float always-float-label$="false"></paper-input>
-                  <br/>
-
-                  <paper-button raised on-tap="submitForm" data-index$="[[index]]">Save</paper-button>
-                  <paper-button class="info" job="[[item]]" raised on-tap="deleteJobTapped">Delete</paper-button>
-                </div>
-
-                <div class="right">
-                  <paper-textarea label="Environment String" name="environment_string" value="[[item.environment_string]]" spellcheck="false"></paper-textarea>
-                </div>
-              </div>
-            </form>
-          </iron-form>
-        </template>
       </div>
     </div>
+    <paginated-list
+      id="paginatedList"
+      result="{{result}}"
+      params="{{params}}"
+      keys="[[paramKeys]]"
+      loading="[[loading]]"
+      on-params-modified="paramsModified">
+      <div class="section">
+        <div class="error" hidden$="[[!shouldShowError(result, result.error)]]">
+          <span class="title">[[result.error.message]]</span>
+          <span class="trace-dump" hidden$="[[!result.error.traceDump]]"
+            >[[result.error.traceDump]]</span>
+        </div>
+        <div class="empty" hidden$="[[!shouldShowEmpty(result, result.items)]]">
+          Didn't find anything with the current search.<br/>
+        </div>
+        <div class="body" hidden$="[[!shouldShowItems(result, result.items)]]">
+          <template is="dom-repeat" items="[[result.items]]">
+            <iron-form id="form_[[index]]" allow-redirect>
+              <form action="[[fieldValues.update_job_url]]" method="post">
+                <input type="hidden" name="csrf_token" value="[[fieldValues.csrf_token]]" />
+                <input type="hidden" name="upload_key" id="upload_key_[[index]]" />
+                <div class="container flex">
+                  <div class="left">
+                    <paper-input label="Name" name="name" value="[[item.name]]" readonly></paper-input>
+        
+                    <paper-dropdown-menu label="Platform" name="platform" no-animations="true" noink>
+                      <paper-listbox selected="[[item.platform]]" attr-for-selected="value" slot="dropdown-content" class="dropdown-content">
+                        <template is="dom-repeat" items="[[fieldValues.queues]]">
+                          <paper-item label="[[item.name]]" value="[[item.name]]">[[item.display_name]]</paper-item>
+                        </template>
+                      </paper-listbox>
+                    </paper-dropdown-menu>
+        
+                    <paper-input label="Description (optional)" name="description" value="[[item.description]]"></paper-input>
+        
+                    <paper-textarea label="Templates (optional)" name="templates" value="[[getTemplatesString(item.templates)]]"></paper-textarea>
+                    <br/>
+        
+                    <div class="label">
+                      Custom Build (optional)
+                    </div>
+                    <template is="dom-if" if="[[item.custom_binary_key]]">
+                      <a href="/download/[[item.custom_binary_key]]">[[item.custom_binary_filename]]</a>
+                    </template>
+                    <paper-input type="file" id="file_[[index]]" label="File" no-label-float always-float-label$="false"></paper-input>
+                    <br/>
+        
+                    <paper-button raised on-tap="submitForm" data-index$="[[index]]">Save</paper-button>
+                    <paper-button class="info" job="[[item]]" raised on-tap="deleteJobTapped">Delete</paper-button>
+                  </div>
+        
+                  <div class="right">
+                    <paper-textarea label="Environment String" name="environment_string" value="[[item.environment_string]]" spellcheck="false"></paper-textarea>
+                  </div>
+                </div>
+              </form>
+            </iron-form>
+          </template>
+        </div>
+      </div>
+    </paginated-list>
   </template>
   <script>
     class JobsPage extends Polymer.Element {
@@ -219,9 +258,21 @@
 
       static get properties() {
         return {
-          jobs: Array,
+          result: Object,
           templates: Array,
           fieldValues: Object,
+          params: Object,
+          paramKeys: {
+            type: Array,
+            value: [
+              'page', 'q'
+            ]
+          },
+          response: Object,
+          loading: {
+            type: Boolean,
+            value: false
+          },
         };
       }
 
@@ -261,20 +312,90 @@
         }
         xhr.send(uploadData);
       }
+      
+      paramsModified(ev) {
+        this.search();
+      }
 
-      computeFilter(searchKey) {
-        if (!searchKey)
-          return null;
+      search() {
+        this.ajaxParams = {};
+        this.paramKeys.forEach((key) => {
+          if (this.params[key]) {
+            this.ajaxParams[key] = this.params[key];
+          }
+        });
 
-        searchKey = searchKey.toLowerCase();
-        return (el) => (
-            el['name'].toLowerCase().indexOf(searchKey) != -1 ||
-            el['environment_string'].toLowerCase().indexOf(searchKey) != -1);
+        this.$.paginatedList.updateQuery();
+        this.$.ajax.generateRequest();
       }
 
       deleteJobTapped(e) {
         this.$.deleteJobDialog.opened = true;
         this.toDelete = e.target.job;
+      }
+      
+      handleRequest() {
+        var reqs = this.$.ajax.activeRequests;
+        for (let i=0;i<reqs.length;i++) {
+          if (reqs[i] != this.request) {
+            reqs[i].abort();
+          }
+        }
+      }
+
+      handleResponse() {
+        this.result = this.response;
+        this.set('result.error', null);
+        this.$.paginatedList.save();
+      }
+
+      handleError() {
+        let error = parseError(this.error);
+        if (!error) {
+          // this.error is undefined because its request is aborted.
+          return;
+        }
+
+        this.set('result.items', null);
+        this.set('result.error', error);
+
+        this.$.paginatedList.save();
+      }
+      
+      searchButtonTapped(ev) {
+        let self = this;
+        let thisId = ++self.submitId;
+
+        if (ev.keyCode == 13) {
+          self.resetPageAndSearch();
+        } else {
+          setTimeout(
+              () => {
+                if (self.submitId == thisId) {
+                  self.resetPageAndSearch();
+                }
+              },
+              600
+          );
+        }
+      }
+      
+      resetPageAndSearch() {
+        this.params.page = '';
+        this.set('result.page', 1);
+        this.search();
+      }
+
+      shouldShowError(result, error) {
+        return error;
+      }
+
+      shouldShowEmpty(result, items) {
+        return items && items.length == 0;
+      }
+      
+      shouldShowItems(result, items) {
+        return items && items.length > 0;
       }
     }
 

--- a/src/appengine/private/templates/jobs.html
+++ b/src/appengine/private/templates/jobs.html
@@ -38,8 +38,9 @@
     <template>
       <template is="dom-if" if="[[data]]">
         <jobs-page
-            jobs="[[data.jobs]]"
+            result="[[data.result]]"
             templates="[[data.templates]]"
+            params="[[data.params]]"
             field-values="[[data.fieldValues]]">
         </jobs-page>
       </template>
@@ -47,9 +48,10 @@
   </dom-bind>
   <script>
     document.querySelector('#page').data = {
-      jobs : JSON.parse(atob('{{jobs|json}}')),
+      result : JSON.parse(atob('{{result|json}}')),
       templates : JSON.parse(atob('{{templates|json}}')),
       fieldValues: JSON.parse(atob('{{fieldValues|json}}')),
+      params: JSON.parse(atob('{{params|json}}')),
     };
   </script>
 {% endblock %}

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -11,44 +11,236 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Handler for showing crash stats inside the testcase detail page."""
+"""server.py initialises the appengine server for ClusterFuzz."""
+from __future__ import absolute_import
 
+from webapp2_extras import routes
+import webapp2
+
+from base import utils
+from config import local_config
 from handlers import base_handler
-from libs import crash_stats
-from libs import handler
-from libs import helpers
+from handlers import bots
+from handlers import commit_range
+from handlers import configuration
+from handlers import corpora
+from handlers import coverage_report
+from handlers import crash_stats
+from handlers import domain_verifier
+from handlers import download
+from handlers import fuzzer_stats
+from handlers import fuzzers
+from handlers import gcs_redirector
+from handlers import help_redirector
+from handlers import home
+from handlers import issue_redirector
+from handlers import jobs
+from handlers import login
+from handlers import report_csp_failure
+from handlers import revisions_info
+from handlers import testcase_list
+from handlers import upload_testcase
+from handlers import viewer
+from handlers.cron import backup
+from handlers.cron import batch_fuzzer_jobs
+from handlers.cron import build_crash_stats
+from handlers.cron import cleanup
+from handlers.cron import corpus_backup
+from handlers.cron import fuzz_strategy_selection
+from handlers.cron import fuzzer_and_job_weights
+from handlers.cron import fuzzer_coverage
+from handlers.cron import load_bigquery_stats
+from handlers.cron import manage_vms
+from handlers.cron import ml_train
+from handlers.cron import oss_fuzz_apply_ccs
+from handlers.cron import oss_fuzz_build_status
+from handlers.cron import oss_fuzz_generate_certs
+from handlers.cron import predator_pull
+from handlers.cron import project_setup
+from handlers.cron import recurring_tasks
+from handlers.cron import schedule_corpus_pruning
+from handlers.cron import sync_admins
+from handlers.cron import triage
+from handlers.performance_report import (show as show_performance_report)
+from handlers.reproduce_tool import get_config
+from handlers.reproduce_tool import testcase_info
+from handlers.testcase_detail import (crash_stats as crash_stats_on_testcase)
+from handlers.testcase_detail import (show as show_testcase)
+from handlers.testcase_detail import create_issue
+from handlers.testcase_detail import delete
+from handlers.testcase_detail import download_testcase
+from handlers.testcase_detail import find_similar_issues
+from handlers.testcase_detail import mark_fixed
+from handlers.testcase_detail import mark_security
+from handlers.testcase_detail import mark_unconfirmed
+from handlers.testcase_detail import redo
+from handlers.testcase_detail import remove_duplicate
+from handlers.testcase_detail import remove_group
+from handlers.testcase_detail import remove_issue
+from handlers.testcase_detail import testcase_variants
+from handlers.testcase_detail import update_from_trunk
+from handlers.testcase_detail import update_issue
+from metrics import logs
+
+_is_chromium = utils.is_chromium()
+_is_oss_fuzz = utils.is_oss_fuzz()
 
 
-def get_result(testcase, end, block, days, group_by):
-  """Get slots for crash stats."""
-  query = crash_stats.Query()
-  query.group_by = group_by
-  query.sort_by = 'total_count'
-  query.set_time_params(end, days, block)
+class _TrailingSlashRemover(webapp2.RequestHandler):
 
-  query.filter('crash_type', testcase.crash_type)
-  query.filter('crash_state', testcase.crash_state)
-  query.filter('security_flag', testcase.security_flag)
-
-  _, rows = crash_stats.get(query, crash_stats.Query(), 0, 1)
-
-  if not rows:
-    return {'end': end, 'days': days, 'block': block, 'groups': []}
-
-  return rows[0]
+  def get(self, url):
+    self.redirect(url)
 
 
-class Handler(base_handler.Handler):
-  """Serve crash stats data on testcase detail."""
+def redirect_to(to_domain):
+  """Create a redirect handler to a domain."""
 
-  @handler.post(handler.JSON, handler.JSON)
-  @handler.check_testcase_access
-  def post(self, testcase):
-    """Server crash stats."""
-    end = helpers.cast(self.request.get('end'), int, "'end' is not an int.")
-    days = helpers.cast(self.request.get('days'), int, "'days' is not an int.")
-    group_by = helpers.cast(
-        self.request.get('groupBy'), str, "'groupBy' is not a string.")
-    block = helpers.cast(
-        self.request.get('block'), str, "'block' is not a string.")
-    self.render_json(get_result(testcase, end, block, days, group_by))
+  class RedirectHandler(webapp2.RequestHandler):
+    """Handler to redirect to domain."""
+
+    def get(self, _):
+      self.redirect(
+          'https://' + to_domain + self.request.path_qs, permanent=True)
+
+  return RedirectHandler
+
+
+# Add item to the navigation menu. Order is important.
+base_handler.add_menu('Testcases', '/testcases')
+base_handler.add_menu('Fuzzer Statistics', '/fuzzer-stats')
+base_handler.add_menu('Crash Statistics', '/crash-stats')
+base_handler.add_menu('Upload Testcase', '/upload-testcase')
+
+if _is_chromium:
+  base_handler.add_menu('Crashes by range', '/commit-range')
+
+if not _is_oss_fuzz:
+  base_handler.add_menu('Fuzzers', '/fuzzers')
+  base_handler.add_menu('Corpora', '/corpora')
+  base_handler.add_menu('Bots', '/bots')
+
+base_handler.add_menu('Jobs', '/jobs')
+base_handler.add_menu('Configuration', '/configuration')
+base_handler.add_menu('Report Bug', '/report-bug')
+base_handler.add_menu('Documentation', '/docs')
+
+# We need to separate routes for cron to avoid redirection.
+_CRON_ROUTES = [
+    ('/backup', backup.Handler),
+    ('/batch-fuzzer-jobs', batch_fuzzer_jobs.Handler),
+    ('/build-crash-stats', build_crash_stats.Handler),
+    ('/cleanup', cleanup.Handler),
+    ('/corpus-backup/make-public', corpus_backup.MakePublicHandler),
+    ('/fuzzer-coverage', fuzzer_coverage.Handler),
+    ('/fuzzer-stats/cache', fuzzer_stats.RefreshCacheHandler),
+    ('/fuzzer-stats/preload', fuzzer_stats.PreloadHandler),
+    ('/fuzzer-and-job-weights', fuzzer_and_job_weights.Handler),
+    ('/fuzz-strategy-selection', fuzz_strategy_selection.Handler),
+    ('/home-cache', home.RefreshCacheHandler),
+    ('/load-bigquery-stats', load_bigquery_stats.Handler),
+    ('/manage-vms', manage_vms.Handler),
+    ('/oss-fuzz-apply-ccs', oss_fuzz_apply_ccs.Handler),
+    ('/oss-fuzz-build-status', oss_fuzz_build_status.Handler),
+    ('/oss-fuzz-generate-certs', oss_fuzz_generate_certs.Handler),
+    ('/project-setup', project_setup.Handler),
+    ('/predator-pull', predator_pull.Handler),
+    ('/schedule-corpus-pruning', schedule_corpus_pruning.Handler),
+    ('/schedule-impact-tasks', recurring_tasks.ImpactTasksScheduler),
+    ('/schedule-ml-train-tasks', ml_train.Handler),
+    ('/schedule-progression-tasks', recurring_tasks.ProgressionTasksScheduler),
+    ('/schedule-upload-reports-tasks',
+     recurring_tasks.UploadReportsTaskScheduler),
+    ('/sync-admins', sync_admins.Handler),
+    ('/testcases/cache', testcase_list.CacheHandler),
+    ('/triage', triage.Handler),
+]
+
+_ROUTES = [
+    ('/', home.Handler if _is_oss_fuzz else testcase_list.Handler),
+    (r'(.*)/$', _TrailingSlashRemover),
+    (r'/(google.+\.html)$', domain_verifier.Handler),
+    ('/bots', bots.Handler),
+    ('/bots/dead', bots.DeadBotsHandler),
+    ('/commit-range', commit_range.Handler),
+    ('/commit-range/load', commit_range.JsonHandler),
+    ('/configuration', configuration.Handler),
+    ('/add-external-user-permission', configuration.AddExternalUserPermission),
+    ('/delete-external-user-permission',
+     configuration.DeleteExternalUserPermission),
+    ('/coverage-report/([^/]+)/([^/]+)/([^/]+)(/.*)?', coverage_report.Handler),
+    ('/crash-stats/load', crash_stats.JsonHandler),
+    ('/crash-stats', crash_stats.Handler),
+    ('/corpora', corpora.Handler),
+    ('/corpora/create', corpora.CreateHandler),
+    ('/corpora/delete', corpora.DeleteHandler),
+    ('/docs', help_redirector.DocumentationHandler),
+    ('/download/?([^/]+)?', download.Handler),
+    ('/fuzzers', fuzzers.Handler),
+    ('/fuzzers/create', fuzzers.CreateHandler),
+    ('/fuzzers/delete', fuzzers.DeleteHandler),
+    ('/fuzzers/edit', fuzzers.EditHandler),
+    ('/fuzzers/log/([^/]+)', fuzzers.LogHandler),
+    ('/fuzzer-stats/load', fuzzer_stats.LoadHandler),
+    ('/fuzzer-stats/load-filters', fuzzer_stats.LoadFiltersHandler),
+    ('/fuzzer-stats', fuzzer_stats.Handler),
+    ('/fuzzer-stats/.*', fuzzer_stats.Handler),
+    ('/gcs-redirect', gcs_redirector.Handler),
+    ('/issue/([0-9]+)', issue_redirector.Handler),
+    ('/jobs', jobs.Handler),
+    ('/jobs/delete-job', jobs.DeleteJobHandler),
+    ('/jobs/load', jobs.JsonHandler),
+    ('/login', login.Handler),
+    ('/logout', login.LogoutHandler),
+    ('/update-job', jobs.UpdateJob),
+    ('/update-job-template', jobs.UpdateJobTemplate),
+    ('/performance-report/(.+)/(.+)/(.+)', show_performance_report.Handler),
+    ('/report-csp-failure', report_csp_failure.ReportCspFailureHandler),
+    ('/reproduce-tool/get-config', get_config.Handler),
+    ('/reproduce-tool/testcase-info', testcase_info.Handler),
+    ('/session-login', login.SessionLoginHandler),
+    ('/testcase', show_testcase.DeprecatedHandler),
+    ('/testcase-detail/([0-9]+)', show_testcase.Handler),
+    ('/testcase-detail/crash-stats', crash_stats_on_testcase.Handler),
+    ('/testcase-detail/create-issue', create_issue.Handler),
+    ('/testcase-detail/delete', delete.Handler),
+    ('/testcase-detail/download-testcase', download_testcase.Handler),
+    ('/testcase-detail/find-similar-issues', find_similar_issues.Handler),
+    ('/testcase-detail/mark-fixed', mark_fixed.Handler),
+    ('/testcase-detail/mark-security', mark_security.Handler),
+    ('/testcase-detail/mark-unconfirmed', mark_unconfirmed.Handler),
+    ('/testcase-detail/redo', redo.Handler),
+    ('/testcase-detail/refresh', show_testcase.RefreshHandler),
+    ('/testcase-detail/remove-duplicate', remove_duplicate.Handler),
+    ('/testcase-detail/remove-issue', remove_issue.Handler),
+    ('/testcase-detail/remove-group', remove_group.Handler),
+    ('/testcase-detail/testcase-variants', testcase_variants.Handler),
+    ('/testcase-detail/update-from-trunk', update_from_trunk.Handler),
+    ('/testcase-detail/update-issue', update_issue.Handler),
+    ('/testcases', testcase_list.Handler),
+    ('/testcases/load', testcase_list.JsonHandler),
+    ('/upload-testcase', upload_testcase.Handler),
+    ('/upload-testcase/get-url-oauth', upload_testcase.UploadUrlHandlerOAuth),
+    ('/upload-testcase/prepare', upload_testcase.PrepareUploadHandler),
+    ('/upload-testcase/load', upload_testcase.JsonHandler),
+    ('/upload-testcase/upload', upload_testcase.UploadHandler),
+    ('/upload-testcase/upload-oauth', upload_testcase.UploadHandlerOAuth),
+    ('/revisions', revisions_info.Handler),
+    ('/report-bug', help_redirector.ReportBugHandler),
+    ('/viewer', viewer.Handler),
+]
+
+logs.configure('appengine')
+
+config = local_config.GAEConfig()
+main_domain = config.get('domains.main')
+redirect_domains = config.get('domains.redirects')
+_DOMAIN_ROUTES = []
+if main_domain and redirect_domains:
+  for redirect_domain in redirect_domains:
+    _DOMAIN_ROUTES.append(
+        routes.DomainRoute(redirect_domain, [
+            webapp2.Route('<:.*>', redirect_to(main_domain)),
+        ]))
+
+app = webapp2.WSGIApplication(
+    _CRON_ROUTES + _DOMAIN_ROUTES + _ROUTES, debug=False)

--- a/src/local/butler/scripts/migration/__init__.py
+++ b/src/local/butler/scripts/migration/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/local/butler/scripts/migration/__init__.py
+++ b/src/local/butler/scripts/migration/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/local/butler/scripts/migration/jobs_keywords.py
+++ b/src/local/butler/scripts/migration/jobs_keywords.py
@@ -21,8 +21,5 @@ def execute(args):
   """Build keywords for jobs."""
   jobs = list(data_types.Job.query())
   if args.non_dry_run:
-    try:
-      ndb.put_multi(jobs)
-      print("Done building keywords for jobs.")
-    except Exception:
-      print("Error during building keywords for jobs.")
+    ndb.put_multi(jobs)
+    print("Done building keywords for jobs.")

--- a/src/local/butler/scripts/migration/jobs_keywords.py
+++ b/src/local/butler/scripts/migration/jobs_keywords.py
@@ -1,0 +1,35 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Build keyword attributes for every job."""
+
+import sys
+
+from datastore import data_types
+from google.cloud import ndb
+
+
+def execute(args):
+  """Build keywords for jobs."""
+  jobs = list(data_types.Job.query())
+  if args.non_dry_run:
+    try:
+      ndb.put_multi(jobs)
+    except Exception:
+      for job in jobs:
+        try:
+          job.put()
+        except Exception:
+          print('Error: %s %s' % (job.key.id(), sys.exc_info()))
+
+    print("Done building keywords for jobs.")

--- a/src/local/butler/scripts/migration/jobs_keywords.py
+++ b/src/local/butler/scripts/migration/jobs_keywords.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Build keyword attributes for every job."""
 
-import sys
-
 from datastore import data_types
 from google.cloud import ndb
 
@@ -25,11 +23,6 @@ def execute(args):
   if args.non_dry_run:
     try:
       ndb.put_multi(jobs)
+      print("Done building keywords for jobs.")
     except Exception:
-      for job in jobs:
-        try:
-          job.put()
-        except Exception:
-          print('Error: %s %s' % (job.key.id(), sys.exc_info()))
-
-    print("Done building keywords for jobs.")
+      print("Error during building keywords for jobs.")

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -946,16 +946,16 @@ class Job(Model):
     return environment_string
 
   def populate_indices(self):
-    """Populate keywords for fast test case list searching."""
+    """Populate keywords for fast job searching."""
     self.keywords = list(
         search_tokenizer.tokenize(self.name)
         | search_tokenizer.tokenize(self.project))
 
   def _pre_put_hook(self):
     """Pre-put hook."""
-    self.populate_indices()
     self.project = self.get_environment().get('PROJECT_NAME',
                                               utils.default_project_name())
+    self.populate_indices()
 
 
 class CSRFToken(Model):

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -909,6 +909,9 @@ class Job(Model):
   # Project name.
   project = StringProperty()
 
+  # keywords is used for searching.
+  keywords = ndb.StringProperty(repeated=True)
+
   def get_environment(self):
     """Get the environment as a dict for this job, including any environment
     variables in its template."""
@@ -942,8 +945,13 @@ class Job(Model):
 
     return environment_string
 
+  def populate_indices(self):
+    """Populate keywords for fast test case list searching."""
+    self.keywords = list(search_tokenizer.tokenize(self.name))
+
   def _pre_put_hook(self):
     """Pre-put hook."""
+    self.populate_indices()
     self.project = self.get_environment().get('PROJECT_NAME',
                                               utils.default_project_name())
 

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -909,7 +909,7 @@ class Job(Model):
   # Project name.
   project = StringProperty()
 
-  # keywords is used for searching.
+  # Keywords is used for searching.
   keywords = ndb.StringProperty(repeated=True)
 
   def get_environment(self):
@@ -947,7 +947,9 @@ class Job(Model):
 
   def populate_indices(self):
     """Populate keywords for fast test case list searching."""
-    self.keywords = list(search_tokenizer.tokenize(self.name))
+    self.keywords = list(
+        search_tokenizer.tokenize(self.name)
+        | search_tokenizer.tokenize(self.project))
 
   def _pre_put_hook(self):
     """Pre-put hook."""

--- a/src/python/tests/appengine/handlers/jobs_test.py
+++ b/src/python/tests/appengine/handlers/jobs_test.py
@@ -61,10 +61,10 @@ class JobsTest(unittest.TestCase):
     self.mock.has_access.return_value = True
     expected_items = {1: [], 2: [], 3: []}
 
-    for i, job_num in enumerate(string.ascii_lowercase):
-      job_name = "test_job" + job_num
+    for job_num, job_suffix in enumerate(string.ascii_lowercase):
+      job_name = "test_job_" + job_suffix
       job = self._create_job(job_name, 'APP_NAME = launcher.py\n')
-      expected_items[(i//10)+1].append(job.key.id())
+      expected_items[(job_num // 10) + 1].append(job.key.id())
 
     resp = self.app.post_json('/', {'page': 1})
     self.assertListEqual(expected_items[1],
@@ -127,5 +127,6 @@ class JobsSearchTest(unittest.TestCase):
                          [item['id'] for item in resp.json['items']])
 
     resp = self.app.post_json('/', {'q': "test"})
-    self.assertListEqual([job_asan.key.id(), job_ubsan.key.id()],
-                         [item['id'] for item in resp.json['items']])
+    self.assertListEqual(
+        [job_asan.key.id(), job_ubsan.key.id()],
+        [item['id'] for item in resp.json['items']])

--- a/src/python/tests/appengine/handlers/jobs_test.py
+++ b/src/python/tests/appengine/handlers/jobs_test.py
@@ -64,12 +64,13 @@ class JobsTest(unittest.TestCase):
     job4 = self._create_job('test_job4', 'APP_NAME = launcher4.py\n')
 
     expected_items = [
-        job1.key.id(), job2.key.id(),
-        job3.key.id(), job4.key.id()]
+        job1.key.id(),
+        job2.key.id(),
+        job3.key.id(),
+        job4.key.id()
+    ]
 
     resp = self.app.post_json('/', {'page': 1})
 
-    self.assertListEqual(
-        expected_items,
-        [item['id'] for item in resp.json['items']]
-    )
+    self.assertListEqual(expected_items,
+                         [item['id'] for item in resp.json['items']])

--- a/src/python/tests/appengine/handlers/jobs_test.py
+++ b/src/python/tests/appengine/handlers/jobs_test.py
@@ -78,6 +78,9 @@ class JobsTest(unittest.TestCase):
     self.assertListEqual(expected_items[3],
                          [item['id'] for item in resp.json['items']])
 
+    resp = self.app.post_json('/', {'page': 4})
+    self.assertListEqual([], [item['id'] for item in resp.json['items']])
+
 
 @test_utils.with_cloud_emulators('datastore')
 class JobsSearchTest(unittest.TestCase):
@@ -125,6 +128,9 @@ class JobsSearchTest(unittest.TestCase):
     resp = self.app.post_json('/', {'q': "ubsan"})
     self.assertListEqual([job_ubsan.key.id()],
                          [item['id'] for item in resp.json['items']])
+
+    resp = self.app.post_json('/', {'q': "testing"})
+    self.assertListEqual([], [item['id'] for item in resp.json['items']])
 
     resp = self.app.post_json('/', {'q': "test"})
     self.assertListEqual(

--- a/src/python/tests/appengine/handlers/jobs_test.py
+++ b/src/python/tests/appengine/handlers/jobs_test.py
@@ -115,8 +115,8 @@ class JobsSearchTest(unittest.TestCase):
     """Test post method."""
     self.mock.has_access.return_value = True
 
-    job_asan = self._create_job('test_job_asan', 'APP_NAME = launcher.py\n')
-    job_ubsan = self._create_job('test_job_ubsan', 'APP_NAME = launcher.py\n')
+    job_asan = self._create_job('test_job_asan', 'PROJECT_NAME = proj_1\n')
+    job_ubsan = self._create_job('test_job_ubsan', 'PROJECT_NAME = proj_2\n')
 
     resp = self.app.post_json('/', {'q': "asan"})
     self.assertListEqual([job_asan.key.id()],
@@ -127,6 +127,19 @@ class JobsSearchTest(unittest.TestCase):
                          [item['id'] for item in resp.json['items']])
 
     resp = self.app.post_json('/', {'q': "test"})
+    self.assertListEqual(
+        [job_asan.key.id(), job_ubsan.key.id()],
+        [item['id'] for item in resp.json['items']])
+
+    resp = self.app.post_json('/', {'q': "1"})
+    self.assertListEqual([job_asan.key.id()],
+                         [item['id'] for item in resp.json['items']])
+
+    resp = self.app.post_json('/', {'q': "2"})
+    self.assertListEqual([job_ubsan.key.id()],
+                         [item['id'] for item in resp.json['items']])
+
+    resp = self.app.post_json('/', {'q': "proj"})
     self.assertListEqual(
         [job_asan.key.id(), job_ubsan.key.id()],
         [item['id'] for item in resp.json['items']])


### PR DESCRIPTION
Update (6th July, 2020): Keywords search requires a re-puts for all jobs, so @oliverchang has suggested to make a migration command for the same. I have added the script in src/local/butler/scripts/migration and the instructions in Next section in Changelog.

Hi, This PR is to add pagination support to Jobs page(Issue #780). Along with that some other changes that are made:
1. Requests for search and page change will be using AJAX. Added a JsonHandler in page handler.
2. Search shifted from on-browser to server side using keywords present in name. (Due to this, the existing builds' jobs data should be modified as a new attribute is added to Job model)
3. Added new test for changed APIs.

I will share the design doc for new jobs dataflow and these changes in the core group.

Screenshots:
Number of pages are set to 5 by default, each page will have 10 jobs.
![Screenshot 2020-07-02 at 12 03 57 PM](https://user-images.githubusercontent.com/30122295/86400151-bdf8cd80-bcc5-11ea-8861-3b5e979f97fd.png)

Please have a look and let me know if any changes are required!