### PR TITLE
Request bisection for regression earlier.

### DIFF
--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -469,4 +469,4 @@ def execute_task(testcase_id, job_type):
   # regression and fixed ranges are requested once. Regression is also requested
   # here as the bisection service may require details that are not yet available
   # (e.g. issue ID) at the time regress_task completes.
-  task_creation.request_bisection(testcase)
+  task_creation.request_bisection(testcase.key.id())

--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -210,9 +210,6 @@ def _save_fixed_range(testcase_id, min_revision, max_revision,
       testcase, max_revision, message='fixed in range r%s' % testcase.fixed)
   _write_to_bigquery(testcase, min_revision, max_revision)
 
-  # If there is a fine grained bisection service available, request it.
-  task_creation.request_bisection(testcase)
-
   _store_testcase_for_regression_testing(testcase, testcase_file_path)
 
 
@@ -467,3 +464,9 @@ def execute_task(testcase_id, job_type):
     error_message = 'Unable to recover from bad build'
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                          error_message)
+
+  # If there is a fine grained bisection service available, request it. Both
+  # regression and fixed ranges are requested once. Regression is also requested
+  # here as the bisection service may require details that are not yet available
+  # (e.g. issue ID) at the time regress_task completes.
+  task_creation.request_bisection(testcase)

--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -252,11 +252,13 @@ def _get_commits(commit_range, job_type):
   return old_commit, new_commit
 
 
-def request_bisection(testcase):
+def request_bisection(testcase_id):
   """Request precise bisection."""
   pubsub_topic = local_config.ProjectConfig().get('bisect_service.pubsub_topic')
   if not pubsub_topic:
     return
+
+  testcase = data_handler.get_testcase_by_id(testcase_id)
 
   # Only request bisects for reproducible security bugs with a bug filed, found
   # by engine fuzzers.
@@ -272,9 +274,6 @@ def request_bisection(testcase):
   target = testcase.get_fuzz_target()
   if not target:
     return
-
-  # Avoid stale updates.
-  testcase = data_handler.get_testcase_by_id(testcase.key.id())
 
   # Only make 1 request of each type per testcase.
   if (not testcase.get_metadata('requested_regressed_bisect') and

--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -237,6 +237,8 @@ def _get_commits(commit_range, job_type):
 
   start, end = revisions.get_start_and_end_revision(commit_range)
   components = revisions.get_component_range_list(start, end, job_type)
+  if not components:
+    return None, None
 
   commits = components[0]['link_text']
 
@@ -271,12 +273,19 @@ def request_bisection(testcase):
   if not target:
     return
 
-  _make_bisection_request(pubsub_topic, testcase, target, 'regressed')
-  _make_bisection_request(pubsub_topic, testcase, target, 'fixed')
+  # Only make 1 request of each type per testcase.
+  if (not testcase.get_metadata('requested_regressed_bisect') and
+      _make_bisection_request(pubsub_topic, testcase, target, 'regressed')):
+    testcase.set_metadata('requested_regressed_bisect', True)
+
+  if (not testcase.get_metadata('requested_fixed_bisect') and
+      _make_bisection_request(pubsub_topic, testcase, target, 'fixed')):
+    testcase.set_metadata('requested_fixed_bisect', True)
 
 
 def _make_bisection_request(pubsub_topic, testcase, target, bisect_type):
-  """Make a bisection request to the external bisection service."""
+  """Make a bisection request to the external bisection service. Returns whether
+  or not a request was actually made."""
   if bisect_type == 'fixed':
     old_commit, new_commit = _get_commits(testcase.fixed, testcase.job_type)
   elif bisect_type == 'regressed':
@@ -287,7 +296,7 @@ def _make_bisection_request(pubsub_topic, testcase, target, bisect_type):
 
   if not new_commit:
     # old_commit can be empty (i.e. '0' case), but new_commit should never be.
-    return
+    return False
 
   reproducer = blobs.read_key(testcase.minimized_keys or testcase.fuzzed_keys)
   pubsub_client = pubsub.PubSubClient()
@@ -318,3 +327,4 @@ def _make_bisection_request(pubsub_topic, testcase, target, bisect_type):
                   str(testcase.security_flag),
           })
   ])
+  return True

--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -273,6 +273,9 @@ def request_bisection(testcase):
   if not target:
     return
 
+  # Avoid stale updates.
+  testcase = data_handler.get_testcase_by_id(testcase.key.id())
+
   # Only make 1 request of each type per testcase.
   if (not testcase.get_metadata('requested_regressed_bisect') and
       _make_bisection_request(pubsub_topic, testcase, target, 'regressed')):

--- a/src/python/tests/core/bot/tasks/task_creation_test.py
+++ b/src/python/tests/core/bot/tasks/task_creation_test.py
@@ -65,7 +65,7 @@ class RequestBisectionTest(unittest.TestCase):
 
   def _test(self, sanitizer):
     """Test task publication."""
-    task_creation.request_bisection(self.testcase)
+    task_creation.request_bisection(self.testcase.key.id())
     publish_calls = self.mock.publish.call_args_list
     bisect_types = ('regressed', 'fixed')
 
