### PR TITLE
libClusterFuzz fixes.

### DIFF
--- a/src/python/lib/build.sh
+++ b/src/python/lib/build.sh
@@ -16,20 +16,27 @@
 # Delete existing symlinks.
 find clusterfuzz/ -type l | xargs rm
 
-# Symlink dependencies.
-ln -s $(pwd)/../base clusterfuzz/
-ln -s $(pwd)/../bot clusterfuzz/
-ln -s $(pwd)/../build_management clusterfuzz/
-ln -s $(pwd)/../config clusterfuzz/
-ln -s $(pwd)/../crash_analysis clusterfuzz/
-ln -s $(pwd)/../datastore clusterfuzz/
-ln -s $(pwd)/../fuzzer_utils clusterfuzz/
-ln -s $(pwd)/../fuzzing clusterfuzz/
-ln -s $(pwd)/../google_cloud_utils clusterfuzz/
-ln -s $(pwd)/../metrics clusterfuzz/
-ln -s $(pwd)/../platforms clusterfuzz/
-ln -s $(pwd)/../system clusterfuzz/
-ln -s $(pwd)/../../protos clusterfuzz/
+DEPENDENCIES=(
+    $(pwd)/../base
+    $(pwd)/../bot
+    $(pwd)/../build_management
+    $(pwd)/../config
+    $(pwd)/../crash_analysis
+    $(pwd)/../datastore
+    $(pwd)/../fuzzer_utils
+    $(pwd)/../fuzzing
+    $(pwd)/../google_cloud_utils
+    $(pwd)/../metrics
+    $(pwd)/../platforms
+    $(pwd)/../system
+    $(pwd)/../../protos
+)
+
+for dependency in ${DEPENDENCIES[@]}; do
+  ln -s "$dependency" clusterfuzz/_internal/
+done
+
+# Symlink config dir.
 ln -s $(pwd)/../../../configs/test clusterfuzz/lib-config
 
 python setup.py sdist bdist_wheel

--- a/src/python/lib/clusterfuzz/.gitignore
+++ b/src/python/lib/clusterfuzz/.gitignore
@@ -1,2 +1,3 @@
-_internal/
+_internal/*
+!_internal/__init__.py
 lib-config

--- a/src/python/lib/clusterfuzz/.gitignore
+++ b/src/python/lib/clusterfuzz/.gitignore
@@ -1,0 +1,2 @@
+_internal/
+lib-config

--- a/src/python/lib/clusterfuzz/__init__.py
+++ b/src/python/lib/clusterfuzz/__init__.py
@@ -12,8 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """libClusterfuzz package."""
-
-import os
-import sys
-
-sys.path.append(os.path.dirname(__file__))

--- a/src/python/lib/clusterfuzz/_internal/__init__.py
+++ b/src/python/lib/clusterfuzz/_internal/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Internal imports for libClusterFuzz."""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))

--- a/src/python/lib/clusterfuzz/fuzz/__init__.py
+++ b/src/python/lib/clusterfuzz/fuzz/__init__.py
@@ -19,10 +19,17 @@ _initialized = False
 
 
 def _initialize():
+  """Initialize the engine implementations."""
   global _initialized
 
-  from bot.fuzzers.honggfuzz import engine as honggfuzz_engine
-  from bot.fuzzers.libFuzzer import engine as libFuzzer_engine
+  try:
+    from clusterfuzz._internal.bot.fuzzers.honggfuzz \
+        import engine as honggfuzz_engine
+    from clusterfuzz._internal.bot.fuzzers.libFuzzer \
+        import engine as libFuzzer_engine
+  except:
+    from bot.fuzzers.honggfuzz import engine as honggfuzz_engine
+    from bot.fuzzers.libFuzzer import engine as libFuzzer_engine
 
   engine.register('honggfuzz', honggfuzz_engine.HonggfuzzEngine)
   engine.register('libFuzzer', libFuzzer_engine.LibFuzzerEngine)
@@ -31,6 +38,7 @@ def _initialize():
 
 
 def get_engine(name):
+  """Get the engine with the given name."""
   if not _initialized:
     _initialize()
 

--- a/src/python/lib/clusterfuzz/fuzz/__init__.py
+++ b/src/python/lib/clusterfuzz/fuzz/__init__.py
@@ -27,7 +27,7 @@ def _initialize():
         import engine as honggfuzz_engine
     from clusterfuzz._internal.bot.fuzzers.libFuzzer \
         import engine as libFuzzer_engine
-  except:
+  except ImportError:
     from bot.fuzzers.honggfuzz import engine as honggfuzz_engine
     from bot.fuzzers.libFuzzer import engine as libFuzzer_engine
 

--- a/src/python/lib/clusterfuzz/stacktraces/__init__.py
+++ b/src/python/lib/clusterfuzz/stacktraces/__init__.py
@@ -17,10 +17,16 @@ import re
 import string
 import subprocess
 
-from base import utils
-from crash_analysis import crash_analyzer
-from metrics import logs
-from system import environment
+try:
+  from clusterfuzz._internal.base import utils
+  from clusterfuzz._internal.crash_analysis import crash_analyzer
+  from clusterfuzz._internal.metrics import logs
+  from clusterfuzz._internal.system import environment
+except ImportError:
+  from base import utils
+  from crash_analysis import crash_analyzer
+  from metrics import logs
+  from system import environment
 
 from .constants import *
 

--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -15,7 +15,10 @@
 
 import re
 
-from crash_analysis.stack_parsing import stack_parser
+try:
+  from clusterfuzz._internal.crash_analysis.stack_parsing import stack_parser
+except ImportError:
+  from crash_analysis.stack_parsing import stack_parser
 
 C_CPP_EXTENSIONS = ['c', 'cc', 'cpp', 'cxx', 'h', 'hh', 'hpp', 'hxx']
 

--- a/src/python/lib/setup.py
+++ b/src/python/lib/setup.py
@@ -55,7 +55,8 @@ setuptools.setup(
         'six',
     ],
     package_data={
-        'clusterfuzz': ['lib-config/**',],
+        'clusterfuzz': ['lib-config/*', 'lib-config/**/*'],
     },
     python_requires='>=3.7',
+    zip_safe=False,
 )


### PR DESCRIPTION
- Move internal imports into explicit `_internal` dir when packaged as a pip
  package to prevent clashes and accidental imports. This is guarded
  with a try/catch to fall back to importing them normally when called
  from a normal ClusterFuzz context (where the symlinks don't exist).
- Set zip_safe=False to not zip up the resulting built egg. Otherwise
  local_config does not work.
- Fix glob format to include all config files.