### PR TITLE
Add NVIDIA package repositories before installing TF GPU dependencies (#1540).

### DIFF
--- a/docker/chromium/ml-with-gpu/Dockerfile
+++ b/docker/chromium/ml-with-gpu/Dockerfile
@@ -31,12 +31,10 @@ RUN apt-get install -y gnupg-curl && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
     dpkg -i cuda-repo-ubuntu1604_10.1.243-1_amd64.deb && \
     apt-get update && \
-    wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
+    wget https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
     apt install -y ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
-    apt-get update
-
-# Delete the files we downloaded and used above.
-RUN rm -f cuda-repo-* nvidia-machine-learning-repo-*
+    apt-get update && \
+    rm -f cuda-repo-* nvidia-machine-learning-repo-*
 
 # Install development and runtime libraries (~4GB).
 RUN apt-get install -y --no-install-recommends \

--- a/docker/chromium/ml-with-gpu/Dockerfile
+++ b/docker/chromium/ml-with-gpu/Dockerfile
@@ -23,8 +23,22 @@ WORKDIR /data
 
 # The dependencies installation commands below follow
 # https://www.tensorflow.org/install/gpu#ubuntu_1604_cuda_101.
+#
+# Add NVIDIA package repositories.
+# Add HTTPS support for apt-key.
+RUN apt-get install -y gnupg-curl && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.1.243-1_amd64.deb && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
+    dpkg -i cuda-repo-ubuntu1604_10.1.243-1_amd64.deb && \
+    apt-get update && \
+    wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
+    apt install -y ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
+    apt-get update
 
-# Install development and runtime libraries (~4GB)
+# Delete the files we downloaded and used above.
+RUN rm -f cuda-repo-* nvidia-machine-learning-repo-*
+
+# Install development and runtime libraries (~4GB).
 RUN apt-get install -y --no-install-recommends \
     cuda-10-1 \
     libcudnn7=7.6.4.38-1+cuda10.1  \

--- a/docker/ml-with-gpu/Dockerfile
+++ b/docker/ml-with-gpu/Dockerfile
@@ -31,12 +31,10 @@ RUN apt-get install -y gnupg-curl && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
     dpkg -i cuda-repo-ubuntu1604_10.1.243-1_amd64.deb && \
     apt-get update && \
-    wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
+    wget https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
     apt install -y ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
-    apt-get update
-
-# Delete the files we downloaded and used above.
-RUN rm -f cuda-repo-* nvidia-machine-learning-repo-*
+    apt-get update && \
+    rm -f cuda-repo-* nvidia-machine-learning-repo-*
 
 # Install development and runtime libraries (~4GB).
 RUN apt-get install -y --no-install-recommends \

--- a/docker/ml-with-gpu/Dockerfile
+++ b/docker/ml-with-gpu/Dockerfile
@@ -23,8 +23,22 @@ WORKDIR /data
 
 # The dependencies installation commands below follow
 # https://www.tensorflow.org/install/gpu#ubuntu_1604_cuda_101.
+#
+# Add NVIDIA package repositories.
+# Add HTTPS support for apt-key.
+RUN apt-get install -y gnupg-curl && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.1.243-1_amd64.deb && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
+    dpkg -i cuda-repo-ubuntu1604_10.1.243-1_amd64.deb && \
+    apt-get update && \
+    wget http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64/nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
+    apt install -y ./nvidia-machine-learning-repo-ubuntu1604_1.0.0-1_amd64.deb && \
+    apt-get update
 
-# Install development and runtime libraries (~4GB)
+# Delete the files we downloaded and used above.
+RUN rm -f cuda-repo-* nvidia-machine-learning-repo-*
+
+# Install development and runtime libraries (~4GB).
 RUN apt-get install -y --no-install-recommends \
     cuda-10-1 \
     libcudnn7=7.6.4.38-1+cuda10.1  \


### PR DESCRIPTION
Turns out I missed a few more important commands:

```
E: Unable to locate package cuda-10-1
E: Unable to locate package libcudnn7
E: Unable to locate package libcudnn7-dev
The command '/bin/sh -c apt-get install -y --no-install-recommends     cuda-10-1     libcudnn7=7.6.4.38-1+cuda10.1      libcudnn7-dev=7.6.4.38-1+cuda10.1' returned a non-zero code: 100
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 100

```