### PR TITLE
libFuzzer: Don't subtract buffer times from the provided timeout.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -316,12 +316,11 @@ class LibFuzzerEngine(engine.Engine):
     timeout_limit = fuzzer_utils.extract_argument(
         options.arguments, constants.TIMEOUT_FLAG, remove=False)
 
-    expected_duration = runner.get_max_total_time(max_time)
     actual_duration = int(fuzz_result.time_executed)
-    fuzzing_time_percent = 100 * actual_duration / float(expected_duration)
+    fuzzing_time_percent = 100 * actual_duration / float(max_time)
     parsed_stats.update({
         'timeout_limit': int(timeout_limit),
-        'expected_duration': expected_duration,
+        'expected_duration': max_time,
         'actual_duration': actual_duration,
         'fuzzing_time_percent': fuzzing_time_percent,
     })

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -160,13 +160,13 @@ class LibFuzzerCommon(object):
         timeout=analyze_timeout,
         max_stdout_len=MAX_OUTPUT_LEN)
 
-  def get_max_total_time(self, timeout):
-    """Calculate value of `-max_total_time=` argument to be passed to fuzzer.
+  def get_total_timeout(self, timeout):
+    """Calculate the total process timeout.
 
     Args:
       timeout: The maximum time in seconds that libFuzzer is allowed to run for.
     """
-    timeout = timeout - self.LIBFUZZER_CLEAN_EXIT_TIME - self.SIGTERM_WAIT_TIME
+    timeout = timeout + self.LIBFUZZER_CLEAN_EXIT_TIME
     return int(timeout)
 
   def get_minimize_total_time(self, timeout):
@@ -205,7 +205,7 @@ class LibFuzzerCommon(object):
     if additional_args is None:
       additional_args = []
 
-    max_total_time = self.get_max_total_time(fuzz_timeout)
+    max_total_time = fuzz_timeout
     if any(arg.startswith(constants.FORK_FLAG) for arg in additional_args):
       max_total_time -= self.LIBFUZZER_FORK_MODE_CLEAN_EXIT_TIME
     assert max_total_time > 0
@@ -227,7 +227,7 @@ class LibFuzzerCommon(object):
     additional_args.extend(corpus_directories)
     return self.run_and_wait(
         additional_args=additional_args,
-        timeout=fuzz_timeout - self.SIGTERM_WAIT_TIME,
+        timeout=self.get_total_timeout(fuzz_timeout),
         terminate_before_kill=True,
         terminate_wait_time=self.SIGTERM_WAIT_TIME,
         max_stdout_len=MAX_OUTPUT_LEN,
@@ -488,7 +488,7 @@ class FuchsiaUndercoatLibFuzzerRunner(new_process.UnicodeProcessRunner,
     undercoat.prepare_fuzzer(self.handle, self.executable_path)
     self._push_corpora_from_host_to_target(corpus_directories)
 
-    max_total_time = self.get_max_total_time(fuzz_timeout)
+    max_total_time = fuzz_timeout
     if any(arg.startswith(constants.FORK_FLAG) for arg in additional_args):
       max_total_time -= self.LIBFUZZER_FORK_MODE_CLEAN_EXIT_TIME
     assert max_total_time > 0
@@ -828,7 +828,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.UnicodeProcessRunner,
     self._test_ssh()
     self._push_corpora_from_host_to_target(corpus_directories)
 
-    max_total_time = self.get_max_total_time(fuzz_timeout)
+    max_total_time = fuzz_timeout
     if any(arg.startswith(constants.FORK_FLAG) for arg in additional_args):
       max_total_time -= self.LIBFUZZER_FORK_MODE_CLEAN_EXIT_TIME
     assert max_total_time > 0

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -354,9 +354,9 @@ class FuzzTest(fake_fs_unittest.TestCase):
         'dict_used': 1,
         'edge_coverage': 411,
         'edges_total': 398467,
-        'expected_duration': 3580,
+        'expected_duration': 3600,
         'feature_coverage': 1873,
-        'fuzzing_time_percent': 0.055865921787709494,
+        'fuzzing_time_percent': 0.05555555555555555,
         'initial_edge_coverage': 410,
         'initial_feature_coverage': 1869,
         'leak_count': 0,
@@ -438,12 +438,6 @@ def setup_testcase_and_corpus(testcase, corpus):
     os.mkdir(copied_corpus_path)
 
   return copied_testcase_path, copied_corpus_path
-
-
-def get_fuzz_timeout(fuzz_time):
-  """Return timeout for fuzzing."""
-  return (fuzz_time + libfuzzer.LibFuzzerCommon.LIBFUZZER_CLEAN_EXIT_TIME +
-          libfuzzer.LibFuzzerCommon.SIGTERM_WAIT_TIME)
 
 
 def mock_get_directory_file_count(dir_path):
@@ -544,8 +538,7 @@ class IntegrationTests(BaseIntegrationTest):
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5.0))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5.0)
     self.assert_has_stats(results.stats)
     self.compare_arguments(
         os.path.join(DATA_DIR, 'test_fuzzer'), [
@@ -579,8 +572,7 @@ class IntegrationTests(BaseIntegrationTest):
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
     self.assert_has_stats(results.stats)
     self.compare_arguments(
         os.path.join(DATA_DIR, 'test_fuzzer_old'), [
@@ -610,8 +602,7 @@ class IntegrationTests(BaseIntegrationTest):
                                                  'always_crash_fuzzer')
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
     self.assert_has_stats(results.stats)
     self.compare_arguments(
@@ -651,8 +642,7 @@ class IntegrationTests(BaseIntegrationTest):
     target_path = engine_common.find_fuzzer_path(DATA_DIR, 'test_fuzzer')
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
     self.compare_arguments(
         os.path.join(DATA_DIR, 'test_fuzzer'), [
@@ -722,7 +712,7 @@ class IntegrationTests(BaseIntegrationTest):
     target_path = engine_common.find_fuzzer_path(DATA_DIR,
                                                  'analyze_dict_fuzzer')
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
-    engine_impl.fuzz(target_path, options, TEMP_DIR, get_fuzz_timeout(5))
+    engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
     expected_recommended_dictionary = set([
         '"APPLE"',
         '"GINGER"',
@@ -759,8 +749,7 @@ class IntegrationTests(BaseIntegrationTest):
       target_path = engine_common.find_fuzzer_path(DATA_DIR, fuzz_target_name)
       engine_impl = engine.LibFuzzerEngine()
       options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
-      results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                                 get_fuzz_timeout(5))
+      results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
     finally:
       shutil.rmtree(os.environ['MUTATOR_PLUGINS_DIR'])
 
@@ -817,7 +806,7 @@ class IntegrationTests(BaseIntegrationTest):
     engine_impl = engine.LibFuzzerEngine()
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
     options.arguments.append('-runs=10')
-    engine_impl.fuzz(target_path, options, TEMP_DIR, get_fuzz_timeout(5))
+    engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
     # Verify that both the newly found minimal testcase and the nonminimal
     # testcase are in the corpus.
@@ -843,8 +832,7 @@ class IntegrationTests(BaseIntegrationTest):
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
     options.extra_env['EXIT_FUZZER_CODE'] = '1'
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
     self.assertEqual(1, self.mock.log_error.call_count)
 
     self.assertEqual(1, len(results.crashes))
@@ -870,8 +858,7 @@ class IntegrationTests(BaseIntegrationTest):
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
     options.extra_env['EXIT_FUZZER_CODE'] = exit_code
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
     self.assertEqual(1, len(results.crashes))
     self.assertEqual(TEMP_DIR, os.path.dirname(results.crashes[0].input_path))
@@ -897,7 +884,7 @@ class IntegrationTests(BaseIntegrationTest):
     invalid_dict_path = os.path.join(DATA_DIR, 'invalid.dict')
     options.arguments.append('-dict=' + invalid_dict_path)
 
-    engine_impl.fuzz(target_path, options, TEMP_DIR, get_fuzz_timeout(5))
+    engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
 
 @unittest.skip('needs root')
@@ -968,8 +955,7 @@ class MinijailIntegrationTests(IntegrationTests):
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
     options.extra_env['EXIT_FUZZER_CODE'] = exit_code
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
     self.assertEqual(1, len(results.crashes))
     self.assertEqual(TEMP_DIR, os.path.dirname(results.crashes[0].input_path))
@@ -1025,7 +1011,7 @@ class IntegrationTestsFuchsia(BaseIntegrationTest):
     options = engine_impl.prepare(corpus_path, 'example-fuzzers/crash_fuzzer',
                                   DATA_DIR)
     results = engine_impl.fuzz('example-fuzzers/crash_fuzzer', options,
-                               TEMP_DIR, get_fuzz_timeout(20))
+                               TEMP_DIR, 20)
 
     # If we don't get a crash, something went wrong.
     self.assertIn('Test unit written to', results.logs)
@@ -1183,8 +1169,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, ANDROID_DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
     self.assert_has_stats(results.stats)
     self.assertEqual([
@@ -1221,8 +1206,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
                                                  'always_crash_fuzzer')
     options = engine_impl.prepare(corpus_path, target_path, ANDROID_DATA_DIR)
 
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
     self.assert_has_stats(results.stats)
     self.assertEqual([
@@ -1270,8 +1254,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
                                                  'test_fuzzer')
     dict_path = target_path + '.dict'
     options = engine_impl.prepare(corpus_path, target_path, ANDROID_DATA_DIR)
-    results = engine_impl.fuzz(target_path, options, TEMP_DIR,
-                               get_fuzz_timeout(5))
+    results = engine_impl.fuzz(target_path, options, TEMP_DIR, 5)
 
     self.assertEqual([
         self.adb_path,
@@ -1348,7 +1331,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
                                                  'analyze_dict_fuzzer')
     options = engine_impl.prepare(corpus_path, target_path, DATA_DIR)
 
-    engine_impl.fuzz(target_path, options, TEMP_DIR, get_fuzz_timeout(5.0))
+    engine_impl.fuzz(target_path, options, TEMP_DIR, 5.0)
     expected_recommended_dictionary = set([
         '"APPLE"',
         '"GINGER"',


### PR DESCRIPTION
Previously we were subtracting some buffer timeouts from the provided timeout and
passing that to libFuzzer's `-max_total_time`. This was a relic from our launcher script
days when timeouts were much more strict. 

Now, instead leave `-max_total_time` to be exactly what is passed.
Add the buffer timeouts in the actual process timeout instead.
A difference of up to extra 20 seconds should be inconsequential.

This makes libClusterFuzz much more usable. 

Also for https://github.com/google/oss-fuzz/pull/6375