### PR TITLE
Use TEST_TIMEOUT-5 for timeout rather than hardcoded 60 sec.

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/constants.py
+++ b/src/python/bot/fuzzers/libFuzzer/constants.py
@@ -66,8 +66,6 @@ DEFAULT_RSS_LIMIT_MB = 2560
 
 DEFAULT_TIMEOUT_LIMIT = 25
 
-REPRODUCTION_TIMEOUT_LIMIT = 60
-
 # libFuzzer's exit code if a bug occurred in libFuzzer.
 LIBFUZZER_ERROR_EXITCODE = 1
 

--- a/src/python/bot/fuzzers/libFuzzer/constants.py
+++ b/src/python/bot/fuzzers/libFuzzer/constants.py
@@ -61,10 +61,14 @@ TMP_ARTIFACT_PREFIX_ARGUMENT = '/tmp/'
 
 VALUE_PROFILE_ARGUMENT = '-use_value_profile=1'
 
-# Value for RSS_LIMIT_FLAG to catch OOM.
+# Default value for rss_limit_mb flag to catch OOM.s
 DEFAULT_RSS_LIMIT_MB = 2560
 
+# Default value for timeout flag to catch timeouts.
 DEFAULT_TIMEOUT_LIMIT = 25
+
+# Buffer for processing crash reports.
+REPORT_PROCESSING_TIME = 5
 
 # libFuzzer's exit code if a bug occurred in libFuzzer.
 LIBFUZZER_ERROR_EXITCODE = 1

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1537,11 +1537,13 @@ def remove_fuzzing_arguments(arguments, is_merge=False):
 
 
 def fix_timeout_argument_for_reproduction(arguments):
-  """Changes timeout argument for reproduction. This is higher than default to
-  avoid noise with smaller fuzzing defaults."""
+  """Changes timeout argument for reproduction. This is slightly less than the
+  |TEST_TIMEOUT| value for the job."""
   fuzzer_utils.extract_argument(arguments, constants.TIMEOUT_FLAG)
-  arguments.append(
-      '%s%d' % (constants.TIMEOUT_FLAG, constants.REPRODUCTION_TIMEOUT_LIMIT))
+
+  # Leave 5 sec buffer for report processing.
+  adjusted_test_timeout = max(1, environment.get_value('TEST_TIMEOUT') - 5)
+  arguments.append('%s%d' % (constants.TIMEOUT_FLAG, adjusted_test_timeout))
 
 
 def parse_log_stats(log_lines):

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1542,7 +1542,9 @@ def fix_timeout_argument_for_reproduction(arguments):
   fuzzer_utils.extract_argument(arguments, constants.TIMEOUT_FLAG)
 
   # Leave 5 sec buffer for report processing.
-  adjusted_test_timeout = max(1, environment.get_value('TEST_TIMEOUT') - 5)
+  adjusted_test_timeout = max(
+      1,
+      environment.get_value('TEST_TIMEOUT') - constants.REPORT_PROCESSING_TIME)
   arguments.append('%s%d' % (constants.TIMEOUT_FLAG, adjusted_test_timeout))
 
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -197,6 +197,7 @@ class FuzzTest(fake_fs_unittest.TestCase):
         'os.getpid',
     ])
 
+    os.environ['TEST_TIMEOUT'] = '65'
     os.environ['JOB_NAME'] = 'libfuzzer_asan_job'
     os.environ['FUZZ_INPUTS_DISK'] = '/fuzz-inputs'
 
@@ -435,6 +436,7 @@ class BaseIntegrationTest(unittest.TestCase):
     os.environ['FAIL_RETRIES'] = '1'
     os.environ['FUZZ_INPUTS_DISK'] = TEMP_DIR
     os.environ['FUZZ_TEST_TIMEOUT'] = '4800'
+    os.environ['TEST_TIMEOUT'] = '65'
     os.environ['JOB_NAME'] = 'libfuzzer_asan'
     os.environ['INPUT_DIR'] = TEMP_DIR
 


### PR DESCRIPTION
Fixes 2) in https://github.com/google/clusterfuzz/issues/1940.