### PR TITLE
Set PYTHONUNBUFFERED in CI tests.

### DIFF
--- a/local/tests/run_all_tests
+++ b/local/tests/run_all_tests
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 SCRIPT_DIR=$(dirname $(readlink -f "$0"))
 
+export PYTHONUNBUFFERED=1
 INTEGRATION=1 $SCRIPT_DIR/run_tests
 $SCRIPT_DIR/run_reproduce_tool_tests
 $SCRIPT_DIR/run_js_tests


### PR DESCRIPTION
Otherwise exceptions etc that happen early on can be omitted. 