### PR TITLE
Add DOCTYPE to force standards mode rendering

### DIFF
--- a/src/appengine/private/templates/layout.html
+++ b/src/appengine/private/templates/layout.html
@@ -13,6 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="apple-touch-icon" sizes="76x76" href="/favicon/apple-touch-icon.png?v=A0RYylnML6">


### PR DESCRIPTION
This avoids rendering the page in quirks mode.

https://quirks.spec.whatwg.org/