### PR TITLE
Move timeout subtraction outside Engine.fuzz.

### DIFF
--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -64,6 +64,10 @@ MAX_OUTPUT_LEN = 1 * 1024 * 1024  # 1 MB
 # .options file option for the number of persistent executions.
 PERSISTENT_EXECUTIONS_OPTION = 'n'
 
+# Grace period for the launcher to complete any processing before it's killed.
+# This will no longer be needed when we migrate to the engine interface.
+POSTPROCESSING_TIMEOUT = 30
+
 
 class AflOptionType(object):
   ARG = 0
@@ -1440,7 +1444,7 @@ def get_first_stacktrace(stderr_data):
 
 def get_fuzz_timeout(is_mutations_run):
   """Get the maximum amount of time that should be spent fuzzing."""
-  hard_timeout = engine_common.get_hard_timeout()
+  hard_timeout = engine_common.get_hard_timeout() - POSTPROCESSING_TIMEOUT
   merge_timeout = engine_common.get_merge_timeout(DEFAULT_MERGE_TIMEOUT)
   fuzz_timeout = hard_timeout - merge_timeout
   mutations_timeout = engine_common.get_new_testcase_mutations_timeout()

--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -52,9 +52,6 @@ CORPUS_SUBSET_NUM_TESTCASES = [10, 20, 50, 75, 75, 100, 100, 100, 125, 125, 150]
 # file extension.
 SEED_CORPUS_ARCHIVE_SUFFIX = '_seed_corpus'
 
-# Number of seconds to allow for extra processing.
-POSTPROCESSING_TIME = 30.0
-
 # Maximum number of files in the corpus for which we will unpack the seed
 # corpus.
 MAX_FILES_FOR_UNPACK = 5
@@ -351,9 +348,7 @@ def get_hard_timeout(total_timeout=None):
   if total_timeout is None:
     total_timeout = environment.get_value('FUZZ_TEST_TIMEOUT')
 
-  # Give a small window of time to process (upload) the fuzzer output.
-  hard_timeout = total_timeout - POSTPROCESSING_TIME
-  return get_overridable_timeout(hard_timeout, 'HARD_TIMEOUT_OVERRIDE')
+  return get_overridable_timeout(total_timeout, 'HARD_TIMEOUT_OVERRIDE')
 
 
 def get_merge_timeout(default_merge_timeout):

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -96,11 +96,10 @@ class LibFuzzerEngine(engine.Engine):
     Returns:
       An int representing the number of seconds required.
     """
-    # Use a large value to compute the delta.
-    original_timeout = 1000000
     fuzz_timeout = libfuzzer.get_fuzz_timeout(
-        options.is_mutations_run, total_timeout=original_timeout)
-    return original_timeout - fuzz_timeout
+        options.is_mutations_run, total_timeout=0)
+    # get_fuzz_timeout returns a negative value.
+    return -fuzz_timeout
 
   def prepare(self, corpus_dir, target_path, build_dir):
     """Prepare for a fuzzing session, by generating options. Returns a

