### PR TITLE
Remove entropic and value profile argument from repro stack.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/constants.py
+++ b/src/python/bot/fuzzers/libFuzzer/constants.py
@@ -24,8 +24,6 @@ ARTIFACT_PREFIX_FLAG = '-artifact_prefix='
 
 DATA_FLOW_TRACE_FLAG = '-data_flow_trace='
 
-ENTROPIC_ARGUMENT = '-entropic=1'
-
 DICT_FLAG = '-dict='
 
 FOCUS_FUNCTION_FLAG = '-focus_function='
@@ -48,6 +46,8 @@ EXACT_ARTIFACT_PATH_FLAG = '-exact_artifact_path='
 ANALYZE_DICT_ARGUMENT = '-analyze_dict=1'
 
 CLEANSE_CRASH_ARGUMENT = '-cleanse_crash=1'
+
+ENTROPIC_ARGUMENT = '-entropic=1'
 
 MERGE_ARGUMENT = '-merge=1'
 

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -311,16 +311,19 @@ class LibFuzzerEngine(engine.Engine):
     })
 
     # Remove fuzzing arguments before merge and dictionary analysis step.
-    arguments = options.arguments[:]
-    libfuzzer.remove_fuzzing_arguments(arguments)
+    merge_arguments = options.arguments[:]
+    libfuzzer.remove_fuzzing_arguments(merge_arguments, is_merge=True)
     self._merge_new_units(target_path, options.corpus_dir, new_corpus_dir,
-                          options.fuzz_corpus_dirs, arguments, parsed_stats)
+                          options.fuzz_corpus_dirs, merge_arguments,
+                          parsed_stats)
 
     fuzz_logs = '\n'.join(log_lines)
     crashes = []
     if crash_testcase_file_path:
+      reproduce_arguments = options.arguments[:]
+      libfuzzer.remove_fuzzing_arguments(reproduce_arguments)
+
       # Use higher timeout for reproduction.
-      reproduce_arguments = arguments[:]
       libfuzzer.fix_timeout_argument_for_reproduction(reproduce_arguments)
 
       # Write the new testcase.
@@ -331,7 +334,7 @@ class LibFuzzerEngine(engine.Engine):
 
     libfuzzer.analyze_and_update_recommended_dictionary(
         runner, project_qualified_fuzzer_name, log_lines, options.corpus_dir,
-        arguments)
+        merge_arguments)
 
     return engine.FuzzResult(fuzz_logs, fuzz_result.command, crashes,
                              parsed_stats, fuzz_result.time_executed)

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1513,12 +1513,22 @@ def copy_from_corpus(dest_corpus_path, src_corpus_path, num_testcases):
 def remove_fuzzing_arguments(arguments):
   """Remove arguments used during fuzzing."""
   for argument in [
-      constants.DICT_FLAG,  # User for fuzzing only.
-      constants.MAX_LEN_FLAG,  # This may shrink the testcases.
-      constants.RUNS_FLAG,  # Make sure we don't have any '-runs' argument.
+      # Remove as it overrides `-merge` argument.
       constants.FORK_FLAG,  # It overrides `-merge` argument.
-      constants.DATA_FLOW_TRACE_FLAG,  # Used for fuzzing only.
-      constants.FOCUS_FUNCTION_FLAG,  # Used for fuzzing only.
+
+      # Remove as it may shrink the testcase.
+      constants.MAX_LEN_FLAG,  # This may shrink the testcases.
+
+      # Remove any existing runs argument as we will create our own for
+      # reproduction.
+      constants.RUNS_FLAG,  # Make sure we don't have any '-runs' argument.
+
+      # Remove the following flags/arguments that are only used for fuzzing.
+      constants.DATA_FLOW_TRACE_FLAG,
+      constants.DICT_FLAG,
+      constants.ENTROPIC_ARGUMENT,
+      constants.FOCUS_FUNCTION_FLAG,
+      constants.VALUE_PROFILE_ARGUMENT,
   ]:
     fuzzer_utils.extract_argument(arguments, argument)
 

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1510,7 +1510,7 @@ def copy_from_corpus(dest_corpus_path, src_corpus_path, num_testcases):
     shutil.copy(os.path.join(to_copy), os.path.join(dest_corpus_path, str(i)))
 
 
