### PR TITLE
Do not pass custom NVIDIA driver URL to cos-gpu-installer (#1540).

### DIFF
--- a/configs/test/gce/linux-init-ml-with-gpu.yaml
+++ b/configs/test/gce/linux-init-ml-with-gpu.yaml
@@ -43,8 +43,6 @@ write_files:
     owner: root
     content: |
       NVIDIA_DRIVER_VERSION=418.152.00
-      NVIDIA_DRIVER_DOWNLOAD_URL=https://storage.googleapis.com/clusterfuzz-data/nvidia/418.152.00/NVIDIA-Linux-x86_64-418.152.00.run
-      NVIDIA_DRIVER_MD5SUM=63467de91898fd602538ff29fa104085
       COS_NVIDIA_INSTALLER_CONTAINER=gcr.io/cos-cloud/cos-gpu-installer:latest
       NVIDIA_INSTALL_DIR_HOST=/var/lib/nvidia
       NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia


### PR DESCRIPTION
Fixes one more quirk of cos-gpu-installer. Turns out it doesn't use the custom download URL if the requested version is present in the official nvidia drivers bucket. However, it does use the custom checksum anyways, and it doesn't match since the installer uses a different .cos file.