### PR TITLE
Add chrome extended stable support in impact task executing flow

### DIFF
--- a/src/python/bot/tasks/impact_task.py
+++ b/src/python/bot/tasks/impact_task.py
@@ -62,13 +62,16 @@ class Impacts(object):
     self.extended_stable = extended_stable or Impact()
 
   def is_empty(self):
-    return self.extended_stable.is_empty() and self.stable.is_empty() and self.beta.is_empty()
+    return (self.extended_stable.is_empty() and self.stable.is_empty() and
+            self.beta.is_empty())
 
   def get_extra_trace(self):
-    return (self.extended_stable.extra_trace + '\n' + self.stable.extra_trace + '\n' + self.beta.extra_trace).strip()
+    return (self.extended_stable.extra_trace + '\n' + self.stable.extra_trace +
+            '\n' + self.beta.extra_trace).strip()
 
   def __eq__(self, other):
-    return self.extended_stable == other.extended_stable and self.stable == other.stable and self.beta == other.beta
+    return (self.extended_stable == other.extended_stable and
+            self.stable == other.stable and self.beta == other.beta)
 
 
 def get_chromium_component_start_and_end_revision(start_revision, end_revision,
@@ -133,9 +136,6 @@ def get_component_impacts_from_url(component_name,
 
   found_impacts = dict()
   for build in ['extended_stable', 'stable', 'beta']:
-    # build_revision_mappings = revisions.get_build_to_revision_mappings(platform)
-    # if not build_revision_mappings:
-    #   return Impacts()
     mapping = build_revision_mappings.get(build)
     # TODO(yuanjunh): bypass for now but remove it after ES is enabled.
     if build == 'extended_stable' and not mapping:
@@ -157,7 +157,8 @@ def get_component_impacts_from_url(component_name,
         'version': mapping['version']
     }, start_revision, end_revision)
     found_impacts[build] = impact
-  return Impacts(found_impacts['stable'], found_impacts['beta'], found_impacts['extended_stable'])
+  return Impacts(found_impacts['stable'], found_impacts['beta'],
+                 found_impacts['extended_stable'])
 
 
 def get_impacts_from_url(regression_range, job_type, platform=None):
@@ -177,14 +178,14 @@ def get_impacts_from_url(regression_range, job_type, platform=None):
     return Impacts()
 
   extended_stable = get_impact(
-      build_revision_mappings.get('extended_stable'), start_revision, end_revision)
+      build_revision_mappings.get('extended_stable'), start_revision,
+      end_revision)
   stable = get_impact(
       build_revision_mappings.get('stable'), start_revision, end_revision)
   beta = get_impact(
       build_revision_mappings.get('beta'), start_revision, end_revision)
 
   return Impacts(stable, beta, extended_stable)
-
 
 
 def get_impact(build_revision, start_revision, end_revision):
@@ -211,7 +212,8 @@ def get_impact(build_revision, start_revision, end_revision):
 
 
 def get_impacts_on_prod_builds(testcase, testcase_file_path):
