### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/src/python/bot/fuzzers/libFuzzer/stats.py
+++ b/src/python/bot/fuzzers/libFuzzer/stats.py
@@ -167,7 +167,6 @@ def process_strategies(strategies, name_modifier=strategy_column_name):
 
 def parse_performance_features(log_lines, strategies, arguments):
   """Extract stats for performance analysis."""
-  # TODO(ochang): Remove include_strategies once refactor is complete.
   # Initialize stats with default values.
   stats = {
       'bad_instrumentation': 0,


### PR DESCRIPTION
##### SUMMARY
Found an obsolete TODO comment within src/python/bot/fuzzers/libFuzzer/stats.py (line:170). 
The TODO comment mentions that "remove include_strategies", but the parameter "include_strategies" had already been removed in an earlier version (https://github.com/google/clusterfuzz/commit/055b529c4c8958711c0530637fa901e1b935d53a), which means this TODO comment is obsolete & may confuse the developers who perform the subsequent development.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix issue

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
src/python/bot/fuzzers/libFuzzer/stats.py (line:170)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: https://github.com/google/clusterfuzz/commit/055b529c4c8958711c0530637fa901e1b935d53a