### PR TITLE
Start adding engine support to libClusterFuzz.

### DIFF
--- a/src/python/base/memoize.py
+++ b/src/python/base/memoize.py
@@ -18,7 +18,6 @@ import functools
 import json
 import threading
 
-import redis
 import six
 
 from base import persistent_cache
@@ -37,6 +36,8 @@ _DEFAULT_REDIS_PORT = 6379
 
 def _redis_client():
   """Get the redis client."""
+  import redis
+
   if hasattr(_local, 'redis'):
     return _local.redis
 
@@ -134,6 +135,7 @@ class Memcache(object):
   @bot_noop
   def put(self, key, value):
     """Put (key, value) into cache."""
+    import redis
     try:
       _redis_client().set(
           json.dumps(key), json.dumps(value), ex=self.ttl_in_seconds)
@@ -144,6 +146,7 @@ class Memcache(object):
   @bot_noop
   def get(self, key):
     """Get the value from cache."""
+    import redis
     try:
       value_raw = _redis_client().get(json.dumps(key))
     except redis.RedisError:

--- a/src/python/bot/fuzzers/blackbox/engine.py
+++ b/src/python/bot/fuzzers/blackbox/engine.py
@@ -16,8 +16,8 @@
 import os
 
 from bot import testcase_manager
-from bot.fuzzers import engine
 from crash_analysis.stack_parsing import stack_analyzer
+from lib.clusterfuzz.fuzz import engine
 from system import environment
 from system import new_process
 from system import shell

--- a/src/python/bot/fuzzers/builtin.py
+++ b/src/python/bot/fuzzers/builtin.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Builtin fuzzer."""
-# NOTE: This module is deprecated and will be replaced with bot.fuzzers.engine.
+# NOTE: This module is deprecated and will be replaced with
+# lib.clusterfuzz.fuzz.engine.
 
 import os
 import random

--- a/src/python/bot/fuzzers/honggfuzz/engine.py
+++ b/src/python/bot/fuzzers/honggfuzz/engine.py
@@ -19,7 +19,7 @@ import re
 
 from base import utils
 from bot.fuzzers import dictionary_manager
-from bot.fuzzers import engine
+from lib.clusterfuzz.fuzz import engine
 from metrics import logs
 from system import environment
 from system import new_process

--- a/src/python/bot/fuzzers/init.py
+++ b/src/python/bot/fuzzers/init.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Fuzzing engine initialization."""
 
-from bot.fuzzers import engine
 from bot.fuzzers.blackbox import engine as blackbox_engine
 from bot.fuzzers.honggfuzz import engine as honggfuzz_engine
 from bot.fuzzers.libFuzzer import engine as libFuzzer_engine
 from bot.fuzzers.syzkaller import engine as syzkaller_engine
+from lib.clusterfuzz.fuzz import engine
 
 
 def run():

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -19,7 +19,6 @@ import tempfile
 
 from base import utils
 from bot.fuzzers import dictionary_manager
-from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from bot.fuzzers import libfuzzer
 from bot.fuzzers import strategy_selection
@@ -29,6 +28,7 @@ from bot.fuzzers.libFuzzer import fuzzer
 from bot.fuzzers.libFuzzer import stats
 from datastore import data_types
 from fuzzing import strategy
+from lib.clusterfuzz.fuzz import engine
 from metrics import logs
 from metrics import profiler
 from system import environment

--- a/src/python/bot/fuzzers/syzkaller/engine.py
+++ b/src/python/bot/fuzzers/syzkaller/engine.py
@@ -16,11 +16,11 @@
 import os
 import shutil
 
-from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from bot.fuzzers import utils as fuzzer_utils
 from bot.fuzzers.syzkaller import constants
 from bot.fuzzers.syzkaller import runner
+from lib.clusterfuzz.fuzz import engine
 from metrics import profiler
 from system import environment
 from system import shell

--- a/src/python/bot/fuzzers/syzkaller/runner.py
+++ b/src/python/bot/fuzzers/syzkaller/runner.py
@@ -19,9 +19,9 @@ import re
 import tempfile
 
 from base import utils
