### PR TITLE
Added fuzzer-to-job configurability on /jobs page

### DIFF
--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -100,6 +100,9 @@ class Handler(base_handler.Handler):
     templates = list(data_types.JobTemplate.query().order(
         data_types.JobTemplate.name))
     queues = get_queues()
+    fuzzers = [
+        fuzzer.name for fuzzer in data_types.Fuzzer.query(projection=['name'])
+    ]
 
     result, params = get_results(self)
     self.render(
@@ -107,18 +110,12 @@ class Handler(base_handler.Handler):
             'result': result,
             'templates': templates,
             'fieldValues': {
-                'csrf_token':
-                    form.generate_csrf_token(),
-                'fuzzers':
-                    data_handler.get_all_fuzzer_names_including_children(),
-                'queues':
-                    queues,
-                'update_job_url':
-                    '/update-job',
-                'update_job_template_url':
-                    '/update-job-template',
-                'upload_info':
-                    gcs.prepare_blob_upload()._asdict(),
+                'csrf_token': form.generate_csrf_token(),
+                'fuzzers': fuzzers,
+                'queues': queues,
+                'update_job_url': '/update-job',
+                'update_job_template_url': '/update-job-template',
+                'upload_info': gcs.prepare_blob_upload()._asdict(),
             },
             'params': params,
         })

--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -140,6 +140,7 @@ class UpdateJob(base_handler.GcsUploadHandler):
           'Job name can only contain letters, numbers, dashes and underscores.',
           400)
 
+    # Retriving old associated fuzzers.
     query = data_types.Fuzzer.query()
     query = query.filter(data_types.Fuzzer.jobs == name)
     old_fuzzers = ndb_utils.get_all_from_query(query)
@@ -147,6 +148,7 @@ class UpdateJob(base_handler.GcsUploadHandler):
     for fuzzer in old_fuzzers:
       old_mappings[fuzzer.name] = fuzzer
 
+    # Adding new associated fuzzers.
     new_fuzzer_names = self.request.get('fuzzers', []).split(',')
     for fuzzer_name in new_fuzzer_names:
       fuzzer = old_mappings.pop(fuzzer_name, None)
@@ -165,6 +167,7 @@ class UpdateJob(base_handler.GcsUploadHandler):
       fuzzer.put()
       fuzzer_selection.update_mappings_for_fuzzer(fuzzer)
 
+    # Removing job from now non-associated fuzzers.
     for fuzzer_name, fuzzer in old_mappings.items():
       fuzzer.jobs.remove(name)
       fuzzer.put()

--- a/src/appengine/private/components/jobs/jobs.html
+++ b/src/appengine/private/components/jobs/jobs.html
@@ -17,6 +17,7 @@
 <link rel="import" href="../../bower_components/iron-form/iron-form.html">
 <link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../bower_components/paper-input/paper-textarea.html">
@@ -25,6 +26,7 @@
 <link rel="import" href="../common/paginated-list/paginated-list.html">
 
 <link rel="import" href="delete-job-dialog.html">
+<link rel="import" href="multi-listbox.html">
 
 <dom-module id="jobs-page">
   <link rel="import" href="../../stylesheets/main.css" type="css">
@@ -55,6 +57,28 @@
         --iron-autogrow-textarea: {
           overflow: hidden;
         }
