### PR TITLE
Pin Fuchsia and Chromium images to specific base images.

### DIFF
--- a/docker/chromium/base/Dockerfile
+++ b/docker/chromium/base/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/clusterfuzz-images/base
+FROM gcr.io/clusterfuzz-images/base@sha256:1110514de5bb678562b75e5cf65130923bd22bb9371dcbc9e99483fd277ac135
 
 ENV UPDATE_WEB_TESTS True
 ENV NFS_ROOT /mnt/nfs/cfvolume

--- a/docker/chromium/builder/Dockerfile
+++ b/docker/chromium/builder/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/clusterfuzz-images/base
+FROM gcr.io/clusterfuzz-images/base@sha256:1110514de5bb678562b75e5cf65130923bd22bb9371dcbc9e99483fd277ac135
 
 ENV RUN_CMD \
    "python3.7 $ROOT_DIR/src/python/other-bots/chromium-builder/run.py"

--- a/docker/chromium/tests-syncer/Dockerfile
+++ b/docker/chromium/tests-syncer/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/clusterfuzz-images/base
+FROM gcr.io/clusterfuzz-images/base@sha256:1110514de5bb678562b75e5cf65130923bd22bb9371dcbc9e99483fd277ac135
 
 ENV RUN_CMD \
     "python3.7 $ROOT_DIR/src/python/other-bots/chromium-tests-syncer/run.py"

--- a/docker/fuchsia/Dockerfile
+++ b/docker/fuchsia/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/clusterfuzz-images/base
+FROM gcr.io/clusterfuzz-images/base@sha256:1110514de5bb678562b75e5cf65130923bd22bb9371dcbc9e99483fd277ac135
 
 RUN apt-get update && apt-get install -y openssh-client
 


### PR DESCRIPTION
This is so that we don't have to these images when
we upgrade the OSS-Fuzz images.

This is related to https://github.com/google/oss-fuzz/issues/6180