-  """Get testcase impact on production builds, which are extended stable, stable and beta."""
+  """Get testcase impact on production builds, which are extended stable, stable
+  and beta."""
   impacts = Impacts()
   try:
     impacts.stable = get_impact_on_build(
@@ -227,12 +229,12 @@ def get_impacts_on_prod_builds(testcase, testcase_file_path):
     pass
 
   try:
-    impacts.extended_stable = get_impact_on_build('extended_stable', testcase.impact_extended_stable_version,
-                                       testcase, testcase_file_path)
+    impacts.extended_stable = get_impact_on_build(
+        'extended_stable', testcase.impact_extended_stable_version, testcase,
+        testcase_file_path)
   except Exception as e:
     # TODO(yuanjunh): undo the exception bypass for ES.
     logs.log_warn('Caught errors in getting impact on extended stable: %s' % e)
-    pass
 
   return impacts
 
@@ -275,7 +277,8 @@ def get_impact_on_build(build_type, current_version, testcase,
 def set_testcase_with_impacts(testcase, impacts):
   """Set testcase's impact-related fields given impacts."""
   testcase.impact_extended_stable_version = impacts.extended_stable.version
-  testcase.impact_extended_stable_version_likely = impacts.extended_stable.likely
+  testcase.impact_extended_stable_version_likely = \
+    impacts.extended_stable.likely
   testcase.impact_stable_version = impacts.stable.version
   testcase.impact_stable_version_likely = impacts.stable.likely
   testcase.impact_beta_version = impacts.beta.version
@@ -342,7 +345,8 @@ def execute_task(testcase_id, job_type):
   if not file_list:
     return
 
-  # Setup extended stable, stable, beta builds and get impact and crash stacktrace.
+  # Setup extended stable, stable, beta builds
+  # and get impact and crash stacktrace.
   try:
     impacts = get_impacts_on_prod_builds(testcase, testcase_file_path)
   except BuildFailedException as error:

--- a/src/python/bot/tasks/impact_task.py
+++ b/src/python/bot/tasks/impact_task.py
@@ -127,11 +127,15 @@ def get_component_impacts_from_url(component_name,
   if not end_revision:
     return Impacts()
 
+  build_revision_mappings = revisions.get_build_to_revision_mappings(platform)
+  if not build_revision_mappings:
+    return Impacts()
+
   found_impacts = dict()
-  for build in ['stable', 'beta', 'extended_stable']:
-    build_revision_mappings = revisions.get_build_to_revision_mappings(platform)
-    if not build_revision_mappings:
-      return Impacts()
+  for build in ['extended_stable', 'stable', 'beta']:
+    # build_revision_mappings = revisions.get_build_to_revision_mappings(platform)
+    # if not build_revision_mappings:
+    #   return Impacts()
     mapping = build_revision_mappings.get(build)
     # TODO(yuanjunh): bypass for now but remove it after ES is enabled.
     if build == 'extended_stable' and not mapping:

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -48,7 +48,7 @@ REVISION_FILE_NAME = 'REVISION'
 
 # Various build type mapping strings.
 BUILD_TYPE_SUBSTRINGS = [
-    '-beta', '-stable', '-debug', '-release', '-symbolized'
+    '-beta', '-stable', '-debug', '-release', '-symbolized', '-extended_stable'
 ]
 
 # Build eviction constants.
@@ -1518,7 +1518,7 @@ def is_custom_binary():
 
 def has_production_builds():
   """Return a bool on if job type has build urls for stable and beta builds."""
-  # TODO(yuanjunh): change if after ES exists.
+  # TODO(yuanjunh): change it if after ES exists.
   return (environment.get_value('STABLE_BUILD_BUCKET_PATH') and
           environment.get_value('BETA_BUILD_BUCKET_PATH'))
 

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -603,12 +603,11 @@ class Build(BaseBuild):
     """Check if build already exists."""
     revision_file = os.path.join(self.build_dir, REVISION_FILE_NAME)
     if os.path.exists(revision_file):
-      file_handle = open(revision_file, 'r')
-      try:
-        current_revision = int(file_handle.read())
-      except ValueError:
-        current_revision = -1
-      file_handle.close()
+      with open(revision_file, 'r') as file_handle:
+        try:
+          current_revision = int(file_handle.read())
+        except ValueError:
+          current_revision = -1
 
       # We have the revision required locally, no more work to do, other than
       # setting application path environment variables.

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -1427,7 +1427,8 @@ def setup_production_build(build_type):
   """Sets up build with a particular revision."""
   # Bail out if there are not stable and beta build urls.
   if build_type == 'extended_stable':
-    build_bucket_path = environment.get_value('EXTENDED_STABLE_BUILD_BUCKET_PATH')
+    build_bucket_path = environment.get_value(
+        'EXTENDED_STABLE_BUILD_BUCKET_PATH')
   elif build_type == 'stable':
     build_bucket_path = environment.get_value('STABLE_BUILD_BUCKET_PATH')
   elif build_type == 'beta':

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -1426,7 +1426,9 @@ def setup_custom_binary(target_weights=None):
 def setup_production_build(build_type):
   """Sets up build with a particular revision."""
   # Bail out if there are not stable and beta build urls.
-  if build_type == 'stable':
+  if build_type == 'extended_stable':
+    build_bucket_path = environment.get_value('EXTENDED_STABLE_BUILD_BUCKET_PATH')
+  elif build_type == 'stable':
     build_bucket_path = environment.get_value('STABLE_BUILD_BUCKET_PATH')
   elif build_type == 'beta':
     build_bucket_path = environment.get_value('BETA_BUILD_BUCKET_PATH')
@@ -1516,6 +1518,7 @@ def is_custom_binary():
 
 def has_production_builds():
   """Return a bool on if job type has build urls for stable and beta builds."""
+  # TODO(yuanjunh): change if after ES exists.
   return (environment.get_value('STABLE_BUILD_BUCKET_PATH') and
           environment.get_value('BETA_BUILD_BUCKET_PATH'))
 

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -1428,6 +1428,9 @@ def setup_production_build(build_type):
   if build_type == 'extended_stable':
     build_bucket_path = environment.get_value(
         'EXTENDED_STABLE_BUILD_BUCKET_PATH')
+    # TODO(yuanjunh): remove it after ES exists.
+    if not build_bucket_path:
+      return None
   elif build_type == 'stable':
     build_bucket_path = environment.get_value('STABLE_BUILD_BUCKET_PATH')
   elif build_type == 'beta':

--- a/src/python/tests/core/bot/tasks/impact_task_test.py
+++ b/src/python/tests/core/bot/tasks/impact_task_test.py
@@ -41,7 +41,8 @@ class ExecuteTaskTest(unittest.TestCase):
     ])
     impacts = impact_task.Impacts(
         stable=impact_task.Impact('stable', False, 'trace-stable'),
-        beta=impact_task.Impact('beta', True, 'trace-beta'))
+        beta=impact_task.Impact('beta', True, 'trace-beta'),
+        extended_stable= impact_task.Impact('extended stable', False, 'trace-extended-stable'))
     self.mock.is_chromium.return_value = True
     self.mock.is_custom_binary.return_value = False
     self.mock.has_production_builds.return_value = True