+      }
+
+      .inline {
+        display: flex;
+      }
+
+      .inline > * {
+        flex: 1;
+      }
+
+      .inline.narrow > * {
+        width: 350px;
+        margin: 0 0px;
+      }
+
+      .fuzzer-select {
+        padding: 0;
+      }
+
+      .job-checkbox {
+        padding: 0.5em;
+        display: block;
       }
 
       :root {
@@ -157,6 +181,41 @@
                   </paper-listbox>
                 </paper-dropdown-menu>
 
+                <div class="inline narrow">
+                  <paper-menu-button class="fuzzer-select dropdown-filter" no-animations="true" ignore-select="true" noink>
+                    <div slot="dropdown-trigger">
+                      <paper-input
+                          readonly
+                          label="Select/modify fuzzers"
+                          title="Set of fuzzers to run with this job.">
+                        <iron-icon icon="paper-dropdown-menu:arrow-drop-down" suffix slot="suffix"></iron-icon>
+                      </paper-input>
+                    </div>
+                    <multi-listbox
+                        name="fuzzers"
+                        slot="dropdown-content"
+                        multi
+                        attr-for-selected="val"
+                        selected-attribute="checked">
+                      <paper-input
+                          autofocus
+                          label="Search fuzzers"
+                          value="{{fuzzerKey}}"
+                          on-tap="stopEventPropagation"
+                          on-keydown="stopEventPropagation"
+                          on-keyup="stopEventPropagation" no-label-float>
+                        <iron-icon icon="icons:search" slot="prefix"></iron-icon>
+                        <iron-icon icon="icons:clear" slot="suffix" on-click="clearSearchInput"></iron-icon>
+                      </paper-input>
+                      <template is="dom-repeat" items="[[fieldValues.fuzzers]]" filter="{{onmatch(fuzzerKey)}}">
+                        <paper-checkbox class="job-checkbox" val="[[item]]">
+                          [[item]]
+                        </paper-checkbox>
+                      </template>
+                    </multi-listbox>
+                  </paper-menu-button>
+                </div>
+
                 <paper-input label="Description (optional)" name="description"></paper-input>
 
                 <paper-textarea label="Templates (optional, one per line)" name="templates" value=""></paper-textarea>
@@ -222,6 +281,42 @@
                         </template>
                       </paper-listbox>
                     </paper-dropdown-menu>
+
+                    <div class="inline narrow">
+                      <paper-menu-button class="fuzzer-select dropdown-filter" no-animations="true" ignore-select="true" noink>
+                        <div slot="dropdown-trigger">
+                          <paper-input
+                              readonly
+                              label="Select/modify fuzzers"
+                              title="Set of fuzzers to run with this job.">
+                            <iron-icon icon="paper-dropdown-menu:arrow-drop-down" suffix slot="suffix"></iron-icon>
+                          </paper-input>
+                        </div>
+                        <multi-listbox
+                            name="fuzzers"
+                            slot="dropdown-content"
+                            multi
+                            attr-for-selected="val"
+                            value="{{item.fuzzers}}"
+                            selected-attribute="checked">
+                          <paper-input
+                              autofocus
+                              label="Search fuzzers"
+                              value="{{fuzzerKey}}"
+                              on-tap="stopEventPropagation"
+                              on-keydown="stopEventPropagation"
+                              on-keyup="stopEventPropagation" no-label-float>
+                            <iron-icon icon="icons:search" slot="prefix"></iron-icon>
+                            <iron-icon icon="icons:clear" slot="suffix" on-click="clearSearchInput"></iron-icon>
+                          </paper-input>
+                          <template is="dom-repeat" items="[[fieldValues.fuzzers]]" filter="{{onmatch(fuzzerKey)}}">
+                            <paper-checkbox class="job-checkbox" val="[[item]]">
+                              [[item]]
+                            </paper-checkbox>
+                          </template>
+                        </multi-listbox>
+                      </paper-menu-button>
+                    </div>
         
                     <paper-input label="Description (optional)" name="description" value="[[item.description]]"></paper-input>
         
@@ -375,6 +470,33 @@
 
         this.$.paginatedList.save();
       }
+
+      clearSearchInput(ev) {
+        // Clear the search box.
+        let searchBox = ev.target.parentNode;
+        searchBox.value = '';
+
+        // Clear the selection in the list box;
+        let listBox = searchBox.parentNode;
+        listBox.selected = '';
+
+        // Restore focus to searchbox.
+        searchBox.$.input.focus();
+      }
+
+      onmatch(key) {
+        if (!key)
+          return null;
+
+        try {
+          key = key.toLowerCase();
+        } catch (err) {}
+
+        return function(item) {
+          if (item.toLowerCase().search(key) >= 0)
+            return true;
+        };
+      }
       
       searchInputTimeout(ev) {
         let self = this;
@@ -412,6 +534,10 @@
       
       shouldShowItems(result, items) {
         return items && items.length > 0;
+      }
+
+      stopEventPropagation(ev) {
+        ev.stopPropagation();
       }
     }
 

--- a/src/appengine/private/components/jobs/multi-listbox.html
+++ b/src/appengine/private/components/jobs/multi-listbox.html
@@ -35,8 +35,7 @@
                    slot="dropdown-content"
                    attr-for-selected="[[attrForSelected]]"
                    selected-values="{{value}}"
-                   selected-attribute="[[selectedAttribute]]"
-                   on-iron-activate="_clearError">
+                   selected-attribute="[[selectedAttribute]]">
                    <slot></slot>
     </paper-listbox>
   </template>
@@ -60,22 +59,7 @@
         selectedAttribute: {
           type: String,
         },
-        invalid: {
-          type: Boolean,
-          reflectToAttribute: true
-        }
       },
-
-      validate: function() {
-        const isValid = !this.required || !!(this.value && this.value.length > 0);
-        this.invalid = !isValid;
-        console.log('invalid', this.invalid);
-        return isValid;
-      },
-
-      _clearError: function() {
-        this.invalid = false;
-      }
     });
   </script>
 </dom-module>

