### PR TITLE
Detect Jazzer exceptions without message

### DIFF
--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -105,7 +105,7 @@ GOOGLE_LOG_FATAL_REGEX = re.compile(GOOGLE_LOG_FATAL_PREFIX + r'\s*(.*)')
 HWASAN_ALLOCATION_TAIL_OVERWRITTEN_ADDRESS_REGEX = re.compile(
     r'.*ERROR: HWAddressSanitizer: allocation-tail-overwritten; '
     r'heap object \[([xX0-9a-fA-F]+),.*of size')
-JAZZER_JAVA_EXCEPTION_REGEX = re.compile('== Java Exception: .*: .*')
+JAZZER_JAVA_EXCEPTION_REGEX = re.compile('== Java Exception: .*')
 JAVA_EXCEPTION_CRASH_STATE_REGEX = re.compile(r'\s*at (.*)\(.*\)')
 KASAN_ACCESS_TYPE_REGEX = re.compile(r'(Read|Write) of size ([0-9]+)')
 KASAN_ACCESS_TYPE_ADDRESS_REGEX = re.compile(


### PR DESCRIPTION
Java exception do not have to have a message (e.g. StackOverflowError)
and if they don't, the first line of the Jazzer crash report will not
contain two colons and thus not be detected as a crash.

Since the "== Java Exception:" marker should be unique enough on its
own, this commit makes the Jazzer regex look only for this prefix and
not for an additional colon.