### PR TITLE
Use LLVM main branch

### DIFF
--- a/docs/setting-up-fuzzing/build_afl.bash
+++ b/docs/setting-up-fuzzing/build_afl.bash
@@ -45,7 +45,7 @@ make afl-fuzz afl-showmap
 mkdir -p llvm_mode
 curl "https://raw.githubusercontent.com/google/AFL/master/llvm_mode/afl-llvm-rt.o.c" > "llvm_mode/afl-llvm-rt.o.c"
 $CC -c llvm_mode/afl-llvm-rt.o.c -Wno-pointer-sign -O3
-curl -O "https://raw.githubusercontent.com/llvm/llvm-project/master/compiler-rt/lib/fuzzer/afl/afl_driver.cpp"
+curl -O "https://raw.githubusercontent.com/llvm/llvm-project/main/compiler-rt/lib/fuzzer/afl/afl_driver.cpp"
 $CXX -c afl_driver.cpp -fsanitize=address -O3
 ar r FuzzingEngine.a afl-llvm-rt.o.o afl_driver.o
 


### PR DESCRIPTION
LLVM has deprecated the "master" branch, see https://github.com/llvm/llvm-project/blob/master/README.md

Since the branch was not deleted, existing references to the branch are not redirected to main.