### PR TITLE
Implement an API endpoint for checking if a crash is known.

### DIFF
--- a/src/appengine/handlers/crash_query.py
+++ b/src/appengine/handlers/crash_query.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Handler for the crash query api."""
+
+from flask import request
+
+from crash_analysis import crash_analyzer
+from crash_analysis.stack_parsing import stack_analyzer
+from datastore import data_handler
+from handlers import base_handler
+from libs import auth
+from libs import handler
+from libs import helpers
+
+
+class Handler(base_handler.Handler):
+  """Handler that gets the crash stats when user first lands on the page."""
+
+  @handler.post(handler.JSON, handler.JSON)
+  @handler.oauth
+  def post(self):
+    """Handle a post request."""
+    if not auth.get_current_user():
+      raise helpers.AccessDeniedException()
+
+    project = request.get('project')
+    fuzz_target = request.get('fuzz_target')
+    stacktrace = request.get('stacktrace')
+
+    state = stack_analyzer.get_crash_data(
+        stacktrace,
+        symbolize_flag=False,
+        fuzz_target=fuzz_target,
+        already_symbolized=True,
+        detect_ooms_and_hangs=True)
+    security_flag = crash_analyzer.is_security_issue(
+        state.crash_stacktrace, state.crash_type, state.crash_address)
+
+    if data_handler.find_testcase(project, state.crash_type, state.crash_state,
+                                  security_flag):
+      new_or_duplicate = 'duplicate'
+    else:
+      new_or_duplicate = 'new'
+
+    return self.render_json({
+        'result': new_or_duplicate,
+        'state': state.crash_state,
+        'type': state.crash_type,
+        'security': security_flag,
+    })

--- a/src/appengine/handlers/crash_query.py
+++ b/src/appengine/handlers/crash_query.py
@@ -25,7 +25,7 @@ from libs import helpers
 
 
 class Handler(base_handler.Handler):
-  """Handler that gets the crash stats when user first lands on the page."""
+  """Handler for crash querying."""
 
   @handler.post(handler.JSON, handler.JSON)
   @handler.oauth

--- a/src/appengine/server.py
+++ b/src/appengine/server.py
@@ -26,6 +26,7 @@ from handlers import commit_range
 from handlers import configuration
 from handlers import corpora
 from handlers import coverage_report
+from handlers import crash_query
 from handlers import crash_stats
 from handlers import domain_verifier
 from handlers import download
@@ -170,13 +171,14 @@ handlers = [
      coverage_report.Handler),
     ('/coverage-report/<report_type>/<argument>/<date>/<path:extra>',
      coverage_report.Handler),
-    ('/delete-external-user-permission',
-     configuration.DeleteExternalUserPermission),
+    ('/crash-query', crash_query.Handler),
     ('/crash-stats/load', crash_stats.JsonHandler),
     ('/crash-stats', crash_stats.Handler),
     ('/corpora', corpora.Handler),
     ('/corpora/create', corpora.CreateHandler),
     ('/corpora/delete', corpora.DeleteHandler),
+    ('/delete-external-user-permission',
+     configuration.DeleteExternalUserPermission),
     ('/docs', help_redirector.DocumentationHandler),
     ('/download', download.Handler),
     ('/download/<resource>', download.Handler),

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -632,10 +632,7 @@ class StackAnalyzerState(object):
     self.raw_frames = []
     self.last_frame_id = -1
 
-    if fuzz_target:
-      self.fuzz_target = fuzz_target
-    else:
-      self.fuzz_target = environment.get_value('FUZZ_TARGET')
+    self.fuzz_target = fuzz_target or environment.get_value('FUZZ_TARGET')
 
     # Additional tracking for Android bugs.
     self.found_java_exception = False

--- a/src/python/tests/appengine/handlers/crash_query_test.py
+++ b/src/python/tests/appengine/handlers/crash_query_test.py
@@ -1,0 +1,112 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for jobs."""
+import flask
+import unittest
+import webtest
+
+from datastore import data_types
+from handlers import crash_query
+from tests.test_libs import helpers as test_helpers
+from tests.test_libs import test_utils
+
+TEST_STACKTRACE_OVERFLOW = '''
+=================================================================
+==14479==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x615000000c80 at pc 0x000000c43002 bp 0x7ffc7ba6fae0 sp 0x7ffc7ba6fad8
+WRITE of size 4 at 0x615000000c80 thread T0
+SCARINESS: 36 (4-byte-write-heap-buffer-overflow)
+    #0 0xc48001 in Foo foo.c:36:4
+    #1 0x3d912f in Bar bar.c:2:6
+    #2 0x41e77e in Main main.c:47:13
+    #3 0x3f0778 in LLVMFuzzerTestOneInput fuzzer.cpp:12:1
+    #4 0x4f216b in main
+    #5 0x7f371939782f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/libc-start.c:291
+    #6 0x441bb8 in _start
+SUMMARY: AddressSanitizer: heap-buffer-overflow ()
+==14479==ABORTING
+'''
+
+TEST_STACKTRACE_OOM = '''
+==1== ERROR: libFuzzer: out-of-memory (used: 2590Mb; limit: 2560Mb)
+   To change the out-of-memory limit use -rss_limit_mb=<N>
+SUMMARY: libFuzzer: out-of-memory
+'''
+
+
+@test_utils.with_cloud_emulators('datastore')
+class CrashQueryTest(unittest.TestCase):
+  """Jobs tests."""
+
+  def setUp(self):
+    test_helpers.patch(self, [
+        'libs.auth.get_current_user',
+    ])
+    flaskapp = flask.Flask('testflask')
+    flaskapp.add_url_rule('/', view_func=crash_query.Handler.as_view('/'))
+    self.app = webtest.TestApp(flaskapp)
+
+  def test_new(self):
+    """Test new."""
+    response = self.app.post_json(
+        '/', {
+            'project': 'project',
+            'fuzz_target': 'target',
+            'stacktrace': TEST_STACKTRACE_OVERFLOW,
+        })
+
+    self.assertEqual({
+        'result': 'new',
+        'type': 'Heap-buffer-overflow\nWRITE 4',
+        'state': 'Foo\nBar\nMain\n',
+        'security': True,
+    }, response.json)
+
+  def test_duplicate(self):
+    """Test duplicate."""
+    expected_crash_state = 'Foo\nBar\nMain\n'
+    data_types.Testcase(
+        open=True,
+        status='Processed',
+        crash_state=expected_crash_state,
+        crash_type='Heap-buffer-overflow\nWRITE 4',
+        project_name='project',
+        security_flag=True).put()
+
+    response = self.app.post_json(
+        '/', {
+            'project': 'project',
+            'fuzz_target': 'target',
+            'stacktrace': TEST_STACKTRACE_OVERFLOW,
+        })
+    self.assertEqual({
+        'result': 'duplicate',
+        'type': 'Heap-buffer-overflow\nWRITE 4',
+        'state': expected_crash_state,
+        'security': True,
+    }, response.json)
+
+  def test_oom(self):
+    """Test OOM parsing."""
+    response = self.app.post_json(
+        '/', {
+            'project': 'project',
+            'fuzz_target': 'target',
+            'stacktrace': TEST_STACKTRACE_OOM,
+        })
+    self.assertEqual({
+        'result': 'new',
+        'type': 'Out-of-memory',
+        'state': 'target\n',
+        'security': False,
+    }, response.json)


### PR DESCRIPTION
Input (JSON POST):
{
  "stacktrace": "stacktrace as string",
  "project": "project name",
  "fuzz_target": "fuzz target if applicable (optional)"
}

Output (JSON):
{
  "result": "new/duplicate",
  "state": "crash state",
  "type": "crash type",
  "security": "true/false",
}

Also modify stack_analyzer.get_crash_data to:
- remove reliance on environment variables for getting the fuzz target
  and whether or not to parse OOMs/timeouts.
- add "already_symbolized" argument to indicate that a stacktrace is
  already symbolized.