### PR TITLE
local run_docker fixes.

### DIFF
--- a/local/emulators/metadata.go
+++ b/local/emulators/metadata.go
@@ -110,7 +110,7 @@ func refreshTokenIfNeeded() error {
 	tokenLock.RUnlock()
 
 	cmd := exec.Command("gcloud", "auth", "application-default", "print-access-token")
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
 		return err
 	}

--- a/local/run_docker.bash
+++ b/local/run_docker.bash
@@ -40,7 +40,7 @@ else
   CONFIG_DIR_OVERRIDE="/config"
 fi
 
-docker run -e COMMAND_OVERRIDE=$COMMAND_OVERRIDE -e SETUP_NFS= -e HOST_UID=$UID \
+sudo docker run -e COMMAND_OVERRIDE="$COMMAND_OVERRIDE" -e SETUP_NFS= -e HOST_UID=$UID \
               -e LOCAL_METADATA_SERVER=$docker_ip -e LOCAL_METADATA_PORT=8080 \
               -e USE_LOCAL_DIR_FOR_NFS=1 $MOUNT_ARGS \
               -e LOCAL_SRC=$LOCAL_SRC \


### PR DESCRIPTION
- Fix metadata server to not include stderr in access token command.
- Quote COMMAND_OVERRIDE in run_docker.bash
- Use sudo for docker in run_docker.bash