### PR TITLE
Handle deleted targets from split target builds.

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1324,6 +1324,9 @@ def _setup_split_targets_build(bucket_path, target_weights, revision=None):
     raise BuildManagerException(
         'Failed to choose a fuzz target (path=%s).' % bucket_path)
 
+  if fuzz_target not in targets_list:
+    raise errors.BuildNotFoundError(revision, environment.get_value('JOB_NAME'))
+
   fuzz_target_bucket_path = _full_fuzz_target_path(bucket_path, fuzz_target)
   if not revision:
     revision = _get_latest_revision([fuzz_target_bucket_path])

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -1970,6 +1970,12 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
         os.environ['FUZZ_TARGET_BUILD_BUCKET_PATH'])
     six.assertCountEqual(self, ['target1', 'target3'], targets_list)
 
+  def test_target_no_longer_built(self):
+    """Test a target that's not longer listed in target.list."""
+    os.environ['FUZZ_TARGET'] = 'target4'
+    with self.assertRaises(errors.BuildNotFoundError):
+      build_manager.setup_build()
+
 
 class GetPrimaryBucketPathTest(unittest.TestCase):
   """Tests for get_primary_bucket_path."""


### PR DESCRIPTION
Previously, if a target was removed from targets.list, existing
testcases will stay open indefinitely.

This change raises an exception during build setup if the expected
target no longer exists in the targets.list, which will lead to
progression_task marking the testcase as invalid.