### PR TITLE
Close testcase whose fuzzers got deleted automatically.

### DIFF
--- a/src/python/bot/tasks/progression_task.py
+++ b/src/python/bot/tasks/progression_task.py
@@ -273,10 +273,8 @@ def find_fixed_range(testcase_id, job_type):
   revision_list = build_manager.get_revisions_list(
       build_bucket_path, testcase=testcase)
   if not revision_list:
-    testcase = data_handler.get_testcase_by_id(testcase_id)
-    data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
-                                         'Failed to fetch revision list')
-    tasks.add_task('progression', testcase_id, job_type)
+    data_handler.close_testcase_with_error(testcase_id,
+                                           'Failed to fetch revision list')
     return
 
   # Use min, max_index to mark the start and end of revision list that is used

--- a/src/python/bot/tasks/regression_task.py
+++ b/src/python/bot/tasks/regression_task.py
@@ -239,10 +239,8 @@ def find_regression_range(testcase_id, job_type):
   revision_list = build_manager.get_revisions_list(
       build_bucket_path, testcase=testcase)
   if not revision_list:
-    testcase = data_handler.get_testcase_by_id(testcase_id)
-    data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
-                                         'Failed to fetch revision list')
-    tasks.add_task('regression', testcase_id, job_type)
+    data_handler.close_testcase_with_error(testcase_id,
+                                           'Failed to fetch revision list')
     return
 
   # Don't burden NFS server with caching these random builds.

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -1522,3 +1522,12 @@ def get_coverage_information(fuzzer_name, date, create_if_needed=False):
         fuzzer=fuzzer_name, date=date)
 
   return coverage_info
+
+
+def close_testcase_with_error(testcase_id, error_message):
+  """Close testcase (fixed=NA) with an error message."""
+  testcase = get_testcase_by_id(testcase_id)
+  update_testcase_comment(testcase, data_types.TaskState.ERROR, error_message)
+  testcase.fixed = 'NA'
+  testcase.open = False
+  testcase.put()


### PR DESCRIPTION
GCS Bucket can have lifecycle policy. For deleted fuzzers,
this would mean empty revision list. So, rather than retry,
just close the testcase. It should never happen in regular
case and instead result in exception.

Fixes #1825