### PR TITLE
Adding hostname to logs and serial numbers for android

### DIFF
--- a/src/python/bot/fuzzers/engine_common.py
+++ b/src/python/bot/fuzzers/engine_common.py
@@ -68,8 +68,7 @@ COMPONENTS_FILE_EXTENSION = '.components'
 METADATA_FILE_EXTENSION = '.issue_metadata'
 
 # Header format for logs.
-LOG_HEADER_FORMAT = (
-    'Command: {command}\n' + 'Bot: {bot}\n' + 'Time ran: {time}\n')
+LOG_HEADER_FORMAT = ('Command: {command}\n' + 'Time ran: {time}\n')
 
 # Number of radamsa mutations.
 RADAMSA_MUTATIONS = 2000
@@ -711,7 +710,7 @@ def unpack_seed_corpus_if_needed(fuzz_target_path,
            (idx, seed_corpus_archive_path))
 
 
-def get_log_header(command, bot_name, time_executed):
+def get_log_header(command, time_executed):
   """Get the log header."""
   return LOG_HEADER_FORMAT.format(
-      command=get_command_quoted(command), bot=bot_name, time=time_executed)
+      command=get_command_quoted(command), time=time_executed)

--- a/src/python/bot/tasks/fuzz_task.py
+++ b/src/python/bot/tasks/fuzz_task.py
@@ -1274,7 +1274,6 @@ def run_engine_fuzzer(engine_impl, target_name, sync_corpus_directory,
 
   # Format logs with header and strategy information.
   log_header = engine_common.get_log_header(result.command,
-                                            environment.get_value('BOT_NAME'),
                                             result.time_executed)
 
   formatted_strategies = engine_common.format_fuzzing_strategies(

--- a/src/python/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/python/tests/core/bot/tasks/fuzz_task_test.py
@@ -1399,6 +1399,7 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
     os.environ['FUZZ_TARGET'] = 'test_target'
     os.environ['APP_REVISION'] = '1'
     os.environ['FUZZ_TEST_TIMEOUT'] = '2000'
+    os.environ['BOT_NAME'] = 'hostname.company.com'
 
     expected_crashes = [engine.Crash('/input', 'stack', ['args'], 1.0)]
 
@@ -1432,9 +1433,9 @@ class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):
     log_time = datetime.datetime(1970, 1, 1, 0, 0)
     log_call = mock.call(
         b'Component revisions (build r1):\n'
-        b'component: rev\n\n'
+        b'component: rev\n\nBot name: hostname.company.com\n'
         b'Return code: 1\n\n'
-        b'Command: cmd\nBot: None\nTime ran: 42.0\n\n'
+        b'Command: cmd\nTime ran: 42.0\n\n'
         b'logs\n'
         b'cf::fuzzing_strategies: strategy_1:1,strategy_2:50', log_time)
     self.mock.upload_log.assert_has_calls([log_call, log_call])

--- a/src/python/tests/core/bot/testcase_manager_test.py
+++ b/src/python/tests/core/bot/testcase_manager_test.py
@@ -116,6 +116,7 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
         '"TestcaseRun", "job": "job", "fuzzer": "fuzzer", '
         '"build_revision": 123}\n')
 
+    environment.set_value('BOT_NAME', 'hostname.company.com')
     crash_result = CrashResult(
         return_code=1, crash_time=5, output='fake output')
 
@@ -128,13 +129,15 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
     self.mock.write_data.assert_called_once_with(
         b'Component revisions (build r123):\n'
         b'Component: REVISION\nComponent2: REVISION2\n\n'
+        b'Bot name: hostname.company.com\n'
         b'Return code: 1\n\nfake output',
         'gs://fake-gcs-logs/fuzzer/job/2016-09-02/19:59:01:017923.log')
 
-  def test_upload_without_timestamp(self):
+  def test_upload_with_hostname(self):
     """Log name should be generated using current (mocked) timestamp value."""
     mock_gsutil = mock.MagicMock()
     self.mock.write_data.return_value = mock_gsutil
