### PR TITLE
Include recovered issue filing exceptions in triage message.

### DIFF
--- a/src/appengine/handlers/testcase_detail/create_issue.py
+++ b/src/appengine/handlers/testcase_detail/create_issue.py
@@ -39,7 +39,7 @@ class Handler(base_handler.Handler):
     if cc_me:
       additional_ccs.append(user_email)
 
-    issue_id = issue_filer.file_issue(
+    issue_id, _ = issue_filer.file_issue(
         testcase,
         issue_tracker,
         security_severity=severity,

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/triage_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/triage_test.py
@@ -354,7 +354,7 @@ class CheckAndUpdateSimilarBug(unittest.TestCase):
 
 
 @test_utils.with_cloud_emulators('datastore')
-class FileIssue(unittest.TestCase):
+class FileIssueTest(unittest.TestCase):
   """Tests for _file_issue."""
 
   def setUp(self):

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/testcase_detail/create_issue_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/testcase_detail/create_issue_test.py
@@ -53,7 +53,7 @@ class HandlerTest(unittest.TestCase):
     """Create issue successfully."""
     issue_tracker = mock.Mock()
     self.mock.get_issue_tracker_for_testcase.return_value = issue_tracker
-    self.mock.file_issue.return_value = 100
+    self.mock.file_issue.return_value = 100, None
 
     resp = self.app.post_json(
         '/', {
@@ -113,7 +113,7 @@ class HandlerTest(unittest.TestCase):
     """Invalid severity."""
     issue_tracker = mock.Mock()
     self.mock.get_issue_tracker_for_testcase.return_value = issue_tracker
-    self.mock.file_issue.return_value = 100
+    self.mock.file_issue.return_value = 100, None
 
     resp = self.app.post_json(
         '/', {
@@ -129,7 +129,7 @@ class HandlerTest(unittest.TestCase):
     """Fail to create issue."""
     issue_tracker = mock.Mock()
     self.mock.get_issue_tracker_for_testcase.return_value = issue_tracker
-    self.mock.file_issue.return_value = None
+    self.mock.file_issue.return_value = None, None
 
     resp = self.app.post_json(
         '/', {

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -304,7 +304,8 @@ class IssueFilerTests(unittest.TestCase):
     """Tests issue filing for chromium."""
     self.mock.get.return_value = CHROMIUM_POLICY
     issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
-    issue_filer.file_issue(self.testcase4, issue_tracker)
+    _, exception = issue_filer.file_issue(self.testcase4, issue_tracker)
+    self.assertIsNone(exception)
     self.assertIn('OS-Chrome', issue_tracker._itm.last_issue.labels)
     self.assertEqual('Untriaged', issue_tracker._itm.last_issue.status)
     self.assertNotIn('Restrict-View-SecurityTeam',
@@ -438,7 +439,8 @@ class IssueFilerTests(unittest.TestCase):
     self.mock.save.side_effect = my_save
 
     issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
-    issue_filer.file_issue(self.testcase5, issue_tracker)
+    _, exception = issue_filer.file_issue(self.testcase5, issue_tracker)
+    self.assertIsInstance(exception, Exception)
 
     six.assertCountEqual(self,
                          ['fallback>component', '-component1', '-component2'],
@@ -453,7 +455,8 @@ class IssueFilerTests(unittest.TestCase):
     setattr(my_save, 'raise_exception', True)
     issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
     self.mock.get.return_value = CHROMIUM_POLICY
-    issue_filer.file_issue(self.testcase1, issue_tracker)
+    with self.assertRaises(Exception):
+      issue_filer.file_issue(self.testcase1, issue_tracker)
 
     self.assertIsNone(issue_tracker._itm.last_issue)
 


### PR DESCRIPTION
For issues filed to a fallback component, surface the exception in the
testcase triage message.

Also fix incorrect behaviour with failed issue filings not raising any
exception.