### PR TITLE
Fix alert deployment.

### DIFF
--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -289,10 +289,9 @@ def _preprocess_alerts(alerts_path):
 
   counts = _get_region_counts()
   for region, count in counts.items():
-    alerts_data = re.sub(
-        'BOT_COUNT:' + region + r'(?=\s|$)',
-        str(int(count * EXPECTED_BOT_COUNT_PERCENT)),
-        alerts_data)
+    alerts_data = re.sub('BOT_COUNT:' + region + r'(?=\s|$)',
+                         str(int(count * EXPECTED_BOT_COUNT_PERCENT)),
+                         alerts_data)
 
   with tempfile.NamedTemporaryFile(mode='w') as f:
     f.write(alerts_data)

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -289,8 +289,10 @@ def _preprocess_alerts(alerts_path):
 
   counts = _get_region_counts()
   for region, count in counts.items():
-    alerts_data = alerts_data.replace(
-        'BOT_COUNT:' + region, str(int(count * EXPECTED_BOT_COUNT_PERCENT)))
+    alerts_data = re.sub(
+        'BOT_COUNT:' + region + r'(?=\s|$)',
+        str(int(count * EXPECTED_BOT_COUNT_PERCENT)),
+        alerts_data)
 
   with tempfile.NamedTemporaryFile(mode='w') as f:
     f.write(alerts_data)

--- a/src/python/tests/core/local/butler/deploy_test.py
+++ b/src/python/tests/core/local/butler/deploy_test.py
@@ -149,8 +149,12 @@ class DeployTest(fake_filesystem_unittest.TestCase):
                                    ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([
+        mock.call(mock.ANY, 'deployment-manager', 'deployments', 'describe',
+                  'pubsub'),
         mock.call(mock.ANY, 'deployment-manager', 'deployments', 'update',
                   'pubsub', '--config=./configs/test/pubsub/queues.yaml'),
+        mock.call(mock.ANY, 'deployment-manager', 'deployments', 'describe',
+                  'bigquery'),
         mock.call(mock.ANY, 'deployment-manager', 'deployments', 'update',
                   'bigquery', '--config=./configs/test/bigquery/datasets.yaml'),
     ])
@@ -219,8 +223,12 @@ class DeployTest(fake_filesystem_unittest.TestCase):
                                    ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([
+        mock.call(mock.ANY, 'deployment-manager', 'deployments', 'describe',
+                  'pubsub'),
         mock.call(mock.ANY, 'deployment-manager', 'deployments', 'update',
                   'pubsub', '--config=./configs/test/pubsub/queues.yaml'),
+        mock.call(mock.ANY, 'deployment-manager', 'deployments', 'describe',
+                  'bigquery'),
         mock.call(mock.ANY, 'deployment-manager', 'deployments', 'update',
                   'bigquery', '--config=./configs/test/bigquery/datasets.yaml'),
     ])
@@ -280,8 +288,12 @@ class DeployTest(fake_filesystem_unittest.TestCase):
                                      ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([
+        mock.call(mock.ANY, 'deployment-manager', 'deployments', 'describe',
+                  'pubsub'),
         mock.call(mock.ANY, 'deployment-manager', 'deployments', 'update',
                   'pubsub', '--config=./configs/test/pubsub/queues.yaml'),
+        mock.call(mock.ANY, 'deployment-manager', 'deployments', 'describe',
+                  'bigquery'),
         mock.call(mock.ANY, 'deployment-manager', 'deployments', 'update',
                   'bigquery', '--config=./configs/test/bigquery/datasets.yaml'),
     ])


### PR DESCRIPTION
- Only replace BOT_COUNT:region(space or end of line), to prevent issues
  with overlapping region names.
- Add retries.