### PR TITLE
[fuchsia] Avoid decode error when a fuzzer outputs invalid unicode

### DIFF
--- a/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
+++ b/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
@@ -85,7 +85,8 @@ def undercoat_api_command(*args):
     if result.return_code != 0:
       # Dump the undercoat log to assist in debugging
       log_data = utils.read_from_handle_truncated(undercoat_log, 1024 * 1024)
-      logs.log_warn('Log output from undercoat: ' + utils.decode_to_unicode(log_data))
+      logs.log_warn('Log output from undercoat: ' +
+                    utils.decode_to_unicode(log_data))
 
       # The API error message is returned on stdout
       raise UndercoatError(

--- a/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
+++ b/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
@@ -80,12 +80,12 @@ def undercoat_api_command(*args):
   with tempfile.TemporaryFile() as undercoat_log:
     result = undercoat.run_and_wait(
         stderr=undercoat_log, extra_env={'TMPDIR': get_temp_dir()})
-    result.output = result.output.decode('utf-8', errors='backslashreplace')
+    result.output = utils.decode_to_unicode(result.output)
 
     if result.return_code != 0:
       # Dump the undercoat log to assist in debugging
       log_data = utils.read_from_handle_truncated(undercoat_log, 1024 * 1024)
-      logs.log_warn('Log output from undercoat: ' + log_data.decode('utf-8'))
+      logs.log_warn('Log output from undercoat: ' + utils.decode_to_unicode(log_data))
 
       # The API error message is returned on stdout
       raise UndercoatError(

--- a/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
+++ b/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
@@ -80,7 +80,7 @@ def undercoat_api_command(*args):
   with tempfile.TemporaryFile() as undercoat_log:
     result = undercoat.run_and_wait(
         stderr=undercoat_log, extra_env={'TMPDIR': get_temp_dir()})
-    result.output = result.output.decode('utf-8')
+    result.output = result.output.decode('utf-8', errors='backslashreplace')
 
     if result.return_code != 0:
       # Dump the undercoat log to assist in debugging


### PR DESCRIPTION
Some fuzzers may print random data to stdout, but we don't need to treat
this as a fatal error.