@@ -72,6 +73,8 @@ class ExecuteTaskTest(unittest.TestCase):
     """Expect testcase's impacts to be changed."""
     self.reload()
     self.assertTrue(self.testcase.is_impact_set_flag)
+    self.assertEqual('extended stable', self.testcase.impact_extended_stable_version)
+    self.assertFalse(self.testcase.impact_stable_version_likely)
     self.assertEqual('stable', self.testcase.impact_stable_version)
     self.assertFalse(self.testcase.impact_stable_version_likely)
     self.assertEqual('beta', self.testcase.impact_beta_version)
@@ -203,6 +206,7 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
         }
     }
     self.mock.get_impact.side_effect = [
+        impact_task.Impact(),
         impact_task.Impact('s', False),
         impact_task.Impact('b', True)
     ]
@@ -290,10 +294,59 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
     self.mock.get_build_to_revision_mappings.assert_has_calls(
         [mock.call('windows')])
 
-  def test_get_impacts(self):
-    """Test getting impacts."""
+  def test_get_impacts_es_not_exists(self):
+    """Test getting impacts when extended stable doesn't exist."""
     impacts = impact_task.get_impacts_from_url('123:456', 'job', 'windows')
 
+    self.assertEqual('', impacts.extended_stable.version)
+    self.assertFalse(impacts.extended_stable.likely)
+    self.assertEqual('s', impacts.stable.version)
+    self.assertFalse(impacts.stable.likely)
+    self.assertEqual('b', impacts.beta.version)
+    self.assertTrue(impacts.beta.likely)
+
+    self.mock.get_start_and_end_revision.assert_has_calls(
+        [mock.call('123:456', 'job')])
+    self.mock.get_build_to_revision_mappings.assert_has_calls(
+        [mock.call('windows')])
+    self.mock.get_impact.assert_has_calls([
+        mock.call(None, 1, 100),
+        mock.call({
+            'version': '74.0.1345.34',
+            'revision': '398287'
+        }, 1, 100),
+        mock.call({
+            'version': '75.0.1353.43',
+            'revision': '399171'
+        }, 1, 100)
+    ])
+
+  def test_get_impacts_es_exists(self):
+    """Test getting impacts when extended stable exists."""
+    self.mock.get_build_to_revision_mappings.return_value = {
+        'extended_stable': {
+            'revision': '398287',
+            'version': '74.0.1345.34'
+        },
+        'stable': {
+            'revision': '398287',
+            'version': '74.0.1345.34'
+        },
+        'beta': {
+            'revision': '399171',
+            'version': '75.0.1353.43'
+        }
+    }
+    self.mock.get_impact.side_effect = [
+        impact_task.Impact('es', False),
+        impact_task.Impact('s', False),
+        impact_task.Impact('b', True)
+    ]
+
+    impacts = impact_task.get_impacts_from_url('123:456', 'job', 'windows')
+
+    self.assertEqual('es', impacts.extended_stable.version)
+    self.assertFalse(impacts.extended_stable.likely)
     self.assertEqual('s', impacts.stable.version)
     self.assertFalse(impacts.stable.likely)
     self.assertEqual('b', impacts.beta.version)