--- a/src/python/bot/fuzzers/libFuzzer/engine.py
+++ b/src/python/bot/fuzzers/libFuzzer/engine.py
@@ -97,7 +97,7 @@ class LibFuzzerEngine(engine.Engine):
       An int representing the number of seconds required.
     """
     # Use a large value to compute the delta.
-    original_timeout = 100000
+    original_timeout = 1000000
     fuzz_timeout = libfuzzer.get_fuzz_timeout(
         options.is_mutations_run, total_timeout=original_timeout)
     return original_timeout - fuzz_timeout

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1301,6 +1301,14 @@ def run_engine_fuzzer(engine_impl, target_name, sync_corpus_directory,
   options = engine_impl.prepare(sync_corpus_directory, target_path, build_dir)
 
   fuzz_test_timeout = environment.get_value('FUZZ_TEST_TIMEOUT')
+  additional_processing_time = engine_impl.fuzz_additional_processing_timeout(
+      options)
+  fuzz_test_timeout -= additional_processing_time
+  if fuzz_test_timeout <= 0:
+    raise FuzzTaskException(
+        f'Invalid engine timeout: '
+        f'{fuzz_test_timeout} - {additional_processing_time}')
+
   result = engine_impl.fuzz(target_path, options, testcase_directory,
                             fuzz_test_timeout)
 

--- a/src/python/lib/clusterfuzz/fuzz/engine.py
+++ b/src/python/lib/clusterfuzz/fuzz/engine.py
@@ -70,6 +70,19 @@ class Engine(object):
     """Get the name of the engine."""
     raise NotImplementedError
 
+  def fuzz_additional_processing_timeout(self, options):
+    """Return the maximum additional timeout in seconds for additional
+    operations in fuzz() (e.g. merging back new items).
+
+    Args:
+      options: A FuzzOptions object.
+
+    Returns:
+      An int representing the number of seconds required.
+    """
+    del options
+    return 0
+
   def prepare(self, corpus_dir, target_path, build_dir):
     """Prepare for a fuzzing session, by generating options. Returns a
     FuzzOptions object.

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_test.py
@@ -831,7 +831,7 @@ class GetFuzzTimeoutTest(GetTimeoutTestBase):
   def test_correctness(self):
     """Test that get_fuzz_timeout returns what we expect."""
     expected_fuzz_timeout = (
-        self.valid_hard_timeout - engine_common.POSTPROCESSING_TIME -
+        self.valid_hard_timeout - launcher.POSTPROCESSING_TIME -
         self.valid_merge_timeout)
 
     self.call_helper(

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_test.py
@@ -193,7 +193,7 @@ class AflFuzzInputDirectoryTest(LauncherTestBase):
 
   def setUp(self):
     self.temp_input_dir = os.path.join(self.TEMP_DIR, 'afl_input_dir')
-    super(AflFuzzInputDirectoryTest, self).setUp()
+    super().setUp()
     test_helpers.patch(self, ['bot.fuzzers.engine_common.is_lpm_fuzz_target'])
     self.mock.is_lpm_fuzz_target.return_value = True
     self.strategies = launcher.FuzzingStrategies(None)
@@ -315,7 +315,7 @@ class AflFuzzOutputDirectoryTest(LauncherTestBase):
   QUEUE_TESTCASE_INO = 2
 
   def setUp(self):
-    super(AflFuzzOutputDirectoryTest, self).setUp()
+    super().setUp()
     # Creates self.OUTPUT_DIR.
     self.afl_output = launcher.AflFuzzOutputDirectory()
     os.mkdir(self.CRASHES_DIR)
@@ -462,7 +462,7 @@ class SetSanitizerOptionsTest(LauncherTestBase):
       self.assertIn(opt, sanitizer_options_value)
 
   def setUp(self):
-    super(SetSanitizerOptionsTest, self).setUp()
+    super().setUp()
     test_helpers.patch_environ(self)
 
   def test_left_unset(self):
@@ -515,7 +515,7 @@ class AflRunnerTest(LauncherTestBase):
   BAD_FILE_CONTENTS = 'bad'
 
   def setUp(self):
-    super(AflRunnerTest, self).setUp()
+    super().setUp()
     test_helpers.patch_environ(self)
     test_helpers.patch(self, ['bot.fuzzers.engine_common.is_lpm_fuzz_target'])
     self.mock.is_lpm_fuzz_target.return_value = True
@@ -845,7 +845,7 @@ class AflConfigTest(LauncherTestBase):
   """Test AflConfig."""
 
   def setUp(self):
-    super(AflConfigTest, self).setUp()
+    super().setUp()
     self.target_path = '/build_dir/target'
     self.options_path = self.target_path + '.options'
 
@@ -927,7 +927,7 @@ class ListFullFilePathsTest(LauncherTestBase):
   DUMMY_3_FILENAME = 'dummyfile3'
 
   def setUp(self):
-    super(ListFullFilePathsTest, self).setUp()
+    super().setUp()
     self.dummy_file_path = os.path.join(self.INPUT_DIR, fuzzer.AFL_DUMMY_INPUT)
     self.dummy_3_file_path, _ = self._create_file(self.DUMMY_3_FILENAME)
 

--- a/src/python/tests/core/bot/fuzzers/afl/afl_launcher_test.py
+++ b/src/python/tests/core/bot/fuzzers/afl/afl_launcher_test.py
@@ -831,7 +831,7 @@ class GetFuzzTimeoutTest(GetTimeoutTestBase):
   def test_correctness(self):
     """Test that get_fuzz_timeout returns what we expect."""
     expected_fuzz_timeout = (
-        self.valid_hard_timeout - launcher.POSTPROCESSING_TIME -
+        self.valid_hard_timeout - launcher.POSTPROCESSING_TIMEOUT -
         self.valid_merge_timeout)
 
     self.call_helper(

--- a/src/python/tests/core/bot/fuzzers/engine_common_test.py
+++ b/src/python/tests/core/bot/fuzzers/engine_common_test.py
@@ -107,7 +107,6 @@ class GetTimeoutTestBase(unittest.TestCase):
   def setUp(self):
     test_helpers.patch_environ(self)
     self.valid_hard_timeout = 500
-    self.invalid_hard_timeout = engine_common.POSTPROCESSING_TIME - 1
     self.valid_merge_timeout = 15
 
   def _set_environment_values(self, environment_variable_values):
@@ -151,28 +150,19 @@ class GetHardTimeoutTest(GetTimeoutTestBase):
         'HARD_TIMEOUT_OVERRIDE': -1
     })
 
