### PR TITLE
More datetime fixes.

### DIFF
--- a/src/python/bot/startup/run.py
+++ b/src/python/bot/startup/run.py
@@ -20,7 +20,6 @@ from python.base import modules
 modules.fix_module_search_paths()
 
 import atexit
-import datetime
 import os
 import subprocess
 import time

--- a/src/python/bot/startup/run.py
+++ b/src/python/bot/startup/run.py
@@ -166,7 +166,7 @@ def run_loop(bot_command, heartbeat_command):
 
 def set_start_time():
   """Set START_TIME."""
-  environment.set_value('START_TIME', datetime.datetime.utcnow().timestamp())
+  environment.set_value('START_TIME', time.time())
 
 
 def main():

--- a/src/python/datastore/data_handler.py
+++ b/src/python/datastore/data_handler.py
@@ -1101,7 +1101,7 @@ def bot_run_timed_out():
   if not start_time:
     return False
 
-  start_time = datetime.datetime.fromtimestamp(start_time)
+  start_time = datetime.datetime.utcfromtimestamp(start_time)
 
   # Actual run timeout takes off the duration for one task.
   average_task_duration = environment.get_value('AVERAGE_TASK_DURATION', 0)


### PR DESCRIPTION
Use time.time() instead of datetime.datetime.utcnow().timestamp()
which causes issues depending on the timezone.

This causes issues because the timezone changes after we call
environment.set_bot_environment().