### PR TITLE
Don't ignore exceptions in issue_tracker_utils.get_issue_for_testcase.

### DIFF
--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -20,7 +20,6 @@ from libs import request_cache
 from libs.issue_management import issue_tracker_policy
 from libs.issue_management import jira
 from libs.issue_management import monorail
-from metrics import logs
 
 _ISSUE_TRACKER_CACHE_CAPACITY = 8
 _ISSUE_TRACKER_CONSTRUCTORS = {

--- a/src/appengine/libs/issue_management/issue_tracker_utils.py
+++ b/src/appengine/libs/issue_management/issue_tracker_utils.py
@@ -93,15 +93,8 @@ def get_issue_for_testcase(testcase):
   if not issue_tracker:
     return None
 
-  try:
-    issue_id = testcase.bug_information
-    issue = issue_tracker.get_original_issue(issue_id)
-  except:
-    logs.log_error(
-        'Error occurred when fetching issue %s.' % testcase.bug_information)
-    return None
-
-  return issue
+  issue_id = testcase.bug_information
+  return issue_tracker.get_original_issue(issue_id)
 
 
 def get_search_keywords(testcase):


### PR DESCRIPTION
This can lead to bad updates in cleanup task, as it may mark testcases
as triaged even though there was an error in accessing issues. This can
lead to issues getting left open indefinitely.

Prefer to exception out early here.