### PR TITLE
Fix bug with fuzzers.utils.get_supporting_file.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -124,7 +124,18 @@ def get_build_revision():
 
 def get_supporting_file(fuzz_target_path, extension_or_suffix):
   """Get supporting file for a fuzz target with the provided extension."""
-  return utils.get_path_without_ext(fuzz_target_path) + extension_or_suffix
+  base_fuzz_target_path = fuzz_target_path
+
+  # Strip any known extensions.
+  for ext in ALLOWED_FUZZ_TARGET_EXTENSIONS:
+    if not ext:
+      continue
+
+    if base_fuzz_target_path.endswith(ext):
+      base_fuzz_target_path = base_fuzz_target_path[:-len(ext)]
+      break
+
+  return base_fuzz_target_path + extension_or_suffix
 
 
 def get_temp_dir():

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/utils_test.py
@@ -110,3 +110,27 @@ class IsFuzzTargetLocalTest(unittest.TestCase):
         'abc', contents=b'anything\nLLVMFuzzerTestOneInput')
     with open(path, 'rb') as f:
       self.assertTrue(utils.is_fuzz_target_local('name', f))
+
+
+class GetSupportingFileTest(unittest.TestCase):
+  """Tests for get_supporting_file."""
+
+  def test_no_extension(self):
+    """Test no extension."""
+    self.assertEqual('/a/b.labels', utils.get_supporting_file(
+        '/a/b', '.labels'))
+
+  def test_unknown_extension(self):
+    """Test unknown extension."""
+    self.assertEqual('/a/b.c.labels',
+                     utils.get_supporting_file('/a/b.c', '.labels'))
+
+  def test_exe(self):
+    """Test exe extension."""
+    self.assertEqual('/a/b.labels',
+                     utils.get_supporting_file('/a/b.exe', '.labels'))
+
+  def test_par(self):
+    """Test par extension."""
+    self.assertEqual('/a/b.labels',
+                     utils.get_supporting_file('/a/b.par', '.labels'))


### PR DESCRIPTION
Only strip allowed fuzzer extensions. Otherwise we incorrect strip
fuzzers that have period in them as part of the name. This is common
with "googlefuzztest" targets.