### PR TITLE
For component HEAD revisions, return HEAD impact.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/impact_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/impact_task.py
@@ -158,7 +158,8 @@ def get_component_impacts_from_url(component_name,
     branched_from = revisions.revision_to_branched_from(
         component_revision['url'], component_revision['rev'])
     if not branched_from:
-      return Impacts()
+      branched_from = component_revision['rev'] # this is a head revision,
+        # not branched
     impact = get_impact({
         'revision': branched_from,
         'version': mapping['version']

--- a/src/clusterfuzz/_internal/bot/tasks/impact_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/impact_task.py
@@ -158,8 +158,8 @@ def get_component_impacts_from_url(component_name,
     branched_from = revisions.revision_to_branched_from(
         component_revision['url'], component_revision['rev'])
     if not branched_from:
-      branched_from = component_revision['rev'] # this is a head revision,
-        # not branched
+      # This is a head revision, not branched.
+      branched_from = component_revision['rev']
     impact = get_impact({
         'revision': branched_from,
         'version': mapping['version']


### PR DESCRIPTION
Previously for a 'component', i.e. some sub-repository of
Chromium, if we found that the only affected branch was HEAD,
we would not return any valid impacts. This prevented
ClusterFuzz from setting the FoundIn label correctly.

Bug: https://crbug.com/1222484
Change-Id: Ifc9bcc6822a0b83f0027c8cd80a4d984ed728ec8