### PR TITLE
correctly assign ccs from issue trackers config.yaml

### DIFF
--- a/src/appengine/libs/issue_management/issue_tracker_policy.py
+++ b/src/appengine/libs/issue_management/issue_tracker_policy.py
@@ -134,7 +134,7 @@ class IssueTrackerPolicy(object):
       policy.status = self._data['status'][issue_type['status']]
 
     if 'ccs' in issue_type:
-      policy.labels.extend(issue_type['ccs'])
+      policy.ccs.extend(issue_type['ccs'])
 
     labels = issue_type.get('labels')
     if labels:


### PR DESCRIPTION
Currently if ccs are defined in issue_trackers/config.yaml then these are incorrectly assigned as labels instead of ccs/watchers.
This PR rectifies the variable where ccs should be assigned.