### PR TITLE
Android Kernel linkification

### DIFF
--- a/src/python/platforms/android/kernel_utils.py
+++ b/src/python/platforms/android/kernel_utils.py
@@ -1,0 +1,116 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Android kernel util functions."""
+
+import os
+import re
+
+from base import utils
+from build_management import source_mapper
+from metrics import logs
+from platforms.android import constants
+from platforms.android import settings
+from platforms.android import symbols_downloader
+from system import environment
+
+# Linux version 3.18.0-g(8de8e79)-ab(1234567) where 8de8e79 is the hash and
+# 1234567 optional is the kernel build id.
+LINUX_VERSION_REGEX = re.compile(
+    r'Linux version .+-g([0-9a-f]+)[\s\-](ab([0-9a-f]+)\s)')
+
+
+def get_kernel_stack_frame_link(stack_frame, kernel_prefix, kernel_hash):
+  """Add source links data to kernel stack frames."""
+  match = source_mapper.STACK_FRAME_PATH_LINE_REGEX.search(stack_frame)
+  if not match:
+    # If this stack frame does not contain a path and line, bail out.
+    return stack_frame
+
+  path = match.group(1)
+  line = match.group(3)
+  kernel_prefix = utils.strip_from_left(kernel_prefix, 'kernel/private/')
+  display_path = '/'.join([kernel_prefix, path])
+  kernel_url_info = (r'http://go/pakernel/{prefix}/+/{hash}/{path}#{line};'
+                     r'{display_path};').format(
+                         prefix=kernel_prefix,
+                         hash=kernel_hash,
+                         path=path,
+                         line=line,
+                         display_path=display_path)
+
+  link_added_stack_frame = source_mapper.STACK_FRAME_PATH_LINE_REGEX.sub(
+      kernel_url_info, stack_frame)
+
+  return link_added_stack_frame
+
+
+def _get_prefix_and_full_hash(repo_data, kernel_partial_hash):
+  """Find the prefix and full hash in the repo_data based on the partial."""
+  kernel_partial_hash_lookup = 'u\'%s' % kernel_partial_hash
+  for line in repo_data.splitlines():
+    if kernel_partial_hash_lookup in line:
+      prefix, full_hash = line.split(' ', 1)
+      return prefix, full_hash.strip('u\'')
+
+  return None, None
+
+
+def get_kernel_prefix_and_full_hash():
+  """Download repo.prop and return the full hash and prefix."""
+  symbols_directory = os.path.join(
+      environment.get_value('SYMBOLS_DIR'), 'kernel')
+  kernel_partial_hash, build_id = get_kernel_hash_and_build_id()
+  target = get_kernel_name()
+  if not build_id or not target:
+    logs.log_error('Could not get kernel parameters, exiting.')
+    return None
+
+  repro_filename = symbols_downloader.get_symbols_archive_filename(
+      build_id, target)
+
+  # Grab repo.prop, it is not on the device nor in the build_dir.
+  symbols_downloader.download_system_symbols_if_needed(
+      symbols_directory, is_kernel=True)
+  local_repo_path = utils.find_binary_path(symbols_directory, repro_filename)
+
+  if local_repo_path and os.path.exists(local_repo_path):
+    android_kernel_repo_data = utils.read_data_from_file(
+        local_repo_path, eval_data=False).decode()
+    return _get_prefix_and_full_hash(android_kernel_repo_data,
+                                     kernel_partial_hash)
+
+  return None, None
+
+
+def get_kernel_name():
+  """Returns the kernel name for the device, since some kernels are shared."""
+  product_name = settings.get_product_name()
+  build_product = settings.get_build_product()
+
+  # Strip _kasan off of the end as we will add it later if needed.
+  utils.strip_from_right(product_name, '_kasan')
+
+  # Some devices have a different kernel name than product_name, if so use the
+  # kernel name.
+  return constants.PRODUCT_TO_KERNEL.get(build_product, product_name)
+
+
+def get_kernel_hash_and_build_id():
+  """Returns the build id  and hash of the kernel."""
+  version_string = settings.get_kernel_version_string
+  match = re.match(LINUX_VERSION_REGEX, version_string)
+  if match:
+    return match.group(2), match.group(3)
+
+  return None

--- a/src/python/platforms/android/symbols_downloader.py
+++ b/src/python/platforms/android/symbols_downloader.py
@@ -20,6 +20,7 @@ from base import utils
 from google_cloud_utils import storage
 from metrics import logs
 from platforms.android import fetch_artifact
+from platforms.android import kernel_utils
 from platforms.android import settings
 from system import archive
 from system import environment
@@ -50,8 +51,8 @@ def download_system_symbols_if_needed(symbols_directory, is_kernel=False):
   # Note: kasan and non-kasan kernel should have the same repo.prop for a given
   # build_id.
   if is_kernel:
-    build_id = settings.get_kernel_build_id()
-    target = settings.get_kernel_name()
+    _, build_id = kernel_utils.get_kernel_hash_and_build_id()
+    target = kernel_utils.get_kernel_name()
     if not build_id or not target:
       logs.log_error('Could not get kernel parameters, exiting.')
       return

--- a/src/python/tests/appengine/handlers/testcase_detail/show_test.py
+++ b/src/python/tests/appengine/handlers/testcase_detail/show_test.py
@@ -207,7 +207,7 @@ class FilterStacktraceTest(unittest.TestCase):
     """Ensure that we escape untrusted stacktrace."""
     stack = 'aaaa\n<script>alert("XSS")</script>\ncccc'
     expected = 'aaaa\n&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;\ncccc'
-    self.assertEqual(show.filter_stacktrace(stack, 'type', {}), expected)
+    self.assertEqual(show.filter_stacktrace(stack, 'type', {}, ''), expected)
 
   def test_asan_chromium(self):
     """Ensure it linkifies asan trace for chromium."""
@@ -231,7 +231,7 @@ class FilterStacktraceTest(unittest.TestCase):
                 '</a>\n'
                 'random')
     self.assertEqual(
-        show.filter_stacktrace(stack, 'type', revisions_dict), expected)
+        show.filter_stacktrace(stack, 'type', revisions_dict, ''), expected)
 
   def test_asan_oss_fuzz(self):
     """Ensure it linkifies asan trace for oss-fuzz."""
@@ -257,7 +257,7 @@ class FilterStacktraceTest(unittest.TestCase):
                 '</a>\n'
                 'random')
     self.assertEqual(
-        show.filter_stacktrace(stack, 'type', revisions_dict), expected)
+        show.filter_stacktrace(stack, 'type', revisions_dict, ''), expected)
 
   def test_asan_v8(self):
     """Ensure it linkifies v8 win trace for chromium."""
@@ -277,7 +277,7 @@ class FilterStacktraceTest(unittest.TestCase):
                 'random')
 
     self.assertEqual(
-        show.filter_stacktrace(stack, 'type', revisions_dict), expected)
+        show.filter_stacktrace(stack, 'type', revisions_dict, ''), expected)
 
   def test_no_linkify(self):
     """Ensure that we don't linkify a non-stack frame line."""
