### PR TITLE
Remove incorrect options quoting on Windows.

### DIFF
--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -22,11 +22,6 @@ import socket
 import sys
 import yaml
 
-try:
-  from shlex import quote
-except ImportError:
-  from pipes import quote
-
 # Tools supporting customization of options via ADDITIONAL_{TOOL_NAME}_OPTIONS.
 # FIXME: Support ADDITIONAL_UBSAN_OPTIONS and ADDITIONAL_LSAN_OPTIONS in an
 # ASAN instrumented build.
@@ -111,9 +106,7 @@ def _parse_memory_tool_options(options_str):
 def _quote_value_if_needed(value):
   """Quote environment value as needed for certain platforms like Windows."""
   result = value
-
-  bot_platform = platform()
-  if bot_platform == 'WINDOWS':
+  if ' ' in result or ':' in result:
     result = '"%s"' % result
 
   return result
@@ -329,9 +322,8 @@ def get_sanitizer_options_for_display():
     options_value = os.getenv(options_variable)
     if not options_value:
       continue
-
-    result.append('{options_variable}="{options_value}"'.format(
-        options_variable=options_variable, options_value=quote(options_value)))
+    result.append('{options_variable}={options_value}'.format(
+        options_variable=options_variable, options_value=options_value))
 
   return result
 

--- a/src/python/tests/core/base/utils_test.py
+++ b/src/python/tests/core/base/utils_test.py
@@ -269,7 +269,7 @@ class GetCrashStacktraceOutputTest(unittest.TestCase):
     """Tests that environment settings are added."""
     os.environ['ASAN_OPTIONS'] = 'setting1=value1:setting2=value_2'
     self.assertEqual(
-        '[Environment] ASAN_OPTIONS="setting1=value1:setting2=value_2"\n'
+        '[Environment] ASAN_OPTIONS=setting1=value1:setting2=value_2\n'
         '[Command line] cmd_line\n\n' + self.start_seperator +
         'Release Build Stacktrace' + self.end_seperator + '\nsym_stack',
         utils.get_crash_stacktrace_output('cmd_line', 'sym_stack'))


### PR DESCRIPTION
Also, remove unneeded quoting for posix.
See https://bugs.chromium.org/p/chromium/issues/detail?id=1152549
Keep ' ' and ':' in _quote_value_if_needed as ':' parsing fails
when decoding options value. Use ' ' as it is needed for both
linux and windows.