### PR TITLE
Update URL for cloud storage browser.

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -87,7 +87,7 @@ _local = threading.local()
 
 # Urls for web viewer.
 OBJECT_URL = 'https://storage.cloud.google.com'
-DIRECTORY_URL = 'https://console.cloud.google.com/storage'
+DIRECTORY_URL = 'https://console.cloud.google.com/storage/browser'
 
 
 class StorageProvider(object):


### PR DESCRIPTION
Clicking on, for example, a fuzzer corpus link would result in a "URL
not found" error. This updates the URL to a working one.