@@ -303,7 +303,20 @@ class FilterStacktraceTest(unittest.TestCase):
     ])
 
     self.assertEqual(
-        show.filter_stacktrace(stack, 'type', revisions_dict), expected)
+        show.filter_stacktrace(stack, 'type', revisions_dict, ''), expected)
+
+  def test_linkify_if_needed(self):
+    """Ensure that we don't escape prelinked kernel links."""
+    stack = ('[<ffffff90082bf4bc>] SyS_fchownat+0xdc/0x168 http://go/pakernel/'
+             'msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/fs/open.c'
+             '#622;msm-google/fs/open.c;')
+    expected_stack = ('[&lt;ffffff90082bf4bc&gt;] SyS_fchownat+0xdc/0x168 '
+                      '<a href="http://go/pakernel/'
+                      'msm-google/+/'
+                      '40e9b2ff3a280a8775cfcd5841e530ce78f94355/fs/open.c#622">'
+                      'msm-google/fs/open.c</a>')
+    self.assertEqual(
+        show.filter_stacktrace(stack, 'type', {}, 'android'), expected_stack)
 
 
 @test_utils.with_cloud_emulators('datastore')

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -42,13 +42,13 @@ class StackAnalyzerTestcase(unittest.TestCase):
     helpers.patch(self, [
         'crash_analysis.stack_parsing.stack_symbolizer.symbolize_stacktrace',
         'metrics.logs.log_error',
-        'platforms.android.settings.get_repo_prop_path'
+        'platforms.android.kernel_utils.get_kernel_prefix_and_full_hash'
     ])
 
     os.environ['JOB_NAME'] = TEST_JOB_NAME
 
     self.mock.symbolize_stacktrace.side_effect = self._mock_symbolize_stacktrace
-    self.mock.get_repo_prop_path.return_value = None
+    self.mock.get_kernel_prefix_and_full_hash.return_value = None, None
 
   def _read_test_data(self, name):
     """Helper function to read test data."""

