### PR TITLE
add cmplog arith and transform options

### DIFF
--- a/src/python/bot/fuzzers/afl/constants.py
+++ b/src/python/bot/fuzzers/afl/constants.py
@@ -38,12 +38,10 @@ SCHEDULER_FLAG = '-p'
 
 CMPLOG_FLAG = '-c'
 
-
 # AFL CMPLOG suboptions.
 CMPLOG_ARITH = 'A'
 
 CMPLOG_TRANS = 'T'
-
 
 # AFL environment variables.
 AFL_MAP_SIZE_ENV_VAR = 'AFL_MAP_SIZE'

--- a/src/python/bot/fuzzers/afl/constants.py
+++ b/src/python/bot/fuzzers/afl/constants.py
@@ -38,6 +38,13 @@ SCHEDULER_FLAG = '-p'
 
 CMPLOG_FLAG = '-c'
 
+
+# AFL CMPLOG suboptions.
+CMPLOG_ARITH = 'A'
+
+CMPLOG_TRANS = 'T'
+
+
 # AFL environment variables.
 AFL_MAP_SIZE_ENV_VAR = 'AFL_MAP_SIZE'
 

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -250,6 +250,12 @@ class FuzzingStrategies(object):
       ('3', 0.1),  # Level 3
   ]
 
+  # Probabilty for arithmetic CMPLOG calculations.
+  CMPLOG_ARITH_PROB = 0.3
+
+  # Probability for transforming CMPLOG solving.
+  CMPLOG_TRANS_PROB = 0.3
+
   # Probability to only CMPLOG new found paths. (AFL_CMPLOG_ONLY_NEW=1)
   CMPLOG_ONLY_NEW_PROB = 0.5
 
@@ -1473,6 +1479,10 @@ def rand_cmplog_level(cmplog_level_probs):
     else:
       cmplog_level = cmplog_level_opt
       break
+  if engine_common.decide_with_probability(self.strategies.CMPLOG_ARITH_PROB):
+    cmplog_level += CMPLOG_ARITH
+  if engine_common.decide_with_probability(self.strategies.CMPLOG_TRANS_PROB):
+    cmplog_level += CMPLOG_TRANS
   return cmplog_level
 
 

--- a/src/python/bot/fuzzers/afl/launcher.py
+++ b/src/python/bot/fuzzers/afl/launcher.py
@@ -803,7 +803,7 @@ class AflRunnerCommon(object):
 
       # Select the CMPLOG level (even if no cmplog is used, it does not hurt).
       self.set_arg(fuzz_args, constants.CMPLOG_LEVEL_FLAG,
-                   rand_cmplog_level(self.strategies.CMPLOG_LEVEL_PROBS))
+                   rand_cmplog_level(self.strategies))
 
       # Attempt to start the fuzzer.
       fuzz_result = self.run_and_wait(
@@ -1469,20 +1469,20 @@ def rand_schedule(scheduler_probs):
   return schedule
 
 
-def rand_cmplog_level(cmplog_level_probs):
+def rand_cmplog_level(strategies):
   """Returns a random CMPLOG intensity level."""
   cmplog_level = '2'
   rnd = engine_common.get_probability()
-  for cmplog_level_opt, prob in cmplog_level_probs:
+  for cmplog_level_opt, prob in strategies.CMPLOG_LEVEL_PROBS:
     if rnd > prob:
       rnd -= prob
     else:
       cmplog_level = cmplog_level_opt
       break
-  if engine_common.decide_with_probability(self.strategies.CMPLOG_ARITH_PROB):
-    cmplog_level += CMPLOG_ARITH
-  if engine_common.decide_with_probability(self.strategies.CMPLOG_TRANS_PROB):
-    cmplog_level += CMPLOG_TRANS
+  if engine_common.decide_with_probability(strategies.CMPLOG_ARITH_PROB):
+    cmplog_level += constants.CMPLOG_ARITH
+  if engine_common.decide_with_probability(strategies.CMPLOG_TRANS_PROB):
+    cmplog_level += constants.CMPLOG_TRANS
   return cmplog_level
 
 


### PR DESCRIPTION
This adds CMPLOG arithmetic and transformational solving feature activation.

I am unable to test that this has no bug, when I try to install the depenencies I get:
```
ipfile: /clusterfuzz/Pipfile
Using /usr/bin/python3.8 (3.8.5) to create virtualenv...
⠹ Creating virtual environment...ModuleNotFoundError: No module named 'virtualenv.seed.via_app_data'

✘ Failed creating virtual environment 
```
virtualenv is in the newest version (pip3 install -U ...) ... my python skills are too n00bish
