### PR TITLE
Set FoundIn for impact-head bugs.

### DIFF
--- a/src/appengine/handlers/testcase_list.py
+++ b/src/appengine/handlers/testcase_list.py
@@ -46,6 +46,7 @@ FIELDS = [
     'impact_extended_stable_version',
     'impact_stable_version',
     'impact_beta_version',
+    'impact_head_version',
     'is_impact_set_flag',
 ]
 
@@ -70,6 +71,7 @@ KEYWORD_FILTERS = [
     filters.String('bug_indices', 'issue'),
     filters.String('platform', 'platform'),
     filters.String('impact_extended_stable_version_indices', 'extended_stable'),
+    filters.String('impact_head_version_indices', 'head'),
     filters.String('impact_stable_version_indices', 'stable'),
     filters.String('impact_beta_version_indices', 'beta'),
     filters.String('fuzzer_name_indices', 'fuzzer'),
@@ -145,6 +147,7 @@ def get_result():
             'extendedStable': testcase.impact_extended_stable_version,
             'stable': testcase.impact_stable_version,
             'beta': testcase.impact_beta_version,
+            'head': testcase.impact_head_version,
         },
         'regressionRange': regression_range,
         'fixedRange': fixed_range,

--- a/src/appengine/index.yaml
+++ b/src/appengine/index.yaml
@@ -335,6 +335,7 @@ indexes:
   - name: impact_extended_stable_version
   - name: impact_stable_version
   - name: impact_beta_version
+  - name: impact_head_version
   - name: timestamp
 
 - kind: Testcase
@@ -350,6 +351,7 @@ indexes:
   - name: impact_beta_version
   - name: impact_stable_version
   - name: impact_extended_stable_version
+  - name: impact_head_version
   - name: is_impact_set_flag
   - name: job_type
   - name: one_time_crasher_flag

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -204,7 +204,7 @@ def update_issue_foundin_labels(testcase, issue):
   versions_foundin = [
       x for x in [
           testcase.impact_beta_version, testcase.impact_stable_version,
-          testcase.impact_extended_stable_version
+          testcase.impact_extended_stable_version, testcase.impact_head_version
       ] if x
   ]
   milestones_foundin = {x.split('.')[0] for x in versions_foundin}

--- a/src/appengine/private/components/testcase-detail/testcase-detail.html
+++ b/src/appengine/private/components/testcase-detail/testcase-detail.html
@@ -430,12 +430,6 @@
                                   version="[[info.testcase.impact_beta_version]]"
                                   likely="[[info.testcase.impact_beta_version_likely]]"></impact-button>
                             </template>
-                            <template is="dom-if" if="[[info.testcase.impact_head_version]]">
-                              <impact-button
-                                  release="Head"
-                                  version="[[info.testcase.impact_head_version]]"
-                                  likely="[[info.testcase.impact_head_version_likely]]"></impact-button>
-                            </template>
                           </span>
                           <span slot="f">Head</span>
                         </if-else>

--- a/src/appengine/private/components/testcase-detail/testcase-detail.html
+++ b/src/appengine/private/components/testcase-detail/testcase-detail.html
@@ -430,6 +430,12 @@
                                   version="[[info.testcase.impact_beta_version]]"
                                   likely="[[info.testcase.impact_beta_version_likely]]"></impact-button>
                             </template>
+                            <template is="dom-if" if="[[info.testcase.impact_head_version]]">
+                              <impact-button
+                                  release="Head"
+                                  version="[[info.testcase.impact_head_version]]"
+                                  likely="[[info.testcase.impact_head_version_likely]]"></impact-button>
+                            </template>
                           </span>
                           <span slot="f">Head</span>
                         </if-else>

--- a/src/python/bot/tasks/impact_task.py
+++ b/src/python/bot/tasks/impact_task.py
@@ -247,7 +247,7 @@ def get_impacts_on_prod_builds(testcase, testcase_file_path):
   # Always record the affected head version.
   start_revision, end_revision = get_start_and_end_revision(
       testcase.regression, testcase.job_type)
-  build_revision_mappings = revisions.get_build_to_revision_mappings(None)
+  build_revision_mappings = revisions.get_build_to_revision_mappings()
   impacts.head = get_head_impact(build_revision_mappings, start_revision,
                                  end_revision)
 

--- a/src/python/bot/tasks/impact_task.py
+++ b/src/python/bot/tasks/impact_task.py
@@ -56,22 +56,25 @@ class Impact(object):
 class Impacts(object):
   """Represents extended stable, stable and beta impacts."""
 
-  def __init__(self, stable=None, beta=None, extended_stable=None):
+  def __init__(self, stable=None, beta=None, extended_stable=None, head=None):
     self.stable = stable or Impact()
     self.beta = beta or Impact()
     self.extended_stable = extended_stable or Impact()
+    self.head = head or Impact()
 
   def is_empty(self):
     return (self.extended_stable.is_empty() and self.stable.is_empty() and
-            self.beta.is_empty())
+            self.beta.is_empty() and self.head.is_empty())
 
   def get_extra_trace(self):
