### PR TITLE
Fetch Fuzzer entities more frequently in project_setup.

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -742,8 +742,8 @@ class ProjectSetup(object):
         if job_name not in fuzzer_entity.jobs and not job.is_external():
           # Enable new job.
           fuzzer_entity.jobs.append(job_name)
+          fuzzer_entity.put()
 
-      fuzzer_entity.put()
       job.name = job_name
       if self._segregate_projects:
         job.platform = untrusted.platform_name(project, 'linux')


### PR DESCRIPTION
project_setup is long running and currently only fetches the Fuzzer
entities once at the beginning. This makes manual Fuzzer updates by humans
prone to getting overwritten.