### PR TITLE
Fully enable linux ES check in impact calculation flow

### DIFF
--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -165,8 +165,7 @@ def update_issue_impact_labels(testcase, issue):
   if testcase.regression.startswith('0:'):
     # If the regression range starts from the start of time,
     # then we assume that the bug impacts stable.
-    # TODO(yuanjunh): change to extended stable label when it's fully supported.
-    new_impact = data_types.SecurityImpact.STABLE
+    new_impact = data_types.SecurityImpact.EXTENDED_STABLE
   elif testcase.is_impact_set_flag:
     # Add impact label based on testcase's impact value.
     if testcase.impact_extended_stable_version:

--- a/src/clusterfuzz/_internal/bot/tasks/impact_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/impact_task.py
@@ -25,7 +25,6 @@ from clusterfuzz._internal.build_management import revisions
 from clusterfuzz._internal.chrome import build_info
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
-from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/impact_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/impact_task.py
@@ -277,10 +277,6 @@ def get_head_impact(build_revision_mappings, start_revision, end_revision):
 def get_impact_on_build(build_type, current_version, testcase,
                         testcase_file_path):
   """Return impact and additional trace on a prod build given build_type."""
-  # TODO(yuanjunh): remove es_enabled var after testing is done.
-  es_enabled = testcase.get_metadata('es_enabled', False)
-  if build_type == 'extended_stable' and not es_enabled:
-    return Impact()
   build = build_manager.setup_production_build(build_type)
   if not build:
     raise BuildFailedException(
@@ -296,10 +292,6 @@ def get_impact_on_build(build_type, current_version, testcase,
   app_path = environment.get_value('APP_PATH')
   command = testcase_manager.get_command_line_for_application(
       testcase_file_path, app_path=app_path, needs_http=testcase.http_flag)
-
-  if es_enabled and build_type == 'extended_stable':
-    logs.log(
-        "ES build for testcase %d, command: %s" % (testcase.key.id(), command))
 
   result = testcase_manager.test_for_crash_with_retries(
       testcase,

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1491,13 +1491,10 @@ def setup_custom_binary(target_weights=None):
 
 def setup_production_build(build_type):
   """Sets up build with a particular revision."""
-  # Bail out if there are not stable and beta build urls.
+  # Bail out if there are not extended stable, stable and beta build urls.
   if build_type == 'extended_stable':
     build_bucket_path = environment.get_value(
         'EXTENDED_STABLE_BUILD_BUCKET_PATH')
-    # TODO(yuanjunh): remove it after ES exists.
-    if not build_bucket_path:
-      return None
   elif build_type == 'stable':
     build_bucket_path = environment.get_value('STABLE_BUILD_BUCKET_PATH')
   elif build_type == 'beta':
@@ -1587,10 +1584,12 @@ def is_custom_binary():
 
 
 def has_production_builds():
-  """Return a bool on if job type has build urls for stable and beta builds."""
-  # TODO(yuanjunh): change it if after ES exists.
+  """Return a bool on if job type has build urls for extended stable, stable and
+  beta builds."""
   return (environment.get_value('STABLE_BUILD_BUCKET_PATH') and
-          environment.get_value('BETA_BUILD_BUCKET_PATH'))
+          environment.get_value('BETA_BUILD_BUCKET_PATH') and
+          environment.get_value('EXTENDED_STABLE_BUILD_BUCKET_PATH'))
+
 
 
 def has_symbolized_builds():

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -509,7 +509,7 @@ class Build(BaseBuild):
       # For fuzzing, pick a random fuzz target so that we only un-archive that
       # particular fuzz target and its dependencies and save disk space.  If we
       # are going to unpack everythng in archive based on
-      # |UNPACK_ALL_FUZZ_TARGETS_AND_FILES| in the job definition, then don't set
+      # UNPACK_ALL_FUZZ_TARGETS_AND_FILES in the job definition, then don't set
       # a random fuzz target before we've unpacked the build. It won't actually
       # save us anything in this case and can be really expensive for large
       # builds (such as Chrome OS). Defer setting it until after the build has
@@ -1589,7 +1589,6 @@ def has_production_builds():
   return (environment.get_value('STABLE_BUILD_BUCKET_PATH') and
           environment.get_value('BETA_BUILD_BUCKET_PATH') and
           environment.get_value('EXTENDED_STABLE_BUILD_BUCKET_PATH'))
-
 
 
 def has_symbolized_builds():

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -648,7 +648,7 @@ class UpdateImpactTest(unittest.TestCase):
     mock_issue = self._make_mock_issue()
 
     issue_filer.update_issue_impact_labels(self.testcase, mock_issue)
-    six.assertCountEqual(self, ['Security_Impact-Stable'],
+    six.assertCountEqual(self, ['Security_Impact-Extended'],
                          mock_issue.labels.added)
     six.assertCountEqual(self, [], mock_issue.labels.removed)
 


### PR DESCRIPTION
Fully enable linux ES checking in impact task instead of only for the testcases which have `es_enabled` metadata