### PR TITLE
Encode data in storage.write_data for local GCS.

### DIFF
--- a/src/python/google_cloud_utils/storage.py
+++ b/src/python/google_cloud_utils/storage.py
@@ -494,6 +494,9 @@ class FileSystemProvider(StorageProvider):
   def write_data(self, data, remote_path, metadata=None):
     """Write the data of a remote file."""
     fs_path = self.convert_path_for_write(remote_path)
+    if isinstance(data, str):
+      data = data.encode()
+
     with open(fs_path, 'wb') as f:
       f.write(data)
 

--- a/src/python/tests/core/google_cloud_utils/storage_test.py
+++ b/src/python/tests/core/google_cloud_utils/storage_test.py
@@ -228,6 +228,10 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
     with open('/local/test-bucket/metadata/subdir/a') as f:
       self.assertEqual('{"key": "value"}', f.read())
 
+    self.provider.write_data('b', 'gs://test-bucket/subdir/b')
+    with open('/local/test-bucket/objects/subdir/b') as f:
+      self.assertEqual('b', f.read())
+
   def test_get(self):
     """Test get."""
     mtime = datetime.datetime(2019, 1, 1)


### PR DESCRIPTION
This matches the behaviour of the
google.cloud.storage.blob.Blob.upload_from_string.

Fixes #1925.