@@ -309,16 +362,26 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
             'revision': '398287'
         }, 1, 100),
         mock.call({
+            'version': '74.0.1345.34',
+            'revision': '398287'
+        }, 1, 100),
+        mock.call({
             'version': '75.0.1353.43',
             'revision': '399171'
         }, 1, 100)
     ])
 
-  def test_get_impacts_known_component(self):
-    """Test getting impacts for a known component."""
+  def test_get_impacts_known_component_es_not_exists(self):
+    """Test getting impacts for a known component when extended stable doesn't exists."""
     self.mock.get_component_name.return_value = 'v8'
+    self.mock.get_impact.side_effect = [
+        impact_task.Impact('s', False),
+        impact_task.Impact('b', True)
+    ]
     impacts = impact_task.get_impacts_from_url('123:456', 'job', 'windows')
 
+    self.assertEqual('', impacts.extended_stable.version)
+    self.assertFalse(impacts.extended_stable.likely)
     self.assertEqual('s', impacts.stable.version)
     self.assertFalse(impacts.stable.likely)
     self.assertEqual('b', impacts.beta.version)
@@ -339,6 +402,51 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
         }, 1, 100)
     ])
 
+  def test_get_impacts_known_component_es_exists(self):
+    """Test getting impacts for a known component when extended stable build exists."""
+    self.mock.get_component_name.return_value = 'v8'
+    self.mock.get_build_to_revision_mappings.return_value = {
+        'extended_stable': {
+            'revision': '398287',
+            'version': '74.0.1345.34'
+        },
+        'stable': {
+            'revision': '398287',
+            'version': '74.0.1345.34'
+        },
+        'beta': {
+            'revision': '399171',
+            'version': '75.0.1353.43'
+        }
+    }
+    self.mock.get_impact.side_effect = [
+        impact_task.Impact('es', False),
+        impact_task.Impact('s', False),
+        impact_task.Impact('b', True)
+    ]
+    impacts = impact_task.get_impacts_from_url('123:456', 'job', 'windows')
+
+    self.assertEqual('es', impacts.extended_stable.version)
+    self.assertFalse(impacts.extended_stable.likely)
+    self.assertEqual('s', impacts.stable.version)
+    self.assertFalse(impacts.stable.likely)
+    self.assertEqual('b', impacts.beta.version)
+    self.assertTrue(impacts.beta.likely)
+
+    self.mock.get_start_and_end_revision.assert_has_calls(
+        [mock.call('123:456', 'job')])
+    self.mock.get_build_to_revision_mappings.assert_has_calls(
+        [mock.call('windows')])
+    self.mock.get_impact.assert_has_calls([
+        mock.call({
+            'version': '74.0.1345.34',
+            'revision': '666666'
+        }, 1, 100),
+        mock.call({
+            'version': '75.0.1353.43',
+            'revision': '777777'
+        }, 1, 100)
+    ])
 
 class GetImpactTest(unittest.TestCase):
   """Test get_impact."""
@@ -388,10 +496,12 @@ class GetImpactsOnProdBuilds(unittest.TestCase):
     ])
     self.impacts = impact_task.Impacts(
         stable=impact_task.Impact('s', False),
-        beta=impact_task.Impact('b', True))
+        beta=impact_task.Impact('b', True),
+        extended_stable=impact_task.Impact('es', False))
 
     self.testcase = data_types.Testcase()
     self.testcase.job_type = 'job'
+    self.testcase.impact_extended_stable_version = 'es-ver'
     self.testcase.impact_stable_version = 's-ver'
     self.testcase.impact_beta_version = 'b-ver'
     self.testcase.regression = '123:456'
