### PR TITLE
Convert RNN generation to TF v2.

### DIFF
--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -44,6 +44,35 @@ from bot.fuzzers.ml.rnn import utils
 #     curves stay close. To see the curves drift apart ("overfitting") try
 #     to use an insufficient amount of training data.
 
+def build_model(num_rnn_cells, dropout_pkeep, batch_size, debug):
+  """Build the RNN model.
+
+  Since we use the Keras sequential model and we use different batch sizes for
+  train, validation and demo output generation, we use this function to rebatch
+  the model.
+
+  Args:
+    num_rnn_cells: number of RNN cells to use.
+    dropout_pkeep: probability of keeping a node in dropout.
+    batch_size: batch size used by the model layer.
+    debug: if True, print a summary of the model.
+
+  Returns:
+    Keras Sequential RNN model.
+  """
+  model = tf.keras.Sequential([
+      tf.keras.layers.Embedding(constants.ALPHA_SIZE, constants.ALPHA_SIZE,
+                                batch_input_shape=[batch_size, None]),
+      tf.keras.layers.GRU(num_rnn_cells, return_sequences=True, stateful=True,
+                          dropout=1-dropout_pkeep),
+      tf.keras.layers.Dense(constants.ALPHA_SIZE),
+  ])
+
+  # Display a summary of the model to debug shapes.
+  if debug:
+    model.summary()
+
+  return model
 
 def main(args):
   """Main function to train the model.

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -183,7 +183,7 @@ def main(args):
   output_bytes = tf.reshape(output_bytes, [batchsize, -1], name='output_bytes')
 
   # Choose Adam optimizer to compute gradients.
-  optimizer = tf.compat.v1.train.AdamOptimizer(lr).minimize(loss)
+  optimizer = tf.keras.optimizers.Adam(learning_rate)
 
   # Stats for display.
   seqloss = tf.reduce_mean(input_tensor=loss, axis=1)

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -231,7 +231,7 @@ def main(args):
       utils.print_learning_learned_comparison(
           input_batch, output_bytes, seq_loss, input_ranges, batch_loss,
           accuracy, epoch_size, steps, epoch)
-      with summary_writer.as_default():
+      with summary_writer.as_default():  # pylint: disable=not-context-manager
         tf.summary.scalar('batch_loss', batch_loss, step=steps)
         tf.summary.scalar('batch_accuracy', accuracy, step=steps)
       summary_writer.flush()
@@ -261,7 +261,7 @@ def main(args):
       utils.print_validation_stats(batch_loss, accuracy)
 
       # Save validation data for Tensorboard.
-      with validation_writer.as_default():
+      with validation_writer.as_default(): # pylint: disable=not-context-manager
         tf.summary.scalar('batch_loss', batch_loss, step=steps)
         tf.summary.scalar('batch_accuracy', accuracy, step=steps)
       validation_writer.flush()

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -126,9 +126,9 @@ def main(args):
   epoch_size = len(code_text) // (batch_size * constants.TRAINING_SEQLEN)
   utils.print_data_stats(len(code_text), len(validation_text), epoch_size)
 
-  # Set graph-level random seed, so any random sequence generated in this
-  # graph is repeatable. It could also be removed.
-  tf.compat.v1.set_random_seed(0)
+  # Set global random seed, so any random sequence generated is repeatable.
+  # It could also be removed.
+  tf.random.set_seed(0)
 
   # Define placeholder for learning rate, dropout and batch size.
   lr = tf.compat.v1.placeholder(tf.float32, name='lr')

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -155,7 +155,7 @@ def main(args):
       size=constants.DISPLAY_LEN,
       msg='Training on next {} batches'.format(constants.DISPLAY_FREQ))
 
-  # We continue training on exsiting model, or start with a new model.
+  # We continue training on existing model, or start with a new model.
   if existing_model:
     print('Continue training on existing model: {}'.format(existing_model))
     try:

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -201,9 +201,9 @@ def main(args):
   # Two sets of data are saved so that you can compare training and
   # validation curves visually in Tensorboard.
   timestamp = str(math.trunc(time.time()))
-  summary_writer = tf.compat.v1.summary.FileWriter(
+  summary_writer = tf.summary.create_file_writer(
       os.path.join(log_dir, timestamp + '-training'))
-  validation_writer = tf.compat.v1.summary.FileWriter(
+  validation_writer = tf.summary.create_file_writer(
       os.path.join(log_dir, timestamp + '-validation'))
 
   # Init for saving models.
@@ -274,9 +274,12 @@ def main(args):
           [output_bytes, seqloss, batchloss, accuracy, summaries],
           feed_dict=feed_dict)
       utils.print_learning_learned_comparison(
-          input_batch, predicted, seq_loss, input_ranges, batch_loss, acc_value,
-          epoch_size, steps, epoch)
-      summary_writer.add_summary(summaries_value, steps)
+          input_batch, output_bytes, seq_loss, input_ranges, batch_loss,
+          accuracy, epoch_size, steps, epoch)
+      with summary_writer.as_default():
+        tf.summary.scalar('batch_loss', batch_loss, step=steps)
+        tf.summary.scalar('batch_accuracy', accuracy, step=steps)
+      summary_writer.flush()
 
     # Run a validation step every `frequency` batches.
     # The validation text should be a single sequence but that's too slow.

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -44,6 +44,7 @@ from bot.fuzzers.ml.rnn import utils
 #     curves stay close. To see the curves drift apart ("overfitting") try
 #     to use an insufficient amount of training data.
 
+
 def build_model(num_rnn_cells, dropout_pkeep, batch_size, debug):
   """Build the RNN model.
 
