### PR TITLE
Disable fuzzing strategies for libClusterFuzz.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/engine.py
@@ -54,7 +54,12 @@ class AFLEngine(engine.Engine):
     afl_config = launcher.AflConfig.from_target_path(target_path)
     arguments = afl_config.additional_afl_arguments
     # TODO(mbarbella): Select all strategies here instead of deferring to fuzz.
-    strategies = launcher.FuzzingStrategies(target_path).to_strategy_dict()
+
+    if self.do_strategies:
+      strategies = launcher.FuzzingStrategies(target_path).to_strategy_dict()
+    else:
+      strategies = {}
+
     return engine.FuzzOptions(corpus_dir, arguments, strategies)
 
   def fuzz(self, target_path, options, reproducers_dir, max_time):

--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
@@ -291,7 +291,7 @@ class FuzzingStrategies(object):
 
     # If we have already generated a strategy dict, use that in favor of
     # creating a new pool and picking randomly.
-    if strategy_dict:
+    if strategy_dict is not None:
       self.use_corpus_subset = 'corpus_subset' in strategy_dict
       if self.use_corpus_subset:
         self.corpus_subset_size = strategy_dict['corpus_subset']

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -109,10 +109,15 @@ class LibFuzzerEngine(engine.Engine):
     del build_dir
     arguments = fuzzer.get_arguments(target_path)
     grammar = fuzzer.get_grammar(target_path)
-    strategy_pool = strategy_selection.generate_weighted_strategy_pool(
-        strategy_list=strategy.LIBFUZZER_STRATEGY_LIST,
-        use_generator=True,
-        engine_name=self.name)
+
+    if self.do_strategies:
+      strategy_pool = strategy_selection.generate_weighted_strategy_pool(
+          strategy_list=strategy.LIBFUZZER_STRATEGY_LIST,
+          use_generator=True,
+          engine_name=self.name)
+    else:
+      strategy_pool = strategy_selection.StrategyPool()
+
     strategy_info = libfuzzer.pick_strategies(strategy_pool, target_path,
                                               corpus_dir, arguments, grammar)
 

--- a/src/clusterfuzz/fuzz/__init__.py
+++ b/src/clusterfuzz/fuzz/__init__.py
@@ -42,7 +42,9 @@ def get_engine(name):
   if not _initialized:
     _initialize()
 
-  return engine.get(name)
+  engine_impl = engine.get(name)
+  engine_impl.do_strategies = False
+  return engine_impl
 
 
 def is_fuzz_target(file_path, file_handle=None):

--- a/src/clusterfuzz/fuzz/__main__.py
+++ b/src/clusterfuzz/fuzz/__main__.py
@@ -60,6 +60,7 @@ def main():
   os.environ['BUILD_DIR'] = os.path.dirname(args.target)
 
   engine_impl = clusterfuzz.fuzz.get_engine(args.engine)
+  engine_impl.do_strategies = False
   options = engine_impl.prepare(args.corpus, args.target,
                                 os.path.dirname(args.target))
   result = engine_impl.fuzz(args.target, options, args.output,

--- a/src/clusterfuzz/fuzz/__main__.py
+++ b/src/clusterfuzz/fuzz/__main__.py
@@ -60,7 +60,6 @@ def main():
   os.environ['BUILD_DIR'] = os.path.dirname(args.target)
 
   engine_impl = clusterfuzz.fuzz.get_engine(args.engine)
-  engine_impl.do_strategies = False
   options = engine_impl.prepare(args.corpus, args.target,
                                 os.path.dirname(args.target))
   result = engine_impl.fuzz(args.target, options, args.output,

--- a/src/clusterfuzz/fuzz/engine.py
+++ b/src/clusterfuzz/fuzz/engine.py
@@ -65,6 +65,9 @@ class ReproduceResult(object):
 class Engine(object):
   """Base interface for a grey box fuzzing engine."""
 
+  def __init__(self):
+    self.do_strategies = True
+
   @property
   def name(self):
     """Get the name of the engine."""


### PR DESCRIPTION
Current strategies can be problematic (e.g. running external mutators).

For: #2400