### PR TITLE
Removed overwrite argument from set_cookie.

### DIFF
--- a/src/appengine/handlers/login.py
+++ b/src/appengine/handlers/login.py
@@ -60,11 +60,7 @@ class SessionLoginHandler(base_handler_flask.Handler):
     expires = datetime.datetime.now() + expires_in
     response = self.render_json({'status': 'success'})
     response.set_cookie(
-        'session',
-        session_cookie,
-        expires=expires,
-        httponly=True,
-        secure=True)
+        'session', session_cookie, expires=expires, httponly=True, secure=True)
     return response
 
 

--- a/src/appengine/handlers/login.py
+++ b/src/appengine/handlers/login.py
@@ -64,8 +64,7 @@ class SessionLoginHandler(base_handler_flask.Handler):
         session_cookie,
         expires=expires,
         httponly=True,
-        secure=True,
-        overwrite=True)
+        secure=True)
     return response
 
 


### PR DESCRIPTION
Removed overwrite argument from set_cookie. set_cookie in [flask](https://tedboy.github.io/flask/generated/generated/flask.Response.set_cookie.html) doesn't have interface for the same. This should fix the exception in the build. 
In flask, if a new cookie with the same name, path and domain is passed, it is automatically overwritten. Otherwise if two cookies of the same name is passed without matching path and domain(which should not be the case with ClusterFuzz), the cookie with the higher precedence is automatically selected by the browser. So, this removal should not cause any problems in the user experience.

Please take a look!