### PR TITLE
Fix NDB transaction exception type.

### DIFF
--- a/src/python/datastore/locks.py
+++ b/src/python/datastore/locks.py
@@ -121,7 +121,7 @@ def acquire_lock(key_name,
       if lock_entity.holder == bot_name:
         logs.log('Got the lock.')
         return lock_entity.expiration_time
-    except exceptions.TransactionFailedError:
+    except exceptions.Error:
       pass
 
     failed_acquires += 1


### PR DESCRIPTION
Use the base Error type, as TransactionFailedError no longer exists.