### PR TITLE
Fix bot_run_timed_out.

### DIFF
--- a/src/python/bot/startup/run.py
+++ b/src/python/bot/startup/run.py
@@ -20,6 +20,7 @@ from python.base import modules
 modules.fix_module_search_paths()
 
 import atexit
+import datetime
 import os
 import subprocess
 import time
@@ -99,7 +100,7 @@ def start_heartbeat(heartbeat_command):
 
   try:
     command = shell.get_command(heartbeat_command)
-    process_handle = subprocess.Popen(command)
+    process_handle = subprocess.Popen(command)  # pylint: disable=consider-using-with
   except Exception:
     logs.log_error(
         'Unable to start heartbeat process (%s).' % heartbeat_command)
@@ -163,6 +164,11 @@ def run_loop(bot_command, heartbeat_command):
     sleep(LOOP_SLEEP_INTERVAL)
 
 
+def set_start_time():
+  """Set START_TIME."""
+  environment.set_value('START_TIME', datetime.datetime.utcnow().timestamp())
+
+
 def main():
   root_directory = environment.get_value('ROOT_DIR')
   if not root_directory:
@@ -171,6 +177,7 @@ def main():
     print('For an example, check init.bash in the local directory.')
     return
 
+  set_start_time()
   environment.set_bot_environment()
   persistent_cache.initialize()
   logs.configure('run')

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -580,9 +580,8 @@ def get_stacktrace(testcase, stack_attribute='crash_stacktrace'):
   blobs.read_blob_to_disk(key, tmp_stacktrace_file)
 
   try:
-    handle = open(tmp_stacktrace_file)
-    result = handle.read()
-    handle.close()
+    with open(tmp_stacktrace_file) as handle:
+      result = handle.read()
   except:
     logs.log_error(
         'Unable to read stacktrace for testcase %d.' % testcase.key.id())
@@ -1098,19 +1097,17 @@ def bot_run_timed_out():
   if not run_timeout:
     return False
 
-  # Check that we have a valid start time from our heartbeat.
-  bot_name = environment.get_value('BOT_NAME')
-  heartbeat = data_types.Heartbeat.query(
-      data_types.Heartbeat.bot_name == bot_name).get()
-  if not heartbeat or not heartbeat.last_beat_time:
+  start_time = environment.get_value('START_TIME')
+  if not start_time:
     return False
+
+  start_time = datetime.datetime.utcfromtimestamp(start_time)
 
   # Actual run timeout takes off the duration for one task.
   average_task_duration = environment.get_value('AVERAGE_TASK_DURATION', 0)
   actual_run_timeout = run_timeout - average_task_duration
 
-  return dates.time_has_expired(
-      heartbeat.last_beat_time, seconds=actual_run_timeout)
+  return dates.time_has_expired(start_time, seconds=actual_run_timeout)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Set START_TIME env var at start of run_bot.py instead of relying on
Heartbeat, which doesn't track the actual start time.