### PR TITLE
Retrieve syzkaller rawcover every interval

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/syzkaller/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/syzkaller/engine.py
@@ -152,11 +152,6 @@ class SyzkallerEngine(engine.Engine):
 
     args = options.arguments
 
-    # TODO(yanghuiz): Dump coverfile from Syzkaller HTTP endpoint and
-    # remove this.
-    if not environment.is_android_cuttlefish():
-      args += ['--coverfile', runner.get_cover_file_path()]
-
     self.init_corpus(options.corpus_dir, runner.get_work_dir())
     fuzz_result = syzkaller_runner.fuzz(max_time, additional_args=args)
     self.save_corpus(runner.get_work_dir(), options.corpus_dir)

--- a/src/clusterfuzz/_internal/bot/fuzzers/syzkaller/runner.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/syzkaller/runner.py
@@ -43,8 +43,7 @@ def get_work_dir():
   work_dir = os.path.join(
       environment.get_value('FUZZ_INPUTS_DISK'), 'syzkaller')
 
-  if not os.path.exists(work_dir):
-    os.mkdir(work_dir)
+  os.makedirs(work_dir, exist_ok=True)
 
   return work_dir
 
@@ -83,8 +82,6 @@ def get_config():
 def get_cover_file_path():
   """Return location of coverage file for Syzkaller."""
   file_path = os.path.join(get_work_dir(), 'coverfile')
-  if not os.path.isfile(file_path):
-    open(file_path, 'w+').close()
 
   logs.log(f'Rawcover file will be stored in {file_path}')
   return file_path

--- a/src/clusterfuzz/_internal/system/new_process.py
+++ b/src/clusterfuzz/_internal/system/new_process.py
@@ -50,11 +50,11 @@ def _end_process(terminate_function, process_result):
   process_result.timed_out = True
 
 
-def _wait_process(process,
-                  timeout,
-                  input_data=None,
-                  terminate_before_kill=False,
-                  terminate_wait_time=None):
+def wait_process(process,
+                 timeout,
+                 input_data=None,
+                 terminate_before_kill=False,
+                 terminate_wait_time=None):
   """Waits until either the process exits or times out.
 
   Args:
@@ -388,7 +388,7 @@ class ProcessRunner(object):
       return ProcessResult(process.command, process.poll(), output,
                            time.time() - start_time, False)
 
-    result = _wait_process(
+    result = wait_process(
         process,
         timeout=timeout,
         input_data=input_data,


### PR DESCRIPTION
clusterfuzz currently relies on user to manually copy / paste / create a `coverfile` from `/rawcover` output. This PR automates this in a loop for a given interval of time (default 180 seconds)

Rev 1:
* Remove need to pass `--coverfile` arg
* Create cover file if does not exist
* Make and use `LoopingTimer` to periodically retrieve raw cover data from localhost:port
* Cleanup doc strings