-from bot.fuzzers import engine
 from bot.fuzzers import utils as fuzzer_utils
 from bot.fuzzers.syzkaller import config
+from lib.clusterfuzz.fuzz import engine
 from metrics import logs
 from system import environment
 from system import new_process

--- a/src/python/bot/tasks/corpus_pruning_task.py
+++ b/src/python/bot/tasks/corpus_pruning_task.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Corpus pruning task."""
 
+from enum import Enum
 import collections
 import datetime
 import os
@@ -22,7 +23,6 @@ import shutil
 from google.cloud import ndb
 
 from base import utils
-from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from bot.fuzzers import options
 from bot.fuzzers.libFuzzer import constants
@@ -36,12 +36,12 @@ from datastore import corpus_tagging
 from datastore import data_handler
 from datastore import data_types
 from datastore import fuzz_target_utils
-from enum import Enum
 from fuzzing import corpus_manager
 from fuzzing import leak_blacklist
 from google_cloud_utils import big_query
 from google_cloud_utils import blobs
 from google_cloud_utils import storage
+from lib.clusterfuzz.fuzz import engine
 from metrics import logs
 from system import archive
 from system import environment

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -30,7 +30,6 @@ from base import utils
 from bot import testcase_manager
 from bot.fuzzers import builtin
 from bot.fuzzers import builtin_fuzzers
-from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from bot.fuzzers import utils as fuzzer_utils
 from bot.fuzzers.libFuzzer import stats as libfuzzer_stats
@@ -54,6 +53,7 @@ from fuzzing import leak_blacklist
 from google_cloud_utils import big_query
 from google_cloud_utils import blobs
 from google_cloud_utils import storage
+from lib.clusterfuzz.fuzz import engine
 from metrics import fuzzer_logs
 from metrics import fuzzer_stats
 from metrics import logs

--- a/src/python/bot/tasks/minimize_task.py
+++ b/src/python/bot/tasks/minimize_task.py
@@ -25,7 +25,6 @@ from base import errors
 from base import tasks
 from base import utils
 from bot import testcase_manager
-from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from bot.fuzzers.libFuzzer.engine import LibFuzzerEngine
 from bot.minimizer import basic_minimizers
@@ -45,6 +44,7 @@ from crash_analysis.crash_result import CrashResult
 from datastore import data_handler
 from datastore import data_types
 from google_cloud_utils import blobs
+from lib.clusterfuzz.fuzz import engine
 from metrics import logs
 from platforms import android
 from system import environment

--- a/src/python/bot/testcase_manager.py
+++ b/src/python/bot/testcase_manager.py
@@ -21,7 +21,6 @@ import re
 import zlib
 
 from base import utils
-from bot.fuzzers import engine
 from bot.fuzzers import engine_common
 from build_management import revisions
 from crash_analysis import crash_analyzer
@@ -30,6 +29,7 @@ from crash_analysis.crash_result import CrashResult
 from datastore import data_handler
 from datastore import data_types
 from datastore import ndb_init
+from lib.clusterfuzz.fuzz import engine
 from metrics import fuzzer_logs
 from metrics import fuzzer_stats
 from metrics import logs

--- a/src/python/bot/untrusted_runner/tasks_host.py
+++ b/src/python/bot/untrusted_runner/tasks_host.py
@@ -22,10 +22,10 @@ import six
 from . import host
 
 from bot import testcase_manager
-from bot.fuzzers import engine
 from bot.tasks import corpus_pruning_task
 from bot.untrusted_runner import file_host
 from datastore import data_types
+from lib.clusterfuzz.fuzz import engine
 from protos import untrusted_runner_pb2
 
 

--- a/src/python/bot/untrusted_runner/tasks_impl.py
+++ b/src/python/bot/untrusted_runner/tasks_impl.py
@@ -18,11 +18,11 @@ from google.protobuf.any_pb2 import Any
 import six
 
 from bot import testcase_manager
-from bot.fuzzers import engine
 from bot.tasks import corpus_pruning_task
 from bot.tasks import fuzz_task
 from bot.tasks import minimize_task
 from datastore import data_types
+from lib.clusterfuzz.fuzz import engine
 from protos import untrusted_runner_pb2
 
 

--- a/src/python/lib/.gitignore
+++ b/src/python/lib/.gitignore
@@ -1,0 +1,3 @@
+dist/
+build/
+*.egg-info

--- a/src/python/lib/clusterfuzz/__init__.py
+++ b/src/python/lib/clusterfuzz/__init__.py
@@ -11,11 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# TODO(ochang): Remove these and package things in a better way.
-import os
-import sys
-os.environ['ROOT_DIR'] = '../../../'
-sys.path.append('../')
-sys.path.append('../../third_party')
-sys.path.append('../../')

--- a/src/python/lib/clusterfuzz/fuzz/__init__.py
+++ b/src/python/lib/clusterfuzz/fuzz/__init__.py
@@ -11,11 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Fuzzing functions."""
 