-    return (self.extended_stable.extra_trace + '\n' + self.stable.extra_trace +
-            '\n' + self.beta.extra_trace).strip()
+    return (
+        self.extended_stable.extra_trace + '\n' + self.stable.extra_trace + '\n'
+        + self.beta.extra_trace + '\n' + self.head.extra_trace).strip()
 
   def __eq__(self, other):
     return (self.extended_stable == other.extended_stable and
-            self.stable == other.stable and self.beta == other.beta)
+            self.stable == other.stable and self.beta == other.beta and
+            self.head == other.head)
 
 
 def get_chromium_component_start_and_end_revision(start_revision, end_revision,
@@ -135,12 +138,16 @@ def get_component_impacts_from_url(component_name,
     return Impacts()
 
   found_impacts = dict()
-  for build in ['extended_stable', 'stable', 'beta']:
+  for build in ['extended_stable', 'stable', 'beta', 'canary']:
     mapping = build_revision_mappings.get(build)
     # TODO(yuanjunh): bypass for now but remove it after ES is enabled.
     if build == 'extended_stable' and not mapping:
       found_impacts[build] = Impact()
       continue
+    # Some platforms don't have canary, so use dev to represent
+    # the affected head version.
+    if build == 'canary' and not mapping:
+      mapping = build_revision_mappings.get('dev')
     if not mapping:
       return Impacts()
     chromium_revision = mapping['revision']
@@ -158,7 +165,7 @@ def get_component_impacts_from_url(component_name,
     }, start_revision, end_revision)
     found_impacts[build] = impact
   return Impacts(found_impacts['stable'], found_impacts['beta'],
-                 found_impacts['extended_stable'])
+                 found_impacts['extended_stable'], found_impacts['canary'])
 
 
 def get_impacts_from_url(regression_range, job_type, platform=None):
@@ -184,8 +191,9 @@ def get_impacts_from_url(regression_range, job_type, platform=None):
       build_revision_mappings.get('stable'), start_revision, end_revision)
   beta = get_impact(
       build_revision_mappings.get('beta'), start_revision, end_revision)
+  head = get_head_impact(build_revision_mappings, start_revision, end_revision)
 
-  return Impacts(stable, beta, extended_stable)
+  return Impacts(stable, beta, extended_stable, head)
 
 
 def get_impact(build_revision, start_revision, end_revision):
@@ -236,7 +244,22 @@ def get_impacts_on_prod_builds(testcase, testcase_file_path):
     # TODO(yuanjunh): undo the exception bypass for ES.
     logs.log_warn('Caught errors in getting impact on extended stable: %s' % e)
 
+  # Always record the affected head version.
+  start_revision, end_revision = get_start_and_end_revision(
+      testcase.regression, testcase.job_type)
+  build_revision_mappings = revisions.get_build_to_revision_mappings(None)
+  impacts.head = get_head_impact(build_revision_mappings, start_revision,
+                                 end_revision)
+
   return impacts
+
+
+def get_head_impact(build_revision_mappings, start_revision, end_revision):
+  """Return the impact on 'head', i.e. the latest build we can find."""
+  latest_build = build_revision_mappings.get('canary')
+  if latest_build is None:
+    latest_build = build_revision_mappings.get('dev')
+  return get_impact(latest_build, start_revision, end_revision)
 
 
 def get_impact_on_build(build_type, current_version, testcase,
@@ -292,6 +315,8 @@ def set_testcase_with_impacts(testcase, impacts):
   testcase.impact_stable_version_likely = impacts.stable.likely
   testcase.impact_beta_version = impacts.beta.version
   testcase.impact_beta_version_likely = impacts.beta.likely
+  testcase.impact_head_version = impacts.head.version
+  testcase.impact_head_version_likely = impacts.head.likely
   testcase.is_impact_set_flag = True
 
 

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -550,6 +550,15 @@ class Testcase(Model):
   # comment on impact_stable_version_likely.
   impact_beta_version_likely = ndb.BooleanProperty()
 
+  # The impacted 'head' version
+  impact_head_version = ndb.StringProperty()
+
+  # The impacted head version indices.
+  impact_head_version_indices = ndb.StringProperty(repeated=True)
+
+  # The impacted head version is likely.
+  impact_head_version_likely = ndb.BooleanProperty()
+
   # Whether or not impact task has been run on this testcase.
   is_impact_set_flag = ndb.BooleanProperty()
 
@@ -600,9 +609,12 @@ class Testcase(Model):
           search_tokenizer.tokenize_impact_version(self.impact_stable_version))
       self.impact_beta_version_indices = (
           search_tokenizer.tokenize_impact_version(self.impact_beta_version))
+      self.impact_head_version_indices = (
+          search_tokenizer.tokenize_impact_version(self.impact_head_version))
       self.impact_version_indices = list(
           set(self.impact_extended_stable_version_indices +
               self.impact_stable_version_indices +
+              self.impact_head_version_indices +
               self.impact_beta_version_indices))
       if self.impact_extended_stable_version:
         self.impact_version_indices.append('extended_stable')


### PR DESCRIPTION
Previously ClusterFuzz recorded FoundIn labels for Chromium
bugs which impacted stable or beta. If a bug was found to impact
only Head, no FoundIn label was recorded.

With this change, we now add a FoundIn label for such situations
which makes for easier downstream triage and handling of such
security bugs.

Most of this consists of recording an extra build number in the
Impacts section of each test case.

The Impact task explicitly checks for reproducibility against
Stable and Beta builds. This change doesn't alter anything
there - we don't test against any additional builds because
ClusterFuzz always already reproduces things against the
head revision.

Instead, we just record the known dev/canary build within the
Impact structure such that we can later rely on it when filing
the issue.

Bug: 1222484