### PR TITLE
Determine trials for every single test run

### DIFF
--- a/src/python/tests/core/bot/tasks/trials_test.py
+++ b/src/python/tests/core/bot/tasks/trials_test.py
@@ -44,45 +44,58 @@ class TrialsTest(unittest.TestCase):
     """Ensure that no additional flags are added if a binary has no trials."""
     self.mock.random.return_value = 0.0
     environment.set_value('APP_NAME', 'app_0')
-    trials.setup_additional_args_for_app()
-    self.assertEqual(environment.get_value('APP_ARGS'), '-x')
-    self.assertIsNone(environment.get_value('TRIAL_APP_ARGS'))
+    env_copy = environment.copy()
+    trial_selector = trials.Trials()
+    trial_selector.setup_additional_args_for_app(env_copy)
+    self.assertEqual(env_copy.get('APP_ARGS'), '-x')
+    self.assertIsNone(env_copy.get('TRIAL_APP_ARGS'))
 
   def test_trial_selected_one_option(self):
     """Ensure that the expected flags are added if a trial is selected."""
     self.mock.random.return_value = 0.3
     environment.set_value('APP_NAME', 'app_1')
-    trials.setup_additional_args_for_app()
-    self.assertEqual(environment.get_value('APP_ARGS'), '-x --a1')
-    self.assertEqual(environment.get_value('TRIAL_APP_ARGS'), '--a1')
+    env_copy = environment.copy()
+    trial_selector = trials.Trials()
+    trial_selector.setup_additional_args_for_app(env_copy)
+    self.assertEqual(env_copy.get('APP_ARGS'), '-x --a1')
+    self.assertEqual(env_copy.get('TRIAL_APP_ARGS'), '--a1')
 
   def test_trial_not_selected(self):
-    """Ensure that no additional flags a trial was not selected."""
+    """Ensure no additional flags if a trial was not selected."""
     self.mock.random.return_value = 0.5
     environment.set_value('APP_NAME', 'app_2')
-    self.assertEqual(environment.get_value('APP_ARGS'), '-x')
-    self.assertIsNone(environment.get_value('TRIAL_APP_ARGS'))
+    env_copy = environment.copy()
+    trial_selector = trials.Trials()
+    trial_selector.setup_additional_args_for_app(env_copy)
+    self.assertEqual(env_copy.get('APP_ARGS'), '-x')
+    self.assertIsNone(env_copy.get('TRIAL_APP_ARGS'))
 
   def test_multiple_trial_selection(self):
     """Ensure that we can suggest the second trial in a batch of multiple."""
     self.mock.random.return_value = 0.1
     environment.set_value('APP_NAME', 'app_3')
-    trials.setup_additional_args_for_app()
-    self.assertEqual(environment.get_value('APP_ARGS'), '-x --c1 --c2 --c3')
-    self.assertEqual(environment.get_value('TRIAL_APP_ARGS'), '--c1 --c2 --c3')
+    env_copy = environment.copy()
+    trial_selector = trials.Trials()
+    trial_selector.setup_additional_args_for_app(env_copy)
+    self.assertEqual(env_copy.get('APP_ARGS'), '-x --c1 --c2 --c3')
+    self.assertEqual(env_copy.get('TRIAL_APP_ARGS'), '--c1 --c2 --c3')
 
   def test_selection_for_windows_executable(self):
     """Ensure that flags are added when the app name ends in ".exe"."""
     self.mock.random.return_value = 0.3
     environment.set_value('APP_NAME', 'app_1.exe')
-    trials.setup_additional_args_for_app()
-    self.assertEqual(environment.get_value('APP_ARGS'), '-x --a1')
-    self.assertEqual(environment.get_value('TRIAL_APP_ARGS'), '--a1')
+    env_copy = environment.copy()
+    trial_selector = trials.Trials()
+    trial_selector.setup_additional_args_for_app(env_copy)
+    self.assertEqual(env_copy.get('APP_ARGS'), '-x --a1')
+    self.assertEqual(env_copy.get('TRIAL_APP_ARGS'), '--a1')
 
   def test_selection_for_android_apk(self):
     """Ensure that flags are added for the Android APK format."""
     self.mock.random.return_value = 0.3
     environment.set_value('APP_NAME', 'App_1.apk')
-    trials.setup_additional_args_for_app()
-    self.assertEqual(environment.get_value('APP_ARGS'), '-x --a1')
-    self.assertEqual(environment.get_value('TRIAL_APP_ARGS'), '--a1')
+    env_copy = environment.copy()
+    trial_selector = trials.Trials()
+    trial_selector.setup_additional_args_for_app(env_copy)
+    self.assertEqual(env_copy.get('APP_ARGS'), '-x --a1')
+    self.assertEqual(env_copy.get('TRIAL_APP_ARGS'), '--a1')


### PR DESCRIPTION
Determining trials is moved to the main test loop of blackbox fuzzing. The trial configuration from DB is set up once in the beginning of the loop. The set of additional flags is then re-determined for every test run.

It's not needed anymore to bail out for engine fuzzing, as we now only use this logic in blackbox fuzzing.