-  def test_fuzz_test_timeout_validation(self):
-    """Test that get_hard_timeout rejects invalid values of
-    FUZZ_TEST_TIMEOUT."""
-    self.validation_helper({
-        'FUZZ_TEST_TIMEOUT': engine_common.POSTPROCESSING_TIME - 1
-    })
-
   def test_hard_timeout_override_correctness(self):
     """Test that get_hard_timeout returns what we expect when we set
     HARD_TIMEOUT_OVERRIDE."""
-    self.call_helper(
-        self.valid_hard_timeout, {
-            'HARD_TIMEOUT_OVERRIDE': self.valid_hard_timeout,
-            'FUZZ_TEST_TIMEOUT': self.invalid_hard_timeout
-        })
+    self.call_helper(self.valid_hard_timeout, {
+        'HARD_TIMEOUT_OVERRIDE': self.valid_hard_timeout,
+        'FUZZ_TEST_TIMEOUT': -1
+    })
 
   def test_fuzz_test_timeout_correctness(self):
     """Test that get_hard_timeout returns what we expect when we set
     FUZZ_TEST_TIMEOUT."""
-    self.call_helper(
-        self.valid_hard_timeout - engine_common.POSTPROCESSING_TIME,
-        {'FUZZ_TEST_TIMEOUT': self.valid_hard_timeout})
+    self.call_helper(self.valid_hard_timeout,
+                     {'FUZZ_TEST_TIMEOUT': self.valid_hard_timeout})
 
 
 class GetMergeTimeoutTest(GetTimeoutTestBase):

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -274,7 +274,7 @@ class FuzzTest(fake_fs_unittest.TestCase):
         ],
         artifact_prefix='/fake',
         extra_env={},
-        fuzz_timeout=1470.0)
+        fuzz_timeout=3600)
 
     self.assertEqual(2, len(mock_merge_calls))
 
@@ -320,9 +320,9 @@ class FuzzTest(fake_fs_unittest.TestCase):
         'dict_used': 1,
         'edge_coverage': 411,
         'edges_total': 398467,
-        'expected_duration': 1450,
+        'expected_duration': 3580,
         'feature_coverage': 1873,
-        'fuzzing_time_percent': 0.13793103448275862,
+        'fuzzing_time_percent': 0.055865921787709494,
         'initial_edge_coverage': 410,
         'initial_feature_coverage': 1869,
         'leak_count': 0,
@@ -501,7 +501,6 @@ class IntegrationTests(BaseIntegrationTest):
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
         [strategy.VALUE_PROFILE_STRATEGY])
 
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.LibFuzzerEngine()
 
