### PR TITLE
Remove support for Python 2 fuzzers.

### DIFF
--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1474,10 +1474,7 @@ class FuzzingSession(object):
         return error_occurred, None, None, None, None
 
       # Build the fuzzer command execution string.
-      # TODO(mbarbella): Conditionally invoke with Python 2 depending on
-      # the fuzzer. At present, all were implemented to work with Python 2.
-      command = shell.get_execute_command(
-          fuzzer_executable, is_blackbox_fuzzer=True)
+      command = shell.get_execute_command(fuzzer_executable)
 
       # NodeJS and shell script expect space seperator for arguments.
       if command.startswith('node ') or command.startswith('sh '):

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -939,8 +939,7 @@ def get_command_line_for_application(file_to_run='',
       # have app_name == launcher. In this case don't prepend launcher to
       # command - just use app_name.
       if os.path.basename(launcher) != app_name:
-        launcher_with_interpreter = shell.get_execute_command(
-            launcher, is_blackbox_fuzzer=True)
+        launcher_with_interpreter = shell.get_execute_command(launcher)
         command += launcher_with_interpreter + ' '
     elif is_android:
       # Android-specific testcase path fixup for fuzzers that don't rely on

--- a/src/python/system/process_handler.py
+++ b/src/python/system/process_handler.py
@@ -307,7 +307,7 @@ def run_process(cmdline,
     # If the process is still running, then terminate it.
     if not process_status.finished:
       launcher_with_interpreter = shell.get_execute_command(
-          launcher, is_blackbox_fuzzer=True) if launcher else None
+          launcher) if launcher else None
       if (launcher_with_interpreter and
           cmdline.startswith(launcher_with_interpreter)):
         # If this was a launcher script, we KILL all child processes created

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -351,7 +351,7 @@ def get_free_disk_space(path='/'):
   return psutil.disk_usage(path).free
 
 
-def get_interpreter(file_to_execute, is_blackbox_fuzzer=False):
+def get_interpreter(file_to_execute):
   """Gives the interpreter needed to execute |file_to_execute|."""
   interpreters = {
       '.bash': 'bash',
@@ -371,10 +371,9 @@ def get_interpreter(file_to_execute, is_blackbox_fuzzer=False):
   return interpreter
 
 
-def get_execute_command(file_to_execute, is_blackbox_fuzzer=False):
+def get_execute_command(file_to_execute):
   """Return command to execute |file_to_execute|."""
-  interpreter_path = get_interpreter(
-      file_to_execute, is_blackbox_fuzzer=is_blackbox_fuzzer)
+  interpreter_path = get_interpreter(file_to_execute)
 
   # Hack for Java scripts.
   file_to_execute = file_to_execute.replace('.class', '')

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -368,12 +368,6 @@ def get_interpreter(file_to_execute, is_blackbox_fuzzer=False):
   except KeyError:
     return None
 
-  # TODO(mbarbella): Remove this when fuzzers have been migrated to Python 3.
-  if (is_blackbox_fuzzer and interpreter == sys.executable and
-      environment.get_value('USE_PYTHON2_FOR_BLACKBOX_FUZZERS') and
-      sys.version_info.major == 3):
-    interpreter = 'python2'
-
   return interpreter
 
 


### PR DESCRIPTION
PTAL. There are a few minor breakages left which I'll try to resolve (3 minor issues with external fuzzers), but overall I don't think it's worth keeping Python 2 around for them. After this lands there are no remaining Python 2 dependencies on bots that I know of.

Oliver, are there any other Python 2 dependencies you can think of? I don't think it's urgent that we remove Python 2 from the images, but it should be safe to do so after this.