### PR TITLE
Add support for specifying a unreproducible component.

### DIFF
--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -415,6 +415,9 @@ def file_issue(testcase,
   for component in metadata_components:
     issue.components.add(component)
 
+  if testcase.one_time_crasher_flag and policy.unreproducible_component:
+    issue.components.add(policy.unreproducible_component)
+
   issue.reporter = user_email
   issue.save()
 

--- a/src/appengine/libs/issue_management/issue_tracker_policy.py
+++ b/src/appengine/libs/issue_management/issue_tracker_policy.py
@@ -89,8 +89,13 @@ class IssueTrackerPolicy(object):
 
   @property
   def deadline_policy_message(self):
-    """Get the deadline policy message, if if exists."""
+    """Get the deadline policy message, if it exists."""
     return self._data.get('deadline_policy_message')
+
+  @property
+  def unreproducible_component(self):
+    """Get the component for unreproducible bugs, if it exists."""
+    return self._data.get('unreproducible_component')
 
   def get_new_issue_properties(self, is_security, is_crash):
     """Get the properties to apply to a new issue."""

--- a/src/python/tests/appengine/libs/issue_filer_test.py
+++ b/src/python/tests/appengine/libs/issue_filer_test.py
@@ -73,7 +73,8 @@ CHROMIUM_POLICY = issue_tracker_policy.IssueTrackerPolicy({
     },
     'existing': {
         'labels': ['Stability-%SANITIZER%']
-    }
+    },
+    'unreproducible_component': 'Unreproducible>Component'
 })
 
 OSS_FUZZ_POLICY = issue_tracker_policy.IssueTrackerPolicy({
@@ -489,6 +490,8 @@ class IssueFilerTests(unittest.TestCase):
     self.testcase1.put()
     issue_filer.file_issue(self.testcase1, issue_tracker)
     self.assertIn('Unreproducible', issue_tracker._itm.last_issue.labels)
+    self.assertCountEqual(['Unreproducible>Component'],
+                          issue_tracker._itm.last_issue.components)
 
     self.testcase1.one_time_crasher_flag = False
     self.testcase1.put()


### PR DESCRIPTION
This will be added to issues we file for Testcases that are not
consistently reproducible.

Fixes #2335.