@@ -429,10 +539,31 @@ class GetImpactsOnProdBuilds(unittest.TestCase):
     ])
     self.mock.get_impacts_from_url.assert_has_calls([])
 
+  def test_any_exception_on_extended_stable(self):
+    """Test exceptions on extended stable. Current expected behavior is the failure is ignored"""
+    self.mock.get_impact_on_build.side_effect = [
+        self.impacts.stable,
+        self.impacts.beta,
+        Exception(),
+    ]
+
+    self.assertEqual(
+        impact_task.Impacts(self.impacts.stable, self.impacts.beta),
+        impact_task.get_impacts_on_prod_builds(self.testcase, 'path'))
+    self.mock.get_impact_on_build.assert_has_calls([
+        mock.call('stable', self.testcase.impact_stable_version, self.testcase,
+                  'path'),
+        mock.call('beta', self.testcase.impact_beta_version, self.testcase,
+                  'path'),
+        mock.call('extended_stable', self.testcase.impact_extended_stable_version, self.testcase,
+                  'path'),
+    ])
+    self.mock.get_impacts_from_url.assert_has_calls([])
+
   def test_get_impacts(self):
     """Test getting impacts."""
     self.mock.get_impact_on_build.side_effect = [
-        self.impacts.stable, self.impacts.beta
+        self.impacts.stable, self.impacts.beta, self.impacts.extended_stable
     ]
 
     self.assertEqual(
@@ -442,6 +573,8 @@ class GetImpactsOnProdBuilds(unittest.TestCase):
         mock.call('stable', self.testcase.impact_stable_version, self.testcase,
                   'path'),
         mock.call('beta', self.testcase.impact_beta_version, self.testcase,
+                  'path'),
+        mock.call('extended_stable', self.testcase.impact_extended_stable_version, self.testcase,
                   'path'),
     ])
     self.mock.get_impacts_from_url.assert_has_calls([])

--- a/src/python/tests/core/bot/tasks/impact_task_test.py
+++ b/src/python/tests/core/bot/tasks/impact_task_test.py
@@ -42,7 +42,8 @@ class ExecuteTaskTest(unittest.TestCase):
     impacts = impact_task.Impacts(
         stable=impact_task.Impact('stable', False, 'trace-stable'),
         beta=impact_task.Impact('beta', True, 'trace-beta'),
-        extended_stable= impact_task.Impact('extended stable', False, 'trace-extended-stable'))
+        extended_stable=impact_task.Impact('extended stable', False,
+                                           'trace-extended-stable'))
     self.mock.is_chromium.return_value = True
     self.mock.is_custom_binary.return_value = False
     self.mock.has_production_builds.return_value = True
@@ -73,7 +74,8 @@ class ExecuteTaskTest(unittest.TestCase):
     """Expect testcase's impacts to be changed."""
     self.reload()
     self.assertTrue(self.testcase.is_impact_set_flag)
-    self.assertEqual('extended stable', self.testcase.impact_extended_stable_version)
+    self.assertEqual('extended stable',
+                     self.testcase.impact_extended_stable_version)
     self.assertFalse(self.testcase.impact_stable_version_likely)
     self.assertEqual('stable', self.testcase.impact_stable_version)
     self.assertFalse(self.testcase.impact_stable_version_likely)
@@ -183,7 +185,7 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
 
   def setUp(self):
     """Setup for get impacts from url test."""
-    super(GetImpactsFromUrlTest, self).setUp()
+    super().setUp()
     helpers.patch(self, [
         'bot.tasks.impact_task.get_start_and_end_revision',
         'bot.tasks.impact_task.get_impact',
@@ -372,7 +374,8 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
     ])
 
   def test_get_impacts_known_component_es_not_exists(self):
-    """Test getting impacts for a known component when extended stable doesn't exists."""
+    """Test getting impacts for a known component
+    when extended stable doesn't exists."""
     self.mock.get_component_name.return_value = 'v8'
     self.mock.get_impact.side_effect = [
         impact_task.Impact('s', False),
@@ -403,7 +406,8 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
     ])
 
   def test_get_impacts_known_component_es_exists(self):
