### PR TITLE
Fix afl-showmap exception, helps see actual error.

### DIFF
--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -1073,10 +1073,8 @@ class AflRunnerCommon(object):
     if showmap_result.timed_out or self.merge_timeout <= 0:
       return None, True
 
-    showmap_output = engine_common.read_data_from_file(self.showmap_output_path)
-
     # Log an error if showmap didn't write any coverage.
-    if showmap_output is None:
+    if not os.path.exists(self.showmap_output_path):
       if not self.showmap_no_output_logged:
         self.showmap_no_output_logged = True
         logs.log_error(
@@ -1088,6 +1086,8 @@ class AflRunnerCommon(object):
                  showmap_result.time_executed, showmap_result.output))
 
       return None, True
+
+    showmap_output = engine_common.read_data_from_file(self.showmap_output_path)
 
     features = set()
     for match in re.finditer(self.SHOWMAP_REGEX, showmap_output):


### PR DESCRIPTION
Fix incorrect code since read_data_from_file does not return
None and always requires file to exist.

Will help to fix rare
```
FileNotFoundError: [Errno 2] No such file or directory: '/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-45905/afl_showmap_output'
at read_data_from_file (/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/engine_common.py:536)
at get_file_features (/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/afl/launcher.py:1053)
at merge_corpus (/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/afl/launcher.py:1107)
at libfuzzerize_corpus (/mnt/scratch0/clusterfuzz/src/python/bot/fuzzers/afl/launcher.py:1176)
```