### PR TITLE
Specify the HTML document’s encoding

### DIFF
--- a/src/appengine/private/templates/layout.html
+++ b/src/appengine/private/templates/layout.html
@@ -15,6 +15,7 @@
 -->
 <html>
   <head>
+    <meta charset="utf-8">
     <link rel="apple-touch-icon" sizes="76x76" href="/favicon/apple-touch-icon.png?v=A0RYylnML6">
     <link rel="icon" type="image/png" href="/favicon/favicon-32x32.png?v=A0RYylnML6" sizes="32x32">
     <link rel="icon" type="image/png" href="/favicon/favicon-16x16.png?v=A0RYylnML6" sizes="16x16">


### PR DESCRIPTION
This avoids rendering non-ASCII symbols as mojibake.

Fixes: https://bugs.chromium.org/p/chromium/issues/detail?id=920160