### PR TITLE
Add console path to Cuttlefish syzkaller config.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/syzkaller/config.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/syzkaller/config.py
@@ -64,6 +64,11 @@ def generate(serial,
     data['target'] = 'linux/amd64'
     data['disable_syscalls'] = ['openat$vhost_vsock']
     data['sandbox'] = 'none'
+    # Cuttlefish pass kernel log as console input in Syzkaller config.
+    device = {}
+    device['serial'] = serial
+    device['console'] = '/home/vsoc-01/cuttlefish_runtime.1/kernel.log'
+    devices['devices'] = [device]
 
   if syzhub_address and syzhub_client and syzhub_key:
     data['hub_addr'] = syzhub_address

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/syzkaller/runner_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/syzkaller/runner_test.py
@@ -13,12 +13,20 @@
 # limitations under the License.
 """Tests for syzkaller runner."""
 # pylint: disable=protected-access
+import os
 import unittest
 
+import mock
+
+from clusterfuzz._internal.bot.fuzzers.syzkaller import runner
 from clusterfuzz._internal.bot.fuzzers.syzkaller.runner import \
     AndroidSyzkallerRunner
 
 EXECUTABLE_PATH = '/usr/local/google/home/username/syzkaller'
+TEST_PATH = os.path.abspath(os.path.dirname(__file__))
+TEMP_DIR = os.path.join(TEST_PATH, 'temp')
+BUILD_DIR = os.path.join(TEST_PATH, 'build')
+INPUT_DIR = os.path.join(TEST_PATH, 'input')
 
 
 class RunnerTest(unittest.TestCase):
@@ -43,3 +51,49 @@ class RunnerTest(unittest.TestCase):
         self.target._filter_log(content),
         'KASAN: null-ptr-deref in range [0x0000000000000088-0x000000000000008f]',
     )
+
+  @mock.patch('clusterfuzz._internal.system.environment.get_value')
+  @mock.patch('clusterfuzz._internal.bot.fuzzers.utils.get_temp_dir')
+  def test_get_config(self, mock_temp_dir, mock_get_value):
+    """Test get_config generates syzkaller config correctly."""
+    env = {
+        'ANDROID_SERIAL': '172.18.0.2:6520',
+        'FUZZ_INPUTS_DISK': INPUT_DIR,
+        'BUILD_DIR': BUILD_DIR,
+        'OS_OVERRIDE': 'ANDROID_X86',
+        'VMLINUX_PATH': BUILD_DIR
+    }
+    mock_temp_dir.return_value = TEMP_DIR
+    mock_get_value.side_effect = env.get
+
+    runner.get_config()
+    expected_config = (
+        '{"target": "linux/amd64", '
+        '"reproduce": false, '
+        f'"workdir": "{INPUT_DIR}/syzkaller", '
+        '"http": "localhost:0", '
+        f'"syzkaller": "{BUILD_DIR}/syzkaller", '
+        '"suppressions": ["do_rt_sigqueueinfo", "do_rt_tgsigqueueinfo"], '
+        '"vm": {"devices": ['
+        '{'
+        '"serial": "172.18.0.2:6520", '
+        '"console": "/home/vsoc-01/cuttlefish_runtime.1/kernel.log"'
+        '}'
+        ']}, '
+        f'"kernel_obj": "{BUILD_DIR}", '
+        '"sandbox": "none", '
+        '"ignores": ["WARNING:", "INFO:"], '
+        '"type": "adb", '
+        '"procs": 1, '
+        '"cover": true, '
+        '"disable_syscalls": ["openat$vhost_vsock"]}')
+    with open(f'{TEMP_DIR}/config.json', 'r') as file:
+      actual_config = file.read()
+      self.assertEqual(expected_config, actual_config)
+
+    # Check syzkaller config for physical device has correct devices format.
+    env['OS_OVERRIDE'] = 'ANDROID'
+    runner.get_config()
+    with open(f'{TEMP_DIR}/config.json', 'r') as file:
+      actual_config = file.read()
+      self.assertIn('"devices": ["172.18.0.2:6520"]', actual_config)


### PR DESCRIPTION
Syzkaller connects to the console of physical device through serial cable, but Cuttlefish is a virtual device that doesn't have physical cable. So we implement Syzkaller the way that directly tails to the kernel.log of Cuttlefish to get the stack trace when crash happens.

Syzkaller implementation is https://github.com/google/syzkaller/pull/2713