--- a/src/appengine/private/components/jobs/multi-listbox.html
+++ b/src/appengine/private/components/jobs/multi-listbox.html
@@ -1,0 +1,81 @@
+<!--
+  Copyright 2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-listbox/paper-listbox.html">
+
+<dom-module id="multi-listbox">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+
+      paper-listbox {
+        border: solid 2px lightgray;
+      }
+
+      :host([invalid]) paper-listbox {
+        border: solid 2px var(--error-color, red);
+      }
+    </style>
+    <paper-listbox multi
+                   slot="dropdown-content"
+                   attr-for-selected="[[attrForSelected]]"
+                   selected-values="{{value}}"
+                   selected-attribute="[[selectedAttribute]]"
+                   on-iron-activate="_clearError">
+                   <slot></slot>
+    </paper-listbox>
+  </template>
+  <script>
+    Polymer({
+      is: 'multi-listbox',
+
+      behaviors: [
+        Polymer.IronFormElementBehavior
+      ],
+
+      properties: {
+        value: {
+          type: Array,
+          value: () => [],
+          notify: true
+        },
+        attrForSelected: {
+          type: String,
+        },
+        selectedAttribute: {
+          type: String,
+        },
+        invalid: {
+          type: Boolean,
+          reflectToAttribute: true
+        }
+      },
+
+      validate: function() {
+        const isValid = !this.required || !!(this.value && this.value.length > 0);
+        this.invalid = !isValid;
+        console.log('invalid', this.invalid);
+        return isValid;
+      },
+
+      _clearError: function() {
+        this.invalid = false;
+      }
+    });
+  </script>
+</dom-module>

--- a/src/python/fuzzing/fuzzer_selection.py
+++ b/src/python/fuzzing/fuzzer_selection.py
@@ -68,6 +68,7 @@ def update_mappings_for_job(job, mappings):
   existing_fuzzers_query = data_types.Fuzzer.query(
       data_types.Fuzzer.jobs == job.name)
   existing_fuzzers = {fuzzer.name: fuzzer for fuzzer in existing_fuzzers_query}
+  modified_fuzzers = []
 
   for fuzzer_name in mappings:
     fuzzer = existing_fuzzers.pop(fuzzer_name, None)
@@ -82,15 +83,16 @@ def update_mappings_for_job(job, mappings):
       continue
 
     fuzzer.jobs.append(job.name)
-    fuzzer.put()
+    modified_fuzzers.append(fuzzer)
     update_mappings_for_fuzzer(fuzzer)
 
   # Removing the remaining values in exisiting_fuzzers as
   # they are no longer mapped.
   for fuzzer in existing_fuzzers.values():
     fuzzer.jobs.remove(job.name)
+    modified_fuzzers.append(fuzzer)
     update_mappings_for_fuzzer(fuzzer)
-  ndb.put_multi(existing_fuzzers.values())
+  ndb.put_multi(modified_fuzzers)
 
 
 def update_platform_for_job(job_name, new_platform):

--- a/src/python/tests/appengine/handlers/jobs_test.py
+++ b/src/python/tests/appengine/handlers/jobs_test.py
@@ -81,6 +81,21 @@ class JobsTest(unittest.TestCase):
     resp = self.app.post_json('/', {'page': 4})
     self.assertListEqual([], [item['id'] for item in resp.json['items']])
 
+  def test_fuzzers_result(self):
+    """Test fuzzers result obtained in post method."""
+    self.mock.has_access.return_value = True
+
+    job = self._create_job('test_job', 'APP_NAME = launcher.py\n')
+    fuzzer = data_types.Fuzzer()
+    fuzzer.name = 'fuzzer'
+    fuzzer.jobs = ['test_job']
+    fuzzer.put()
+
+    resp = self.app.post_json('/', {'page': 1})
+    self.assertListEqual([job.key.id()],
+                         [item['id'] for item in resp.json['items']])
+    self.assertIn('fuzzer', resp.json['items'][0]['fuzzers'])
+
 
 @test_utils.with_cloud_emulators('datastore')
 class JobsSearchTest(unittest.TestCase):

