### PR TITLE
[fuchsia] Only dump last 64kb of QEMU log on error

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -740,7 +740,10 @@ class FuchsiaQemuLibFuzzerRunner(new_process.UnicodeProcessRunner,
       with open(QemuProcess.LOG_PATH) as f:
         # Strip non-printable characters at beginning of qemu log
         qemu_log = ''.join(c for c in f.read() if c in string.printable)
-        logs.log_warn(qemu_log)
+        # Only report the tail of the log; otherwise we would only end up seeing
+        # the beginning of it once the logging library later truncates it to the
+        # STACKDRIVER_LOG_MESSAGE_LIMIT.
+        logs.log_warn(qemu_log[-64 * 1024:])
     else:
       logs.log_error('Qemu log not found in {}'.format(QemuProcess.LOG_PATH))
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -740,10 +740,7 @@ class FuchsiaQemuLibFuzzerRunner(new_process.UnicodeProcessRunner,
       with open(QemuProcess.LOG_PATH) as f:
         # Strip non-printable characters at beginning of qemu log
         qemu_log = ''.join(c for c in f.read() if c in string.printable)
-        # Only report the tail of the log; otherwise we would only end up seeing
-        # the beginning of it once the logging library later truncates it to the
-        # STACKDRIVER_LOG_MESSAGE_LIMIT.
-        logs.log_warn(qemu_log[-64 * 1024:])
+        logs.log_warn(qemu_log[-undercoat.QEMU_LOG_LIMIT:])
     else:
       logs.log_error('Qemu log not found in {}'.format(QemuProcess.LOG_PATH))
 

--- a/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
+++ b/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
@@ -131,7 +131,10 @@ def dump_instance_logs(handle):
   """Dump logs from an undercoat instance."""
   qemu_log = undercoat_instance_command(
       'get_logs', handle, abort_on_error=False).output
-  logs.log_warn(qemu_log)
+  # Only report the tail of the log; otherwise we would only end up seeing the
+  # beginning of it once the logging library later truncates it to the
+  # STACKDRIVER_LOG_MESSAGE_LIMIT.
+  logs.log_warn(qemu_log[-64 * 1024:])
 
 
 def start_instance():

--- a/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
+++ b/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
@@ -24,6 +24,12 @@ from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.system import new_process
 
+# Maximum number of bytes to report from the QEMU log on error.
+# We only report the tail of the log because otherwise we would only end up
+# seeing the beginning of it once the logging library later truncates it to the
+# STACKDRIVER_LOG_MESSAGE_LIMIT.
+QEMU_LOG_LIMIT = 64 * 1024
+
 # In order to properly clean up any stale instances, we keep track of handles in
 # the persistent cache. We assume that only one instance of a bot will be
 # accessing this cache at a time.
@@ -131,10 +137,7 @@ def dump_instance_logs(handle):
   """Dump logs from an undercoat instance."""
   qemu_log = undercoat_instance_command(
       'get_logs', handle, abort_on_error=False).output
-  # Only report the tail of the log; otherwise we would only end up seeing the
-  # beginning of it once the logging library later truncates it to the
-  # STACKDRIVER_LOG_MESSAGE_LIMIT.
-  logs.log_warn(qemu_log[-64 * 1024:])
+  logs.log_warn(qemu_log[-QEMU_LOG_LIMIT:])
 
 
 def start_instance():


### PR DESCRIPTION
The tail of QEMU logs was being truncated due to maximum log size
limits, so instead we now strip off the head ourselves.