@@ -509,7 +508,8 @@ class IntegrationTests(BaseIntegrationTest):
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5.0))
     self.assert_has_stats(results.stats)
     self.compare_arguments(
         os.path.join(DATA_DIR, 'test_fuzzer'), [
@@ -536,7 +536,6 @@ class IntegrationTests(BaseIntegrationTest):
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
         [strategy.VALUE_PROFILE_STRATEGY])
 
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.LibFuzzerEngine()
 
@@ -544,7 +543,8 @@ class IntegrationTests(BaseIntegrationTest):
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
     self.assert_has_stats(results.stats)
     self.compare_arguments(
         os.path.join(DATA_DIR, 'test_fuzzer_old'), [
@@ -567,7 +567,6 @@ class IntegrationTests(BaseIntegrationTest):
 
   def test_fuzz_crash(self):
     """Tests fuzzing (crash)."""
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.LibFuzzerEngine()
 
@@ -575,7 +574,8 @@ class IntegrationTests(BaseIntegrationTest):
                                                  'always_crash_fuzzer')
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
 
     self.assert_has_stats(results.stats)
     self.compare_arguments(
@@ -607,7 +607,6 @@ class IntegrationTests(BaseIntegrationTest):
     """Tests fuzzing from corpus subset."""
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
         [strategy.CORPUS_SUBSET_STRATEGY])
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
 
     _, corpus_path = setup_testcase_and_corpus('empty',
                                                'corpus_with_some_files')
@@ -616,7 +615,8 @@ class IntegrationTests(BaseIntegrationTest):
     target_path = engine_common.find_fuzzer_path(DATA_DIR, 'test_fuzzer')
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
 
     self.compare_arguments(
         os.path.join(DATA_DIR, 'test_fuzzer'), [
@@ -678,7 +678,6 @@ class IntegrationTests(BaseIntegrationTest):
         '"BEET"',
         '"USELESS_3"',
     ])
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
 
     _, corpus_path = setup_testcase_and_corpus('empty',
                                                'corpus_with_some_files')
@@ -687,7 +686,7 @@ class IntegrationTests(BaseIntegrationTest):
     target_path = engine_common.find_fuzzer_path(DATA_DIR,
                                                  'analyze_dict_fuzzer')
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
-    engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    engine_impl.fuzz(target_path, options, TEMP_DIR, get_fuzz_timeout(5))
     expected_recommended_dictionary = set([
         '"APPLE"',
         '"GINGER"',
@@ -699,7 +698,6 @@ class IntegrationTests(BaseIntegrationTest):
 
   def test_fuzz_with_mutator_plugin(self):
     """Tests fuzzing with a mutator plugin."""
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
 
     os.environ['MUTATOR_PLUGINS_DIR'] = os.path.join(TEMP_DIR,
                                                      'mutator-plugins')
@@ -725,7 +723,8 @@ class IntegrationTests(BaseIntegrationTest):
       target_path = engine_common.find_fuzzer_path(DATA_DIR, fuzz_target_name)
       engine_impl = engine.LibFuzzerEngine()
       options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
-      results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+      results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                                 get_fuzz_timeout(5))
     finally:
       shutil.rmtree(os.environ['MUTATOR_PLUGINS_DIR'])
 
@@ -737,8 +736,6 @@ class IntegrationTests(BaseIntegrationTest):
   def test_merge_reductions(self):
     """Tests that reduced testcases are merged back into the original corpus
     without deleting the larger version."""
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(1.0)
-
     _, corpus_path = setup_testcase_and_corpus('empty', 'empty_corpus')
     fuzz_target_name = 'analyze_dict_fuzzer'
 
@@ -783,7 +780,7 @@ class IntegrationTests(BaseIntegrationTest):
     engine_impl = engine.LibFuzzerEngine()
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
     options.arguments.append('-runs=10')
-    engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    engine_impl.fuzz(target_path, options, TEMP_DIR, get_fuzz_timeout(5))
 
     # Verify that both the newly found minimal testcase and the nonminimal
     # testcase are in the corpus.
@@ -809,7 +806,8 @@ class IntegrationTests(BaseIntegrationTest):
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
     options.extra_env['EXIT_FUZZER_CODE'] = '1'
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
     self.assertEqual(1, self.mock.log_error.call_count)
 
     self.assertEqual(1, len(results.crashes))
@@ -835,7 +833,8 @@ class IntegrationTests(BaseIntegrationTest):
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
     options.extra_env['EXIT_FUZZER_CODE'] = exit_code
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
 
     self.assertEqual(1, len(results.crashes))
     self.assertEqual(TEMP_DIR, os.path.dirname(results.crashes[0].input_path))
@@ -852,7 +851,6 @@ class IntegrationTests(BaseIntegrationTest):
                     args[0])
 
     self.mock.log_error.side_effect = mocked_log_error
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.LibFuzzerEngine()
 
@@ -862,7 +860,7 @@ class IntegrationTests(BaseIntegrationTest):
     invalid_dict_path = os.path.join(DATA_DIR, 'invalid.dict')
     options.arguments.append('-dict=' + invalid_dict_path)
 
-    engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    engine_impl.fuzz(target_path, options, TEMP_DIR, get_fuzz_timeout(5))
 
 
 @unittest.skip('needs root')
@@ -933,7 +931,8 @@ class MinijailIntegrationTests(IntegrationTests):
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
     options.extra_env['EXIT_FUZZER_CODE'] = exit_code
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
 
     self.assertEqual(1, len(results.crashes))
     self.assertEqual(TEMP_DIR, os.path.dirname(results.crashes[0].input_path))
@@ -986,11 +985,10 @@ class IntegrationTestsFuchsia(BaseIntegrationTest):
     num_files_original = len(os.listdir(corpus_path))
     engine_impl = engine.LibFuzzerEngine()
 
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(20.0)
     options = engine_impl.prepare(corpus_path, 'example-fuzzers/crash_fuzzer',
                                   DATA_DIR)
     results = engine_impl.fuzz('example-fuzzers/crash_fuzzer', options,
-                               TEMP_DIR, 20)
+                               TEMP_DIR, get_fuzz_timeout(20))
 
     # If we don't get a crash, something went wrong.
     self.assertIn('Test unit written to', results.logs)
@@ -1130,7 +1128,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
         [strategy.VALUE_PROFILE_STRATEGY])
 
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.LibFuzzerEngine()
 
