### PR TITLE
Fix recursion issue with Android usb reset.

### DIFF
--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -515,7 +515,7 @@ def reset_usb():
     return False
 
   # Wait for usb to recover.
-  wait_for_device()
+  wait_for_device(recover=False)
   return True
 
 
@@ -682,9 +682,9 @@ def time_since_last_reboot():
     return float('inf')
 
 
-def wait_for_device():
+def wait_for_device(recover=True):
   """Waits indefinitely for the device to come online."""
-  run_command('wait-for-device', timeout=RECOVERY_CMD_TIMEOUT)
+  run_command('wait-for-device', timeout=RECOVERY_CMD_TIMEOUT, recover=recover)
 
 
 def wait_until_fully_booted():


### PR DESCRIPTION
wait_for_device inside usb_reset can try to recover a bad device
recursing into usb_reset again. Avoid stack recursion and don't
recover in wait_for_device call for that instance.