### PR TITLE
ignore symbolicated libc with versions

### DIFF
--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -534,6 +534,7 @@ STACK_FRAME_IGNORE_REGEXES_IF_SYMBOLIZED = [
     r'.*libc\+\+\.so',
     r'.*libc\+\+_shared\.so',
     r'.*libstdc\+\+\.so',
+    r'.*libc-\d+\.\d+(?:\.\d+)?\.so',
 ]
 
 IGNORE_CRASH_TYPES_FOR_ABRT_BREAKPOINT_AND_ILLS = [

--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -534,7 +534,7 @@ STACK_FRAME_IGNORE_REGEXES_IF_SYMBOLIZED = [
     r'.*libc\+\+\.so',
     r'.*libc\+\+_shared\.so',
     r'.*libstdc\+\+\.so',
-    r'.*libc-\d+\.\d+(?:\.\d+)?\.so',
+    r'.*libc-.*\.so',
 ]
 
 IGNORE_CRASH_TYPES_FOR_ABRT_BREAKPOINT_AND_ILLS = [

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1588,7 +1588,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('sanitizer_signal_abrt.txt')
     expected_type = 'Abrt'
     expected_address = ''
-    expected_state = ('/tmp/coredump\n')
+    expected_state = ('/tmp/coredump\n/tmp/coredump\n')
     expected_stacktrace = data
     expected_security_flag = False
 

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1588,9 +1588,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('sanitizer_signal_abrt.txt')
     expected_type = 'Abrt'
     expected_address = ''
-    expected_state = ('/lib/x86_64-linux-gnu/libc-2.15.so\n'
-                      '/lib/x86_64-linux-gnu/libc-2.15.so\n'
-                      '/tmp/coredump\n')
+    expected_state = ('/tmp/coredump\n')
     expected_stacktrace = data
     expected_security_flag = False
 


### PR DESCRIPTION
As is, `libc.so` is ignored, but `libc-2.31.so` is not.  This PR adds ignoring libc versions used by glibc.

Ref: [glibc release timeline](https://sourceware.org/glibc/wiki/Glibc%20Timeline)