### PR TITLE
ignore VC SEH initialization function

### DIFF
--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -438,6 +438,7 @@ STACK_FRAME_IGNORE_REGEXES = [
     r'^std::panic',
     r'^std::process::abort',
     r'^std::sys::unix::abort',
+    r'^__scrt_common_main_seh',
 
     # Functions names (contains).
     r'.*ASAN_OnSIGSEGV',


### PR DESCRIPTION
This ignores SEH initialization from the minimized call stack for Visual Studio built libFuzzer targets.

Example ASAN log that includes the frame that should be ignored:
```
    #0 0x7ff739e118a8 in __sanitizer_print_stack_trace C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\asan\asan_stack.cpp:86
    #1 0x7ff739e38a84 in fuzzer::PrintStackTrace(void) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\fuzzer\FuzzerUtil.cpp:205
    #2 0x7ff739e570d1 in fuzzer::Fuzzer::HandleMalloc(unsigned __int64) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\fuzzer\FuzzerLoop.cpp:130
    #3 0x7ff739e56ff7 in fuzzer::MallocHook(void const volatile *, unsigned __int64) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\fuzzer\FuzzerLoop.cpp:99
    #4 0x7ff739e0a739 in __sanitizer::RunMallocHooks(void const *, unsigned __int64) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\sanitizer_common\sanitizer_common.cpp:299
    #5 0x7ff739e2c862 in __asan::Allocator::Allocate(unsigned __int64, unsigned __int64, struct __sanitizer::BufferedStackTrace *, enum __asan::AllocType, bool) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\asan\asan_allocator.cpp:560
    #6 0x7ff739e2c169 in __asan::asan_malloc(unsigned __int64, struct __sanitizer::BufferedStackTrace *) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\asan\asan_allocator.cpp:892
    #7 0x7ff739e19730 in malloc C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\asan\asan_malloc_win.cpp:99
    #8 0x7ff739df1061 in LLVMFuzzerTestOneInput (X:\fuzz\fuzz.exe+0x140001061)
    #9 0x7ff739e5a0ea in fuzzer::Fuzzer::ExecuteCallback(unsigned char const *, unsigned __int64) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\fuzzer\FuzzerLoop.cpp:556
    #10 0x7ff739e6d025 in fuzzer::RunOneTest(class fuzzer::Fuzzer *, char const *, unsigned __int64) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\fuzzer\FuzzerDriver.cpp:293
    #11 0x7ff739e72076 in fuzzer::FuzzerDriver(int *, char ***, int (__cdecl *)(unsigned char const *, unsigned __int64)) C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\fuzzer\FuzzerDriver.cpp:779
    #12 0x7ff739e33ec2 in main C:\src\llvm_package_1000-final\llvm-project\compiler-rt\lib\fuzzer\FuzzerMain.cpp:19
    #13 0x7ff739e79b5f in __scrt_common_main_seh d:\A01\_work\6\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #14 0x7ffa95e46fd3 in BaseThreadInitThunk (C:\WINDOWS\System32\KERNEL32.DLL+0x180016fd3)
    #15 0x7ffa975bcec0 in RtlUserThreadStart (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18004cec0)
```