### PR TITLE
Fix timestamp to datetime conversion in bot_run_timed_out.

### DIFF
--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -1101,7 +1101,7 @@ def bot_run_timed_out():
   if not start_time:
     return False
 
-  start_time = datetime.datetime.utcfromtimestamp(start_time)
+  start_time = datetime.datetime.fromtimestamp(start_time)
 
   # Actual run timeout takes off the duration for one task.
   average_task_duration = environment.get_value('AVERAGE_TASK_DURATION', 0)


### PR DESCRIPTION
This broke as part of the Python 3 migration, which has the following
behaviour:

>>> d = datetime.datetime.utcnow()
>>> ts = d.timestamp()
>>> d2 = datetime.datetime.utcfromtimestamp(ts)
>>> d == d2
False  # ???

utcfromtimestamp() is incorrect and actually converts the datetime to
the local time.