### PR TITLE
Pinned tag using SHA

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2
       - run: |  # Needed for git diff to work.
           git fetch origin master --depth 1
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
       - name: Setup python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # v2
         with:
           python-version: 3.7
 


### PR DESCRIPTION
Pinned actions by SHA instead of a tag because tags can be moved while SHA can’t.

https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies