### PR TITLE
Fix severity exception.

### DIFF
--- a/src/python/crash_analysis/severity_analyzer.py
+++ b/src/python/crash_analysis/severity_analyzer.py
@@ -202,7 +202,7 @@ def severity_to_string(severity):
       SecuritySeverity.MISSING: MISSING_VALUE_STRING,
   }
 
-  return severity_map[severity]
+  return severity_map.get(severity, '')
 
 
 def string_to_severity(severity):


### PR DESCRIPTION
```
KeyError: None
at severity_to_string (/mnt/scratch0/bots/oss-fuzz-linux-zone5-host-04tq-9/clusterfuzz/src/python/crash_analysis/severity_analyzer.py:205)
at _make_bisection_request (/mnt/scratch0/bots/oss-fuzz-linux-zone5-host-04tq-9/clusterfuzz/src/python/bot/tasks/task_creation.py:365)
at request_bisection (/mnt/scratch0/bots/oss-fuzz-linux-zone5-host-04tq-9/clusterfuzz/src/python/bot/tasks/task_creation.py:283)
at execute_task (/mnt/scratch0/bots/oss-fuzz-linux-zone5-host-04tq-9/clusterfuzz/src/python/bot/tasks/progression_task.py:470)
at run_command (/mnt/scratch0/bots/oss-fuzz-linux-zone5-host-04tq-9/clusterfuzz/src/python/bot/tasks/commands.py:201)
at process_command (/mnt/scratch0/bots/oss-fuzz-linux-zone5-host-04tq-9/clusterfuzz/src/python/bot/tasks/commands.py:377)
at wrapper (/mnt/scratch0/bots/oss-fuzz-linux-zone5-host-04tq-9/clusterfuzz/src/python/bot/tasks/commands.py:147)
at task_loop (/mnt/scratch0/bots/oss-fuzz-linux-zone5-host-04tq-9/clusterfuzz/src/python/bot/startup/run_bot.py:87)
```