### PR TITLE
Android Kernel repro.prop acquisition

### DIFF
--- a/src/python/platforms/android/constants.py
+++ b/src/python/platforms/android/constants.py
@@ -38,3 +38,13 @@ BUILD_PROP_MD5_KEY = 'android_build_prop_md5'
 LAST_TEST_ACCOUNT_CHECK_KEY = 'android_last_test_account_check'
 LAST_FLASH_BUILD_KEY = 'android_last_flash'
 LAST_FLASH_TIME_KEY = 'android_last_flash_time'
+
+PRODUCT_TO_KERNEL = {
+    'blueline': 'bluecross',
+    'crosshatch': 'bluecross',
+    'flame': 'floral',
+    'coral': 'floral',
+    'walleye': 'wahoo',
+    'muskie': 'wahoo',
+    'taimen': 'wahoo',
+}

--- a/src/python/platforms/android/settings.py
+++ b/src/python/platforms/android/settings.py
@@ -15,9 +15,14 @@
 
 from builtins import str
 
+import os
 import re
 
 from . import adb
+from base import utils
+from metrics import logs
+from platforms.android import constants
+from platforms.android import symbols_downloader
 from system import environment
 
 BUILD_FINGERPRINT_REGEX = re.compile(
@@ -132,6 +137,11 @@ def get_product_name():
   return adb.get_property('ro.product.name')
 
 
+def get_build_product():
+  """Return builds's product."""
+  return adb.get_property('ro.build.product')
+
+
 def get_sanitizer_tool_name():
   """Return sanitizer tool name e.g. ASAN if found on device."""
   build_flavor = get_build_flavor()
@@ -148,6 +158,32 @@ def get_sanitizer_tool_name():
 def get_security_patch_level():
   """Return the security patch level reported by the device."""
   return adb.get_property('ro.build.version.security_patch')
+
+
+def get_kernel_build_id():
+  """Returns the build id of the kernel from the kernel version string."""
+  version_string = adb.run_shell_command('cat /proc/version').strip()
+  # Linux version 3.18.0-g(8de8e79)-ab(1234567) where 8de8e79 is the hash and
+  # 1234567 optional is the kernel build id.
+  match = re.match(r'Linux version .+-g([0-9a-f]+)[\s\-](ab([0-9a-f]+)\s)',
+                   version_string)
+  if match:
+    return match.group(3)
+
+  return None
+
+
+def get_kernel_name():
+  """Returns the kernel name for the device, since some kernels are shared."""
+  product_name = get_product_name()
+  build_product = get_build_product()
+
+  # Strip _kasan off of the end as we will add it later if needed.
+  utils.strip_from_right(product_name, '_kasan')
+
+  # Some devices have a different kernel name than product_name, if so use the
+  # kernel name.
+  return constants.PRODUCT_TO_KERNEL.get(build_product, product_name)
 
 
 def is_google_device():
@@ -194,3 +230,23 @@ def set_database_setting(database_path, table, key, value):
   sql_command_string = ('"UPDATE %s SET value=\'%s\' WHERE name=\'%s\'"') % (
       table, str(value), key)
   adb.run_shell_command(['sqlite3', database_path, sql_command_string])
+
+
+def get_repo_prop_path():
+  """Download repo.prop and return path of it on local machine."""
+  symbols_directory = os.path.join(
+      environment.get_value('SYMBOLS_DIR'), 'kernel')
+  build_id = get_kernel_build_id()
+  target = get_kernel_name()
+  if not build_id or not target:
+    logs.log_error('Could not get kernel parameters, exiting.')
+    return None
+
+  repro_filename = symbols_downloader.get_symbols_archive_filename(
+      build_id, target)
+
+  # Grab repo.prop, it is not on the device nor in the build_dir.
+  symbols_downloader.download_system_symbols_if_needed(
+      symbols_directory, is_kernel=True)
+  local_binary_path = utils.find_binary_path(symbols_directory, repro_filename)
+  return local_binary_path

--- a/src/python/platforms/android/symbols_downloader.py
+++ b/src/python/platforms/android/symbols_downloader.py
@@ -1,0 +1,140 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Used to download Android symbols."""
+from __future__ import print_function
+
+import os
+
+from base import utils
+from google_cloud_utils import storage
+from metrics import logs
+from platforms.android import fetch_artifact
+from platforms.android import settings
+from system import archive
+from system import environment
+from system import shell
+
+
+def get_symbols_archive_filename(build_id, target):
+  return '%s-%s-repo.prop' % (target, build_id)
+
+
+def download_system_symbols_if_needed(symbols_directory, is_kernel=False):
+  """Download system libraries from |SYMBOLS_URL| and cache locally."""
+  # For local testing, we do not have access to the cloud storage bucket with
+  # the symbols. In this case, just bail out.
+  if environment.get_value('LOCAL_DEVELOPMENT'):
+    return
+
+  # When running reproduce tool locally, we do not have access to the cloud
+  # storage bucket with the symbols. In this case, just bail out.
+  if environment.get_value('REPRODUCE_TOOL'):
+    return
+
+  # We have archived symbols for google builds only.
+  if not settings.is_google_device():
+    return
+
+  # For Android kernel we want to get the repro.prop
+  # Note: kasan and non-kasan kernel should have the same repo.prop for a given
+  # build_id.
+  if is_kernel:
+    build_id = settings.get_kernel_build_id()
+    target = settings.get_kernel_name()
+    if not build_id or not target:
+      logs.log_error('Could not get kernel parameters, exiting.')
+      return
+
+    artifact_file_name = 'repo.prop'
+    symbols_archive_filename = get_symbols_archive_filename(build_id, target)
+    output_filename_override = symbols_archive_filename
+    # We create our own build_params for cache
+    build_params = {'build_id': build_id, 'target': target, 'type': 'kernel'}
+  else:
+    # Get the build fingerprint parameters.
+    build_params = settings.get_build_parameters()
+    if not build_params:
+      logs.log_error('Unable to determine build parameters.')
+      return
+
+    build_id = build_params.get('build_id')
+    target = build_params.get('target')
+    build_type = build_params.get('type')
+    if not build_id or not target or not build_type:
+      logs.log_error('Null build parameters found, exiting.')
+      return
+
+    symbols_archive_filename = '%s-symbols-%s.zip' % (target, build_id)
+    artifact_file_name = symbols_archive_filename
+    output_filename_override = None
+
+  # Check if we already have the symbols in cache.
+  build_params_check_path = os.path.join(symbols_directory,
+                                         '.cached_build_params')
+  cached_build_params = utils.read_data_from_file(
+      build_params_check_path, eval_data=True)
+  if cached_build_params and cached_build_params == build_params:
+    # No work to do, same system symbols already in cache.
+    return
+
+  symbols_archive_path = os.path.join(symbols_directory,
+                                      symbols_archive_filename)
+
+  # Delete existing symbols directory first.
+  shell.remove_directory(symbols_directory, recreate=True)
+
+  # Fetch symbol file from cloud storage cache (if available).
+  found_in_cache = storage.get_file_from_cache_if_exists(
+      symbols_archive_path, update_modification_time_on_access=False)
+  if not found_in_cache:
+    tool_suffix = environment.get_value('SANITIZER_TOOL_NAME')
+
+    if is_kernel:
+      # Some kernels are just 'kernel', some are kernel_target
+      if tool_suffix:
+        targets_with_type_and_san = [
+            'kernel_%s' % tool_suffix,
+            'kernel_%s_%s' % (tool_suffix, target)
+        ]
+      else:
+        targets_with_type_and_san = ['kernel', 'kernel_%s' % target]
+    else:
+      # Include type and sanitizer information in the target.
+      target_with_type_and_san = '%s-%s' % (target, build_type)
+      if tool_suffix and not tool_suffix in target_with_type_and_san:
+        target_with_type_and_san += '_%s' % tool_suffix
+
+      targets_with_type_and_san = [target_with_type_and_san]
+
+    for target_with_type_and_san in targets_with_type_and_san:
+      # Fetch the artifact now.
+      fetch_artifact.get(build_id, target_with_type_and_san, artifact_file_name,
+                         symbols_directory, output_filename_override)
+      if os.path.exists(symbols_archive_path):
+        break
+
+  if not os.path.exists(symbols_archive_path):
+    logs.log_error(
+        'Unable to locate symbols archive %s.' % symbols_archive_path)
+    return
+
+  # Store the artifact for later use or for use by other bots.
+  storage.store_file_in_cache(symbols_archive_path)
+
+  # repo.prop is not a zip archive.
+  if not is_kernel:
+    archive.unpack(symbols_archive_path, symbols_directory, trusted=True)
+    shell.remove_file(symbols_archive_path)
+
+  utils.write_data_to_file(build_params, build_params_check_path)

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -42,11 +42,13 @@ class StackAnalyzerTestcase(unittest.TestCase):
     helpers.patch(self, [
         'crash_analysis.stack_parsing.stack_symbolizer.symbolize_stacktrace',
         'metrics.logs.log_error',
+        'platforms.android.settings.get_repo_prop_path'
     ])
 
     os.environ['JOB_NAME'] = TEST_JOB_NAME
 
     self.mock.symbolize_stacktrace.side_effect = self._mock_symbolize_stacktrace
+    self.mock.get_repo_prop_path.return_value = None
 
   def _read_test_data(self, name):
     """Helper function to read test data."""

--- a/src/python/tests/core/platforms/android/stack_analyzer_data/kasan_syzkaller_android.txt
+++ b/src/python/tests/core/platforms/android/stack_analyzer_data/kasan_syzkaller_android.txt
@@ -1,0 +1,20 @@
+BUG: KASAN: null-ptr-deref in sockfs_setattr+0x68/0x90 net/socket.c:544
+Write of size 4 at addr 000000000000027c by task syz-executor/16883
+
+CPU: 7 PID: 16883 Comm: syz-executor Tainted: G         C      4.4.155-g9ef595a18d67 #1
+Hardware name: Qualcomm Technologies, Inc. MSM8998 v2.1 (DT)
+Call trace:
+[<ffffff900808f5ac>] dump_backtrace+0x0/0x34c arch/arm64/kernel/traps.c:96
+[<ffffff900808fa38>] show_stack+0x1c/0x24 arch/arm64/kernel/traps.c:242
+[<ffffff9008580198>] __dump_stack lib/dump_stack.c:15 [inline]
+[<ffffff9008580198>] dump_stack+0xb8/0xe8 lib/dump_stack.c:51
+[<ffffff90082b0e78>] kasan_report_error mm/kasan/report.c:348 [inline]
+[<ffffff90082b0e78>] kasan_report+0xe4/0x340 mm/kasan/report.c:407
+[<ffffff90082af1bc>] check_memory_region_inline mm/kasan/kasan.c:325 [inline]
+[<ffffff90082af1bc>] __asan_store4+0x78/0x94 mm/kasan/kasan.c:758
+[<ffffff9009602804>] sockfs_setattr+0x68/0x90 net/socket.c:544
+[<ffffff90082f0c0c>] notify_change2+0x568/0x5e8 fs/attr.c:283
+[<ffffff90082bd3e4>] chown_common+0xf4/0x1e8 fs/open.c:612
+[<ffffff90082bf4bc>] SYSC_fchownat fs/open.c:642 [inline]
+[<ffffff90082bf4bc>] SyS_fchownat+0xdc/0x168 fs/open.c:622
+[<ffffff90080842b0>] el0_svc_naked+0x24/0x28

--- a/src/python/tests/core/platforms/android/stack_analyzer_test.py
+++ b/src/python/tests/core/platforms/android/stack_analyzer_test.py
@@ -1,0 +1,117 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the stack analyzer module for android specifically."""
+
+import os
+import unittest
+
+from base import utils
+from crash_analysis.stack_parsing import stack_analyzer
+from system import environment
+from tests.test_libs import helpers as test_helpers
+
+DATA_DIRECTORY = os.path.join(os.path.dirname(__file__), 'stack_analyzer_data')
+TEST_JOB_NAME = 'test'
+
+KERNEL_REPRO = """kernel/build u'c059b39e1caf2b96aa376582eeb93062b43d69d5'
+kernel/manifest u'75a64986ab455f8b45087b8ad54db68bcb8988f4'
+kernel/private/msm-google u'40e9b2ff3a280a8775cfcd5841e530ce78f94355'
+kernel/private/msm-google-extra/audiokernel u'112a618d5b757b0600c69f7385892b3f57ccd93e'
+kernel/private/msm-google-modules/data-kernel u'e7210f09d00c91f87b295c7a952f040c73506cc0'
+kernel/private/msm-google-modules/fts_touch u'8f6a4e9f5649deff59174ffed1d5c2af196d9f63'
+kernel/private/msm-google-modules/qca-wfi-host-cmn u'7d4b05ac12d6a1b5d5247da35ae7e370a2cba07d'
+kernel/private/msm-google-modules/qcacld u'0a077b0073c48555d0edb2b9b0510fb883181828'
+kernel/private/msm-google-modules/wlan-fw-api u'53d899727e4278f4e9fb46328d740a8fb2d9a493'
+kernel/private/tests/patchwork u'204e78fb6d905016bfc16ebe7b64547f388cfdb5'
+kernel/tests u'bfef3bb78b23cb3f3f12a6880ecafd5def3b66a5'
+platform/external/fff u'c82edb1fc60dc81bd319d9b8d0bee9f8963a6960'
+platform/external/googletest u'a037984aea3317260edd1127abb39e30e845bc94'
+platform/prebuilts/clang/host/linux-x86 u'4b1f275e6b3826c86f791ae8c4d5ec3563c2fc11'
+platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9 u'961622e926a1b21382dba4dd9fe0e5fb3ee5ab7c'
+platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9 u'cb7b3ac1b7fdb49474ff68761909934d1142f594'
+platform/prebuilts/misc u'15560bb32cdb9b47db48eb4865b736df9708a8fe'
+platform/tools/repohooks u'233b8010f7f5e3c544b47c68ffae781860156945'
+"""
+
+
+# pylint: disable=unused-argument
+def _mock_symbolize_stacktrace(stacktrace, enable_inline_frames=True):
+  """No-op mocked version of symbolize_stacktrace."""
+  return stacktrace
+
+
+def _mock_fetch_artifact_get(bid,
+                             target,
+                             regex,
+                             output_directory,
+                             output_filename_override=None):
+  if output_filename_override:
+    artifact_path = os.path.join(output_directory, output_filename_override)
+    with open(artifact_path, 'w') as artifact_file:
+      artifact_file.write(KERNEL_REPRO)
+
+
+# pylint: enable=unused-argument
+
+
+class AndroidStackAnalyzerTest(unittest.TestCase):
+  """Android specific Stack analyzer tests."""
+
+  def setUp(self):
+    test_helpers.patch_environ(self)
+    test_helpers.patch(self, [
+        'crash_analysis.stack_parsing.stack_symbolizer.symbolize_stacktrace',
+        'metrics.logs.log_error',
+    ])
+    os.environ['JOB_NAME'] = TEST_JOB_NAME
+
+    self.mock.symbolize_stacktrace.side_effect = _mock_symbolize_stacktrace
+
+  def _mock_read_data_from_file(self, file_path, eval_data=True, default=None):
+    if file_path.endswith('repo.prop'):
+      return self._real_read_data_from_file(file_path, eval_data, default)
+
+    return None
+
+  def _read_test_data(self, name):
+    """Helper function to read test data."""
+    with open(os.path.join(DATA_DIRECTORY, name)) as handle:
+      return handle.read()
+
+  def test_syzkaller_kasan_android_with_env(self):
+    """Test syzkaller kasan."""
+    environment.set_value('OS_OVERRIDE', 'ANDROID')
+    environment.set_bot_environment()
+    self._real_read_data_from_file = utils.read_data_from_file
+    test_helpers.patch(self, [
+        'platforms.android.fetch_artifact.get',
+        'platforms.android.settings.get_kernel_build_id',
+        'platforms.android.settings.get_kernel_name',
+        'platforms.android.settings.get_product_brand',
+        'google_cloud_utils.storage.get_file_from_cache_if_exists',
+        'google_cloud_utils.storage.store_file_in_cache',
+        'base.utils.write_data_to_file', 'base.utils.read_data_from_file'
+    ])
+    self.mock.get.side_effect = _mock_fetch_artifact_get
+    self.mock.get_kernel_build_id.return_value = '12345'
+    self.mock.get_kernel_name.return_value = 'device_kernel'
+    self.mock.get_product_brand.return_value = 'google'
+    self.mock.get_file_from_cache_if_exists.return_value = False
+    self.mock.store_file_in_cache.return_value = None
+    self.mock.write_data_to_file = None
+    self.mock.read_data_from_file.side_effect = self._mock_read_data_from_file
+
+    data = self._read_test_data('kasan_syzkaller_android.txt')
+    actual_state = stack_analyzer.get_crash_data(data)
+    self.assertEqual(actual_state.android_kernel_repo, KERNEL_REPRO)


### PR DESCRIPTION
This is the first part of 2 changes that will allow linkification of
Android kernel crashes.  This change simply gets the repo.prop from the
Android build server and places it as a new element of the
StackAnalyzerState.