### PR TITLE
Fix broken link in libFuzzer/afl fuzzing setup doc.

### DIFF
--- a/docs/setting-up-fuzzing/libfuzzer_and_afl.md
+++ b/docs/setting-up-fuzzing/libfuzzer_and_afl.md
@@ -45,6 +45,8 @@ greater which you can download from the [LLVM Snapshot Builds page].
 
 AFL is only supported on Linux.
 
+[LLVM Snapshot Builds page]: https://llvm.org/builds/
+
 ## Builds
 
 ### libFuzzer


### PR DESCRIPTION
TBR for a trivial fix.