### PR TITLE
Add missing OpenJDK dependency

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -68,6 +68,8 @@ RUN cd /tmp && \
     mkdir -p $JAVA_HOME && \
     tar -xzv --strip-components=1 -f openjdk-15.0.2_linux-x64_bin.tar.gz --directory $JAVA_HOME && \
     rm -rf openjdk*.tar.gz $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
+# Install Java AWT dependencies.
+RUN apt-get install libxext-dev -y
 
 # Install Python 3.
 RUN curl -sS https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz | tar -C /tmp -xzv && \


### PR DESCRIPTION
The library `libXext.so` is required by some Java AWT classes even in headless environments. Without this library, fuzz targets that perform non-trivial image operations fail with an `UnsatisfiedLinkError` (see e.g. https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33489).