+    environment.set_value('BOT_NAME', 'hostname.company.com')
 
     self.fs.create_file(
         self.testcase_path + '.stats2',
@@ -149,6 +152,56 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
     self.mock.write_data.assert_called_once_with(
         b'Component revisions (build r123):\n'
         b'Component: REVISION\nComponent2: REVISION2\n\n'
+        b'Bot name: hostname.company.com\n'
+        b'Return code: None\n\nNo output!',
+        'gs://fake-gcs-logs/fuzzer/job/2017-05-15/16:10:28:374119.log')
+
+  def test_upload_with_hostname_and_serial(self):
+    """Log name should be generated using current (mocked) timestamp value."""
+    mock_gsutil = mock.MagicMock()
+    self.mock.write_data.return_value = mock_gsutil
+    environment.set_value('BOT_NAME', 'hostname.company.com')
+    environment.set_value('OS_OVERRIDE', 'ANDROID_KERNEL')
+    environment.set_value('ANDROID_SERIAL', '123456789')
+
+    self.fs.create_file(
+        self.testcase_path + '.stats2',
+        contents='{"stat": 1000, "kind": "TestcaseRun", "job": "job", '
+        '"fuzzer": "fuzzer", "build_revision": 123}\n')
+
+    crash_result = CrashResult(return_code=None, crash_time=None, output=None)
+    log = testcase_manager.prepare_log_for_upload(crash_result.get_stacktrace(),
+                                                  crash_result.return_code)
+    log_time = testcase_manager._get_testcase_time(self.testcase_path)
+    testcase_manager.upload_log(log, log_time)
+    self.mock.write_data.assert_called_once_with(
+        b'Component revisions (build r123):\n'
+        b'Component: REVISION\nComponent2: REVISION2\n\n'
+        b'Bot name: hostname.company.com\n'
+        b'Device serial: 123456789\n'
+        b'Return code: None\n\nNo output!',
+        'gs://fake-gcs-logs/fuzzer/job/2017-05-15/16:10:28:374119.log')
+
+  def test_upload_without_timestamp(self):
+    """Log name should be generated using current (mocked) timestamp value."""
+    mock_gsutil = mock.MagicMock()
+    self.mock.write_data.return_value = mock_gsutil
+
+    self.fs.create_file(
+        self.testcase_path + '.stats2',
+        contents='{"stat": 1000, "kind": "TestcaseRun", "job": "job", '
+        '"fuzzer": "fuzzer", "build_revision": 123}\n')
+
+    environment.set_value('BOT_NAME', 'hostname.company.com')
+    crash_result = CrashResult(return_code=None, crash_time=None, output=None)
+    log = testcase_manager.prepare_log_for_upload(crash_result.get_stacktrace(),
+                                                  crash_result.return_code)
+    log_time = testcase_manager._get_testcase_time(self.testcase_path)
+    testcase_manager.upload_log(log, log_time)
+    self.mock.write_data.assert_called_once_with(
+        b'Component revisions (build r123):\n'
+        b'Component: REVISION\nComponent2: REVISION2\n\n'
+        b'Bot name: hostname.company.com\n'
         b'Return code: None\n\nNo output!',
         'gs://fake-gcs-logs/fuzzer/job/2017-05-15/16:10:28:374119.log')
 
@@ -165,6 +218,7 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
         '"TestcaseRun", "job": "job", "fuzzer": "fuzzer", '
         '"build_revision": 123}\n')
 
+    environment.set_value('BOT_NAME', 'hostname.company.com')
     crash_result = CrashResult(
         return_code=1, crash_time=5, output='fake output')
     log = testcase_manager.prepare_log_for_upload(crash_result.get_stacktrace(),
@@ -176,6 +230,7 @@ class UploadTestcaseOutputTest(fake_filesystem_unittest.TestCase):
     self.mock.write_data.assert_called_once_with(
         b'Component revisions (build r123):\n'
         b'Not available.\n\n'
+        b'Bot name: hostname.company.com\n'
         b'Return code: 1\n\nfake output',
         'gs://fake-gcs-logs/fuzzer/job/2016-09-02/19:59:01:017923.log')
 
@@ -360,9 +415,8 @@ def mock_get_crash_data(output, symbolize_flag=True):  # pylint: disable=unused-
 class TestcaseRunningTest(fake_filesystem_unittest.TestCase):
   """Tests for running testcases."""
 
-  GREYBOX_FUZZER_NO_CRASH = (
-      'Command: cmd\nBot: bot_name\nTime ran: 0\n\noutput')
-  GREYBOX_FUZZER_CRASH = 'Command: cmd\nBot: bot_name\nTime ran: 1\n\ncrash'
+  GREYBOX_FUZZER_NO_CRASH = ('Command: cmd\nTime ran: 0\n\noutput')
+  GREYBOX_FUZZER_CRASH = 'Command: cmd\nTime ran: 1\n\ncrash'
 
   def setUp(self):
     """Setup for testcase running test."""


### PR DESCRIPTION
In order to help with debugging, this change allows for linking tradefed
logs with use hostname/serial number and clusterfuzz logs.