--- a/src/python/tests/appengine/handlers/jobs_test.py
+++ b/src/python/tests/appengine/handlers/jobs_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for jobs."""
 import collections
+import mock
 import string
 import unittest
 import webapp2
@@ -20,6 +21,7 @@ import webtest
 
 from datastore import data_types
 from handlers import jobs
+from libs import form
 from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils
 
@@ -164,3 +166,54 @@ class JobsSearchTest(unittest.TestCase):
     self.assertListEqual(
         [job_asan.key.id(), job_ubsan.key.id()],
         [item['id'] for item in resp.json['items']])
+
+
+@test_utils.with_cloud_emulators('datastore')
+class JobsUpdateTest(unittest.TestCase):
+  """Job update tests."""
+
+  def setUp(self):
+    test_helpers.patch(self, [
+        'libs.auth.get_current_user',
+        'libs.access.has_access',
+        'libs.access.get_access',
+        'libs.gcs.prepare_blob_upload',
+        'fuzzing.fuzzer_selection.update_mappings_for_job',
+    ])
+    self.mock.get_current_user().email = 'test@user.com'
+    self.mock.prepare_blob_upload.return_value = (
+        collections.namedtuple('GcsUpload', [])())
+    self.app = webtest.TestApp(webapp2.WSGIApplication([('/', jobs.UpdateJob)]))
+
+  def _create_job(self,
+                  name,
+                  environment_string,
+                  description='',
+                  platform='LINUX'):
+    """Create a test job."""
+    job = data_types.Job()
+    job.name = name
+    if environment_string.strip():
+      job.environment_string = environment_string
+    job.platform = platform
+    job.descripton = description
+    job.put()
+
+    return job
+
+  def test_post(self):
+    """Test post method."""
+    self.mock.has_access.return_value = True
+    job = self._create_job('test_job', 'PROJECT_NAME = proj\n')
+    resp = self.app.post(
+        '/', {
+            'csrf_token': form.generate_csrf_token(),
+            'name': job.name,
+            'desciption': job.description,
+            'platform': job.platform,
+            'fuzzers': ['test_fuzzer']
+        },
+        expect_errors=True)
+    self.assertEqual(200, resp.status_int)
+    self.mock.update_mappings_for_job.assert_called_with(
+        mock.ANY, ['test_fuzzer'])

--- a/src/python/tests/appengine/handlers/jobs_test.py
+++ b/src/python/tests/appengine/handlers/jobs_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tests for jobs."""
 import collections
-import mock
 import string
 import unittest
 import webapp2
@@ -24,6 +23,7 @@ from handlers import jobs
 from libs import form
 from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils
+from unittest import mock
 
 
 @test_utils.with_cloud_emulators('datastore')

--- a/src/python/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/python/tests/core/fuzzing/fuzzer_selection_test.py
@@ -183,7 +183,7 @@ class UpdateMappingsForJobTest(unittest.TestCase):
     self.assertIn('fuzzer_2', mappings)
 
   def test_mapping_substituted(self):
-    """Ensure that mappings are subsituted properly."""
+    """Ensure that mappings are substituted properly."""
     job = data_types.Job()
     job.name = 'substitute_fuzzers'
     job.put()

--- a/src/python/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/python/tests/core/fuzzing/fuzzer_selection_test.py
@@ -236,8 +236,8 @@ class GetFuzzTaskPayloadTest(unittest.TestCase):
 
   def test_no_mappings(self):
     """Ensure that we raise an exception if we don't find a task."""
-    self.assertEqual((None, None),
-                     fuzzer_selection.get_fuzz_task_payload(platform='linux'))
+    self.assertEqual(
+        (None, None), fuzzer_selection.get_fuzz_task_payload(platform='linux'))
 
   @parameterized.parameterized.expand([('False',), ('True',)])
   def test_platform_restriction(self, local_development):
@@ -252,8 +252,8 @@ class GetFuzzTaskPayloadTest(unittest.TestCase):
     data_types.FuzzerJobs(
         platform='windows', fuzzer_jobs=[windows_mapping]).put()
 
-    self.assertEqual((None, None),
-                     fuzzer_selection.get_fuzz_task_payload(platform='linux'))
+    self.assertEqual(
+        (None, None), fuzzer_selection.get_fuzz_task_payload(platform='linux'))
 
     linux_mapping = data_types.FuzzerJob()
     linux_mapping.fuzzer = 'right_fuzzer'

--- a/src/python/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/python/tests/core/fuzzing/fuzzer_selection_test.py
@@ -182,7 +182,7 @@ class UpdateMappingsForJobTest(unittest.TestCase):
     self.assertIn('fuzzer_1', mappings)
     self.assertIn('fuzzer_2', mappings)
 
-  def test_mapping_subsituted(self):
+  def test_mapping_substituted(self):
     """Ensure that mappings are subsituted properly."""
     job = data_types.Job()
     job.name = 'substitute_fuzzers'


### PR DESCRIPTION
Hi, This PR is to add Fuzzer Selection option to /jobs page. The relationship defined between the jobs and fuzzer is many-to-many and the ground truth for the relationships is considered to be Fuzzer.jobs with automatic updation to JobFuzzer as well. This PR will fixes #596. 

Screenshot of the location of the menu:
![Screenshot 2020-07-13 at 4 47 09 PM](https://user-images.githubusercontent.com/30122295/87298909-affa4680-c528-11ea-9720-f7aecc974c68.png)


Screenshot of the drop-down:
![Screenshot 2020-07-13 at 4 44 39 PM](https://user-images.githubusercontent.com/30122295/87298708-411ced80-c528-11ea-9d08-db6f9ed7f72a.png)

Please have a look and let me know if there are any changes required!