### PR TITLE
add EMULATED_ANDROID platform

### DIFF
--- a/configs/test/pubsub/queues.yaml
+++ b/configs/test/pubsub/queues.yaml
@@ -44,7 +44,7 @@ resources:
     type: queue.jinja
   - name: jobs-android-x86
     type: queue.jinja
-  - name: jobs-emulated-android
+  - name: jobs-android-emulator
     type: queue.jinja
   - name: high-end-jobs-android-x86
     type: queue.jinja

--- a/configs/test/pubsub/queues.yaml
+++ b/configs/test/pubsub/queues.yaml
@@ -44,6 +44,8 @@ resources:
     type: queue.jinja
   - name: jobs-android-x86
     type: queue.jinja
+  - name: jobs-emulated-android
+    type: queue.jinja
   - name: high-end-jobs-android-x86
     type: queue.jinja
   - name: jobs-android-local-devices

--- a/src/python/base/tasks.py
+++ b/src/python/base/tasks.py
@@ -63,7 +63,7 @@ TASK_QUEUE_DISPLAY_NAMES = {
     'ANDROID_KERNEL': 'Android Kernel',
     'ANDROID_AUTO': 'Android Auto',
     'ANDROID_X86': 'Android (x86)',
-    'EMULATED_ANDROID': 'Android (Emulated)',
+    'ANDROID_EMULATOR': 'Android (Emulated)',
     'CHROMEOS': 'Chrome OS',
     'FUCHSIA': 'Fuchsia OS',
     'MAC': 'Mac',

--- a/src/python/base/tasks.py
+++ b/src/python/base/tasks.py
@@ -63,6 +63,7 @@ TASK_QUEUE_DISPLAY_NAMES = {
     'ANDROID_KERNEL': 'Android Kernel',
     'ANDROID_AUTO': 'Android Auto',
     'ANDROID_X86': 'Android (x86)',
+    'EMULATED_ANDROID': 'Android (Emulated)',
     'CHROMEOS': 'Chrome OS',
     'FUCHSIA': 'Fuchsia OS',
     'MAC': 'Mac',

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1298,6 +1298,7 @@ class AndroidLibFuzzerRunner(new_process.UnicodeProcessRunner, LibFuzzerCommon):
 
       return result
 
+
 class EmulatedAndroidLibFuzzerRunner(AndroidLibFuzzerRunner):
   """Android libFuzzer runner."""
 
@@ -1312,7 +1313,8 @@ class EmulatedAndroidLibFuzzerRunner(AndroidLibFuzzerRunner):
     start_emulator()
 
     super().__init__(
-        executable_path=executable_path, build_directory=build_directory,
+        executable_path=executable_path,
+        build_directory=build_directory,
         default_args=default_args)
 
   def __del__(self):

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -37,8 +37,6 @@ from fuzzing import strategy
 from metrics import logs
 from platforms import android
 from platforms import fuchsia
-from platforms.android.emulator import start_emulator
-from platforms.android.emulator import stop_emulator
 from platforms.fuchsia.device import QemuProcess
 from platforms.fuchsia.device import start_qemu
 from platforms.fuchsia.device import stop_qemu
@@ -1299,28 +1297,6 @@ class AndroidLibFuzzerRunner(new_process.UnicodeProcessRunner, LibFuzzerCommon):
       return result
 
 
-class EmulatedAndroidLibFuzzerRunner(AndroidLibFuzzerRunner):
-  """Android libFuzzer runner."""
-
-  def __init__(self, executable_path, build_directory, default_args=None):
-    """Inits the EmulatedAndroidLibFuzzerRunner.
-
-    Args:
-      executable_path: Path to the fuzzer executable.
-      build_directory: A MinijailChroot.
-      default_args: Default arguments to always pass to the fuzzer.
-    """
-    start_emulator()
-
-    super().__init__(
-        executable_path=executable_path,
-        build_directory=build_directory,
-        default_args=default_args)
-
-  def __del__(self):
-    stop_emulator()
-
-
 def get_runner(fuzzer_path, temp_dir=None, use_minijail=None, use_unshare=None):
   """Get a libfuzzer runner."""
   if use_minijail is None:
@@ -1390,10 +1366,7 @@ def get_runner(fuzzer_path, temp_dir=None, use_minijail=None, use_unshare=None):
   elif is_fuchsia:
     runner = FuchsiaQemuLibFuzzerRunner(fuzzer_path)
   elif is_android:
-    if environment.is_android_emulator():
-      runner = EmulatedAndroidLibFuzzerRunner(fuzzer_path, build_dir)
-    else:
-      runner = AndroidLibFuzzerRunner(fuzzer_path, build_dir)
+    runner = AndroidLibFuzzerRunner(fuzzer_path, build_dir)
   elif use_unshare:
     runner = UnshareLibFuzzerRunner(fuzzer_path)  # pylint: disable=too-many-function-args
   else:

--- a/src/python/bot/fuzzers/libfuzzer.py
+++ b/src/python/bot/fuzzers/libfuzzer.py
@@ -1390,7 +1390,7 @@ def get_runner(fuzzer_path, temp_dir=None, use_minijail=None, use_unshare=None):
   elif is_fuchsia:
     runner = FuchsiaQemuLibFuzzerRunner(fuzzer_path)
   elif is_android:
-    if environment.platform() == 'EMULATED_ANDROID':
+    if environment.is_android_emulator():
       runner = EmulatedAndroidLibFuzzerRunner(fuzzer_path, build_dir)
     else:
       runner = AndroidLibFuzzerRunner(fuzzer_path, build_dir)

--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -170,9 +170,11 @@ def run_platform_init_scripts():
   logs.log('Running platform initialization scripts.')
 
   plt = environment.platform()
-  if environment.is_android():
-    if not environment.is_android_emulator():
-      android_init.run()
+  if environment.is_android_emulator():
+    # Nothing to do here since emulator is not started yet.
+    pass
+  elif environment.is_android():
+    android_init.run()
   elif plt == 'CHROMEOS':
     chromeos_init.run()
   elif plt == 'FUCHSIA':

--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -171,7 +171,7 @@ def run_platform_init_scripts():
 
   plt = environment.platform()
   if environment.is_android():
-    if plt != 'EMULATED_ANDROID':
+    if not environment.is_android_emulator():
       android_init.run()
   elif plt == 'CHROMEOS':
     chromeos_init.run()

--- a/src/python/bot/tasks/update_task.py
+++ b/src/python/bot/tasks/update_task.py
@@ -171,7 +171,8 @@ def run_platform_init_scripts():
 
   plt = environment.platform()
   if environment.is_android():
-    android_init.run()
+    if plt != 'EMULATED_ANDROID':
+      android_init.run()
   elif plt == 'CHROMEOS':
     chromeos_init.run()
   elif plt == 'FUCHSIA':

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -791,6 +791,19 @@ class FuchsiaBuild(RegularBuild):
     return result
 
 
+class AndroidEmulatorBuild(RegularBuild):
+  """Represents an Android Emulator build."""
+
+  def setup(self):
+    """Android Emulator build setup."""
+    emu_proc = android.emulator.EmulatorProcess()
+    emu_proc.create()
+    emu_proc.run()
+    android.adb.run_as_root()
+
+    return super().setup()
+
+
 class SymbolizedBuild(Build):
   """Symbolized build."""
 
@@ -1252,6 +1265,8 @@ def setup_regular_build(revision,
     build_class = build_setup_host.RemoteRegularBuild
   elif environment.platform() == 'FUCHSIA':
     build_class = FuchsiaBuild
+  elif environment.is_android_emulator():
+    build_class = AndroidEmulatorBuild
 
   build = build_class(
       base_build_dir,

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -27,8 +27,9 @@ def linkify_kernel_or_lkl_stacktrace_if_needed(crash_info):
   """Linkify Android Kernel or lkl stacktrace."""
   kernel_prefix = ''
   kernel_hash = ''
-  if (environment.is_android() and environment.platform() != 'EMULATED_ANDROID'
-          and (crash_info.found_android_kernel_crash or crash_info.is_kasan)):
+  if (environment.is_android() and
+      environment.platform() != 'EMULATED_ANDROID' and
+      (crash_info.found_android_kernel_crash or crash_info.is_kasan)):
     kernel_prefix, kernel_hash = \
       android_kernel.get_kernel_prefix_and_full_hash()
 

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -27,8 +27,8 @@ def linkify_kernel_or_lkl_stacktrace_if_needed(crash_info):
   """Linkify Android Kernel or lkl stacktrace."""
   kernel_prefix = ''
   kernel_hash = ''
-  if environment.is_android() and (crash_info.found_android_kernel_crash or
-                                   crash_info.is_kasan):
+  if (environment.is_android() and environment.platform() != 'EMULATED_ANDROID'
+          and (crash_info.found_android_kernel_crash or crash_info.is_kasan)):
     kernel_prefix, kernel_hash = \
       android_kernel.get_kernel_prefix_and_full_hash()
 

--- a/src/python/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/python/crash_analysis/stack_parsing/stack_analyzer.py
@@ -27,8 +27,7 @@ def linkify_kernel_or_lkl_stacktrace_if_needed(crash_info):
   """Linkify Android Kernel or lkl stacktrace."""
   kernel_prefix = ''
   kernel_hash = ''
-  if (environment.is_android() and
-      environment.platform() != 'EMULATED_ANDROID' and
+  if (environment.is_android() and not environment.is_android_emulator() and
       (crash_info.found_android_kernel_crash or crash_info.is_kasan)):
     kernel_prefix, kernel_hash = \
       android_kernel.get_kernel_prefix_and_full_hash()

--- a/src/python/platforms/android/__init__.py
+++ b/src/python/platforms/android/__init__.py
@@ -18,6 +18,7 @@ from . import app
 from . import battery
 from . import constants
 from . import device
+from . import emulator
 from . import fetch_artifact
 from . import flash
 from . import gestures

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -734,6 +734,11 @@ def wait_until_fully_booted():
     if is_drive_ready and is_package_manager_ready and is_boot_completed:
       return True
 
+    # is_boot_completed and is_package_manager_ready may never happen on
+    # emulated devices.
+    if is_drive_ready and environment.is_android_emulator():
+      return True
+
     time.sleep(BOOT_WAIT_INTERVAL)
 
   factory_reset()

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -199,12 +199,12 @@ def get_adb_path():
 def get_devices():
   adb_cmd_line = '%s devices' % get_adb_path()
   result = execute_command(adb_cmd_line)
-  out = set()
+  devices = set()
   for line in result.splitlines():
     match = DEVICE_LINE_RE.match(line)
     if match:
-      out.add(match.group(1))
-  return out
+      devices.add(match.group(1))
+  return devices
 
 
 def get_device_state():
@@ -585,7 +585,7 @@ def run_command(cmd,
   if (output in [
       DEVICE_HANG_STRING, DEVICE_OFFLINE_STRING,
       device_not_found_string_with_serial
-  ]) and environment.platform() != 'EMULATED_ANDROID':
+  ]) and not environment.is_android_emulator():
     logs.log_warn('Unable to query device, resetting device connection.')
     if reset_device_connection():
       # Device has successfully recovered, re-run command to get output.

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -51,9 +51,6 @@ STOP_CVD_WAIT = 20
 LSUSB_BUS_RE = re.compile(r'Bus\s+(\d+)\s+Device\s+(\d+):.*')
 LSUSB_SERIAL_RE = re.compile(r'\s+iSerial\s+\d\s+(.*)')
 
-# Output pattners to parse "adb devices" output.
-DEVICE_LINE_RE = re.compile(r'([\w-]+)\s+device')
-
 # This is a constant value defined in usbdevice_fs.h in Linux system.
 USBDEVFS_RESET = ord('U') << 8 | 20
 
@@ -194,16 +191,6 @@ def get_adb_path():
     return adb_path
 
   return os.path.join(environment.get_platform_resources_directory(), 'adb')
-
-
-def get_devices():
-  result = run_command('devices')
-  devices = set()
-  for line in result.splitlines():
-    match = DEVICE_LINE_RE.match(line)
-    if match:
-      devices.add(match.group(1))
-  return devices
 
 
 def get_device_state():

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -197,8 +197,7 @@ def get_adb_path():
 
 
 def get_devices():
-  adb_cmd_line = '%s devices' % get_adb_path()
-  result = execute_command(adb_cmd_line)
+  result = run_command('devices')
   devices = set()
   for line in result.splitlines():
     match = DEVICE_LINE_RE.match(line)

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -149,7 +149,7 @@ def execute_command(cmd, timeout=None, log_error=True):
 
 def factory_reset():
   """Reset device to factory state."""
-  if is_gce():
+  if is_gce() or environment.is_android_emulator():
     # We cannot recover from this since there can be cases like userdata image
     # corruption in /data/data. Till the bug is fixed, we just need to wait
     # for reimage in next iteration.
@@ -561,7 +561,7 @@ def run_command(cmd,
     timeout = ADB_TIMEOUT
 
   output = execute_command(get_adb_command_line(cmd), timeout, log_error)
-  if not recover:
+  if not recover or environment.is_android_emulator():
     if log_output:
       logs.log('Output: (%s)' % output)
     return output
@@ -571,7 +571,7 @@ def run_command(cmd,
   if (output in [
       DEVICE_HANG_STRING, DEVICE_OFFLINE_STRING,
       device_not_found_string_with_serial
-  ]) and not environment.is_android_emulator():
+  ]):
     logs.log_warn('Unable to query device, resetting device connection.')
     if reset_device_connection():
       # Device has successfully recovered, re-run command to get output.
@@ -580,7 +580,7 @@ def run_command(cmd,
     else:
       output = DEVICE_HANG_STRING
 
-  if output is DEVICE_HANG_STRING and not environment.is_android_emulator():
+  if output is DEVICE_HANG_STRING:
     # Handle the case where our command execution hung. This is usually when
     # device goes into a bad state and only way to recover is to restart it.
     logs.log_warn('Unable to query device, restarting device to recover.')

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -137,7 +137,7 @@ def execute_command(cmd, timeout=None, log_error=True):
   thread = threading.Thread(target=run)
   thread.start()
   thread.join(timeout)
-  if thread.isAlive():
+  if thread.is_alive():
     try:
       pipe.kill()
     except OSError:
@@ -194,6 +194,7 @@ def get_adb_path():
     return adb_path
 
   return os.path.join(environment.get_platform_resources_directory(), 'adb')
+
 
 def get_devices():
   adb_cmd_line = '%s devices' % get_adb_path()

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -580,7 +580,7 @@ def run_command(cmd,
     else:
       output = DEVICE_HANG_STRING
 
-  if output is DEVICE_HANG_STRING:
+  if output is DEVICE_HANG_STRING and not environment.is_android_emulator():
     # Handle the case where our command execution hung. This is usually when
     # device goes into a bad state and only way to recover is to restart it.
     logs.log_warn('Unable to query device, restarting device to recover.')

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -17,11 +17,9 @@ import os
 import re
 import subprocess
 import tempfile
-import time
 
 from google_cloud_utils import storage
 from metrics import logs
-from platforms.android import adb
 from system import archive
 from system import environment
 from system import new_process

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -49,8 +49,8 @@ class EmulatorProcess(object):
   def create(self):
     """Configures a emulator process which can subsequently be `run`."""
     # Download emulator image.
-    if not environment.get_value('BOT_TMPDIR'):
-      logs.log_error('BOT_TMPDIR is not set.')
+    if not environment.get_value('ANDROID_EMULATOR_BUCKET_PATH'):
+      logs.log_error('ANDROID_EMULATOR_BUCKET_PATH is not set.')
       return
     temp_directory = environment.get_value('BOT_TMPDIR')
     archive_src_path = environment.get_value('ANDROID_EMULATOR_BUCKET_PATH')

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -27,8 +27,6 @@ from system import environment
 from system import new_process
 from system import shell
 
-_WAIT_SECONDS = 30
-
 # Output pattern to parse stdout for serial number
 DEVICE_SERIAL_RE = re.compile(r'DEVICE_SERIAL: (.+)')
 
@@ -89,8 +87,7 @@ class EmulatorProcess(object):
     environment.set_value('ANDROID_SERIAL', device_serial)
 
     logs.log('Waiting on device')
-    while adb.get_device_state() != 'device':
-      time.sleep(_WAIT_SECONDS)
+    adb.wait_until_fully_booted()
     logs.log('Device is online')
 
   def kill(self):

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -1,0 +1,126 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper functions for running commands on emulated Android devices."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+
+from google_cloud_utils import storage
+from platforms.android import adb
+from metrics import logs
+from system import archive
+from system import environment
+from system import new_process
+
+_WAIT_SECONDS = 10
+
+_emu_proc = None
+_emu_users = 0
+
+
+class EmulatorError(Exception):
+  """Error for errors handling the Android emulator."""
+
+
+class EmulatorProcess(object):
+  """A EmulatorProcess encapsulates the creation, running, and destruction
+  of Android emulator processes."""
+
+  def __init__(self):
+    self.process_runner = None
+    self.popen = None
+    self.logfile = None
+
+    log_path = os.path.join(tempfile.gettempdir(), 'android-emulator-log')
+    self.logfile = open(log_path, 'wb')
+
+  def create(self):
+    """Configures a emulator process which can subsequently be `run`."""
+    # Download emulator image
+    temp_directory = environment.get_value('BOT_TMPDIR')
+
+    archive_src_path = environment.get_value('ANDROID_EMULATOR_BUCKET_PATH')
+    archive_dst_path = os.path.join(temp_directory, 'emulator_bundle.zip')
+
+    storage.copy_file_from(archive_src_path, archive_dst_path)
+
+    # Extract emulator image.
+    self.emu_path = os.path.join(temp_directory, 'emulator')
+    archive.unpack(archive_dst_path, self.emu_path)
+    os.remove(archive_dst_path)
+
+    # Run emulator
+    script_path = os.path.join(self.emu_path,
+            environment.get_value('ANDROID_EMULATOR_SCRIPT_PATH'))
+
+    self.process_runner = new_process.ProcessRunner(script_path, [])
+
+  def run(self):
+    """Actually runs a emulator, assuming `create` has already been called."""
+    if not self.process_runner:
+      raise EmulatorError('Attempted to `run` emulator before calling `create`')
+
+    devices_before = adb.get_devices()
+    new_device = False
+
+    logs.log('Starting emulator.')
+    self.popen = self.process_runner.run(
+        stdout=self.logfile, stderr=subprocess.PIPE)
+
+    logs.log('Waiting for emulated device to come online.')
+    while not new_device:
+      time.sleep(_WAIT_SECONDS)
+      for device in adb.get_devices():
+        if device not in devices_before:
+          environment.set_value('ANDROID_SERIAL', device)
+          new_device = True
+          logs.log('New device online with serial %s' % device)
+
+  def kill(self):
+    """ Kills the currently-running emulator, if there is one. """
+    if self.popen:
+      logs.log('Stopping emulator.')
+      self.popen.kill()
+      self.popen = None
+
+    if self.logfile:
+      self.logfile.close()
+      self.logfile = None
+
+    if self.emu_path:
+      shutil.rmtree(self.emu_path)
+
+
+def start_emulator():
+  """Start emulator."""
+  global _emu_proc
+  global _emu_users
+  if _emu_users == 0:
+    _emu_proc = EmulatorProcess()
+    _emu_proc.create()
+    _emu_proc.run()
+    adb.run_as_root()
+  _emu_users += 1
+
+
+def stop_emulator():
+  """Stop emulator."""
+  global _emu_proc
+  global _emu_users
+  _emu_users -= 1
+  if _emu_users == 0:
+    _emu_proc.kill()

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -20,8 +20,8 @@ import tempfile
 import time
 
 from google_cloud_utils import storage
-from platforms.android import adb
 from metrics import logs
+from platforms.android import adb
 from system import archive
 from system import environment
 from system import new_process

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -17,7 +17,6 @@ import os
 import re
 import subprocess
 import tempfile
-import time
 
 from google_cloud_utils import storage
 from metrics import logs

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -64,8 +64,8 @@ class EmulatorProcess(object):
     os.remove(archive_dst_path)
 
     # Run emulator
-    script_path = os.path.join(self.emu_path,
-            environment.get_value('ANDROID_EMULATOR_SCRIPT_PATH'))
+    script_path = os.path.join(
+        self.emu_path, environment.get_value('ANDROID_EMULATOR_SCRIPT_PATH'))
 
     self.process_runner = new_process.ProcessRunner(script_path, [])
 

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -93,8 +93,6 @@ class EmulatorProcess(object):
       time.sleep(_WAIT_SECONDS)
     logs.log('Device is online')
 
-    adb.run_as_root()
-
   def kill(self):
     """ Kills the currently-running emulator, if there is one. """
     if self.process:

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -200,7 +200,7 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
 
 def get_cpu_arch():
   """Return cpu architecture."""
-  if is_android() and platform() != 'EMULATED_ANDROID':
+  if is_android() and not is_android_emulator():
     # FIXME: Handle this import in a cleaner way.
     from platforms import android
     return android.settings.get_cpu_arch()
@@ -471,7 +471,7 @@ def get_platform_id():
   """Return a platform id as a lowercase string."""
   bot_platform = platform()
   if is_android(bot_platform):
-    if platform() == 'EMULATED_ANDROID':
+    if is_android_emulator():
       return bot_platform.lower()
     # FIXME: Handle this import in a cleaner way.
     from platforms import android
@@ -1054,6 +1054,11 @@ def is_ephemeral():
 def is_android(plt=None):
   """Return true if we are on android platform."""
   return 'ANDROID' in (plt or platform())
+
+
+def is_android_emulator(plt=None):
+  """Return true if we are on android emulator platform."""
+  return 'ANDROID_EMULATOR' == (plt or platform())
 
 
 def is_lib():

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -470,9 +470,9 @@ def get_msan_options():
 def get_platform_id():
   """Return a platform id as a lowercase string."""
   bot_platform = platform()
+  if is_android_emulator():
+    return bot_platform.lower()
   if is_android(bot_platform):
-    if is_android_emulator():
-      return bot_platform.lower()
     # FIXME: Handle this import in a cleaner way.
     from platforms import android
 

--- a/src/python/system/environment.py
+++ b/src/python/system/environment.py
@@ -200,7 +200,7 @@ def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
 
 def get_cpu_arch():
   """Return cpu architecture."""
-  if is_android():
+  if is_android() and platform() != 'EMULATED_ANDROID':
     # FIXME: Handle this import in a cleaner way.
     from platforms import android
     return android.settings.get_cpu_arch()
@@ -471,6 +471,8 @@ def get_platform_id():
   """Return a platform id as a lowercase string."""
   bot_platform = platform()
   if is_android(bot_platform):
+    if platform() == 'EMULATED_ANDROID':
+      return bot_platform.lower()
     # FIXME: Handle this import in a cleaner way.
     from platforms import android
 

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -144,7 +144,7 @@ def clear_data_directories_on_low_disk_space():
 
 def clear_device_temp_directories():
   """Clear device specific temp directories."""
-  if environment.is_android() and not environment.is_android_emulator():
+  if environment.is_android() and environment.get_value('ANDROID_SERIAL'):
     from platforms import android
     android.device.clear_temp_directories()
 

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -144,7 +144,7 @@ def clear_data_directories_on_low_disk_space():
 
 def clear_device_temp_directories():
   """Clear device specific temp directories."""
-  if environment.is_android():
+  if environment.is_android() and environment.platform() != 'EMULATED_ANDROID':
     from platforms import android
     android.device.clear_temp_directories()
 
@@ -216,7 +216,7 @@ def clear_testcase_directories():
   remove_directory(environment.get_value('FUZZ_INPUTS'), recreate=True)
   remove_directory(environment.get_value('FUZZ_INPUTS_DISK'), recreate=True)
 
-  if environment.is_android():
+  if environment.is_android() and environment.platform() != 'EMULATED_ANDROID':
     from platforms import android
     android.device.clear_testcase_directory()
   if environment.platform() == 'FUCHSIA':

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -216,7 +216,7 @@ def clear_testcase_directories():
   remove_directory(environment.get_value('FUZZ_INPUTS'), recreate=True)
   remove_directory(environment.get_value('FUZZ_INPUTS_DISK'), recreate=True)
 
-  if environment.is_android() and not environment.is_android_emulator():
+  if environment.is_android() and environment.get_value('ANDROID_SERIAL'):
     from platforms import android
     android.device.clear_testcase_directory()
   if environment.platform() == 'FUCHSIA':

--- a/src/python/system/shell.py
+++ b/src/python/system/shell.py
@@ -144,7 +144,7 @@ def clear_data_directories_on_low_disk_space():
 
 def clear_device_temp_directories():
   """Clear device specific temp directories."""
-  if environment.is_android() and environment.platform() != 'EMULATED_ANDROID':
+  if environment.is_android() and not environment.is_android_emulator():
     from platforms import android
     android.device.clear_temp_directories()
 
@@ -216,7 +216,7 @@ def clear_testcase_directories():
   remove_directory(environment.get_value('FUZZ_INPUTS'), recreate=True)
   remove_directory(environment.get_value('FUZZ_INPUTS_DISK'), recreate=True)
 
-  if environment.is_android() and environment.platform() != 'EMULATED_ANDROID':
+  if environment.is_android() and not environment.is_android_emulator():
     from platforms import android
     android.device.clear_testcase_directory()
   if environment.platform() == 'FUCHSIA':


### PR DESCRIPTION
This allows downloading an emulator bundle (from the
ANDROID_EMULATOR_BUCKET_PATH variable) and running it (using the
ANDROID_EMULATOR_SCRIPT_PATH variable) before fuzzing.

The emulated Android instance is controlled using 'adb', just as a
physical Android device would. The new EmulatedAndroidLibFuzzerRunner
shares most logic with the existing AndroidLibFuzzerRunner.