### PR TITLE
Use pinned cryptography module as new one requires rust.

### DIFF
--- a/configs/test/gce/android-init.bash
+++ b/configs/test/gce/android-init.bash
@@ -102,7 +102,7 @@ sed -i 's/flush_interval 5s/flush_interval 60s/' \
 sudo service google-fluentd restart
 
 echo "Installing ClusterFuzz package dependencies."
-pip install crcmod==1.7 psutil==5.6.6 pyOpenSSL==19.0.0
+pip install crcmod==1.7 psutil==5.6.6 cryptography==3.3.2 pyOpenSSL==19.0.0
 
 if [ -z "$NFS_CLUSTER_NAME" ]; then
   NFS_ROOT=

--- a/configs/test/gce/windows-init.ps1
+++ b/configs/test/gce/windows-init.ps1
@@ -169,7 +169,7 @@ cmd /c c:\python27\python -m ensurepip --default-pip
 cmd /c c:\python27\python -m pip install -U pip
 cmd /c c:\python27\python -m pip install -U setuptools
 cmd /c c:\python27\python -m pip install -U wheel
-cmd /c c:\python27\python -m pip install crcmod==1.7 pyOpenSSL==17.4.0 pywinauto==0.6.4 psutil==5.4.7 future==0.17.1
+cmd /c c:\python27\python -m pip install crcmod==1.7 cryptography==3.3.2 pyOpenSSL==17.4.0 pywinauto==0.6.4 psutil==5.4.7 future==0.17.1
 
 cmd /c c:\python37\python -m pip install -U pip
 cmd /c c:\python37\python -m pip install pipenv

--- a/docker/chromium/base/Dockerfile
+++ b/docker/chromium/base/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && \
     # 16.04's pyOpenSSL (installed by install-build-deps.sh) is too old for
     # Google Cloud SDK.
     sudo apt-get remove -y python-openssl && \
-    sudo pip2 install pyOpenSSL==19.0.0
+    sudo pip2 install cryptography==3.3.2 pyOpenSSL==19.0.0
 
 # Needed for older versions of Chrome.
 RUN ln -s /usr/lib/x86_64-linux-gnu/libudev.so /usr/lib/x86_64-linux-gnu/libudev.so.0

--- a/docker/chromium/builder/Dockerfile
+++ b/docker/chromium/builder/Dockerfile
@@ -41,7 +41,7 @@ RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula selec
 # 16.04's pyOpenSSL (installed by install-build-deps.sh) is too old for
 # Google Cloud SDK.
 RUN sudo apt-get remove -y python-openssl && \
-    sudo pip2 install pyOpenSSL==19.0.0
+    sudo pip2 install cryptography==3.3.2 pyOpenSSL==19.0.0
 
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \
     /data/depot_tools


### PR DESCRIPTION
Fixes build error

```
Collecting pyOpenSSL==19.0.0
  Downloading https://files.pythonhosted.org/packages/01/c8/ceb170d81bd3941cbeb9940fc6cc2ef2ca4288d0ca8929ea4db5905d904d/pyOpenSSL-19.0.0-py2.py3-none-any.whl (53kB)
Requirement already satisfied (use --upgrade to upgrade): six>=1.5.2 in /usr/lib/python2.7/dist-packages (from pyOpenSSL==19.0.0)
Collecting cryptography>=2.3 (from pyOpenSSL==19.0.0)
  Downloading https://files.pythonhosted.org/packages/fa/2d/2154d8cb773064570f48ec0b60258a4522490fcb115a6c7c9423482ca993/cryptography-3.4.6.tar.gz (546kB)
    Complete output from command python setup.py egg_info:
    
            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:
    
            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-k2bEsB/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ImportError: No module named setuptools_rust
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-k2bEsB/cryptography/
You are using pip version 8.1.1, however version 21.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```