### PR TITLE
Disable --coverfile flag in Syzkaller for Cuttlefish

### DIFF
--- a/src/python/bot/fuzzers/syzkaller/engine.py
+++ b/src/python/bot/fuzzers/syzkaller/engine.py
@@ -152,7 +152,8 @@ class SyzkallerEngine(engine.Engine):
 
     args = options.arguments
 
-    # TODO(yanghuiz): Dump coverfile from Syzkaller HTTP endpoint and remove this.
+    # TODO(yanghuiz): Dump coverfile from Syzkaller HTTP endpoint and
+    # remove this.
     if not environment.is_android_cuttlefish():
       args += ['--coverfile', runner.get_cover_file_path()]
 

--- a/src/python/bot/fuzzers/syzkaller/engine.py
+++ b/src/python/bot/fuzzers/syzkaller/engine.py
@@ -40,7 +40,7 @@ class SyzkallerOptions(engine.FuzzOptions):
 
   def __init__(self, corpus_dir, arguments, strategies, fuzz_corpus_dirs,
                extra_env):
-    super(SyzkallerOptions, self).__init__(corpus_dir, arguments, strategies)
+    super().__init__(corpus_dir, arguments, strategies)
     self.fuzz_corpus_dirs = fuzz_corpus_dirs
     self.extra_env = extra_env
 

--- a/src/python/bot/fuzzers/syzkaller/engine.py
+++ b/src/python/bot/fuzzers/syzkaller/engine.py
@@ -151,7 +151,8 @@ class SyzkallerEngine(engine.Engine):
     self._create_temp_corpus_dir('new')
 
     args = options.arguments
-    args += ['--coverfile', runner.get_cover_file_path()]
+    if not environment.is_android_cuttlefish():
+      args += ['--coverfile', runner.get_cover_file_path()]
 
     self.init_corpus(options.corpus_dir, runner.get_work_dir())
     fuzz_result = syzkaller_runner.fuzz(max_time, additional_args=args)

--- a/src/python/bot/fuzzers/syzkaller/engine.py
+++ b/src/python/bot/fuzzers/syzkaller/engine.py
@@ -151,6 +151,8 @@ class SyzkallerEngine(engine.Engine):
     self._create_temp_corpus_dir('new')
 
     args = options.arguments
+
+    # TODO(yanghuiz): Dump coverfile from Syzkaller HTTP endpoint and remove this.
     if not environment.is_android_cuttlefish():
       args += ['--coverfile', runner.get_cover_file_path()]
 


### PR DESCRIPTION
Syzkaller doesn't support --coverfile flag anymore, disable for Cuttlefish because physical devices are still using the old Syzkaller binaries.