### PR TITLE
Get build fingerprint instead of relying on env variable.

### DIFF
--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -285,7 +285,7 @@ def get_environment_settings_as_string():
     from platforms import android
 
     environment_string += '[Environment] Build fingerprint: %s\n' % (
-        get_value('BUILD_FINGERPRINT'))
+        android.settings.get_build_fingerprint())
 
     environment_string += ('[Environment] Patch level: %s\n' %
                            android.settings.get_security_patch_level())


### PR DESCRIPTION
initialize_device is not called for libfuzzer tasks, so call the
function explicitly.

Fixes https://github.com/google/clusterfuzz/issues/2035