### PR TITLE
improve readability of stack trace regular expressions (continued)

### DIFF
--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -504,7 +504,7 @@ STACK_FRAME_IGNORE_REGEXES = [
     # Others (uncategorized).
     r'.*\+Unknown',
     r'.*<unknown module>',
-    r'.*Inline Function \@',
+    r'.*Inline Function @',
     r'^<unknown>$',
     r'^\[vdso\]$',
 


### PR DESCRIPTION
Similar to #2242, this cleans up the readability of another regular expression by removing nonessential escaping, converting from:
`r'.*Inline Function \@'`
to:
`r'.*Inline Function @'`

The equivalency can be demonstrated in both python2 and python3 with
this test script:

```
import re
assert re.match("^.*(@mom)", "hi@mom").groups()[0] == "@mom"
```