### PR TITLE
Lower down corpus backup public marking time

### DIFF
--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -34,7 +34,7 @@ BLOBSTORE_STACK_PREFIX = 'BLOB_KEY='
 BUILTIN_FUZZERS = ['afl', 'libFuzzer']
 
 # Time to look back to find a corpus backup that is marked public.
-CORPUS_BACKUP_PUBLIC_LOOKBACK_DAYS = 90
+CORPUS_BACKUP_PUBLIC_LOOKBACK_DAYS = 30
 
 # Marker to indicate end of crash stacktrace. Anything after that is excluded
 # from being stored as part of crash stacktrace (e.g. merge content, etc).


### PR DESCRIPTION
Change corpus backup public marking time from 90 to 30 days.

Now that we archive crash regressions in corpus backup, it makes sense for projects to use this corpus backup sooner than later. Also, anyone can generate this corpus with enough cpus, so 30 days seems reasonable.