### PR TITLE
[oss-fuzz] Use flexbox container on OSS-Fuzz home

### DIFF
--- a/src/appengine/private/components/oss-fuzz-home/oss-fuzz-home.html
+++ b/src/appengine/private/components/oss-fuzz-home/oss-fuzz-home.html
@@ -92,8 +92,8 @@
                </if-else>
              </template>
             </div>
-          </template>
-        </paper-card>
+          </paper-card>
+        </template>
       </div>
       </div>
     </template>

--- a/src/appengine/private/components/oss-fuzz-home/oss-fuzz-home.html
+++ b/src/appengine/private/components/oss-fuzz-home/oss-fuzz-home.html
@@ -51,52 +51,52 @@
       }
     </style>
     <div id="flex-container">
-    <paper-card id="welcome" heading="Welcome">
-      <div class="card-content">
-        <p>Welcome to ClusterFuzz, the fuzzing infrastructure behind OSS-Fuzz.
-        Here you can look at crashes, statistics, and coverage information for
-        your fuzzers. Below is an overview of your projects and their fuzzing
-        configurations.</p>
-      </div>
-       <div class="card-actions">
-         <a href="/testcases"><paper-button>All current crashes</paper-button></a>
-         <template is="dom-if" if="[[info.is_internal_user]]">
-           <a href="/fuzzer-stats?fuzzer=libFuzzer&group_by=by-fuzzer"><paper-button>All fuzzer stats</paper-button></a>
-           <a href="/crash-stats"><paper-button>All crash stats</paper-button></a>
-         </template>
-         <a href="https://oss-fuzz-build-logs.storage.googleapis.com/index.html"><paper-button>Builds status</paper-button></a>
-         <a href="https://github.com/google/oss-fuzz"><paper-button>Documentation</paper-button></a>
-         <a href="https://github.com/google/oss-fuzz/issues/new"><paper-button>Report a bug</paper-button></a>
-       </div>
-    </paper-card>
-    <template is="dom-repeat" items="[[info.projects]]" as="project">
-      <div class="project">
-      <h2>[[project.name]]</h2>
-      <div class="project-links">
-        <a href="/testcases?project=[[project.name]]&open=yes"><paper-button raised>Open crashes</paper-button></a>
-        <a href="/crash-stats?project=[[project.name]]"><paper-button raised>Crash stats</paper-button></a>
-        <a href="/coverage-report/job/[[project.coverage_job]]/latest"><paper-button raised>Total coverage</paper-button></a>
-      </div>
-      <div class="layout horizontal wrap">
-        <template is="dom-repeat" items="[[project.jobs]]" as ="job">
-          <paper-card class="target" heading="[[job.name]]">
-            <div class="card-content">
-              <p>Fuzzing engine: [[job.engine_display_name]]</p>
-              <p>[[job.sanitizer_string]]</p>
-            </div>
-            <div class="card-actions">
-             <template is="dom-if" if="{{job.has_stats}}">
-               <if-else condition="[[job.single_target]]">
-                  <a slot="t" href="/fuzzer-stats?project=[[project.name]]&fuzzer=[[job.single_target]]&job=[[job.name]]&group_by=by-day"><paper-button>Fuzzer stats/coverage</paper-button></a>
-                  <a slot="f" href="/fuzzer-stats?project=[[project.name]]&fuzzer=[[job.engine_name]]&job=[[job.name]]&group_by=by-fuzzer"><paper-button>Fuzzer stats/coverage</paper-button></a>
-               </if-else>
-             </template>
-            </div>
-          </paper-card>
-        </template>
-      </div>
-      </div>
-    </template>
+      <paper-card id="welcome" heading="Welcome">
+        <div class="card-content">
+          <p>Welcome to ClusterFuzz, the fuzzing infrastructure behind OSS-Fuzz.
+          Here you can look at crashes, statistics, and coverage information for
+          your fuzzers. Below is an overview of your projects and their fuzzing
+          configurations.</p>
+        </div>
+        <div class="card-actions">
+          <a href="/testcases"><paper-button>All current crashes</paper-button></a>
+          <template is="dom-if" if="[[info.is_internal_user]]">
+            <a href="/fuzzer-stats?fuzzer=libFuzzer&group_by=by-fuzzer"><paper-button>All fuzzer stats</paper-button></a>
+            <a href="/crash-stats"><paper-button>All crash stats</paper-button></a>
+          </template>
+          <a href="https://oss-fuzz-build-logs.storage.googleapis.com/index.html"><paper-button>Builds status</paper-button></a>
+          <a href="https://github.com/google/oss-fuzz"><paper-button>Documentation</paper-button></a>
+          <a href="https://github.com/google/oss-fuzz/issues/new"><paper-button>Report a bug</paper-button></a>
+        </div>
+      </paper-card>
+      <template is="dom-repeat" items="[[info.projects]]" as="project">
+        <div class="project">
+          <h2>[[project.name]]</h2>
+          <div class="project-links">
+            <a href="/testcases?project=[[project.name]]&open=yes"><paper-button raised>Open crashes</paper-button></a>
+            <a href="/crash-stats?project=[[project.name]]"><paper-button raised>Crash stats</paper-button></a>
+            <a href="/coverage-report/job/[[project.coverage_job]]/latest"><paper-button raised>Total coverage</paper-button></a>
+          </div>
+          <div class="layout horizontal wrap">
+            <template is="dom-repeat" items="[[project.jobs]]" as ="job">
+              <paper-card class="target" heading="[[job.name]]">
+                <div class="card-content">
+                  <p>Fuzzing engine: [[job.engine_display_name]]</p>
+                  <p>[[job.sanitizer_string]]</p>
+                </div>
+                <div class="card-actions">
+                  <template is="dom-if" if="{{job.has_stats}}">
+                    <if-else condition="[[job.single_target]]">
+                      <a slot="t" href="/fuzzer-stats?project=[[project.name]]&fuzzer=[[job.single_target]]&job=[[job.name]]&group_by=by-day"><paper-button>Fuzzer stats/coverage</paper-button></a>
+                      <a slot="f" href="/fuzzer-stats?project=[[project.name]]&fuzzer=[[job.engine_name]]&job=[[job.name]]&group_by=by-fuzzer"><paper-button>Fuzzer stats/coverage</paper-button></a>
+                    </if-else>
+                  </template>
+                </div>
+              </paper-card>
+            </template>
+          </div>
+        </div>
+      </template>
     </div>
   </template>
   <script>

