### PR TITLE
[fuchsia] Add Fuchsia-specific list of stale processes to kill

### DIFF
--- a/src/clusterfuzz/_internal/system/process_handler.py
+++ b/src/clusterfuzz/_internal/system/process_handler.py
@@ -565,6 +565,13 @@ def terminate_stale_application_instances():
     # Artifical sleep to let the processes get terminated.
     time.sleep(1)
 
+  elif platform == 'FUCHSIA':
+    processes_to_kill += [
+        'undercoat',
+        llvm_symbolizer_filename,
+    ]
+    terminate_processes_matching_names(processes_to_kill, kill=True)
+
   else:
     # Handle Linux and Mac platforms.
     processes_to_kill += [


### PR DESCRIPTION
The default behavior matched processes with cmdlines including the
builds directory. This ended up inadvertently killing the qemu
instance, which is intended to be long-running.