### PR TITLE
Change the way to restart Cuttlefish and reconnect to adb after relaunch

### DIFF
--- a/src/python/bot/init_scripts/android.py
+++ b/src/python/bot/init_scripts/android.py
@@ -15,10 +15,9 @@
 
 from bot.init_scripts import init_runner
 from platforms import android
-from platforms.android import adb
 from system import environment
 
-TIME_SINCE_REBOOT_MIN_THRESHOLD = 10 * 60  # 10 minutes.
+TIME_SINCE_REBOOT_MIN_THRESHOLD = 30 * 60  # 30 minutes.
 
 
 def run():
@@ -27,14 +26,14 @@ def run():
 
   # Set cuttlefish device serial if needed.
   if environment.is_android_cuttlefish():
-    adb.set_cuttlefish_device_serial()
+    android.adb.set_cuttlefish_device_serial()
 
   # Check if we need to reflash device to latest build.
   android.flash.flash_to_latest_build_if_needed()
 
   # Reconnect to cuttlefish device if connection is ever lost.
   if environment.is_android_cuttlefish():
-    adb.connect_to_cuttlefish_device()
+    android.adb.connect_to_cuttlefish_device()
 
   # Reboot to bring device in a good state if not done recently.
   if android.adb.time_since_last_reboot() > TIME_SINCE_REBOOT_MIN_THRESHOLD:

--- a/src/python/build_management/build_manager.py
+++ b/src/python/build_management/build_manager.py
@@ -903,6 +903,7 @@ class CuttlefishKernelBuild(RegularBuild):
       adb.copy_to_cuttlefish(image_src, image_dest)
 
     adb.start_cuttlefish_device(use_kernel=True)
+    adb.connect_to_cuttlefish_device()
 
     return True
 

--- a/src/python/platforms/android/adb.py
+++ b/src/python/platforms/android/adb.py
@@ -392,6 +392,15 @@ def stop_cuttlefish_device():
   time.sleep(STOP_CVD_WAIT)
 
 
+def restart_cuttlefish_device():
+  """Restarts the cuttlefish device."""
+  cvd_dir = environment.get_value('CVD_DIR')
+  cvd_bin_dir = os.path.join(cvd_dir, 'bin')
+  restart_cvd_cmd = os.path.join(cvd_bin_dir, 'restart_cvd')
+
+  execute_command(restart_cvd_cmd, on_cuttlefish_host=True)
+
+
 def recreate_cuttlefish_device():
   """Recreate cuttlefish device, restoring from backup images."""
   logs.log('Reimaging cuttlefish device.')
@@ -439,8 +448,7 @@ def reset_device_connection():
   """Reset the connection to the physical device through USB. Returns whether
   or not the reset succeeded."""
   if environment.is_android_cuttlefish():
-    stop_cuttlefish_device()
-    start_cuttlefish_device()
+    restart_cuttlefish_device()
   else:
     # Physical device. Try restarting usb.
     reset_usb()


### PR DESCRIPTION
1. Increase the Cuttlefish reboot threshold because launch process may take more than 10 min
2. Use restart_cvd tool to restart Cuttlefish
3. Reconnect to Cuttlefish device after relaunch with kernel build because the previous connection will be lost