### PR TITLE
Upgrade CPU tensorflow to 2.3.0-rc0 and re-enable training test (#1540).

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ future = "==0.17.1"
 protobuf = "==3.11.3"
 psutil = "==5.7.0"
 numpy = "==1.18.4"
-tensorflow = "==2.2.0rc4"
+tensorflow = "==2.3.0-rc0"
 
 [dev-packages]
 pylint = "~=2.4"

--- a/src/python/tests/core/bot/tasks/ml_train_task_test.py
+++ b/src/python/tests/core/bot/tasks/ml_train_task_test.py
@@ -158,8 +158,6 @@ class ExecuteTaskTest(unittest.TestCase):
                                                 model_directory, log_directory)
 
 
-# TODO(mmoroz): Re-enable this.
-@unittest.skip('Training is broken.')
 @test_utils.integration
 class MLRnnTrainTaskIntegrationTest(unittest.TestCase):
   """ML RNN training integration tests."""


### PR DESCRIPTION
I was preparing this for @mihaimaruseac as discussed in https://github.com/google/clusterfuzz/issues/1540, but the test seems to pass locally now. Maybe something's wrong with my environment, let's see what CI thinks about this.