### PR TITLE
File kasan crash with address range

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/syzkaller/runner.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/syzkaller/runner.py
@@ -269,12 +269,16 @@ class AndroidSyzkallerRunner(new_process.UnicodeProcessRunner):
     vs.
     BUG: KASAN: use-after-free...
 
+    [ 1850.287295] KASAN: ...
+    vs.
+    KASAN: ...
+
     Args:
       content (str): log content
     Returns:
       filtered log with new lines (str)
     """
-    strip_regex = re.compile(r'^(\[.*?\]\s+)?c\d+\s+\d+\s')
+    strip_regex = re.compile(r'^(\[.*?\]\s+)?(c\d+\s+\d+\s)?')
     result = [strip_regex.sub('', line) for line in content.splitlines()]
     return '\n'.join(result)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/syzkaller/runner_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/syzkaller/runner_test.py
@@ -34,3 +34,11 @@ class RunnerTest(unittest.TestCase):
         self.target._filter_log(content),
         'BUG: KASAN: use-after-free in f2fs_register_inmem_page+0x208/0x390',
     )
+
+  def test_filter_log_without_pid(self):
+    content = ('[ 1850.287295] KASAN: null-ptr-deref in range '
+               '[0x0000000000000088-0x000000000000008f]')
+    self.assertEqual(
+        self.target._filter_log(content),
+        'KASAN: null-ptr-deref in range [0x0000000000000088-0x000000000000008f]',
+    )

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/syzkaller/runner_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/syzkaller/runner_test.py
@@ -22,6 +22,7 @@ EXECUTABLE_PATH = '/usr/local/google/home/username/syzkaller'
 
 
 class RunnerTest(unittest.TestCase):
+  """Tests for AndroidSyzkallerRunner."""
 
   def setUp(self):
     super(RunnerTest, self).setUp()

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/kasan_syzkaller_x86.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/kasan_syzkaller_x86.txt
@@ -1,0 +1,34 @@
+general protection fault, probably for non-canonical address 0xdffffc0000000011: 0000 [#1] PREEMPT SMP KASAN PTI
+KASAN: null-ptr-deref in range [0x0000000000000088-0x000000000000008f]
+CPU: 1 PID: 4285 Comm: syz-executor Tainted: G           O      5.10.43-android12-9-00082-gb683931b2a63-ab7681925 #1
+Hardware name: ChromiumOS crosvm, BIOS 0
+RIP: 0010:io_uring_create+0x1a63/0x30f0
+Code: 03 49 bc 00 00 00 00 00 fc ff df 42 80 3c 20 00 74 08 4c 89 f7 e8 5d c1 e1 ff 41 bf 88 00 00 00 4d 03 3e 4c 89 f8 48 c1 e8 03 <42> 80 3c 20 00 74 08 4c 89 ff e8 3e c1 e1 ff 4d 8b 37 4d 85 f6 74
+RSP: 0018:ffff888008c2fd50 EFLAGS: 00010206
+RAX: 0000000000000011 RBX: dffffc0000000000 RCX: ffffffff840ccb81
+RDX: 0000000000000001 RSI: 0000000000000008 RDI: ffff888008c2fd08
+RBP: ffff888008c2fe80 R08: dffffc0000000000 R09: ffffed1001185fa2
+R10: ffffed1001185fa2 R11: 0000000000000000 R12: dffffc0000000000
+R13: 00000000fffffffc R14: ffff888015a800e8 R15: 0000000000000088
+FS:  00007da641089700(0000) GS:ffff888066500000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 00007da641046db8 CR3: 000000005e074006 CR4: 0000000000170ea0
+DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+Call Trace:
+? io_free_work+0x5f0/0x5f0
+? io_sq_wake_function+0xe0/0xe0
+__x64_sys_io_uring_setup+0x157/0x200
+do_syscall_64+0x37/0x50
+entry_SYSCALL_64_after_hwframe+0x44/0xa9
+RIP: 0033:0x46a1b9
+Code: ff ff c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 40 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 c7 c1 bc ff ff ff f7 d8 64 89 01 48
+RSP: 002b:00007da641088bd8 EFLAGS: 00000202 ORIG_RAX: 00000000000001a9
+RAX: ffffffffffffffda RBX: 0000000020000040 RCX: 000000000046a1b9
+RDX: 0000000020fff000 RSI: 0000000020000040 RDI: 00000000000052b2
+RBP: 00000000004b9d4e R08: 0000000020000100 R09: 0000000020000100
+R10: 00000000200000c0 R11: 0000000000000202 R12: 0000000020fff000
+R13: 0000000020ffc000 R14: 0000000020000100 R15: 00000000200000c0
+Modules linked in: virt_wifi_sim(O) virtio_gpu(O) goldfish_sync(O) goldfish_pipe(O) goldfish_battery(O) goldfish_address_space(O) vmw_vsock_virtio_transport snd_intel8x0 snd_hda_intel snd_intel_dspcfg snd_hda_codec_realtek snd_hda_codec_generic snd_hda_codec snd_hda_core snd_ac97_codec ac97_bus gnss_cmdline gnss_serial ledtrig_audio dummy_cpufreq hci_vhci md_mod pulse8_cec rtc_test psmouse virtio_net net_failover failover virt_wifi mac80211_hwsim mac80211 cfg80211 slcan vcan gs_usb system_heap virtio_pmem nd_virtio zram virtio_blk tpm_vtpm_proxy tpm virtio_console virtio_rng virtio_dma_buf virtio_mem virtio_input virtio_balloon virtio_pci virtio_mmio test_meminit test_stackinit lzo_rle lzo zsmalloc
+---[ end trace f110a649e41b2fb7 ]---
+RIP: 0010:io_uring_create+0x1a63/0x30f0

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1687,6 +1687,21 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_syzkaller_kasan_x86(self):
+    """Test syzkaller kasan x86."""
+    data = self._read_test_data('kasan_syzkaller_x86.txt')
+    expected_type = 'Kernel failure\nNull-ptr-deref'
+    expected_state = ('__x64_sys_io_uring_setup\n'
+                      'do_syscall_64\n'
+                      'entry_SYSCALL_64_after_hwframe\n')
+    expected_address = '0x000000000088'
+    expected_stacktrace = data
+    expected_security_flag = True
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_kasan_gpf(self):
     """Test a KASan GPF."""
     data = self._read_test_data('kasan_gpf.txt')

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -759,28 +759,25 @@ class StackParser:
             type_filter=get_fault_description_for_android_kernel)
 
       # Generic KASan errors.
-      address_match = self.update_state_on_match(
+      if self.update_state_on_match(
           KASAN_CRASH_TYPE_ADDRESS_REGEX,
           line,
           state,
           new_type='Kernel failure',
           type_from_group=1,
           address_from_group=4,
-          type_filter=filter_kasan_crash_type)
-
-      if address_match is not None:
+          type_filter=filter_kasan_crash_type):
         state.crash_address = f'0x{state.crash_address}'
 
-      address_range_match = self.update_state_on_match(
+      # Generic KASan errors with an address range.
+      if self.update_state_on_match(
           KASAN_CRASH_TYPE_ADDRESS_RANGE_REGEX,
           line,
           state,
           new_type='Kernel failure',
           type_from_group=1,
           address_from_group=3,
-          type_filter=filter_kasan_crash_type)
-
-      if address_range_match is not None:
+          type_filter=filter_kasan_crash_type):
         state.crash_address = state.crash_address
 
       # Generic KASan errors without an address.
@@ -1146,14 +1143,8 @@ class StackParser:
         continue
 
       # Android kernel stack frame without address
-      android_kernel_match = self.add_frame_on_match(
-          ANDROID_KERNEL_STACK_FRAME_NO_ADDRESS_REGEX,
-          line,
-          state,
-          group=2,
-      )
-
-      if android_kernel_match:
+      if self.add_frame_on_match(
+          ANDROID_KERNEL_STACK_FRAME_NO_ADDRESS_REGEX, line, state, group=2):
         state.found_android_kernel_crash = True
         continue
 

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -37,6 +37,9 @@ ANDROID_KERNEL_STACK_FRAME_REGEX = re.compile(
     r'[^(]*\[\<([x0-9a-fA-F]+)\>\]\s+'
     # e.g. "(msm_vidc_prepare_buf+0xa0/0x124)"; function (3), offset (4)
     r'\(?(([\w]+)\+([\w]+)/[\w]+)\)?')
+ANDROID_KERNEL_STACK_FRAME_NO_ADDRESS_REGEX = re.compile(
+    # e.g. "(msm_vidc_prepare_buf+0xa0/0x124)"; function (2), offset (3)
+    r'\(?(([\w]+)\+([\w]+)/[\w]+)\)?')
 ANDROID_KERNEL_TIME_REGEX = re.compile(r'^\[\s*\d+\.\d+\]\s')
 # Parentheses are optional.
 ANDROID_PROCESS_NAME_REGEX = re.compile(r'.*[(](.*)[)]$')
@@ -110,6 +113,8 @@ KASAN_ACCESS_TYPE_ADDRESS_REGEX = re.compile(
     r'(Read|Write) of size ([0-9]+) at (addr|address) ([a-f0-9]+)')
 KASAN_CRASH_TYPE_ADDRESS_REGEX = re.compile(
     r'BUG: KASAN: (.*) (in|on).*(addr|address) ([a-f0-9]+)')
+KASAN_CRASH_TYPE_ADDRESS_RANGE_REGEX = re.compile(
+    r'KASAN: (.*?) (in|on) range \[([a-z0-9]+)-([a-z0-9]+)\]')
 KASAN_CRASH_TYPE_FUNCTION_REGEX = re.compile(
     r'BUG: KASAN: (.*) (in|on).* ([\w]+)\+([\w]+)\/([\w]+)')
 KASAN_GPF_REGEX = re.compile(r'general protection fault:.*KASAN')


### PR DESCRIPTION
Rev 1:
* make `c\d+\s+\d+\s` optional for `_filter_log`
* add observed kernel crash to a test case
* add new match for kernel crash with address range
* add unit tests