### PR TITLE
ignore __chk_fail and __fortify_fail in minimized stack traces

### DIFF
--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -334,6 +334,8 @@ STACK_FRAME_IGNORE_REGEXES = [
     r'^pthread_kill$',
     r'^raise$',
     r'^tgkill$',
+    r'^__chk_fail$',
+    r'^__fortify_fail$',
 
     # Function names (startswith).
     r'^(|__)aeabi_',


### PR DESCRIPTION
Ignores [__chk_fail](http://sourceware.org/git/?p=glibc.git;a=blob;f=debug/chk_fail.c;hb=refs/heads/master#l30) and [__fortify_fail](http://sourceware.org/git/?p=glibc.git;a=blob;f=debug/fortify_fail.c;hb=refs/heads/master#l28) in minimized stack traces.