@@ -1139,7 +1136,8 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, ANDROID_DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
 
     self.assert_has_stats(results.stats)
     self.assertEqual([
@@ -1169,7 +1167,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
 
   def test_fuzz_crash(self):
     """Tests fuzzing (crash)."""
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.LibFuzzerEngine()
 
@@ -1177,7 +1174,8 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
                                                  'always_crash_fuzzer')
     options = engine_impl.prepare(corpus_path, target_path, ANDROID_DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
 
     self.assert_has_stats(results.stats)
     self.assertEqual([
@@ -1216,7 +1214,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     """Tests fuzzing from corpus subset."""
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
         [strategy.CORPUS_SUBSET_STRATEGY])
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
 
     _, corpus_path = setup_testcase_and_corpus('empty',
                                                'corpus_with_some_files')
@@ -1226,7 +1223,8 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
                                                  'test_fuzzer')
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, ANDROID_DATA_DIR)
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
+                               get_fuzz_timeout(5))
 
     self.assertEqual([
         self.adb_path,
@@ -1294,7 +1292,6 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
         '"BEET"',
         '"USELESS_3"',
     ])
-    self.mock.get_fuzz_timeout.return_value = get_fuzz_timeout(5.0)
 
     _, corpus_path = setup_testcase_and_corpus('empty',
                                                'corpus_with_some_files')
@@ -1304,7 +1301,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
                                                  'analyze_dict_fuzzer')
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
 