-    """Test getting impacts for a known component when extended stable build exists."""
+    """Test getting impacts for a known component
+    when extended stable exists."""
     self.mock.get_component_name.return_value = 'v8'
     self.mock.get_build_to_revision_mappings.return_value = {
         'extended_stable': {
@@ -447,6 +451,7 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
             'revision': '777777'
         }, 1, 100)
     ])
+
 
 class GetImpactTest(unittest.TestCase):
   """Test get_impact."""
@@ -540,7 +545,8 @@ class GetImpactsOnProdBuilds(unittest.TestCase):
     self.mock.get_impacts_from_url.assert_has_calls([])
 
   def test_any_exception_on_extended_stable(self):
-    """Test exceptions on extended stable. Current expected behavior is the failure is ignored"""
+    """Test exceptions on extended stable.
+    Current expected behavior is the failure is ignored"""
     self.mock.get_impact_on_build.side_effect = [
         self.impacts.stable,
         self.impacts.beta,
@@ -555,7 +561,8 @@ class GetImpactsOnProdBuilds(unittest.TestCase):
                   'path'),
         mock.call('beta', self.testcase.impact_beta_version, self.testcase,
                   'path'),
-        mock.call('extended_stable', self.testcase.impact_extended_stable_version, self.testcase,
+        mock.call('extended_stable',
+                  self.testcase.impact_extended_stable_version, self.testcase,
                   'path'),
     ])
     self.mock.get_impacts_from_url.assert_has_calls([])
@@ -574,7 +581,8 @@ class GetImpactsOnProdBuilds(unittest.TestCase):
                   'path'),
         mock.call('beta', self.testcase.impact_beta_version, self.testcase,
                   'path'),
-        mock.call('extended_stable', self.testcase.impact_extended_stable_version, self.testcase,
+        mock.call('extended_stable',
+                  self.testcase.impact_extended_stable_version, self.testcase,
                   'path'),
     ])
     self.mock.get_impacts_from_url.assert_has_calls([])

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -753,15 +753,16 @@ class ProductionBuildTest(fake_filesystem_unittest.TestCase):
     self.mock.get_build_urls_list.side_effect = self._mock_get_build_urls_list
 
   def _mock_get_build_urls_list(self, bucket_path):
