### PR TITLE
Partially revert "Determine trials for every single test run"

### DIFF
--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1735,6 +1735,12 @@ class FuzzingSession(object):
     # Prepare selecting trials in main loop below.
     trial_selector = trials.Trials()
 
+    # TODO(machenbach): Move this back to the main loop and make it test-case
+    # specific in a way that get's persistet on crashes.
+    # For some binaries, we specify trials, which are sets of flags that we
+    # only apply some of the time. Adjust APP_ARGS for them if needed.
+    trial_selector.setup_additional_args_for_app()
+
     logs.log('Starting to process testcases.')
     logs.log('Redzone is %d bytes.' % self.redzone)
     logs.log('Timeout multiplier is %s.' % str(self.timeout_multiplier))
@@ -1758,10 +1764,6 @@ class FuzzingSession(object):
         gestures = testcases_metadata[testcase_file_path]['gestures']
 
         env_copy = environment.copy()
-
-        # For some binaries, we specify trials, which are sets of flags that we
-        # only apply some of the time. Adjust APP_ARGS for them if needed.
-        trial_selector.setup_additional_args_for_app(env_copy)
 
         thread = process_handler.get_process()(
             target=testcase_manager.run_testcase_and_return_result_in_queue,

--- a/src/python/bot/tasks/trials.py
+++ b/src/python/bot/tasks/trials.py
@@ -41,7 +41,7 @@ class Trials:
     self.trials = list(
         data_types.Trial.query(data_types.Trial.app_name == app_name))
 
-  def setup_additional_args_for_app(self, test_env):
+  def setup_additional_args_for_app(self):
     """Select additional args for the specified app at random."""
     trial_args = [
         trial.app_args
@@ -52,6 +52,6 @@ class Trials:
       return
 
     trial_app_args = ' '.join(trial_args)
-    app_args = test_env.get('APP_ARGS', '')
-    test_env['APP_ARGS'] = '%s %s' % (app_args, trial_app_args)
-    test_env['TRIAL_APP_ARGS'] = trial_app_args
+    app_args = environment.get_value('APP_ARGS', '')
+    environment.set_value('APP_ARGS', '%s %s' % (app_args, trial_app_args))
+    environment.set_value('TRIAL_APP_ARGS', trial_app_args)

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1365,8 +1365,8 @@ class DoBlackboxFuzzingTest(fake_filesystem_unittest.TestCase):
     self.mock.random_element_from_list.return_value = 2.0
     # Choose window_arg, timeout multiplier, random seed.
     self.mock.random_number.side_effect = [0, 0, 3]
-    # Different trial profile for for each test.
-    self.mock.random.side_effect = [0.1, 0.1, 0.3, 0.3, 0.9, 0.9]
+    # One trial profile for the session.
+    self.mock.random.side_effect = [0.3, 0.3]
     self.mock.pick_gestures.return_value = []
     self.mock.current_timestamp.return_value = 0.0
 
@@ -1422,7 +1422,7 @@ class DoBlackboxFuzzingTest(fake_filesystem_unittest.TestCase):
         self.process.call_args_list[0],
         thread_index=0,
         testcase_file_path='/tests/0',
-        app_args='-x -y -z',
+        app_args='-x -y',
         window_arg='-r=3')
     assert_exec(
         self.process.call_args_list[1],
@@ -1434,7 +1434,7 @@ class DoBlackboxFuzzingTest(fake_filesystem_unittest.TestCase):
         self.process.call_args_list[2],
         thread_index=0,
         testcase_file_path='/tests/2',
-        app_args='-x',
+        app_args='-x -y',
         window_arg='-r=3')
 
 

--- a/src/python/tests/core/bot/tasks/trials_test.py
+++ b/src/python/tests/core/bot/tasks/trials_test.py
@@ -44,58 +44,52 @@ class TrialsTest(unittest.TestCase):
     """Ensure that no additional flags are added if a binary has no trials."""
     self.mock.random.return_value = 0.0
     environment.set_value('APP_NAME', 'app_0')
-    env_copy = environment.copy()
     trial_selector = trials.Trials()
-    trial_selector.setup_additional_args_for_app(env_copy)
-    self.assertEqual(env_copy.get('APP_ARGS'), '-x')
-    self.assertIsNone(env_copy.get('TRIAL_APP_ARGS'))
+    trial_selector.setup_additional_args_for_app()
+    self.assertEqual(environment.get_value('APP_ARGS'), '-x')
+    self.assertIsNone(environment.get_value('TRIAL_APP_ARGS'))
 
   def test_trial_selected_one_option(self):
     """Ensure that the expected flags are added if a trial is selected."""
     self.mock.random.return_value = 0.3
     environment.set_value('APP_NAME', 'app_1')
-    env_copy = environment.copy()
     trial_selector = trials.Trials()
-    trial_selector.setup_additional_args_for_app(env_copy)
-    self.assertEqual(env_copy.get('APP_ARGS'), '-x --a1')
-    self.assertEqual(env_copy.get('TRIAL_APP_ARGS'), '--a1')
+    trial_selector.setup_additional_args_for_app()
+    self.assertEqual(environment.get_value('APP_ARGS'), '-x --a1')
+    self.assertEqual(environment.get_value('TRIAL_APP_ARGS'), '--a1')
 
   def test_trial_not_selected(self):
     """Ensure no additional flags if a trial was not selected."""
     self.mock.random.return_value = 0.5
     environment.set_value('APP_NAME', 'app_2')
-    env_copy = environment.copy()
     trial_selector = trials.Trials()
-    trial_selector.setup_additional_args_for_app(env_copy)
-    self.assertEqual(env_copy.get('APP_ARGS'), '-x')
-    self.assertIsNone(env_copy.get('TRIAL_APP_ARGS'))
+    trial_selector.setup_additional_args_for_app()
+    self.assertEqual(environment.get_value('APP_ARGS'), '-x')
+    self.assertIsNone(environment.get_value('TRIAL_APP_ARGS'))
 
   def test_multiple_trial_selection(self):
     """Ensure that we can suggest the second trial in a batch of multiple."""
     self.mock.random.return_value = 0.1
     environment.set_value('APP_NAME', 'app_3')
-    env_copy = environment.copy()
     trial_selector = trials.Trials()
-    trial_selector.setup_additional_args_for_app(env_copy)
-    self.assertEqual(env_copy.get('APP_ARGS'), '-x --c1 --c2 --c3')
-    self.assertEqual(env_copy.get('TRIAL_APP_ARGS'), '--c1 --c2 --c3')
+    trial_selector.setup_additional_args_for_app()
+    self.assertEqual(environment.get_value('APP_ARGS'), '-x --c1 --c2 --c3')
+    self.assertEqual(environment.get_value('TRIAL_APP_ARGS'), '--c1 --c2 --c3')
 
   def test_selection_for_windows_executable(self):
     """Ensure that flags are added when the app name ends in ".exe"."""
     self.mock.random.return_value = 0.3
     environment.set_value('APP_NAME', 'app_1.exe')
-    env_copy = environment.copy()
     trial_selector = trials.Trials()
-    trial_selector.setup_additional_args_for_app(env_copy)
-    self.assertEqual(env_copy.get('APP_ARGS'), '-x --a1')
-    self.assertEqual(env_copy.get('TRIAL_APP_ARGS'), '--a1')
+    trial_selector.setup_additional_args_for_app()
+    self.assertEqual(environment.get_value('APP_ARGS'), '-x --a1')
+    self.assertEqual(environment.get_value('TRIAL_APP_ARGS'), '--a1')
 
   def test_selection_for_android_apk(self):
     """Ensure that flags are added for the Android APK format."""
     self.mock.random.return_value = 0.3
     environment.set_value('APP_NAME', 'App_1.apk')
-    env_copy = environment.copy()
     trial_selector = trials.Trials()
-    trial_selector.setup_additional_args_for_app(env_copy)
-    self.assertEqual(env_copy.get('APP_ARGS'), '-x --a1')
-    self.assertEqual(env_copy.get('TRIAL_APP_ARGS'), '--a1')
+    trial_selector.setup_additional_args_for_app()
+    self.assertEqual(environment.get_value('APP_ARGS'), '-x --a1')
+    self.assertEqual(environment.get_value('TRIAL_APP_ARGS'), '--a1')


### PR DESCRIPTION
This partially reverts pull request:
https://github.com/google/clusterfuzz/pull/2163

Trial app args are now again session specific. We'll work on a more robust solution on reland. 

The PR was incomplete, as the test-specific trial args are not stored in DB. As a result, crashes that depend on a flag from trials are not reproducible.

We don't fully revert the original PR as the new fuzz-task test depends on it and since the first PR also had some code clean-up.