### PR TITLE
Android fixes

### DIFF
--- a/src/python/bot/init_scripts/android.py
+++ b/src/python/bot/init_scripts/android.py
@@ -24,8 +24,14 @@ def run():
   # Check if we need to reflash device to latest build.
   android.flash.flash_to_latest_build_if_needed()
 
+  # Reboot to bring device in a good state.
+  android.device.reboot()
+
   # Make sure that device is in a good condition before we move forward.
   android.adb.wait_until_fully_booted()
 
   # Wait until battery charges to a minimum level and temperature threshold.
   android.battery.wait_until_good_state()
+
+  # Initialize environment settings.
+  android.device.initialize_environment()

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -281,11 +281,15 @@ def get_environment_settings_as_string():
     # FIXME: Handle this import in a cleaner way.
     from platforms import android
 
+    build_fingerprint = get_value('BUILD_FINGERPRINT',
+                                  android.settings.get_build_fingerprint())
     environment_string += '[Environment] Build fingerprint: %s\n' % (
-        android.settings.get_build_fingerprint())
+        build_fingerprint)
 
-    environment_string += ('[Environment] Patch level: %s\n' %
-                           android.settings.get_security_patch_level())
+    security_patch_level = get_value(
+        'SECURITY_PATCH_LEVEL', android.settings.get_security_patch_level())
+    environment_string += (
+        '[Environment] Patch level: %s\n' % security_patch_level)
 
     environment_string += (
         '[Environment] Local properties file "%s" with contents:\n%s\n' %
@@ -631,6 +635,12 @@ def is_honggfuzz_job(job_name=None):
 def is_engine_fuzzer_job(job_name=None):
   """Return if true is this is an engine fuzzer."""
   return bool(get_engine_for_job(job_name))
+
+
+def is_kernel_fuzzer_job(job_name=None):
+  """Return true if the current job uses libFuzzer."""
+  # Prefix matching is not sufficient.
+  return _job_substring_match('syzkaller', job_name)
 
 
 def get_engine_for_job(job_name=None):

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -638,7 +638,7 @@ def is_engine_fuzzer_job(job_name=None):
 
 
 def is_kernel_fuzzer_job(job_name=None):
-  """Return true if the current job uses libFuzzer."""
+  """Return true if the current job uses syzkaller."""
   # Prefix matching is not sufficient.
   return _job_substring_match('syzkaller', job_name)
 


### PR DESCRIPTION
- Don't run initialize_device or try to configure system build.prop
  changes on libFuzzer and syzkaller jobs.
- Initialize environment early on, and make sure that stacktrace
  generation uses environment vars rather than trying to query a
  possibly dead device.