### PR TITLE
Add monitoring metric of task run time.

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -146,3 +146,12 @@ TASK_COUNT = monitor.CounterMetric(
         monitor.StringField('task'),
         monitor.StringField('job'),
     ])
+
+TASK_TOTAL_RUN_TIME = monitor.CounterMetric(
+    'task/total_time',
+    description=('The task run time in seconds'),
+    field_spec=[
+        monitor.StringField('task'),
+        monitor.StringField('job'),
+    ],
+)

--- a/src/clusterfuzz/_internal/platforms/android/device.py
+++ b/src/clusterfuzz/_internal/platforms/android/device.py
@@ -345,6 +345,7 @@ def initialize_environment():
                         settings.get_sanitizer_tool_name())
   environment.set_value('SECURITY_PATCH_LEVEL',
                         settings.get_security_patch_level())
+  environment.set_value('LOG_TASK_TIMES', True)
 
 
 def install_application_if_needed(apk_path, force_update):

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -58,8 +58,7 @@ class _Monitor(object):
     self.start_time = self.time_module.time()
 
   def __exit__(self, exc_type, value, trackback):
-    # Only log task run time for Android platform.
-    if not environment.is_android():
+    if not environment.get_value('LOG_TASK_TIMES'):
       return
     duration = self.time_module.time() - self.start_time
     monitoring_metrics.TASK_TOTAL_RUN_TIME.increment_by(

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -63,10 +63,10 @@ class _Monitor(object):
       return
     duration = self.time_module.time() - self.start_time
     monitoring_metrics.TASK_TOTAL_RUN_TIME.increment_by(
-      int(duration), {
-        'task': self.task.command or '',
-        'job': self.task.job or '',
-    })
+        int(duration), {
+            'task': self.task.command or '',
+            'job': self.task.job or '',
+        })
 
 
 def task_loop():

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -58,7 +58,15 @@ class _Monitor(object):
     self.start_time = self.time_module.time()
 
   def __exit__(self, exc_type, value, trackback):
-    pass
+    # Only log task run time for Android platform.
+    if not environment.is_android():
+      return
+    duration = self.time_module.time() - self.start_time
+    monitoring_metrics.TASK_TOTAL_RUN_TIME.increment_by(
+      int(duration), {
+        'task': self.task.command or '',
+        'job': self.task.job or '',
+    })
 
 
 def task_loop():


### PR DESCRIPTION
Add "job" field to the metric instead of "platform" but filter out non-Android platforms.
Let me know if this works