### PR TITLE
Add FoundIn labels for Chrome bugs.

### DIFF
--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -198,7 +198,7 @@ def update_issue_foundin_labels(testcase, issue):
       x for x in [testcase.impact_beta_version, testcase.impact_stable_version]
       if x
   ]
-  milestones_foundin = set([x.split('.')[0] for x in versions_foundin])
+  milestones_foundin = {x.split('.')[0] for x in versions_foundin}
   for found_milestone in milestones_foundin:
     if f'foundin-{found_milestone}' in issue.labels:
       continue

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -178,28 +178,29 @@ def update_issue_impact_labels(testcase, issue):
     # No impact information.
     return
 
-  versions_foundin = [
-      x for x in [testcase.impact_beta_version, testcase.impact_stable_version]
-      if x
-  ]
-  milestones_foundin = set([x.split('.')[0] for x in versions_foundin])
+  update_issue_foundin_labels(testcase, issue)
 
   if existing_impact == new_impact:
     # Correct impact already set.
-    update_issue_foundin_labels(testcase, issue, milestones_foundin)
     return
 
   if existing_impact != data_types.SecurityImpact.MISSING:
     issue.labels.remove('Security_Impact-' + impact_to_string(existing_impact))
 
   issue.labels.add('Security_Impact-' + impact_to_string(new_impact))
-  update_issue_foundin_labels(testcase, issue, milestones_foundin)
 
 
-def update_issue_foundin_labels(testcase, issue, milestones_foundin):
-  labels = [label.lower() for label in issue.labels]
+def update_issue_foundin_labels(testcase, issue):
+  """Updates FoundIn- labels on issue."""
+  if not testcase.is_impact_set_flag:
+    return
+  versions_foundin = [
+      x for x in [testcase.impact_beta_version, testcase.impact_stable_version]
+      if x
+  ]
+  milestones_foundin = set([x.split('.')[0] for x in versions_foundin])
   for found_milestone in milestones_foundin:
-    if 'foundin-%s' % found_milestone in labels:
+    if f'foundin-{found_milestone}' in issue.labels:
       continue
     issue.labels.add('FoundIn-' + found_milestone)
 

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -178,14 +178,30 @@ def update_issue_impact_labels(testcase, issue):
     # No impact information.
     return
 
+  versions_foundin = [
+      x for x in [testcase.impact_beta_version, testcase.impact_stable_version]
+      if x
+  ]
+  milestones_foundin = set([x.split('.')[0] for x in versions_foundin])
+
   if existing_impact == new_impact:
     # Correct impact already set.
+    update_issue_foundin_labels(testcase, issue, milestones_foundin)
     return
 
   if existing_impact != data_types.SecurityImpact.MISSING:
     issue.labels.remove('Security_Impact-' + impact_to_string(existing_impact))
 
   issue.labels.add('Security_Impact-' + impact_to_string(new_impact))
+  update_issue_foundin_labels(testcase, issue, milestones_foundin)
+
+
+def update_issue_foundin_labels(testcase, issue, milestones_foundin):
+  labels = [label.lower() for label in issue.labels]
+  for found_milestone in milestones_foundin:
+    if 'foundin-%s' % found_milestone in labels:
+      continue
+    issue.labels.add('FoundIn-' + found_milestone)
 
 
 def apply_substitutions(policy, label, testcase, security_severity=None):

--- a/src/appengine/requirements.txt
+++ b/src/appengine/requirements.txt
@@ -6,3 +6,6 @@ PyJWT==1.7.1
 pyOpenSSL==19.1.0
 requests-toolbelt==0.9.1
 sendgrid==6.0.4
+mock==4.0.2
+webtest==2.0.35
+parameterized==0.7.4

--- a/src/appengine/requirements.txt
+++ b/src/appengine/requirements.txt
@@ -6,6 +6,3 @@ PyJWT==1.7.1
 pyOpenSSL==19.1.0
 requests-toolbelt==0.9.1
 sendgrid==6.0.4
-mock==4.0.2
-webtest==2.0.35
-parameterized==0.7.4

--- a/src/python/tests/appengine/libs/issue_filer_test.py
+++ b/src/python/tests/appengine/libs/issue_filer_test.py
@@ -652,24 +652,24 @@ class UpdateImpactTest(unittest.TestCase):
   def test_update_impact_stable(self):
     """Tests updating impact to Stable."""
     self.testcase.is_impact_set_flag = True
-    self.testcase.impact_stable_version = 'Stable'
+    self.testcase.impact_stable_version = '99.1024.11.42'
 
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    six.assertCountEqual(self, ['Security_Impact-Stable'],
+    six.assertCountEqual(self, ['Security_Impact-Stable', 'FoundIn-99'],
                          mock_issue.labels.added)
     six.assertCountEqual(self, [], mock_issue.labels.removed)
 
   def test_update_impact_beta(self):
     """Tests updating impact to Beta."""
     self.testcase.is_impact_set_flag = True
-    self.testcase.impact_beta_version = 'Beta'
+    self.testcase.impact_beta_version = '100.1044.44.44'
 
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    six.assertCountEqual(self, ['Security_Impact-Beta'],
+    six.assertCountEqual(self, ['Security_Impact-Beta', 'FoundIn-100'],
                          mock_issue.labels.added)
     six.assertCountEqual(self, [], mock_issue.labels.removed)
 
@@ -733,8 +733,8 @@ class UpdateImpactTest(unittest.TestCase):
   def test_component_add_label(self):
     """Test that we set labels for component builds."""
     self.testcase.job_type = 'job'
-    self.testcase.impact_stable_version = 'Stable'
-    self.testcase.impact_beta_version = 'Beta'
+    self.testcase.impact_stable_version = '2.3.4.5'
+    self.testcase.impact_beta_version = '3.4.5.6'
     self.testcase.put()
 
     data_types.Job(
@@ -746,6 +746,7 @@ class UpdateImpactTest(unittest.TestCase):
     self.testcase.is_impact_set_flag = True
     mock_issue = self._make_mock_issue()
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    six.assertCountEqual(self, ['Security_Impact-Stable'],
+    six.assertCountEqual(self,
+                         ['Security_Impact-Stable', 'FoundIn-2', 'FoundIn-3'],
                          mock_issue.labels.added)
     six.assertCountEqual(self, [], mock_issue.labels.removed)


### PR DESCRIPTION
The `FoundIn=NN` label is a standard for marking which milestone
in which functional bugs are found within Monorail.
ClusterFuzz should adopt this standard for the following reasons:

1) Why not? ClusterFuzz has this information so it would be great
   to add it.
2) Sheriffbot currently relies on `Security_Impact` when deciding on
   merge decisions. Currently, `Security_Impact`s are 'promoted'
   when a new build goes to stable or to beta. This sometimes is
   problematic when a single milestone is both stable and beta.
3) More generally, switching the security sheriffing procedures
   from Security_Impact to FoundIn would be less confusing.

A future change would ideally also set RegressedIn, but that's
a more significant project.

For more information internally within Google, see
https://goto.google.com/clusterfuzz-foundin
