### PR TITLE
Fix bug with AUTOMATIC_LABELS parsing.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
@@ -1217,10 +1217,11 @@ def get_strategy_distribution_from_ndb():
 
 def _get_issue_metadata_from_environment(variable_name):
   """Get issue metadata from environment."""
-  values = str(environment.get_value(variable_name, '')).split()
+  values = str(environment.get_value_string(variable_name, '')).split(',')
   # Allow a variation with a '_1' to specified. This is needed in cases where
   # this is specified in both the job and the bot environment.
-  values.extend(str(environment.get_value(variable_name + '_1', '')).split())
+  values.extend(
+      str(environment.get_value_string(variable_name + '_1', '')).split(','))
   return [value.strip() for value in values if value.strip()]
 
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -585,6 +585,11 @@ def get_ubsan_disabled_options():
   }
 
 
+def get_value_string(environment_variable, default_value=None):
+  """Get environment variable (as a string)."""
+  return os.getenv(environment_variable, default_value)
+
+
 def get_value(environment_variable, default_value=None):
   """Return an environment variable value."""
   value_string = os.getenv(environment_variable)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
@@ -1577,10 +1577,10 @@ class AddIssueMetadataFromEnvironmentTest(unittest.TestCase):
 
   def test_add_numeric(self):
     """Tests adding a numeric label."""
-    os.environ['AUTOMATIC_LABELS'] = '123'
+    os.environ['AUTOMATIC_LABELS'] = '123,456'
 
     metadata = {}
     fuzz_task._add_issue_metadata_from_environment(metadata)
     self.assertDictEqual({
-        'issue_labels': '123',
+        'issue_labels': '123,456',
     }, metadata)


### PR DESCRIPTION
If AUTOMATIC_LABELS has a value of the form '123,456', then
environment.get_value() would return a tuple (123, 456) because it does
an `ast.literal_eval`. This leads to 'issue_metadata' getting incorrectly
stored as '(123,,456)' and breaking issue filing. 