### PR TITLE
Many CI fixes. 

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
     mv tmp/.git .git
     rm -rf tmp
 - name: 'gcr.io/clusterfuzz-images/ci'
-  args: ['pipenv', 'sync', '--dev']
+  args: ['pipenv', 'sync', '--dev', '--python=3.7']
   env:
     - PIPENV_VENV_IN_PROJECT=1
 - name: 'gcr.io/clusterfuzz-images/ci'

--- a/local/tests/ci_tests.bash
+++ b/local/tests/ci_tests.bash
@@ -20,7 +20,7 @@ docker run -i --rm \
   -e PIPENV_VENV_IN_PROJECT=1 \
   -v $(pwd):/workspace \
   $IMAGE \
-  pipenv sync --dev
+  pipenv sync --dev --python=python3.7
 docker run -i --rm \
   -e PIPENV_VENV_IN_PROJECT=1 \
   -v $(pwd):/workspace \

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/afl/afl_launcher_integration_test.py
@@ -293,7 +293,7 @@ class TestLauncher(BaseLauncherTest):
     # *WARNING* Do not lower the fuzz timeout unless you really know what you
     # are doing. Doing so will cause the test to fail on rare ocassion, which
     # will break deploys.
-    mock_get_timeout.return_value = get_fuzz_timeout(90.0)
+    mock_get_timeout.return_value = get_fuzz_timeout(120.0)
     testcase_path = setup_testcase_and_corpus('empty', 'corpus', fuzz=True)
 
     output = run_launcher(testcase_path, 'easy_crash_fuzzer')

--- a/src/clusterfuzz/_internal/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -541,9 +541,9 @@ class UntrustedRunnerIntegrationTest(
     """Tests that large messages work."""
     expected_output = b'A' * 1024 * 1024 * 5 + b'\n'
 
-    runner = remote_process_host.RemoteProcessRunner('/usr/bin/python')
+    runner = remote_process_host.RemoteProcessRunner('/usr/bin/python3')
     result = runner.run_and_wait(
-        additional_args=['-c', 'print "A"*5*1024*1024'])
+        additional_args=['-c', 'print("A"*5*1024*1024)'])
     self.assertEqual(result.return_code, 0)
     self.assertEqual(result.output, expected_output)
 

--- a/src/clusterfuzz/_internal/tests/test_libs/test_utils.py
+++ b/src/clusterfuzz/_internal/tests/test_libs/test_utils.py
@@ -199,7 +199,7 @@ def wait_for_emulator_ready(proc,
   thread.start()
 
   if not ready_event.wait(timeout):
-    output = '\n'.join(output_lines)
+    output = b'\n'.join(output_lines).decode()
     raise RuntimeError(
         f'{emulator} emulator did not get ready in time: {output}.')
 

--- a/src/clusterfuzz/_internal/tests/test_libs/test_utils.py
+++ b/src/clusterfuzz/_internal/tests/test_libs/test_utils.py
@@ -174,6 +174,8 @@ def wait_for_emulator_ready(proc,
                             timeout=EMULATOR_TIMEOUT,
                             output_lines=None):
   """Wait for emulator to be ready."""
+  if output_lines is None:
+    output_lines = []
 
   def _read_thread(proc, ready_event):
     """Thread to continuously read from the process stdout."""
@@ -197,8 +199,9 @@ def wait_for_emulator_ready(proc,
   thread.start()
 
   if not ready_event.wait(timeout):
+    output = '\n'.join(output_lines)
     raise RuntimeError(
-        '{} emulator did not get ready in time.'.format(emulator))
+        f'{emulator} emulator did not get ready in time: {output}.')
 
   return thread
 

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -215,7 +215,6 @@ def execute(args):
   """Run Python unit tests. For unittests involved appengine, sys.path needs
   certain modification."""
   os.environ['PY_UNITTESTS'] = 'True'
-  os.environ['CLOUDSDK_PYTHON'] = 'python2'
 
   if os.getenv('INTEGRATION') or os.getenv('UNTRUSTED_RUNNER_TESTS'):
     # Set up per-user buckets used by integration tests.


### PR DESCRIPTION
Set Python3.7 for pipenv. python3.8 is indirectly installed by another package in the new CI
image and used by default otherwise.

Also remove CLOUDSDK_PYTHON env var which was setting it to `python2`.

Increase flaky afl test timeout.