### PR TITLE
Change actions and merged_into into a property

### DIFF
--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -134,9 +134,11 @@ class Issue(issue_tracker.Issue):
 
     self.itm.save(self)
 
+  @property
   def actions(self):
     pass
 
+  @property
   def merged_into(self):
     pass
 


### PR DESCRIPTION
The jira integration was sending requests like `/rest/api/2/issue/<bound method Issue.merged_into of <libs.issue_management.jira.Issue object at 0x3e14ae683510>>`, and that was due to the merged_into/actions method not being a property.