### PR TITLE
Impact: mark latest milestone if code too recent.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/impact_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/impact_task.py
@@ -40,15 +40,10 @@ class AppFailedException(Exception):
 class Impact(object):
   """Represents impact on a build type."""
 
-  def __init__(self,
-               version='',
-               likely=False,
-               extra_trace='',
-               milestone_only=False):
+  def __init__(self, version='', likely=False, extra_trace=''):
     self.version = str(version)
     self.likely = likely
     self.extra_trace = extra_trace
-    self.milestone_only = milestone_only
 
   def is_empty(self):
     """Return True if empty."""
@@ -56,8 +51,7 @@ class Impact(object):
 
   def __eq__(self, other):
     return (self.version == other.version and self.likely == other.likely and
-            self.extra_trace == other.extra_trace and
-            self.milestone_only == other.milestone_only)
+            self.extra_trace == other.extra_trace)
 
 
 class Impacts(object):
@@ -227,7 +221,7 @@ def get_impact(build_revision,
       # impacts the milestone. We can't be sure, because the next build
       # might happen to gain a new milestone number, but it's unlikely.
       milestone = version.split('.')[0]
-      return Impact(milestone, likely=True, milestone_only=True)
+      return Impact(milestone, likely=True)
     return Impact()
 
   if end_revision < revision:
@@ -277,7 +271,8 @@ def get_head_impact(build_revision_mappings, start_revision, end_revision):
   latest_build = build_revision_mappings.get('canary')
   if latest_build is None:
     latest_build = build_revision_mappings.get('dev')
-  return get_impact(latest_build, start_revision, end_revision, True)
+  return get_impact(
+      latest_build, start_revision, end_revision, is_last_possible_build=True)
 
 
 def get_impact_on_build(build_type, current_version, testcase,

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
@@ -663,7 +663,6 @@ class GetImpactTest(unittest.TestCase):
     }, 31, 32, True)
     self.assertEqual('50', impact.version)
     self.assertTrue(impact.likely)
-    self.assertTrue(impact.milestone_only)
     self.assertEqual('', impact.extra_trace)
 
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
@@ -395,7 +395,7 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
         mock.call({
             'version': '76.0.1234.43',
             'revision': '400000'
-        }, 1, 100)
+        }, 1, 100, True)
     ])
 
   def test_get_impacts_canary_not_exists(self):
@@ -456,7 +456,7 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
         mock.call({
             'version': '76.0.1234.43',
             'revision': '400000'
-        }, 1, 100)
+        }, 1, 100, True)
     ])
 
   def test_get_impacts_known_component_es_not_exists(self):
@@ -485,15 +485,15 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
         mock.call({
             'version': '74.0.1345.34',
             'revision': '666666'
-        }, 1, 100),
+        }, 1, 100, False),
         mock.call({
             'version': '75.0.1353.43',
             'revision': '888888'
-        }, 1, 100),
+        }, 1, 100, False),
         mock.call({
             'version': '76.0.1234.43',
             'revision': '888888'
-        }, 1, 100)
+        }, 1, 100, True)
     ])
 
   def test_get_impacts_known_component_es_exists(self):
@@ -543,15 +543,15 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
         mock.call({
             'version': '74.0.1345.34',
             'revision': '666666'
-        }, 1, 100),
+        }, 1, 100, False),
         mock.call({
             'version': '75.0.1353.43',
             'revision': '888888'
-        }, 1, 100),
+        }, 1, 100, False),
         mock.call({
             'version': '76.0.1234.43',
             'revision': '888888'
-        }, 1, 100)
+        }, 1, 100, True)
     ])
 
   def test_get_impacts_known_component_es_exists_canary_not_exists(self):
@@ -601,15 +601,15 @@ class GetImpactsFromUrlTest(ComponentRevisionPatchingTest):
         mock.call({
             'version': '74.0.1345.34',
             'revision': '666666'
-        }, 1, 100),
+        }, 1, 100, False),
         mock.call({
             'version': '75.0.1353.43',
             'revision': '888888'
-        }, 1, 100),
+        }, 1, 100, False),
         mock.call({
             'version': '76.0.1234.43',
             'revision': '888888'
-        }, 1, 100)
+        }, 1, 100, True)
     ])
 
 
@@ -632,7 +632,8 @@ class GetImpactTest(unittest.TestCase):
       revision."""
     self.assertTrue(
         impact_task.get_impact({
-            'revision': '10'
+            'revision': '10',
+            'version': '50'
         }, 20, 100).is_empty())
 
   def test_get_impact(self):
@@ -647,6 +648,22 @@ class GetImpactTest(unittest.TestCase):
     impact = impact_task.get_impact({'revision': '30', 'version': '50'}, 20, 31)
     self.assertEqual('50', impact.version)
     self.assertTrue(impact.likely)
+    self.assertEqual('', impact.extra_trace)
+
+  def test_get_beyond_build(self):
+    """Test if the regression range is beyond the version."""
+    impact = impact_task.get_impact({'revision': '30', 'version': '50'}, 31, 32)
+    self.assertTrue(impact.is_empty())
+
+  def test_get_beyond_build_if_final(self):
+    """Test getting likely version."""
+    impact = impact_task.get_impact({
+        'revision': '30',
+        'version': '50.1.2.3'
+    }, 31, 32, True)
+    self.assertEqual('50', impact.version)
+    self.assertTrue(impact.likely)
+    self.assertTrue(impact.milestone_only)
     self.assertEqual('', impact.extra_trace)
 
 


### PR DESCRIPTION
Previously, ClusterFuzz sometimes bisected regression revisions to
versions more recent than *any* available build.

For Chromium builds, this resulted in issue_filer.py being unable
to apply a FoundIn label to the bugs it created, since the test was
not actually found in any specific build. This was completely
reasonable behavior, but was unhelpful for downstream Chromium
processes such as merging, noting regressions, crediting
reporters etc.

With this change, ClusterFuzz records a 'head' impact for the
overall milestone (e.g. '50') even if it can't be sure that
it impacts a specific build (e.g. '50.1.2.3'). This will enable
ClusterFuzz to add suitable FoundIn labels to bugs it files in
this circumstance.

Bug: https://crbug.com/1230588
Change-Id: Ib63e963fe5a4e24e548240fe2b7c06a02545dd5c