### PR TITLE
Check fuzzer before job when preparing fuzzer logs links.

### DIFF
--- a/src/python/metrics/fuzzer_stats.py
+++ b/src/python/metrics/fuzzer_stats.py
@@ -566,11 +566,11 @@ class FuzzerRunLogsContext(BuiltinFieldContext):
 
   def get_logs_bucket(self, fuzzer_name=None, job_type=None):
     """Return logs bucket for the job."""
-    if job_type:
-      return self._get_logs_bucket_from_job(job_type)
-
     if fuzzer_name:
       return self._get_logs_bucket_from_fuzzer(fuzzer_name)
+
+    if job_type:
+      return self._get_logs_bucket_from_job(job_type)
 
     return None
 


### PR DESCRIPTION
PTAL. This should fix an issue where we were generating report links for parent fuzzers, which would be invalid (and which don't really make sense). By switching the order of this check, if the fuzzer is a parent fuzzer we'll bail out early. As of the time of posting, this change is live on OSS-Fuzz staging if you want to test it out.