--- a/src/appengine/private/components/oss-fuzz-home/oss-fuzz-home.html
+++ b/src/appengine/private/components/oss-fuzz-home/oss-fuzz-home.html
@@ -43,7 +43,14 @@
       :host h2 {
         @apply(--paper-font-headline);
       }
+
+      :host #flex-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+      }
     </style>
+    <div id="flex-container">
     <paper-card id="welcome" heading="Welcome">
       <div class="card-content">
         <p>Welcome to ClusterFuzz, the fuzzing infrastructure behind OSS-Fuzz.
@@ -63,6 +70,7 @@
        </div>
     </paper-card>
     <template is="dom-repeat" items="[[info.projects]]" as="project">
+      <div class="project">
       <h2>[[project.name]]</h2>
       <div class="project-links">
         <a href="/testcases?project=[[project.name]]&open=yes"><paper-button raised>Open crashes</paper-button></a>
@@ -87,7 +95,9 @@
           </template>
         </paper-card>
       </div>
+      </div>
     </template>
+    </div>
   </template>
   <script>
     class OssFuzzHome extends Polymer.Element {


### PR DESCRIPTION
Using a flexbox container for the projects on the OSS-Fuzz home page allows up to three projects to be shown in a row instead of listing them all beneath each other.

Also fixes an instance of incorrect tag nesting and reindents in separate commits to keep the diff clean.

Before:
![before](https://user-images.githubusercontent.com/4312191/119099563-50f24180-ba17-11eb-97e3-f0357438c75e.png)
After:
![after](https://user-images.githubusercontent.com/4312191/119099558-5059ab00-ba17-11eb-9f2b-ff251761aab0.png)
