### PR TITLE
Fix an exception for testcases with missing queue.

### DIFF
--- a/src/python/base/tasks.py
+++ b/src/python/base/tasks.py
@@ -405,8 +405,7 @@ def queue_for_platform(platform, is_high_end=False):
 def queue_for_testcase(testcase):
   """Return the right queue for the testcase."""
   is_high_end = (
-      testcase.queue and
-      testcase.queue.startswith(HIGH_END_JOBS_PREFIX))
+      testcase.queue and testcase.queue.startswith(HIGH_END_JOBS_PREFIX))
   return queue_for_job(testcase.job_type, is_high_end=is_high_end)
 
 

--- a/src/python/base/tasks.py
+++ b/src/python/base/tasks.py
@@ -404,7 +404,9 @@ def queue_for_platform(platform, is_high_end=False):
 
 def queue_for_testcase(testcase):
   """Return the right queue for the testcase."""
-  is_high_end = testcase.queue.startswith(HIGH_END_JOBS_PREFIX)
+  is_high_end = (
+      testcase.queue and
+      testcase.queue.startswith(HIGH_END_JOBS_PREFIX))
   return queue_for_job(testcase.job_type, is_high_end=is_high_end)
 
 


### PR DESCRIPTION
These apply to external testcases. This is the only use of this variable
so adding a check here rather than setting an empty string default.