### PR TITLE
Request bisection for whole range again if range is invalid.

### DIFF
--- a/src/python/bot/tasks/task_creation.py
+++ b/src/python/bot/tasks/task_creation.py
@@ -287,7 +287,7 @@ def request_bisection(testcase_id):
 
 def _check_commits(testcase, bisect_type, old_commit, new_commit):
   """Check old and new commit validity."""
-  if old_commit != new_commit:
+  if old_commit != new_commit or build_manager.is_custom_binary():
     return old_commit, new_commit
 
   # Something went wrong during bisection for the same commit to be chosen for


### PR DESCRIPTION
In some cases, regression and progression tasks may bisect to the commit
range X..X, which is really invalid as it represents an empty range.
Rather than assume X is the correctly bisected commit, re-request
bisection for the whole range.