-    engine_impl.fuzz(target_path, options, TEMP_DIR, 10)
+    engine_impl.fuzz(target_path, options, TEMP_DIR, get_fuzz_timeout(5.0))
     expected_recommended_dictionary = set([
         '"APPLE"',
         '"GINGER"',

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -144,6 +144,38 @@ class PrepareTest(fake_fs_unittest.TestCase):
     ], options.arguments)
 
 
+class FuzzAdditionalProcessingTimeoutTest(unittest.TestCase):
+  """fuzz_additional_processing_timeout tests."""
+
+  def test_no_mutations(self):
+    """Test no mutations."""
+    engine_impl = engine.LibFuzzerEngine()
+    options = engine.LibFuzzerOptions(
+        '/corpus',
+        arguments=[],
+        strategies=[],
+        fuzz_corpus_dirs=[],
+        extra_env={},
+        use_dataflow_tracing=False,
+        is_mutations_run=False)
+    self.assertEqual(2100.0,
+                     engine_impl.fuzz_additional_processing_timeout(options))
+
+  def test_mutations(self):
+    """Test with mutations."""
+    engine_impl = engine.LibFuzzerEngine()
+    options = engine.LibFuzzerOptions(
+        '/corpus',
+        arguments=[],
+        strategies=[],
+        fuzz_corpus_dirs=[],
+        extra_env={},
+        use_dataflow_tracing=False,
+        is_mutations_run=True)
+    self.assertEqual(2700.0,
+                     engine_impl.fuzz_additional_processing_timeout(options))
+
+
 class PickStrategiesTest(fake_fs_unittest.TestCase):
   """pick_strategies tests."""
 

--- a/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/python/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -869,7 +869,7 @@ class UnshareIntegrationTests(IntegrationTests):
   """Unshare runner integration tests."""
 
   def setUp(self):
-    super(UnshareIntegrationTests, self).setUp()
+    super().setUp()
     os.environ['USE_UNSHARE'] = 'True'
 
   def compare_arguments(self, target_path, arguments, corpora_or_testcase,

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1382,6 +1382,7 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
 
     os.environ['FUZZ_TARGET'] = 'test_target'
     os.environ['APP_REVISION'] = '1'
+    os.environ['FUZZ_TEST_TIMEOUT'] = '2000'
 
     expected_crashes = [engine.Crash('/input', 'stack', ['args'], 1.0)]
 
@@ -1394,8 +1395,13 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
         })
     engine_impl.fuzz.side_effect = lambda *_: engine.FuzzResult(
         'logs', ['cmd'], expected_crashes, {'stat': 1}, 42.0)
+    engine_impl.fuzz_additional_processing_timeout.return_value = 1337
 
     crashes, fuzzer_metadata = session.do_engine_fuzzing(engine_impl)
+
+    engine_impl.fuzz.assert_called_with('/build_dir/test_target',
+                                        engine_impl.prepare.return_value,
+                                        '/fuzz-inputs', 663)
     self.assertDictEqual({
         'fuzzer_binary_name':
             'test_target',

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1457,7 +1457,7 @@ class UntrustedRunEngineFuzzerTest(
 
   def setUp(self):
     """Set up."""
-    super(UntrustedRunEngineFuzzerTest, self).setUp()
+    super().setUp()
     environment.set_value('JOB_NAME', 'libfuzzer_asan_job')
 
     job = data_types.Job(
@@ -1475,7 +1475,7 @@ class UntrustedRunEngineFuzzerTest(
     environment.set_value('USE_MINIJAIL', False)
 
   def tearDown(self):
-    super(UntrustedRunEngineFuzzerTest, self).tearDown()
+    super().tearDown()
     shutil.rmtree(self.temp_dir, ignore_errors=True)
 
   def test_run_engine_fuzzer(self):


### PR DESCRIPTION
Part of #2101 

Currently it's not obvious at all to users of Engine.fuzz how long
fuzzing will go for when a max_time is passed.

Add Engine.fuzz_additional_processing_timeout so that the caller can
explicitly subtract the necessary processing time themselves if needed.

Remove engine_common.POSTPROCESSING_TIME. This was a holdout from the
launcher days. This is moved to the AFL launcher and can be removed
there as well once that's migrated to the Engine interface.