+    """Mock get_build_urls_list()"""
     if not bucket_path:
       return []
 
     if 'extended_stable' in bucket_path:
       return [
-        'gs://path/file-extended_stable-45.0.1824.2.zip',
-        'gs://path/file-extended_stable-44.0.1824.1.zip',
-        'gs://path/file-extended_stable-44.0.1822.2.zip',
-        ]
+          'gs://path/file-extended_stable-45.0.1824.2.zip',
+          'gs://path/file-extended_stable-44.0.1824.1.zip',
+          'gs://path/file-extended_stable-44.0.1822.2.zip',
+      ]
 
     if 'stable' in bucket_path:
       return [
@@ -848,32 +849,33 @@ class ProductionBuildTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(self.mock._unpack_build.call_count, 1)
 
   def test_setup_extended_stable(self):
-        """Test setting up an extended stable build."""
-        os.environ['EXTENDED_STABLE_BUILD_BUCKET_PATH'] = (
-            'gs://path/file-extended_stable-([0-9.]+).zip')
+    """Test setting up an extended stable build."""
+    os.environ['EXTENDED_STABLE_BUILD_BUCKET_PATH'] = (
+        'gs://path/file-extended_stable-([0-9.]+).zip')
 
-        self.mock.time.return_value = 1000.0
-        build = build_manager.setup_production_build('extended_stable')
-        self.assertIsInstance(build, build_manager.ProductionBuild)
-        self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
+    self.mock.time.return_value = 1000.0
+    build = build_manager.setup_production_build('extended_stable')
+    self.assertIsInstance(build, build_manager.ProductionBuild)
+    self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
 
-        self.assertEqual(build.revision, '45.0.1824.2')
-        self.assertEqual(os.environ['APP_REVISION'], '45.0.1824.2')
-        self._assert_env_vars('extended_stable')
+    self.assertEqual(build.revision, '45.0.1824.2')
+    self.assertEqual(os.environ['APP_REVISION'], '45.0.1824.2')
+    self._assert_env_vars('extended_stable')
 
-        self.mock._unpack_build.assert_called_once_with(
-            mock.ANY, '/builds/path_8102046d3cea496c945743eb5f79284e7b10b51b',
-            '/builds/path_8102046d3cea496c945743eb5f79284e7b10b51b/extended_stable',
-            'gs://path/file-extended_stable-45.0.1824.2.zip')
+    self.mock._unpack_build.assert_called_once_with(
+        mock.ANY, '/builds/path_8102046d3cea496c945743eb5f79284e7b10b51b',
+        '/builds/path_8102046d3cea496c945743eb5f79284e7b10b51b/extended_stable',
+        'gs://path/file-extended_stable-45.0.1824.2.zip')
 
-        self.mock.time.return_value = 1005.0
-        self.assertEqual(
-            build_manager.setup_production_build('extended_stable').revision, '45.0.1824.2')
-        self.assertEqual(_get_timestamp(build.base_build_dir), 1005.0)
-        self._assert_env_vars('extended_stable')
-        self.assertEqual(self.mock._unpack_build.call_count, 1)
+    self.mock.time.return_value = 1005.0
+    self.assertEqual(
+        build_manager.setup_production_build('extended_stable').revision,
+        '45.0.1824.2')
+    self.assertEqual(_get_timestamp(build.base_build_dir), 1005.0)
+    self._assert_env_vars('extended_stable')
+    self.assertEqual(self.mock._unpack_build.call_count, 1)
 
-        self.assertIsNone(build_manager.setup_production_build('wrong'))
+    self.assertIsNone(build_manager.setup_production_build('wrong'))
 
   def test_delete(self):
     """Test deleting this build."""

--- a/src/python/tests/core/build_management/build_manager_test.py
+++ b/src/python/tests/core/build_management/build_manager_test.py
@@ -753,6 +753,16 @@ class ProductionBuildTest(fake_filesystem_unittest.TestCase):
     self.mock.get_build_urls_list.side_effect = self._mock_get_build_urls_list
 
   def _mock_get_build_urls_list(self, bucket_path):
+    if not bucket_path:
+      return []
+
+    if 'extended_stable' in bucket_path:
+      return [
+        'gs://path/file-extended_stable-45.0.1824.2.zip',
+        'gs://path/file-extended_stable-44.0.1824.1.zip',
+        'gs://path/file-extended_stable-44.0.1822.2.zip',
+        ]
+
     if 'stable' in bucket_path:
       return [
           'gs://path/file-stable-45.0.1824.2.zip',
@@ -836,6 +846,34 @@ class ProductionBuildTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(_get_timestamp(build.base_build_dir), 1005.0)
     self._assert_env_vars('beta')
     self.assertEqual(self.mock._unpack_build.call_count, 1)
+
+  def test_setup_extended_stable(self):
+        """Test setting up an extended stable build."""
+        os.environ['EXTENDED_STABLE_BUILD_BUCKET_PATH'] = (
+            'gs://path/file-extended_stable-([0-9.]+).zip')
+
+        self.mock.time.return_value = 1000.0
+        build = build_manager.setup_production_build('extended_stable')
+        self.assertIsInstance(build, build_manager.ProductionBuild)
+        self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
+
+        self.assertEqual(build.revision, '45.0.1824.2')
+        self.assertEqual(os.environ['APP_REVISION'], '45.0.1824.2')
+        self._assert_env_vars('extended_stable')
+
+        self.mock._unpack_build.assert_called_once_with(
+            mock.ANY, '/builds/path_8102046d3cea496c945743eb5f79284e7b10b51b',
+            '/builds/path_8102046d3cea496c945743eb5f79284e7b10b51b/extended_stable',
+            'gs://path/file-extended_stable-45.0.1824.2.zip')
+
+        self.mock.time.return_value = 1005.0
+        self.assertEqual(
+            build_manager.setup_production_build('extended_stable').revision, '45.0.1824.2')
+        self.assertEqual(_get_timestamp(build.base_build_dir), 1005.0)
+        self._assert_env_vars('extended_stable')
+        self.assertEqual(self.mock._unpack_build.call_count, 1)
+
+        self.assertIsNone(build_manager.setup_production_build('wrong'))
 
   def test_delete(self):
     """Test deleting this build."""


### PR DESCRIPTION
It will try to get extended stable build and calculate the impact. But it will silence any exceptions if it fails to get extend stable build. So it won't break the current CF flows even this code is deployed.