### PR TITLE
Change afl hang timeout from 1000+ to 5000+

### DIFF
--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -516,7 +516,7 @@ class AflRunnerCommon(object):
 
   # The timeout we will use if autocalibrating results in too many hangs. This
   # is the maximum autocalibrated timeout afl-fuzz can set.
-  MANUAL_TIMEOUT_MILLISECONDS = 1000
+  MANUAL_TIMEOUT_MILLISECONDS = 5000
 
   # Regexes used to determine which file caused AFL to quit.
   CRASH_REGEX = re.compile(


### PR DESCRIPTION
Some targets can be slow, so need higher timeout, like 5 sec.
1000+ or 1 sec is not enough as all inputs in a corpus can
hang on a slow target and then afl-fuzz will crash. So, 5 sec
seems to work well.

See https://github.com/google/oss-fuzz/pull/5223#issuecomment-782325020