### PR TITLE
change android-emulator to write to build_dir, not $BOT_TMPDIR

### DIFF
--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -864,8 +864,9 @@ class AndroidEmulatorBuild(RegularBuild):
 
   def setup(self):
     """Android Emulator build setup."""
+    self._pre_setup()
     emu_proc = android.emulator.EmulatorProcess()
-    emu_proc.create()
+    emu_proc.create(self.build_dir)
     emu_proc.run()
     android.adb.run_as_root()
 

--- a/src/python/platforms/android/emulator.py
+++ b/src/python/platforms/android/emulator.py
@@ -51,19 +51,18 @@ class EmulatorProcess(object):
     log_path = os.path.join(tempfile.gettempdir(), 'android-emulator.log')
     self.logfile = open(log_path, 'wb')
 
-  def create(self):
+  def create(self, work_dir):
     """Configures a emulator process which can subsequently be `run`."""
     # Download emulator image.
     if not environment.get_value('ANDROID_EMULATOR_BUCKET_PATH'):
       logs.log_error('ANDROID_EMULATOR_BUCKET_PATH is not set.')
       return
-    temp_directory = environment.get_value('BOT_TMPDIR')
     archive_src_path = environment.get_value('ANDROID_EMULATOR_BUCKET_PATH')
-    archive_dst_path = os.path.join(temp_directory, 'emulator_bundle.zip')
+    archive_dst_path = os.path.join(work_dir, 'emulator_bundle.zip')
     storage.copy_file_from(archive_src_path, archive_dst_path)
 
     # Extract emulator image.
-    self.emulator_path = os.path.join(temp_directory, 'emulator')
+    self.emulator_path = os.path.join(work_dir, 'emulator')
     archive.unpack(archive_dst_path, self.emulator_path)
     shell.remove_file(archive_dst_path)
 


### PR DESCRIPTION
The call to self._pre_setup() is needed to create the build directory as needed.