### PR TITLE
[fuchsia] Work around bug in older builds with newer KVM

### DIFF
--- a/src/python/platforms/fuchsia/device.py
+++ b/src/python/platforms/fuchsia/device.py
@@ -21,6 +21,7 @@ from builtins import object
 from builtins import str
 
 import os
+import shlex
 import socket
 import subprocess
 import tempfile
@@ -193,7 +194,7 @@ class QemuProcess(object):
     # Fuzzing jobs that SSH into the QEMU VM need access to this env var.
     environment.set_value('FUCHSIA_PKEY_PATH', qemu_vars['pkey_path'])
     logs.log('Ready to run QEMU. Command: ' + qemu_vars['qemu_path'] + ' ' +
-             ' '.join('"{}"'.format(arg) for arg in qemu_args))
+             ' '.join(shlex.quote(arg) for arg in qemu_args))
     self.process_runner = new_process.ProcessRunner(qemu_vars['qemu_path'],
                                                     qemu_args)
 


### PR DESCRIPTION
Newer KVM versions exposed a bug that caused Fuchsia to fail to boot.
This was previously fixed on the Fuchsia side, but requires a
ClusterFuzz-side workaround in order to be able to run builds from
before that fix rolled (e.g. when bisecting).

This commit also adds the `invtsc` feature to the QEMU CPU config to
bring it in line with Fuchsia defaults and improve performance, and
makes it slightly easier to reproduce the QEMU commands run by
ClusterFuzz.