### PR TITLE
Fix ML task issues.

### DIFF
--- a/src/python/bot/fuzzers/ml/rnn/generator.py
+++ b/src/python/bot/fuzzers/ml/rnn/generator.py
@@ -23,6 +23,7 @@ except ImportError:
 import os
 import sys
 
+from base import utils
 from bot.fuzzers.ml.rnn import constants
 from google_cloud_utils import storage
 from metrics import logs
@@ -222,7 +223,7 @@ def execute(input_directory, output_directory, fuzzer_name, generation_timeout):
       logs.log_error(
           'ML RNN generation for fuzzer %s failed with ExitCode = %d.' %
           (fuzzer_name, result.return_code),
-          output=result.output)
+          output=utils.decode_to_unicode(result.output))
     return
 
   # Timeout is not error, if we have new units generated.
@@ -239,4 +240,4 @@ def execute(input_directory, output_directory, fuzzer_name, generation_timeout):
   else:
     logs.log_error(
         'ML RNN generator did not produce any inputs for %s' % fuzzer_name,
-        output=result.output)
+        output=utils.decode_to_unicode(result.output))

--- a/src/python/bot/tasks/train_rnn_generator_task.py
+++ b/src/python/bot/tasks/train_rnn_generator_task.py
@@ -17,6 +17,7 @@ import glob
 import os
 import sys
 
+from base import utils
 from bot.fuzzers.ml.rnn import constants
 from bot.tasks import ml_train_utils
 from datastore import data_handler
@@ -263,7 +264,7 @@ def execute_task(full_fuzzer_name, job_type):
       logs.log_error(
           'ML RNN training task for fuzzer %s failed with ExitCode = %d.' %
           (fuzzer_name, result.return_code),
-          output=result.output)
+          output=utils.decode_to_unicode(result.output))
     return
 
   # Timing out may be caused by large training corpus, but intermediate models

--- a/src/python/tests/core/bot/tasks/train_gradientfuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/train_gradientfuzz_task_test.py
@@ -73,6 +73,7 @@ class ExecuteTaskTest(unittest.TestCase):
     os.environ['GRADIENTFUZZ_TESTING'] = str(True)
 
     test_helpers.patch(self, [
+        'bot.fuzzers.engine_common.find_fuzzer_path',
         'bot.tasks.ml_train_utils.get_corpus',
         'bot.tasks.train_gradientfuzz_task.gen_inputs_labels',
         'bot.tasks.train_gradientfuzz_task.train_gradientfuzz',
@@ -87,6 +88,7 @@ class ExecuteTaskTest(unittest.TestCase):
         return_code=0), self.run_name
     self.mock.upload_model_to_gcs.return_value = True
     self.mock.setup_build.side_effect = self.mock_build_manager
+    self.mock.find_fuzzer_path.return_value = self.binary_path
 
     # Fakes creating directory tree.
     self.fake_dataset_dir = os.path.join(self.data_dir, self.dataset_name)
@@ -96,10 +98,7 @@ class ExecuteTaskTest(unittest.TestCase):
     os.makedirs(self.fake_model_dir)
 
   def mock_build_manager(self):
-    """
-    Just sets the 'APP_PATH' environment variable.
-    """
-    os.environ['APP_PATH'] = self.binary_path
+    pass
 
   def tearDown(self):
     shell.remove_directory(self.temp_dir)
@@ -206,6 +205,7 @@ class GradientFuzzTrainTaskIntegrationTest(unittest.TestCase):
     os.environ['GRADIENTFUZZ_NUM_EPOCHS'] = str(run_constants.NUM_TEST_EPOCHS)
 
     test_helpers.patch(self, [
+        'bot.fuzzers.engine_common.find_fuzzer_path',
         'bot.tasks.ml_train_utils.get_corpus',
         'bot.tasks.train_gradientfuzz_task.upload_model_to_gcs',
         'build_management.build_manager.setup_build'
@@ -214,12 +214,10 @@ class GradientFuzzTrainTaskIntegrationTest(unittest.TestCase):
     self.mock.upload_model_to_gcs.return_value = True
     self.mock.get_corpus.side_effect = self.mock_get_corpus
     self.mock.setup_build.side_effect = self.mock_build_manager
+    self.mock.find_fuzzer_path.return_value = self.binary_path
 
   def mock_build_manager(self):
-    """
-    Just sets the 'APP_PATH' environment variable.
-    """
-    os.environ['APP_PATH'] = self.binary_path
+    pass
 
   def mock_get_corpus(self, corpus_directory, _):
     """


### PR DESCRIPTION
- Fix some exceptions in ML RNN errors with passing bytes output.
- Fix empty fuzzer binary in ML GradientFuzz task output due to use of unused APP_PATH. Use engine_common.find_fuzzer_path.