### PR TITLE
Fix upload_testcase_test failures.

### DIFF
--- a/src/python/tests/appengine/handlers/upload_testcase_test.py
+++ b/src/python/tests/appengine/handlers/upload_testcase_test.py
@@ -14,11 +14,11 @@
 """Tests for upload_testcase."""
 
 import datetime
+import io
 import os
 import unittest
 
 import flask
-import webtest
 
 from datastore import data_handler
 from datastore import data_types
@@ -110,10 +110,9 @@ class UploadOAuthTest(unittest.TestCase):
         external_reproduction_topic='topic',
         external_updates_subscription='sub').put()
 
-    flaskapp = flask.Flask('testflask')
-    flaskapp.add_url_rule(
+    self.app = flask.Flask('testflask')
+    self.app.add_url_rule(
         '/', view_func=upload_testcase.UploadHandlerOAuth.as_view(''))
-    self.app = webtest.TestApp(flaskapp)
 
   def _read_test_data(self, name):
     """Helper function to read test data."""
@@ -125,19 +124,19 @@ class UploadOAuthTest(unittest.TestCase):
     for key, value in expected.items():
       self.assertEqual(value, actual[key], msg=f'For attribute {key}')
 
-  @unittest.skip('flaky test')
   def test_external_upload_oom(self):
     """Test external upload (oom)."""
     stacktrace = self._read_test_data('oom.txt')
-    response = self.app.post(
-        '/',
-        params={
-            'job': 'libfuzzer_proj_external',
-            'target': 'target',
-            'stacktrace': stacktrace,
-            'revision': 1337,
-        },
-        upload_files=[('file', 'file', b'contents')])
+    with self.app.test_client() as client:
+      response = client.post(
+          '/',
+          data={
+              'job': 'libfuzzer_proj_external',
+              'target': 'target',
+              'stacktrace': stacktrace,
+              'revision': 1337,
+              'file': (io.BytesIO(b'contents'), 'file'),
+          })
 
     self.assertDictEqual({
         'id': '2',
@@ -228,19 +227,19 @@ class UploadOAuthTest(unittest.TestCase):
         'uploader_email': 'uploader@email'
     }, metadata._to_dict())
 
-  @unittest.skip('flaky test')
   def test_external_upload_uaf(self):
     """Test external upload (uaf)."""
     stacktrace = self._read_test_data('uaf.txt')
-    response = self.app.post(
-        '/',
-        params={
-            'job': 'libfuzzer_proj_external',
-            'target': 'target',
-            'stacktrace': stacktrace,
-            'revision': 1337,
-        },
-        upload_files=[('file', 'file', b'contents')])
+    with self.app.test_client() as client:
+      response = client.post(
+          '/',
+          data={
+              'job': 'libfuzzer_proj_external',
+              'target': 'target',
+              'stacktrace': stacktrace,
+              'revision': 1337,
+              'file': (io.BytesIO(b'contents'), 'file'),
+          })
 
     self.assertDictEqual({
         'id': '2',
@@ -384,7 +383,6 @@ class UploadOAuthTest(unittest.TestCase):
         'uploader_email': 'uploader@email'
     }, metadata._to_dict())
 
-  @unittest.skip('flaky test')
   def test_external_duplicate(self):
     """Test uploading a duplicate."""
     existing = data_types.Testcase(
@@ -397,15 +395,16 @@ class UploadOAuthTest(unittest.TestCase):
     existing.put()
 
     stacktrace = self._read_test_data('oom.txt')
-    response = self.app.post(
-        '/',
-        params={
-            'job': 'libfuzzer_proj_external',
-            'target': 'target',
-            'stacktrace': stacktrace,
-            'revision': 1337,
-        },
-        upload_files=[('file', 'file', b'contents')])
+    with self.app.test_client() as client:
+      response = client.post(
+          '/',
+          data={
+              'job': 'libfuzzer_proj_external',
+              'target': 'target',
+              'stacktrace': stacktrace,
+              'revision': 1337,
+              'file': (io.BytesIO(b'contents'), 'file'),
+          })
 
     self.assertDictEqual({
         'id': '3',


### PR DESCRIPTION
These were failing due to some incompatibility between Flask and
WebTest. Use Flask's builtin test client instead for these.