--- a/src/python/tests/core/platforms/android/stack_analyzer_data/kasan_syzkaller_android_linkified.txt
+++ b/src/python/tests/core/platforms/android/stack_analyzer_data/kasan_syzkaller_android_linkified.txt
@@ -1,0 +1,20 @@
+BUG: KASAN: null-ptr-deref in sockfs_setattr+0x68/0x90 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/net/socket.c#544;msm-google/net/socket.c;
+Write of size 4 at addr 000000000000027c by task syz-executor/16883
+
+CPU: 7 PID: 16883 Comm: syz-executor Tainted: G         C      4.4.155-g9ef595a18d67 #1
+Hardware name: Qualcomm Technologies, Inc. MSM8998 v2.1 (DT)
+Call trace:
+[<ffffff900808f5ac>] dump_backtrace+0x0/0x34c http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/arch/arm64/kernel/traps.c#96;msm-google/arch/arm64/kernel/traps.c;
+[<ffffff900808fa38>] show_stack+0x1c/0x24 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/arch/arm64/kernel/traps.c#242;msm-google/arch/arm64/kernel/traps.c;
+[<ffffff9008580198>] __dump_stack lib/dump_stack.c:15 [inline]
+[<ffffff9008580198>] dump_stack+0xb8/0xe8 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/lib/dump_stack.c#51;msm-google/lib/dump_stack.c;
+[<ffffff90082b0e78>] kasan_report_error mm/kasan/report.c:348 [inline]
+[<ffffff90082b0e78>] kasan_report+0xe4/0x340 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/mm/kasan/report.c#407;msm-google/mm/kasan/report.c;
+[<ffffff90082af1bc>] check_memory_region_inline mm/kasan/kasan.c:325 [inline]
+[<ffffff90082af1bc>] __asan_store4+0x78/0x94 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/mm/kasan/kasan.c#758;msm-google/mm/kasan/kasan.c;
+[<ffffff9009602804>] sockfs_setattr+0x68/0x90 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/net/socket.c#544;msm-google/net/socket.c;
+[<ffffff90082f0c0c>] notify_change2+0x568/0x5e8 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/fs/attr.c#283;msm-google/fs/attr.c;
+[<ffffff90082bd3e4>] chown_common+0xf4/0x1e8 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/fs/open.c#612;msm-google/fs/open.c;
+[<ffffff90082bf4bc>] SYSC_fchownat fs/open.c:642 [inline]
+[<ffffff90082bf4bc>] SyS_fchownat+0xdc/0x168 http://go/pakernel/msm-google/+/40e9b2ff3a280a8775cfcd5841e530ce78f94355/fs/open.c#622;msm-google/fs/open.c;
+[<ffffff90080842b0>] el0_svc_naked+0x24/0x28

--- a/src/python/tests/core/platforms/android/stack_analyzer_test.py
+++ b/src/python/tests/core/platforms/android/stack_analyzer_test.py
@@ -96,15 +96,15 @@ class AndroidStackAnalyzerTest(unittest.TestCase):
     self._real_read_data_from_file = utils.read_data_from_file
     test_helpers.patch(self, [
         'platforms.android.fetch_artifact.get',
-        'platforms.android.settings.get_kernel_build_id',
-        'platforms.android.settings.get_kernel_name',
+        'platforms.android.kernel_utils.get_kernel_hash_and_build_id',
+        'platforms.android.kernel_utils.get_kernel_name',
         'platforms.android.settings.get_product_brand',
         'google_cloud_utils.storage.get_file_from_cache_if_exists',
         'google_cloud_utils.storage.store_file_in_cache',
         'base.utils.write_data_to_file', 'base.utils.read_data_from_file'
     ])
     self.mock.get.side_effect = _mock_fetch_artifact_get
-    self.mock.get_kernel_build_id.return_value = '12345'
+    self.mock.get_kernel_hash_and_build_id.return_value = '40e9b2ff3a2', '12345'
     self.mock.get_kernel_name.return_value = 'device_kernel'
     self.mock.get_product_brand.return_value = 'google'
     self.mock.get_file_from_cache_if_exists.return_value = False
@@ -113,5 +113,8 @@ class AndroidStackAnalyzerTest(unittest.TestCase):
     self.mock.read_data_from_file.side_effect = self._mock_read_data_from_file
 
     data = self._read_test_data('kasan_syzkaller_android.txt')
+    expected_stack = self._read_test_data(
+        'kasan_syzkaller_android_linkified.txt')
     actual_state = stack_analyzer.get_crash_data(data)
-    self.assertEqual(actual_state.android_kernel_repo, KERNEL_REPRO)
+
+    self.assertEqual(actual_state.crash_stacktrace, expected_stack)


### PR DESCRIPTION
This is the second part of 2 changes that will allow linkification of
Android kernel crashes.  After this change, all Android kernel and kasan
crashes will have links to the kernel source instead of just paths and
line numbers.