### PR TITLE
ignore asan.module_ctor and asan.module_dtor in minimized stack traces

### DIFF
--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -406,6 +406,8 @@ STACK_FRAME_IGNORE_REGEXES = [
     r'^android\.os\.Parcel\.',
     r'^art::Thread::CreateNativeThread',
     r'^asan_',
+    r'^asan\.module_ctor',
+    r'^asan\.module_dtor',
     r'^calloc',
     r'^check_memory_region',
     r'^common_exit',


### PR DESCRIPTION
Ignores asan instrumentation `asan.module_ctor` and `asan.module_dtor` in minimized stack traces

Ref: [AddressSanitizer.cpp](https://github.com/llvm/llvm-project/blob/cfeecdf7b6df9cd89488948b440f8deeb458104c/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp#L133-L134)