### PR TITLE
add fields from .metadata file to issue description

### DIFF
--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -16,7 +16,6 @@
 import itertools
 import json
 import re
-import six
 
 from base import external_users
 from base import utils
@@ -390,11 +389,6 @@ def file_issue(testcase,
     for result in apply_substitutions(policy, label, testcase,
                                       security_severity):
       issue.labels.add(result)
-
-  # Add additional body text from metadata.
-  additional_fields = json.loads(testcase.get_metadata('additional_fields', ''))
-  for key, value in six.iteritems(additional_fields):
-    issue.body += '\n\n%s: %s' % (key, value)
 
   issue.body += data_handler.format_issue_information(
       testcase, properties.issue_body_footer)

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -16,6 +16,7 @@
 import itertools
 import json
 import re
+import six
 
 from base import external_users
 from base import utils

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -14,6 +14,7 @@
 """Helper functions to file issues."""
 
 import itertools
+import json
 import re
 
 from base import external_users
@@ -388,6 +389,11 @@ def file_issue(testcase,
     for result in apply_substitutions(policy, label, testcase,
                                       security_severity):
       issue.labels.add(result)
+
+  # Add additional body text from metadata.
+  additional_fields = json.loads(testcase.get_metadata('additional_fields', ''))
+  for key, value in six.iteritems(additional_fields):
+    issue.body += '\n\n%s: %s' % (key, value)
 
   issue.body += data_handler.format_issue_information(
       testcase, properties.issue_body_footer)

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -14,7 +14,6 @@
 """Helper functions to file issues."""
 
 import itertools
-import json
 import re
 
 from base import external_users

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -472,9 +472,9 @@ def get_all_issue_metadata(fuzz_target_path):
   if issue_owners:
     metadata['issue_owners'] = ','.join(issue_owners)
 
-  additional_fields = get_additional_fields(fuzz_target_path)
-  if additional_fields:
-    metadata['additional_fields'] = additional_fields
+  additional_issue_fields = get_additional_fields(fuzz_target_path)
+  if additional_issue_fields:
+    metadata['additional_issue_fields'] = additional_issue_fields
 
   return metadata
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import glob
+import json
 import os
 import pipes
 import random
@@ -453,7 +454,11 @@ def get_additional_issue_metadata(fuzz_target_path):
     return {}
 
   with open(metadata_file_path) as handle:
-    return handle.read()
+    try:
+      return json.load(handle)
+    except (ValueError, TypeError):
+      logs.log_error('Invalid metadata file format.', path=metadata_file_path)
+      return {}
 
 
 def get_all_issue_metadata(fuzz_target_path):

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -439,7 +439,7 @@ def get_issue_components(fuzz_target_path):
   return get_issue_metadata(fuzz_target_path, COMPONENTS_FILE_EXTENSION)
 
 
-def get_issue_metadata(fuzz_target_path):
+def get_additional_issue_metadata(fuzz_target_path):
   """Return the additional metadata fields given a fuzz target path. The data
   will be a JSON-formatted dictionary."""
   metadata_file_path = fuzzer_utils.get_supporting_file(
@@ -472,7 +472,7 @@ def get_all_issue_metadata(fuzz_target_path):
   if issue_owners:
     metadata['issue_owners'] = ','.join(issue_owners)
 
-  issue_metadata = get_issue_metadata(fuzz_target_path)
+  issue_metadata = get_addititional_issue_metadata(fuzz_target_path)
   if issue_metadata:
     metadata['issue_metadata'] = issue_metadata
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -472,7 +472,7 @@ def get_all_issue_metadata(fuzz_target_path):
   if issue_owners:
     metadata['issue_owners'] = ','.join(issue_owners)
 
-  issue_metadata = get_addititional_issue_metadata(fuzz_target_path)
+  issue_metadata = get_additional_issue_metadata(fuzz_target_path)
   if issue_metadata:
     metadata['issue_metadata'] = issue_metadata
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -68,7 +68,7 @@ LABELS_FILE_EXTENSION = '.labels'
 COMPONENTS_FILE_EXTENSION = '.components'
 
 # Extension for additional metadata to be added to issue descriptions.
-METADATA_FILE_EXTENSION = '.metadata'
+METADATA_FILE_EXTENSION = '.issue_metadata'
 
 # Header format for logs.
 LOG_HEADER_FORMAT = (
@@ -439,7 +439,7 @@ def get_issue_components(fuzz_target_path):
   return get_issue_metadata(fuzz_target_path, COMPONENTS_FILE_EXTENSION)
 
 
-def get_additional_fields(fuzz_target_path):
+def get_issue_metadata(fuzz_target_path):
   """Return the additional metadata fields given a fuzz target path. The data
   will be a JSON-formatted dictionary."""
   metadata_file_path = fuzzer_utils.get_supporting_file(
@@ -472,9 +472,9 @@ def get_all_issue_metadata(fuzz_target_path):
   if issue_owners:
     metadata['issue_owners'] = ','.join(issue_owners)
 
-  additional_issue_fields = get_additional_fields(fuzz_target_path)
-  if additional_issue_fields:
-    metadata['additional_issue_fields'] = additional_issue_fields
+  issue_metadata = get_issue_metadata(fuzz_target_path)
+  if issue_metadata:
+    metadata['issue_metadata'] = issue_metadata
 
   return metadata
 

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -67,6 +67,9 @@ LABELS_FILE_EXTENSION = '.labels'
 # Extension for per-fuzz target components to be added to issue tracker.
 COMPONENTS_FILE_EXTENSION = '.components'
 
+# Extension for additional metadata to be added to issue descriptions.
+METADATA_FILE_EXTENSION = '.metadata'
+
 # Header format for logs.
 LOG_HEADER_FORMAT = (
     'Command: {command}\n' + 'Bot: {bot}\n' + 'Time ran: {time}\n')
@@ -436,6 +439,23 @@ def get_issue_components(fuzz_target_path):
   return get_issue_metadata(fuzz_target_path, COMPONENTS_FILE_EXTENSION)
 
 
+def get_additional_fields(fuzz_target_path):
+  """Return the additional metadata fields given a fuzz target path. The data
+  will be a JSON-formatted dictionary."""
+  metadata_file_path = fuzzer_utils.get_supporting_file(
+      fuzz_target_path, METADATA_FILE_EXTENSION)
+
+  if environment.is_trusted_host():
+    metadata_file_path = fuzzer_utils.get_file_from_untrusted_worker(
+        metadata_file_path)
+
+  if not os.path.exists(metadata_file_path):
+    return {}
+
+  with open(metadata_file_path) as handle:
+    return handle.read()
+
+
 def get_all_issue_metadata(fuzz_target_path):
   """Get issue related metadata for a target."""
   metadata = {}
@@ -451,6 +471,10 @@ def get_all_issue_metadata(fuzz_target_path):
   issue_owners = get_issue_owners(fuzz_target_path)
   if issue_owners:
     metadata['issue_owners'] = ','.join(issue_owners)
+
+  additional_fields = get_additional_fields(fuzz_target_path)
+  if additional_fields:
+    metadata['additional_fields'] = additional_fields
 
   return metadata
 

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -549,13 +549,13 @@ def get_issue_description(testcase,
     content_string += '\n\n' + FILE_UNREPRODUCIBLE_TESTCASE_TEXT
 
   # Add additional body text from metadata.
-  additional_issue_fields = json.loads(
-      testcase.get_metadata('additional_issue_fields', '{}'))
-  additional_issue_fields_strs = []
-  for key, value in additional_issue_fields.items():
-    additional_issue_fields_strs.append(f'{key}: {value}')
-  if additional_issue_fields_strs:
-    content_string += '\n\n' + '\n'.join(additional_issue_fields_strs)
+  issue_metadata = json.loads(testcase.get_metadata('issue_metadata', '{}'))
+  additional_fields = issue_metadata.get('additional_fields', {})
+  additional_fields_strs = []
+  for key, value in additional_fields.items():
+    additional_fields_strs.append(f'{key}: {value}')
+  if additional_fields_strs:
+    content_string += '\n\n' + '\n'.join(additional_fields_strs)
 
   return content_string
 

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -547,6 +547,16 @@ def get_issue_description(testcase,
   if not reporter and testcase.one_time_crasher_flag:
     content_string += '\n\n' + FILE_UNREPRODUCIBLE_TESTCASE_TEXT
 
+  # Add additional body text from metadata.
+  additional_issue_fields = json.loads(
+      testcase.get_metadata('additional_issue_fields', '{}'))
+  additional_issue_fields_strs = []
+  for key, value in additional_issue_fields.items():
+      additional_issue_fields_strs.append(f'{key}: {value}')
+  if additional_issue_fields_strs:
+      issue.body += '\n\n' + '\n'.join(additional_issue_fields_strs)
+
+
   return content_string
 
 

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -15,6 +15,7 @@
 
 import collections
 import datetime
+import json
 import os
 import re
 import shlex

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -549,7 +549,7 @@ def get_issue_description(testcase,
     content_string += '\n\n' + FILE_UNREPRODUCIBLE_TESTCASE_TEXT
 
   # Add additional body text from metadata.
-  issue_metadata = json.loads(testcase.get_metadata('issue_metadata', '{}'))
+  issue_metadata = testcase.get_metadata('issue_metadata', {})
   additional_fields = issue_metadata.get('additional_fields', {})
   additional_fields_strs = []
   for key, value in additional_fields.items():

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -550,13 +550,12 @@ def get_issue_description(testcase,
 
   # Add additional body text from metadata.
   additional_issue_fields = json.loads(
-      testcase.get_metadata('additional_issue_fields', '{}'))
+    testcase.get_metadata('additional_issue_fields', '{}'))
   additional_issue_fields_strs = []
   for key, value in additional_issue_fields.items():
-      additional_issue_fields_strs.append(f'{key}: {value}')
+    additional_issue_fields_strs.append(f'{key}: {value}')
   if additional_issue_fields_strs:
-      issue.body += '\n\n' + '\n'.join(additional_issue_fields_strs)
-
+    issue.body += '\n\n' + '\n'.join(additional_issue_fields_strs)
 
   return content_string
 

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -550,12 +550,12 @@ def get_issue_description(testcase,
 
   # Add additional body text from metadata.
   additional_issue_fields = json.loads(
-    testcase.get_metadata('additional_issue_fields', '{}'))
+      testcase.get_metadata('additional_issue_fields', '{}'))
   additional_issue_fields_strs = []
   for key, value in additional_issue_fields.items():
     additional_issue_fields_strs.append(f'{key}: {value}')
   if additional_issue_fields_strs:
-    issue.body += '\n\n' + '\n'.join(additional_issue_fields_strs)
+    content_string += '\n\n' + '\n'.join(additional_issue_fields_strs)
 
   return content_string
 

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -15,7 +15,6 @@
 
 import collections
 import datetime
-import json
 import os
 import re
 import shlex

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -357,12 +357,10 @@ class DataHandlerTest(unittest.TestCase):
     testcase.job_type = 'job_with_help_format'
     testcase.crash_revision = 1337
     testcase.minimized_arguments = '--disable-logging %TESTCASE_FILE_URL%'
-    testcase.set_metadata(
-        'additional_issue_fields',
-        {
-                'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
-                'Answer': 42,
-        })
+    testcase.set_metadata('additional_issue_fields', {
+        'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
+        'Answer': 42,
+    })
     testcase.put()
 
     description = data_handler.get_issue_description(testcase)
@@ -380,8 +378,8 @@ class DataHandlerTest(unittest.TestCase):
         'job=linux_asan_chrome&revision=1337\n\n'
         'Reproducer Testcase: https://test-clusterfuzz.appspot.com/'
         'download?testcase_id=3\n\n'
-        'See help_url for instructions to reproduce this bug locally.\n\n',
-        'Acknowledgements: [\'Alice\', \'Bob\', \'Eve\', \'Mallory\']\n',
+        'See help_url for instructions to reproduce this bug locally.\n\n'
+        'Acknowledgements: [\'Alice\', \'Bob\', \'Eve\', \'Mallory\']\n'
         'Answer: 42')
 
   def test_get_issue_summary_with_no_prefix(self):

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -351,48 +351,44 @@ class DataHandlerTest(unittest.TestCase):
         'See help_url for instructions to reproduce this bug locally.')
 
   def test_get_issue_description_additional_issue_fields(self):
-    """Test get_issue_description with a additional fields set in metadata."""
-    testcase = data_types.Testcase(
-        job_type='linux_asan_chrome',
-        fuzzer_name='simple_fuzzer',
-        overridden_fuzzer_name='libfuzzer_binary_name',
-        crash_type='Timeout',
-        crash_address='0x1337',
-        crash_state='A\nB\nC\n',
-        crash_revision=1337)
+    """Test get_issue_description with additional fields set in metadata."""
+    self.mock.get().name = 'chromium'
 
-    testcase.crash_stacktrace = (
+    self.testcase.crash_type = 'Out-of-memory'
+    self.testcase.crash_stacktrace = (
         'Line1\n'
         'Command: /fuzzer -rss_limit_mb=2048 -timeout=25 -max_len=10 /testcase')
-    testcase.set_metadata(
-        'fuzzer_binary_name', 'binary_name', update_testcase=False)
-    testcase.set_metadata(
+    self.testcase.job_type = 'windows_asan_chrome'
+    self.testcase.one_time_crasher_flag = True
+    self.testcase.set_metadata(
         'issue_metadata', {
             'additional_fields': {
                 'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
                 'Answer': 42,
             }
         })
-    testcase.put()
+    self.testcase.put()
 
-    description = data_handler.get_issue_description(testcase)
+    description = data_handler.get_issue_description(self.testcase)
     self.assertEqual(
         description, 'Detailed Report: https://test-clusterfuzz.appspot.com/'
-        'testcase?key=3\n\n'
-        'Project: project\n'
-        'Fuzzer: simple_fuzzer\n'
-        'Job Type: linux_asan_chrome\n'
-        'Crash Type: Timeout\n'
+        'testcase?key=1\n\n'
+        'Fuzzing Engine: libFuzzer\n'
+        'Fuzz Target: binary_name\n'
+        'Job Type: windows_asan_chrome\n'
+        'Crash Type: Out-of-memory (exceeds 2048 MB)\n'
         'Crash Address: 0x1337\n'
         'Crash State:\n  A\n  B\n  C\n  \n'
         'Sanitizer: address (ASAN)\n\n'
         'Crash Revision: https://test-clusterfuzz.appspot.com/revisions?'
-        'job=linux_asan_chrome&revision=1337\n\n'
-        'Reproducer Testcase: https://test-clusterfuzz.appspot.com/'
-        'download?testcase_id=3\n\n'
+        'job=windows_asan_chrome&revision=1337\n\n'
+        'Reproducer Testcase: '
+        'https://test-clusterfuzz.appspot.com/download?testcase_id=1\n\n'
         'See help_url for instructions to reproduce this bug locally.\n\n'
+        '%s\n\n'
         'Acknowledgements: [\'Alice\', \'Bob\', \'Eve\', \'Mallory\']\n'
-        'Answer: 42')
+        'Answer: 42'
+        % data_handler.FILE_UNREPRODUCIBLE_TESTCASE_TEXT)
 
   def test_get_issue_summary_with_no_prefix(self):
     """Test get_issue_description on jobs with no prefix."""

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -354,13 +354,15 @@ class DataHandlerTest(unittest.TestCase):
     """Test get_issue_description with a blackbox fuzzer testcase."""
     testcase = data_types.Testcase()
     testcase.fuzzer_name = 'simple_fuzzer'
+    testcase.crash_type = 'Timeout'
     testcase.job_type = 'job_with_help_format'
     testcase.crash_revision = 1337
     testcase.minimized_arguments = '--disable-logging %TESTCASE_FILE_URL%'
-    testcase.set_metadata('additional_issue_fields', {
-        'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
-        'Answer': 42,
-    })
+    testcase.set_metadata('issue_metadata', {
+        'additional_fields': {
+            'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
+            'Answer': 42,
+        }})
     testcase.put()
 
     description = data_handler.get_issue_description(testcase)
@@ -370,7 +372,7 @@ class DataHandlerTest(unittest.TestCase):
         'Project: project\n'
         'Fuzzer: fuzzer1\n'
         'Job Type: linux_asan_chrome\n'
-        'Crash Type: UNKNOWN\n'
+        'Crash Type: Timeout\n'
         'Crash Address: 0x1337\n'
         'Crash State:\n  NULL\n'
         'Sanitizer: address (ASAN)\n\n'

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -355,6 +355,9 @@ class DataHandlerTest(unittest.TestCase):
     testcase = data_types.Testcase()
     testcase.fuzzer_name = 'simple_fuzzer'
     testcase.crash_type = 'Timeout'
+    testcase.crash_stacktrace = (
+        'Line1\n'
+        'Command: /fuzzer -rss_limit_mb=2048 -timeout=25 -max_len=10 /testcase')
     testcase.job_type = 'job_with_help_format'
     testcase.crash_revision = 1337
     testcase.minimized_arguments = '--disable-logging %TESTCASE_FILE_URL%'

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -351,16 +351,21 @@ class DataHandlerTest(unittest.TestCase):
         'See help_url for instructions to reproduce this bug locally.')
 
   def test_get_issue_description_additional_issue_fields(self):
-    """Test get_issue_description with a blackbox fuzzer testcase."""
-    testcase = data_types.Testcase()
-    testcase.fuzzer_name = 'simple_fuzzer'
-    testcase.crash_type = 'Timeout'
+    """Test get_issue_description with a additional fields set in metadata."""
+    testcase = data_types.Testcase(
+        job_type='linux_asan_chrome',
+        fuzzer_name='simple_fuzzer',
+        overridden_fuzzer_name='libfuzzer_binary_name',
+        crash_type='Timeout',
+        crash_address='0x1337',
+        crash_state='A\nB\nC\n',
+        crash_revision=1337)
+
     testcase.crash_stacktrace = (
         'Line1\n'
         'Command: /fuzzer -rss_limit_mb=2048 -timeout=25 -max_len=10 /testcase')
-    testcase.job_type = 'job_with_help_format'
-    testcase.crash_revision = 1337
-    testcase.minimized_arguments = '--disable-logging %TESTCASE_FILE_URL%'
+    testcase.set_metadata(
+        'fuzzer_binary_name', 'binary_name', update_testcase=False)
     testcase.set_metadata(
         'issue_metadata', {
             'additional_fields': {
@@ -375,11 +380,11 @@ class DataHandlerTest(unittest.TestCase):
         description, 'Detailed Report: https://test-clusterfuzz.appspot.com/'
         'testcase?key=3\n\n'
         'Project: project\n'
-        'Fuzzer: fuzzer1\n'
+        'Fuzzer: simple_fuzzer\n'
         'Job Type: linux_asan_chrome\n'
         'Crash Type: Timeout\n'
         'Crash Address: 0x1337\n'
-        'Crash State:\n  NULL\n'
+        'Crash State:\n  A\n  B\n  C\n  \n'
         'Sanitizer: address (ASAN)\n\n'
         'Crash Revision: https://test-clusterfuzz.appspot.com/revisions?'
         'job=linux_asan_chrome&revision=1337\n\n'

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -358,11 +358,13 @@ class DataHandlerTest(unittest.TestCase):
     testcase.job_type = 'job_with_help_format'
     testcase.crash_revision = 1337
     testcase.minimized_arguments = '--disable-logging %TESTCASE_FILE_URL%'
-    testcase.set_metadata('issue_metadata', {
-        'additional_fields': {
-            'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
-            'Answer': 42,
-        }})
+    testcase.set_metadata(
+        'issue_metadata', {
+            'additional_fields': {
+                'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
+                'Answer': 42,
+            }
+        })
     testcase.put()
 
     description = data_handler.get_issue_description(testcase)

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -387,8 +387,7 @@ class DataHandlerTest(unittest.TestCase):
         'See help_url for instructions to reproduce this bug locally.\n\n'
         '%s\n\n'
         'Acknowledgements: [\'Alice\', \'Bob\', \'Eve\', \'Mallory\']\n'
-        'Answer: 42'
-        % data_handler.FILE_UNREPRODUCIBLE_TESTCASE_TEXT)
+        'Answer: 42' % data_handler.FILE_UNREPRODUCIBLE_TESTCASE_TEXT)
 
   def test_get_issue_summary_with_no_prefix(self):
     """Test get_issue_description on jobs with no prefix."""

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -358,13 +358,12 @@ class DataHandlerTest(unittest.TestCase):
     testcase.crash_revision = 1337
     testcase.minimized_arguments = '--disable-logging %TESTCASE_FILE_URL%'
     testcase.set_metadata(
-    testcase.put()
-
         'additional_issue_fields',
         {
                 'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
                 'Answer': 42,
         })
+    testcase.put()
 
     description = data_handler.get_issue_description(testcase)
     self.assertEqual(

--- a/src/python/tests/core/datastore/data_handler_test.py
+++ b/src/python/tests/core/datastore/data_handler_test.py
@@ -350,6 +350,41 @@ class DataHandlerTest(unittest.TestCase):
         'download?testcase_id=3\n\n'
         'See help_url for instructions to reproduce this bug locally.')
 
+  def test_get_issue_description_additional_issue_fields(self):
+    """Test get_issue_description with a blackbox fuzzer testcase."""
+    testcase = data_types.Testcase()
+    testcase.fuzzer_name = 'simple_fuzzer'
+    testcase.job_type = 'job_with_help_format'
+    testcase.crash_revision = 1337
+    testcase.minimized_arguments = '--disable-logging %TESTCASE_FILE_URL%'
+    testcase.set_metadata(
+    testcase.put()
+
+        'additional_issue_fields',
+        {
+                'Acknowledgements': ['Alice', 'Bob', 'Eve', 'Mallory'],
+                'Answer': 42,
+        })
+
+    description = data_handler.get_issue_description(testcase)
+    self.assertEqual(
+        description, 'Detailed Report: https://test-clusterfuzz.appspot.com/'
+        'testcase?key=3\n\n'
+        'Project: project\n'
+        'Fuzzer: fuzzer1\n'
+        'Job Type: linux_asan_chrome\n'
+        'Crash Type: UNKNOWN\n'
+        'Crash Address: 0x1337\n'
+        'Crash State:\n  NULL\n'
+        'Sanitizer: address (ASAN)\n\n'
+        'Crash Revision: https://test-clusterfuzz.appspot.com/revisions?'
+        'job=linux_asan_chrome&revision=1337\n\n'
+        'Reproducer Testcase: https://test-clusterfuzz.appspot.com/'
+        'download?testcase_id=3\n\n'
+        'See help_url for instructions to reproduce this bug locally.\n\n',
+        'Acknowledgements: [\'Alice\', \'Bob\', \'Eve\', \'Mallory\']\n',
+        'Answer: 42')
+
   def test_get_issue_summary_with_no_prefix(self):
     """Test get_issue_description on jobs with no prefix."""
     self.job.environment_string = 'HELP_URL = help_url\n'


### PR DESCRIPTION
This reads an optional .metadata file, which contains a JSON-formatted
dictionary. These fields will be appended to the issue description.