### PR TITLE
Report generic fatal errors as 'Fatal error'

### DIFF
--- a/src/python/lib/clusterfuzz/stacktraces/__init__.py
+++ b/src/python/lib/clusterfuzz/stacktraces/__init__.py
@@ -1006,7 +1006,7 @@ class StackParser:
           continue
 
         if state.check_failure_source_file:
-          # Generic fatal errors should be replaced by CHECK failures.
+          # Generic fatal errors should be replaced by (D)CHECK failures.
           check_failure_match = self.update_state_on_match(
               FATAL_ERROR_DCHECK_FAILURE,
               line,
@@ -1015,15 +1015,16 @@ class StackParser:
               reset=True)
 
           if not check_failure_match:
-            new_type = state.crash_type
-            if state.crash_type == 'Fatal error':
-              new_type = 'CHECK failure'
             check_failure_match = self.update_state_on_match(
                 FATAL_ERROR_CHECK_FAILURE,
                 line,
                 state,
-                new_type=new_type,
+                new_type='CHECK failure',
                 reset=True)
+
+          if not check_failure_match:
+            check_failure_match = self.update_state_on_match(
+                FATAL_ERROR_GENERIC_FAILURE, line, state, reset=True)
 
           if check_failure_match and check_failure_match.group(2).strip():
             failure_string = fix_check_failure_string(

--- a/src/python/lib/clusterfuzz/stacktraces/constants.py
+++ b/src/python/lib/clusterfuzz/stacktraces/constants.py
@@ -91,8 +91,9 @@ CHROME_MAC_STACK_FRAME_REGEX = re.compile(
     r'(\d+)')  # off[dec] (7)
 MSAN_TSAN_REGEX = re.compile(
     r'.*(ThreadSanitizer|MemorySanitizer):\s+(?!ABRT)(?!ILL)([^(:]+)')
+FATAL_ERROR_GENERIC_FAILURE = re.compile(r'#\s+()(.*)')
 FATAL_ERROR_CHECK_FAILURE = re.compile(
-    r'#\s+(Check failed: |RepresentationChangerError: node #\d+:)?(.*)')
+    r'#\s+(Check failed: |RepresentationChangerError: node #\d+:)(.*)')
 FATAL_ERROR_DCHECK_FAILURE = re.compile(r'#\s+(Debug check failed: )(.*)')
 FATAL_ERROR_REGEX = re.compile(r'#\s*Fatal error in (.*)')
 FATAL_ERROR_LINE_REGEX = re.compile(r'#\s*Fatal error in (.*), line [0-9]+')

--- a/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/python/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -968,7 +968,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
   def test_v8_unknown_fatal_error(self):
     """Test a generic fatal error."""
     data = self._read_test_data('v8_unknown_fatal_error.txt')
-    expected_type = 'CHECK failure'
+    expected_type = 'Fatal error'
     expected_address = ''
     expected_state = ('something that isn\'t supported yet in '
                       'simulator-arm.cc\n')


### PR DESCRIPTION
We were previously overwriting the type with 'CHECK failure' even if
there was no 'Check failed' line in the output.