@@ -95,44 +95,51 @@ class RequestBisectionTest(unittest.TestCase):
   def test_request_bisection_asan(self):
     """Basic regressed test (asan)."""
     self.testcase.job_type = 'libfuzzer_asan_proj'
+    self.testcase.put()
     self._test('address')
 
   def test_request_bisection_msan(self):
     """Basic regressed test (asan)."""
     self.testcase.job_type = 'libfuzzer_msan_proj'
+    self.testcase.put()
     self._test('memory')
 
   def test_request_bisection_ubsan(self):
     """Basic regressed test (ubsan)."""
     self.testcase.job_type = 'libfuzzer_ubsan_proj'
+    self.testcase.put()
     self._test('undefined')
 
   def test_request_bisection_blackbox(self):
     """Test request bisection for blackbox."""
     self.testcase.job_type = 'blackbox'
     self.testcase.overridden_fuzzer_name = None
-    task_creation.request_bisection(self.testcase)
+    self.testcase.put()
+    task_creation.request_bisection(self.testcase.key.id())
     self.assertEqual(0, self.mock.publish.call_count)
 
   def test_request_bisection_non_security(self):
     """Test request bisection for non-security testcases."""
     self.testcase.job_type = 'libfuzzer_asan_proj'
     self.testcase.security_flag = False
-    task_creation.request_bisection(self.testcase)
+    self.testcase.put()
+    task_creation.request_bisection(self.testcase.key.id())
     self.assertEqual(0, self.mock.publish.call_count)
 
   def test_request_bisection_flaky(self):
     """Test request bisection for flaky testcases."""
     self.testcase.job_type = 'libfuzzer_asan_proj'
     self.testcase.one_time_crasher_flag = True
-    task_creation.request_bisection(self.testcase)
+    self.testcase.put()
+    task_creation.request_bisection(self.testcase.key.id())
     self.assertEqual(0, self.mock.publish.call_count)
 
   def test_request_bisection_no_bug(self):
     """Test request bisection for testcases with no bug attached."""
     self.testcase.job_type = 'libfuzzer_asan_proj'
     self.testcase.bug_information = ''
-    task_creation.request_bisection(self.testcase)
+    self.testcase.put()
+    task_creation.request_bisection(self.testcase.key.id())
     self.assertEqual(0, self.mock.publish.call_count)
 
   def test_request_bisection_invalid_range(self):
@@ -140,7 +147,8 @@ class RequestBisectionTest(unittest.TestCase):
     self.testcase.job_type = 'libfuzzer_asan_proj'
     self.testcase.regression = 'NA'
     self.testcase.fixed = 'NA'
-    task_creation.request_bisection(self.testcase)
+    self.testcase.put()
+    task_creation.request_bisection(self.testcase.key.id())
     self.assertEqual(0, self.mock.publish.call_count)
 
   def test_request_bisection_once_only(self):
@@ -148,5 +156,6 @@ class RequestBisectionTest(unittest.TestCase):
     requested."""
     self.testcase.set_metadata('requested_regressed_bisect', True)
     self.testcase.set_metadata('requested_fixed_bisect', True)
-    task_creation.request_bisection(self.testcase)
+    self.testcase.put()
+    task_creation.request_bisection(self.testcase.key.id())
     self.assertEqual(0, self.mock.publish.call_count)

--- a/src/python/tests/core/bot/tasks/task_creation_test.py
+++ b/src/python/tests/core/bot/tasks/task_creation_test.py
@@ -88,6 +88,10 @@ class RequestBisectionTest(unittest.TestCase):
           'type': bisect_type,
       }, message.attributes)
 
+    testcase = self.testcase.key.get()
+    self.assertTrue(testcase.get_metadata('requested_regressed_bisect'))
+    self.assertTrue(testcase.get_metadata('requested_fixed_bisect'))
+
   def test_request_bisection_asan(self):
     """Basic regressed test (asan)."""
     self.testcase.job_type = 'libfuzzer_asan_proj'
@@ -136,5 +140,13 @@ class RequestBisectionTest(unittest.TestCase):
     self.testcase.job_type = 'libfuzzer_asan_proj'
     self.testcase.regression = 'NA'
     self.testcase.fixed = 'NA'
+    task_creation.request_bisection(self.testcase)
+    self.assertEqual(0, self.mock.publish.call_count)
+
+  def test_request_bisection_once_only(self):
+    """Test request bisection for testcases isn't repeated if already
+    requested."""
+    self.testcase.set_metadata('requested_regressed_bisect', True)
+    self.testcase.set_metadata('requested_fixed_bisect', True)
     task_creation.request_bisection(self.testcase)
     self.assertEqual(0, self.mock.publish.call_count)


### PR DESCRIPTION
Previously, a regressed and fixed bisect were requested at the same time
when a Testcase is detected to be fixed in progression_task.

This PR changes this: A regressed bisection can be requested earlier,
even if the Testcase isn't fixed. To ensure that tasks are only
requested once we add corresponding testcase metadata.