### PR TITLE
Update Testcase timestamp when analyze_task completes.

### DIFF
--- a/src/appengine/handlers/cron/triage.py
+++ b/src/appengine/handlers/cron/triage.py
@@ -293,8 +293,12 @@ class Handler(base_handler.Handler):
       if not data_handler.critical_tasks_completed(testcase):
         continue
 
-      # For testcases that are not part of a group, wait an additional time till
-      # group task completes.
+      # For testcases that are not part of a group, wait an additional time to
+      # make sure it is grouped.
+      # The grouper runs prior to this step in the same cron, but there is a
+      # window of time where new testcases can come in after the grouper starts.
+      # This delay needs to be longer than the maximum time the grouper can take
+      # to account for that.
       # FIXME: In future, grouping might be dependent on regression range, so we
       # would have to add an additional wait time.
       if not testcase.group_id and not dates.time_has_expired(

--- a/src/python/bot/tasks/analyze_task.py
+++ b/src/python/bot/tasks/analyze_task.py
@@ -318,6 +318,12 @@ def execute_task(testcase_id, job_type):
     testcase.status = 'Processed'
     metadata.status = 'Confirmed'
 
+    # Reset the timestamp as well, to respect
+    # data_types.MIN_ELAPSED_TIME_SINCE_REPORT. Otherwise it may get filed by
+    # triage task prematurely without the grouper having a chance to run on this
+    # testcase.
+    testcase.timestamp = utils.utcnow()
+
     # Add new leaks to global blacklist to avoid detecting duplicates.
     # Only add if testcase has a direct leak crash and if it's reproducible.
     if is_lsan_enabled:

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -72,7 +72,7 @@ INTERNAL_SANDBOXED_JOB_TYPES = [
 MIN_ELAPSED_TIME_SINCE_FIXED = 2 * 24
 
 # Time to wait for grouping task to finish, before filing the report (hours).
-MIN_ELAPSED_TIME_SINCE_REPORT = 3
+MIN_ELAPSED_TIME_SINCE_REPORT = 4
 
 # Valid name check for fuzzer, job, etc.
 NAME_CHECK_REGEX = re.compile(r'^[a-zA-Z0-9_-]+$')


### PR DESCRIPTION
Triage task waits data_types.MIN_ELAPSED_TIME_SINCE_REPORT for a
testcase to make sure it is considered for any grouping before we file
a bug. This is based on the `timestamp` attribute.

However, for uploaded testcases, the timestamp was previously set to the
time of upload, rather than the time when analyze_task completes and
marks the Testcase as "Processed". This means these testcases could get
filed without being grouped.

Also increase MIN_ELAPSED_TIME_SINCE_REPORT by an hour to be safe, as
the grouper can be quite slow with lots of open testcases.