-# TODO(ochang): Remove these and package things in a better way.
-import os
-import sys
-os.environ['ROOT_DIR'] = '../../../'
-sys.path.append('../')
-sys.path.append('../../third_party')
-sys.path.append('../../')
+from . import engine
+
+_initialized = False
+
+
+def _initialize():
+  global _initialized
+
+  from bot.fuzzers.honggfuzz import engine as honggfuzz_engine
+  from bot.fuzzers.libFuzzer import engine as libFuzzer_engine
+
+  engine.register('honggfuzz', honggfuzz_engine.HonggfuzzEngine)
+  engine.register('libFuzzer', libFuzzer_engine.LibFuzzerEngine)
+
+  _initialized = True
+
+
+def get_engine(name):
+  if not _initialized:
+    _initialize()
+
+  return engine.get(name)

--- a/src/python/lib/clusterfuzz/fuzz/engine.py
+++ b/src/python/lib/clusterfuzz/fuzz/engine.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/python/lib/setup.py
+++ b/src/python/lib/setup.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""setup.py for libClusterFuzz."""
 import setuptools
 
 with open('README.md', 'r') as fh:

--- a/src/python/lib/setup.py
+++ b/src/python/lib/setup.py
@@ -1,0 +1,24 @@
+import setuptools
+
+with open('README.md', 'r') as fh:
+  long_description = fh.read()
+
+setuptools.setup(
+    name='clusterfuzz',
+    version='0.0.1',
+    author='ClusterFuzz authors',
+    author_email='clusterfuzz-announce@googlegroups.com',
+    description='ClusterFuzz',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://github.com/google/clusterfuzz',
+    packages=setuptools.find_packages(),
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+    ],
+    python_requires='>=3.7',
+)
+
+# TODO(ochang): Add and minimize dependencies.

--- a/src/python/lib/setup.py
+++ b/src/python/lib/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     name='clusterfuzz',
     version='0.0.1',
     author='ClusterFuzz authors',
-    author_email='clusterfuzz-announce@googlegroups.com',
+    author_email='clusterfuzz-dev@googlegroups.com',
     description='ClusterFuzz',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
+++ b/src/python/tests/core/bot/tasks/corpus_pruning_task_test.py
@@ -52,7 +52,6 @@ class BaseTest(object):
     """Setup."""
     helpers.patch_environ(self)
     helpers.patch(self, [
-        'bot.fuzzers.engine.get',
         'bot.fuzzers.engine_common.unpack_seed_corpus_if_needed',
         'bot.tasks.corpus_pruning_task.choose_cross_pollination_strategy',
         'bot.tasks.task_creation.create_tasks',
@@ -62,6 +61,7 @@ class BaseTest(object):
         'fuzzing.corpus_manager.FuzzTargetCorpus.rsync_from_disk',
         'google_cloud_utils.blobs.write_blob',
         'google_cloud_utils.storage.write_data',
+        'lib.clusterfuzz.fuzz.engine.get',
     ])
     self.mock.get.return_value = libFuzzer_engine.LibFuzzerEngine()
     self.mock.rsync_to_disk.side_effect = self._mock_rsync_to_disk
@@ -342,9 +342,10 @@ class CorpusPruningTestUntrusted(
     environment.set_value('JOB_NAME', 'libfuzzer_asan_job')
 
     helpers.patch(self, [
-        'bot.fuzzers.engine.get', 'bot.tasks.setup.get_fuzzer_directory',
+        'bot.tasks.setup.get_fuzzer_directory',
         'base.tasks.add_task',
-        'bot.tasks.corpus_pruning_task._record_cross_pollination_stats'
+        'bot.tasks.corpus_pruning_task._record_cross_pollination_stats',
+        'lib.clusterfuzz.fuzz.engine.get',
     ])
 
     self.mock.get.return_value = libFuzzer_engine.LibFuzzerEngine()

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -29,7 +29,6 @@ import six
 
 from base import utils
 from bot import testcase_manager
-from bot.fuzzers import engine
 from bot.fuzzers.libFuzzer import engine as libfuzzer_engine
 from bot.tasks import fuzz_task
 from bot.untrusted_runner import file_host
@@ -39,6 +38,7 @@ from datastore import data_handler
 from datastore import data_types
 from google_cloud_utils import big_query
 from lib.clusterfuzz import stacktraces
+from lib.clusterfuzz.fuzz import engine
 from metrics import monitor
 from metrics import monitoring_metrics
 from system import environment

--- a/src/python/tests/core/bot/testcase_manager_test.py
+++ b/src/python/tests/core/bot/testcase_manager_test.py
@@ -370,11 +370,11 @@ class TestcaseRunningTest(fake_filesystem_unittest.TestCase):
     test_utils.set_up_pyfakefs(self)
 
     test_helpers.patch(self, [
-        'bot.fuzzers.engine.get',
         'bot.fuzzers.engine_common.find_fuzzer_path',
         'crash_analysis.stack_parsing.stack_analyzer.get_crash_data',
         'system.process_handler.run_process',
         'system.process_handler.terminate_stale_application_instances',
+        'lib.clusterfuzz.fuzz.engine.get',
         'metrics.logs.log',
     ])
 

--- a/src/python/tests/core/bot/testcase_manager_test.py
+++ b/src/python/tests/core/bot/testcase_manager_test.py
@@ -22,7 +22,6 @@ import unittest
 from pyfakefs import fake_filesystem_unittest
 
 from bot import testcase_manager
-from bot.fuzzers import engine
 from bot.fuzzers.libFuzzer import constants as libfuzzer_constants
 from bot.fuzzers.libFuzzer import engine as libfuzzer_engine
 from bot.untrusted_runner import file_host
@@ -30,6 +29,7 @@ from build_management import build_manager
 from crash_analysis.crash_result import CrashResult
 from datastore import data_types
 from lib.clusterfuzz import stacktraces
+from lib.clusterfuzz.fuzz import engine
 from system import environment
 from tests.test_libs import helpers as test_helpers
 from tests.test_libs import test_utils

--- a/src/python/tests/core/local/butler/reproduce_test.py
+++ b/src/python/tests/core/local/butler/reproduce_test.py
@@ -89,9 +89,9 @@ class ReproduceTest(unittest.TestCase):
 
   def setUp(self):
     helpers.patch(self, [
-        'bot.fuzzers.engine.get',
         'bot.testcase_manager.engine_reproduce',
         'config.local_config.ProjectConfig',
+        'lib.clusterfuzz.fuzz.engine.get',
         'local.butler.reproduce._download_testcase',
         'local.butler.reproduce._get_testcase',
         'local.butler.reproduce._setup_x',


### PR DESCRIPTION
Move engine.py to lib/clusterfuzz/fuzz/. Engine implementations are
imported from their existing locations in ClusterFuzz.

Also:

- Add initial setup.py
- Move redis imports to be deferred as a start to reducing the number of dependencies
  required by this package.