@@ -60,11 +61,17 @@ def build_model(num_rnn_cells, dropout_pkeep, batch_size, debug):
   Returns:
     Keras Sequential RNN model.
   """
+  dropout_pdrop = 1 - dropout_pkeep
   model = tf.keras.Sequential([
-      tf.keras.layers.Embedding(constants.ALPHA_SIZE, constants.ALPHA_SIZE,
-                                batch_input_shape=[batch_size, None]),
-      tf.keras.layers.GRU(num_rnn_cells, return_sequences=True, stateful=True,
-                          dropout=1-dropout_pkeep),
+      tf.keras.layers.Embedding(
+          constants.ALPHA_SIZE,
+          constants.ALPHA_SIZE,
+          batch_input_shape=[batch_size, None]),
+      tf.keras.layers.GRU(
+          num_rnn_cells,
+          return_sequences=True,
+          stateful=True,
+          dropout=dropout_pdrop),
       tf.keras.layers.Dense(constants.ALPHA_SIZE),
   ])
 
@@ -73,6 +80,7 @@ def build_model(num_rnn_cells, dropout_pkeep, batch_size, debug):
     model.summary()
 
   return model
+
 
 @tf.function
 def train_step(model, optimizer, input_data, expected_data, train=False):
@@ -96,10 +104,10 @@ def train_step(model, optimizer, input_data, expected_data, train=False):
     seq_loss = tf.reduce_mean(input_tensor=loss, axis=1)
     batch_loss = tf.reduce_mean(input_tensor=seq_loss)
 
-    output_bytes = tf.cast(tf.argmax(predicted_data, axis=-1),
-                           expected_data.dtype)
-    accuracy = tf.reduce_mean(tf.cast(tf.equal(expected_data, output_bytes),
-                                      tf.float32))
+    output_bytes = tf.cast(
+        tf.argmax(predicted_data, axis=-1), expected_data.dtype)
+    accuracy = tf.reduce_mean(
+        tf.cast(tf.equal(expected_data, output_bytes), tf.float32))
 
   if train:
     grads = tape.gradient(loss, model.trainable_variables)
@@ -165,8 +173,8 @@ def main(args):
   tf.random.set_seed(0)
 
   # Build the RNN model.
-  model = build_model(hidden_layer_size * hidden_state_size,
-                      dropout_pkeep, batch_size, debug)
+  model = build_model(hidden_layer_size * hidden_state_size, dropout_pkeep,
+                      batch_size, debug)
 
   # Choose Adam optimizer to compute gradients.
   optimizer = tf.keras.optimizers.Adam(learning_rate)
@@ -278,7 +286,8 @@ def main(args):
       for _ in range(file_size - 1):
         prediction = generation_model(ry)
         prediction = tf.squeeze(prediction, 0).numpy()
-        rc = utils.sample_from_probabilities(prediction, topn=10 if epoch <= 1 else 2)
+        rc = utils.sample_from_probabilities(
+            prediction, topn=10 if epoch <= 1 else 2)
         sample.append(rc)
         ry = np.array([[rc]])
 

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -26,10 +26,6 @@ import sys
 import tensorflow as tf
 import time
 
-# TODO(mmoroz): Use replacements for Tensorflow 2.x
-from tensorflow.contrib import layers
-from tensorflow.contrib import rnn
-
 from bot.fuzzers.ml.rnn import constants
 from bot.fuzzers.ml.rnn import utils
 

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -261,7 +261,7 @@ def main(args):
       utils.print_validation_stats(batch_loss, accuracy)
 
       # Save validation data for Tensorboard.
-      with validation_writer.as_default(): # pylint: disable=not-context-manager
+      with validation_writer.as_default():  # pylint: disable=not-context-manager
         tf.summary.scalar('batch_loss', batch_loss, step=steps)
         tf.summary.scalar('batch_accuracy', accuracy, step=steps)
       validation_writer.flush()

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -217,9 +217,11 @@ def main(args):
       validation_model = build_model(hidden_layer_size * hidden_state_size,
                                      dropout_pkeep, validation_batch_size,
                                      False)
-      validation_model.load_weights(tf.train.latest_checkpoint(model_dir))
-      validation_model.build(tf.TensorShape([validation_batch_size, None]))
-      validation_model.reset_states()
+      last_weights = tf.train.latest_checkpoint(model_dir)
+      if last_weights:
+        validation_model.load_weights(tf.train.latest_checkpoint(model_dir))
+        validation_model.build(tf.TensorShape([validation_batch_size, None]))
+        validation_model.reset_states()
 
       predicted = validation_model(validation_x)
       loss = tf.keras.losses.sparse_categorical_crossentropy(
@@ -250,9 +252,11 @@ def main(args):
 
       generation_model = build_model(hidden_layer_size * hidden_state_size,
                                      dropout_pkeep, 1, False)
-      generation_model.load_weights(tf.train.latest_checkpoint(model_dir))
-      generation_model.build(tf.TensorShape([1, None]))
-      generation_model.reset_states()
+      last_weights = tf.train.latest_checkpoint(model_dir)
+      if last_weights:
+        generation_model.load_weights(tf.train.latest_checkpoint(model_dir))
+        generation_model.build(tf.TensorShape([1, None]))
+        generation_model.reset_states()
 
       for _ in range(file_size - 1):
         prediction = generation_model(ry)

--- a/src/python/bot/fuzzers/ml/rnn/train.py
+++ b/src/python/bot/fuzzers/ml/rnn/train.py
@@ -159,7 +159,7 @@ def main(args):
   if existing_model:
     print('Continue training on existing model: {}'.format(existing_model))
     try:
-      saver.restore(session, existing_model)
+      model.load_weights(existing_model)
     except:
       print(
           ('Failed to restore existing model since model '
@@ -168,7 +168,6 @@ def main(args):
       return constants.ExitCode.TENSORFLOW_ERROR
   else:
     print('No existing model provided. Start training with a new model.')
-    session.run(tf.compat.v1.global_variables_initializer())
 
   # Num of bytes we have trained so far.
   steps = 0
@@ -258,8 +257,8 @@ def main(args):
     if steps // 10 % frequency == 0:
       saved_model_name = constants.RNN_MODEL_NAME + '_' + timestamp
       saved_model_path = os.path.join(model_dir, saved_model_name)
-      saved_model = saver.save(session, saved_model_path, global_step=steps)
-      print('Saved model: {}'.format(saved_model))
+      model.save_weights(saved_model_path)
+      print('Saved model: {}'.format(saved_model_path))
 
     # Display progress bar.
     if debug:
@@ -271,8 +270,8 @@ def main(args):
   # Save the model after training is done.
   saved_model_name = constants.RNN_MODEL_NAME + '_' + timestamp
   saved_model_path = os.path.join(model_dir, saved_model_name)
-  saved_model = saver.save(session, saved_model_path, global_step=steps)
-  print('Saved model: {}'.format(saved_model))
+  model.save_weights(saved_model_path)
+  print('Saved model: {}'.format(saved_model_path))
 
   return constants.ExitCode.SUCCESS
 

--- a/src/python/bot/fuzzers/ml/rnn/utils.py
+++ b/src/python/bot/fuzzers/ml/rnn/utils.py
@@ -32,7 +32,6 @@ from bot.fuzzers.ml.rnn import constants
 def validate_model_path(model_path):
   """RNN model consists of three files. This validates if they all exist."""
   model_exists = (
-      os.path.exists(model_path + constants.MODEL_META_SUFFIX) and
       os.path.exists(model_path + constants.MODEL_DATA_SUFFIX) and
       os.path.exists(model_path + constants.MODEL_INDEX_SUFFIX))
   return model_exists

--- a/src/python/bot/fuzzers/ml/rnn/utils.py
+++ b/src/python/bot/fuzzers/ml/rnn/utils.py
@@ -282,7 +282,7 @@ class Progress(object):
       for _ in range(maxi):
         k = 0
         while d >= 0:
-          print('=', end=' ')
+          print('=', end='')
           sys.stdout.write('')
           sys.stdout.flush()
           k += 1

--- a/src/python/bot/tasks/ml_train_task.py
+++ b/src/python/bot/tasks/ml_train_task.py
@@ -194,8 +194,8 @@ def upload_model_to_gcs(model_directory, fuzzer_name):
   gcs_data_path = '%s/%s' % (gcs_model_directory, data_file_name)
   gcs_index_path = '%s/%s' % (gcs_model_directory, index_file_name)
 
-  logs.log('Uploading the model for %s: %s, %s.' %
-           (fuzzer_name, data_file_name, index_file_name))
+  logs.log('Uploading the model for %s: %s, %s.' % (fuzzer_name, data_file_name,
+                                                    index_file_name))
 
   # Upload files to GCS.
   result = (

--- a/src/python/tests/core/bot/tasks/ml_train_task_test.py
+++ b/src/python/tests/core/bot/tasks/ml_train_task_test.py
@@ -45,36 +45,30 @@ class GetLastSavedModelTest(fake_fs_unittest.TestCase):
     # Create model directory.
     self.fs.create_dir(MODEL_DIR)
 
-    # Create fake meta file, index file and data file.
-    # Model_1 has three complete files.
-    self.model_1_meta_path = os.path.join(MODEL_DIR, 'model_1.meta')
+    # Create fake index file and data file.
+    # Model_1 has two complete files.
     self.model_1_data_path = os.path.join(MODEL_DIR,
                                           'model_1.data-00000-of-00001')
     self.model_1_index_path = os.path.join(MODEL_DIR, 'model_1.index')
 
-    # Create three files for model_1.
-    self.fs.create_file(self.model_1_meta_path)
+    # Create two files for model_1.
     self.fs.create_file(self.model_1_data_path)
     self.fs.create_file(self.model_1_index_path)
 
     # Update timestamp.
-    os.utime(self.model_1_meta_path, (1330711140, 1330711160))
     os.utime(self.model_1_data_path, (1330711140, 1330711160))
     os.utime(self.model_1_index_path, (1330711140, 1330711160))
 
-    # Model_2 has three complete files.
-    self.model_2_meta_path = os.path.join(MODEL_DIR, 'model_2.meta')
+    # Model_2 has two complete files.
     self.model_2_data_path = os.path.join(MODEL_DIR,
                                           'model_2.data-00000-of-00001')
     self.model_2_index_path = os.path.join(MODEL_DIR, 'model_2.index')
 
-    # Create three files for model_2.
-    self.fs.create_file(self.model_2_meta_path)
+    # Create two files for model_2.
     self.fs.create_file(self.model_2_data_path)
     self.fs.create_file(self.model_2_index_path)
 
     # Update timestamp. Make sure they are newer than model_1.
-    os.utime(self.model_2_meta_path, (1330713340, 1330713360))
     os.utime(self.model_2_data_path, (1330713340, 1330713360))
     os.utime(self.model_2_index_path, (1330713340, 1330713360))
 
@@ -83,7 +77,6 @@ class GetLastSavedModelTest(fake_fs_unittest.TestCase):
     # Model_2 is newer than model_1, so we will get model_2.
     model_paths = ml_train_task.get_last_saved_model(MODEL_DIR)
     expected = {
-        'meta': self.model_2_meta_path,
         'data': self.model_2_data_path,
         'index': self.model_2_index_path
     }
@@ -98,7 +91,6 @@ class GetLastSavedModelTest(fake_fs_unittest.TestCase):
     # Now we should get model_1.
     model_paths = ml_train_task.get_last_saved_model(MODEL_DIR)
     expected = {
-        'meta': self.model_1_meta_path,
         'data': self.model_1_data_path,
         'index': self.model_1_index_path
     }

--- a/src/python/tests/core/bot/tasks/ml_train_task_test.py
+++ b/src/python/tests/core/bot/tasks/ml_train_task_test.py
@@ -158,8 +158,6 @@ class ExecuteTaskTest(unittest.TestCase):
                                                 model_directory, log_directory)
 
 
-# TODO(mmoroz): Re-enable this.
-@unittest.skip('Training is broken.')
 @test_utils.integration
 class MLRnnTrainTaskIntegrationTest(unittest.TestCase):
   """ML RNN training integration tests."""


### PR DESCRIPTION
TF v2 offers ways to handle validation and TensorBoard during model callback. We can also do the batching using `tf.data` instead of writing the loop manually.

I'm trying it this way now to not do too many changes at once but will probably send another PR later to convert to the recommended way.