### PR TITLE
Use HTTP basic auth for GitHub.

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -173,12 +173,7 @@ def get_github_url(url):
     raise ProjectSetupError('No github credentials.')
 
   client_id, client_secret = github_credentials.strip().split(';')
-
-  response = requests.get(
-      url, params={
-          'client_id': client_id,
-          'client_secret': client_secret
-      })
+  response = requests.get(url, auth=(client_id, client_secret))
   if response.status_code != 200:
     logs.log_error(
         'Failed to get github url: %s' % url, status_code=response.status_code)

--- a/src/python/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/python/tests/appengine/handlers/cron/project_setup_test.py
@@ -91,7 +91,7 @@ class CopyingMock(mock.MagicMock):
   def __call__(self, *args, **kwargs):
     args = copy.deepcopy(args)
     kwargs = copy.deepcopy(kwargs)
-    return super(CopyingMock, self).__call__(*args, **kwargs)
+    return super().__call__(*args, **kwargs)
 
 
 def mock_set_iam_policy(bucket=None, body=None):  # pylint: disable=unused-argument
@@ -1543,7 +1543,7 @@ def mock_get_url(url):
 class MockRequestsGet(object):
   """Mock requests.get."""
 
-  def __init__(self, url, params):  # pylint: disable=unused-argument
+  def __init__(self, url, params=None, auth=None):  # pylint: disable=unused-argument
     if url in URL_RESULTS:
       self.text = URL_RESULTS[url]
       self.status_code = 200


### PR DESCRIPTION
For query param deprecation: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/