-def remove_fuzzing_arguments(arguments):
+def remove_fuzzing_arguments(arguments, is_merge=False):
   """Remove arguments used during fuzzing."""
   for argument in [
       # Remove as it overrides `-merge` argument.
@@ -1528,9 +1528,12 @@ def remove_fuzzing_arguments(arguments):
       constants.DICT_FLAG,
       constants.ENTROPIC_ARGUMENT,
       constants.FOCUS_FUNCTION_FLAG,
-      constants.VALUE_PROFILE_ARGUMENT,
   ]:
     fuzzer_utils.extract_argument(arguments, argument)
+
+  # Value profile is needed during corpus merge, so do not remove if set.
+  if not is_merge:
+    fuzzer_utils.extract_argument(arguments, constants.VALUE_PROFILE_ARGUMENT)
 
 
 def fix_timeout_argument_for_reproduction(arguments):

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -28,6 +28,7 @@ from base import utils
 from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from bot.fuzzers import options
+from bot.fuzzers.libFuzzer import constants
 from bot.tasks import setup
 from bot.tasks import task_creation
 from build_management import build_manager
@@ -86,13 +87,6 @@ MAX_LEN_FLAG = '-max_len=%d'
 
 # Flag to control memory leaks detection.
 DETECT_LEAKS_FLAG = '-detect_leaks=%d'
-
-# Flag to do value profile during merges.
-USE_VALUE_PROFILE_FLAG = '-use_value_profile=%d'
-
-# Corpus size limit to allow use of value profile. This prevents corpus from
-# growing unbounded.
-CORPUS_SIZE_LIMIT_FOR_VALUE_PROFILE = 50000
 
 # Longer than default sync timeout to fix broken (overly large) corpora without
 # losing coverage.
@@ -372,11 +366,7 @@ class Runner(object):
     arguments.append(RSS_LIMIT_MB_FLAG % rss_limit)
     arguments.append(MAX_LEN_FLAG % max_len)
     arguments.append(DETECT_LEAKS_FLAG % detect_leaks)
-
-    corpus_size = shell.get_directory_file_count(
-        self.context.initial_corpus_path)
-    use_value_profile = int(corpus_size <= CORPUS_SIZE_LIMIT_FOR_VALUE_PROFILE)
-    arguments.append(USE_VALUE_PROFILE_FLAG % use_value_profile)
+    arguments.append(constants.VALUE_PROFILE_ARGUMENT)
 
     return arguments
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -207,10 +207,14 @@ class FuzzTest(fake_fs_unittest.TestCase):
   def test_fuzz(self):
     """Test fuzz."""
     engine_impl = engine.LibFuzzerEngine()
-    options = engine.LibFuzzerOptions(
-        '/corpus',
-        ['-arg=1', '-timeout=123', '-dict=blah.dict', '-max_len=9001'], [],
-        ['/corpus'], {}, False, False)
+    options = engine.LibFuzzerOptions('/corpus', [
+        '-arg=1',
+        '-timeout=123',
+        '-dict=blah.dict',
+        '-max_len=9001',
+        '-entropic=1',
+        '-use_value_profile=1',
+    ], [], ['/corpus'], {}, False, False)
 
     with open(os.path.join(TEST_DIR, 'crash.txt')) as f:
       fuzz_output = f.read()
@@ -268,6 +272,8 @@ class FuzzTest(fake_fs_unittest.TestCase):
             '-timeout=123',
             '-dict=blah.dict',
             '-max_len=9001',
+            '-entropic=1',
+            '-use_value_profile=1',
         ],
         artifact_prefix='/fake',
         extra_env={},


### PR DESCRIPTION
These are fuzzing arguments and not needed during reproduction.
Also create confusion for developer.