### PR TITLE
Jira integration fixes

### DIFF
--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -56,24 +56,24 @@ class JsonEncoder(json.JSONEncoder):
   """Json encoder."""
   _EPOCH = datetime.datetime.utcfromtimestamp(0)
 
-  def default(self, obj):  # pylint: disable=arguments-differ,method-hidden
-    if isinstance(obj, ndb.Model):
-      dict_obj = obj.to_dict()
-      dict_obj['id'] = obj.key.id()
+  def default(self, o):  # pylint: disable=arguments-differ,method-hidden
+    if isinstance(o, ndb.Model):
+      dict_obj = o.to_dict()
+      dict_obj['id'] = o.key.id()
       return dict_obj
-    if isinstance(obj, datetime.datetime):
-      return int((obj - self._EPOCH).total_seconds())
-    if hasattr(obj, 'to_dict'):
-      return obj.to_dict()
-    if isinstance(obj, cgi.FieldStorage):
-      return str(obj)
-    if isinstance(obj, bytes):
-      return obj.decode('utf-8')
-    if isinstance(obj, jira.resources.Resource):
-      if obj.raw:
-        return obj.raw
+    if isinstance(o, datetime.datetime):
+      return int((o - self._EPOCH).total_seconds())
+    if hasattr(o, 'to_dict'):
+      return o.to_dict()
+    if isinstance(o, cgi.FieldStorage):
+      return str(o)
+    if isinstance(o, bytes):
+      return o.decode('utf-8')
+    if isinstance(o, jira.resources.Resource):
+      if o.raw:
+        return o.raw
 
-    return json.JSONEncoder.default(self, obj)
+    return json.JSONEncoder.default(self, o)
 
 
 def format_time(dt):

--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -30,6 +30,7 @@ from flask import Response
 from flask.views import MethodView
 from google.cloud import ndb
 import jinja2
+import jira
 
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.config import db_config
@@ -68,6 +69,9 @@ class JsonEncoder(json.JSONEncoder):
       return str(obj)
     if isinstance(obj, bytes):
       return obj.decode('utf-8')
+    if isinstance(obj, jira.resources.Resource):
+      if obj.raw:
+        return obj.raw
 
     return json.JSONEncoder.default(self, obj)
 

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """Jira issue tracker."""
 
-from dateutil import parser
 from urllib.parse import urljoin
+
+from dateutil import parser
 
 from clusterfuzz._internal.config import db_config
 from libs.issue_management import issue_tracker

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -165,7 +165,7 @@ class IssueTracker(issue_tracker.IssueTracker):
   def find_issues(self, keywords=None, only_open=False):
     """Find issues."""
     search_text = 'project = {project_name}' + _get_search_text(keywords)
-    search_text.format(project_name=self._itm.project_name)
+    search_text = search_text.format(project_name=self._itm.project_name)
     if only_open:
       search_text += ' AND resolution = Unresolved'
     issues = self._itm.get_issues(search_text)
@@ -177,9 +177,13 @@ class IssueTracker(issue_tracker.IssueTracker):
     url = config.jira_url + '/browse/' + str(issue_id)
     return url
 
-  # FIXME: Add support for keywords and only_open arguments
-  def find_issues_url(self, keywords=None, only_open=None):  # pylint: disable=unused-argument
-    pass
+  def find_issues_url(self, keywords=None, only_open=None):
+    search_text = 'project = {project_name}' + _get_search_text(keywords)
+    search_text = search_text.format(project_name=self._itm.project_name)
+    if only_open:
+      search_text += ' AND resolution = Unresolved'
+    config = db_config.get()
+    return urljoin(config.jira_url, f'/issues/?jql={search_text}')
 
 
 def _get_issue_tracker_manager_for_project(project_name):

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -14,6 +14,7 @@
 """Jira issue tracker."""
 
 from dateutil import parser
+from urllib.parse import urljoin
 
 from clusterfuzz._internal.config import db_config
 from libs.issue_management import issue_tracker
@@ -174,7 +175,7 @@ class IssueTracker(issue_tracker.IssueTracker):
   def issue_url(self, issue_id):
     """Return the issue URL with the given ID."""
     config = db_config.get()
-    url = config.jira_url + '/browse/' + str(issue_id)
+    url = urljoin(config.jira_url, f'/browse/{str(issue_id)}')
     return url
 
   def find_issues_url(self, keywords=None, only_open=None):


### PR DESCRIPTION
This fixes two Jira integration issues:
1. Jira objects are not JSON encodable, so this fixes it by returning the raw representation of the Jira object which happens to be in JSON.
2. The format string in the find_issues method wasn't assigned back to the variable and so it wasn't working as intended.

Apart from that, this also implements the `find_issues_url` method by reusing the code from `find_issues`.