### PR TITLE
Make ML RNN generator work without legacy .meta files.

### DIFF
--- a/src/python/bot/fuzzers/ml/rnn/constants.py
+++ b/src/python/bot/fuzzers/ml/rnn/constants.py
@@ -59,7 +59,6 @@ TRAINING_SCRIPT_NAME = 'train.py'
 GENERATION_SCRIPT_NAME = 'generate.py'
 
 # Model files suffix.
-MODEL_META_SUFFIX = '.meta'
 MODEL_DATA_SUFFIX = '.data-00000-of-00001'
 MODEL_INDEX_SUFFIX = '.index'
 

--- a/src/python/bot/fuzzers/ml/rnn/generate.py
+++ b/src/python/bot/fuzzers/ml/rnn/generate.py
@@ -73,9 +73,11 @@ def main(args):
     print('\nusing model {} to generate {} inputs...'.format(model_path, count))
 
     # Restore the model.
-    new_saver = tf.compat.v1.train.import_meta_graph(
-        model_path + constants.MODEL_META_SUFFIX)
-    new_saver.restore(session, model_path)
+    # Build the RNN model.
+    model = utils.build_model(
+        constants.HIDDEN_STATE_SIZE * constants.HIDDEN_STATE_SIZE,
+        constants.DROPOUT_PKEEP, constants.BATCH_SIZE, False)
+    model.load_weights(model_path)
 
     corpus_files_info = utils.get_files_info(input_dir)
     if not corpus_files_info:

--- a/src/python/bot/fuzzers/ml/rnn/generator.py
+++ b/src/python/bot/fuzzers/ml/rnn/generator.py
@@ -53,31 +53,26 @@ def download_model_from_gcs(local_model_directory, fuzzer_name):
   logs.log('GCS model directory for fuzzer %s is %s.' % (fuzzer_name,
                                                          gcs_model_directory))
 
-  # RNN model consists of three files.
-  meta_filename = constants.RNN_MODEL_NAME + constants.MODEL_META_SUFFIX
+  # RNN model consists of two files.
   data_filename = constants.RNN_MODEL_NAME + constants.MODEL_DATA_SUFFIX
   index_filename = constants.RNN_MODEL_NAME + constants.MODEL_INDEX_SUFFIX
 
   # Cloud file paths.
-  gcs_meta_path = '%s/%s' % (gcs_model_directory, meta_filename)
   gcs_data_path = '%s/%s' % (gcs_model_directory, data_filename)
   gcs_index_path = '%s/%s' % (gcs_model_directory, index_filename)
 
   # Check if model exists.
-  if not (storage.exists(gcs_meta_path) and storage.exists(gcs_data_path) and
-          storage.exists(gcs_index_path)):
+  if not (storage.exists(gcs_data_path) and storage.exists(gcs_index_path)):
     logs.log('ML RNN model for fuzzer %s does not exist. Skip generation.' %
              fuzzer_name)
     return False
 
   # Local file paths.
-  local_meta_path = os.path.join(local_model_directory, meta_filename)
   local_data_path = os.path.join(local_model_directory, data_filename)
   local_index_path = os.path.join(local_model_directory, index_filename)
 
   # Download model files.
   result = (
-      storage.copy_file_from(gcs_meta_path, local_meta_path) and
       storage.copy_file_from(gcs_data_path, local_data_path) and
       storage.copy_file_from(gcs_index_path, local_index_path))
 
@@ -97,7 +92,7 @@ def prepare_model_directory(fuzzer_name):
 
   Returns:
     Model path. For example, if `/tmp/model` is the directory containing model
-    files(e.g. rnn.meta), the path should be '/tmp/model/rnn'.
+    files(e.g. rnn.index), the path should be '/tmp/model/rnn'.
   """
   # Get temporary directory.
   temp_directory = environment.get_value('BOT_TMPDIR')

--- a/src/python/bot/fuzzers/ml/rnn/utils.py
+++ b/src/python/bot/fuzzers/ml/rnn/utils.py
@@ -19,12 +19,50 @@ import numpy as np
 import os
 import random
 import sys
+import tensorflow as tf
 
 from bot.fuzzers.ml.rnn import constants
 
 
+def build_model(num_rnn_cells, dropout_pkeep, batch_size, debug):
+  """Build the RNN model.
+
+  Since we use the Keras sequential model and we use different batch sizes for
+  train, validation and demo output generation, we use this function to rebatch
+  the model.
+
+  Args:
+    num_rnn_cells: number of RNN cells to use.
+    dropout_pkeep: probability of keeping a node in dropout.
+    batch_size: batch size used by the model layer.
+    debug: if True, print a summary of the model.
+
+  Returns:
+    Keras Sequential RNN model.
+  """
+  dropout_pdrop = 1 - dropout_pkeep
+  model = tf.keras.Sequential([
+      tf.keras.layers.Embedding(
+          constants.ALPHA_SIZE,
+          constants.ALPHA_SIZE,
+          batch_input_shape=[batch_size, None]),
+      tf.keras.layers.GRU(
+          num_rnn_cells,
+          return_sequences=True,
+          stateful=True,
+          dropout=dropout_pdrop),
+      tf.keras.layers.Dense(constants.ALPHA_SIZE),
+  ])
+
+  # Display a summary of the model to debug shapes.
+  if debug:
+    model.summary()
+
+  return model
+
+
 def validate_model_path(model_path):
-  """RNN model consists of three files. This validates if they all exist."""
+  """RNN model consists of two files. This validates if they all exist."""
   model_exists = (
       os.path.exists(model_path + constants.MODEL_DATA_SUFFIX) and
       os.path.exists(model_path + constants.MODEL_INDEX_SUFFIX))


### PR DESCRIPTION
@mihaimaruseac after I've deleted old `.meta` files, the generation stopped working (and it didn't work for new fuzzers whose models didn't have `.meta` files).

I've deleted code handling `.meta` files, but we also need to migrate from the legacy session restore and run to the new `model` thing.

I've found the following guide: https://www.tensorflow.org/guide/migrate#converting_models

But it isn't straightforward to me, as we have slightly different function arguments and output values.

Would you be able to guide me please in fixing the generation code?