### PR TITLE
Jira tracker returning tz-aware datetime

### DIFF
--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Jira issue tracker."""
 
+import datetime
+
 from urllib.parse import urljoin
 
 from dateutil import parser
@@ -69,7 +71,7 @@ class Issue(issue_tracker.Issue):
 
   @property
   def closed_time(self):
-    return parser.parse(self.jira_issue.fields.resolutiondate)
+    return datetime.datetime.fromtimestamp(parser.parse(self.jira_issue.fields.resolutiondate).timestamp())
 
   @property
   def status(self):

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -14,7 +14,6 @@
 """Jira issue tracker."""
 
 import datetime
-
 from urllib.parse import urljoin
 
 from dateutil import parser
@@ -71,7 +70,8 @@ class Issue(issue_tracker.Issue):
 
   @property
   def closed_time(self):
-    return datetime.datetime.fromtimestamp(parser.parse(self.jira_issue.fields.resolutiondate).timestamp())
+    return datetime.datetime.fromtimestamp(
+        parser.parse(self.jira_issue.fields.resolutiondate).timestamp())
 
   @property
   def status(self):

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
@@ -15,9 +15,8 @@
 
 import datetime
 import unittest
-import pytz
 
-from dateutil import tz
+import pytz
 import six
 
 from clusterfuzz._internal.tests.test_libs import helpers

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
@@ -15,6 +15,7 @@
 
 import datetime
 import unittest
+import pytz
 
 from dateutil import tz
 import six
@@ -59,7 +60,7 @@ class Fields(object):
     self.status = Status()
     self.labels = []
     self.components = []
-    self.resolutiondate = '2020-01-14T11:46:34.000-0800'
+    self.resolutiondate = '2020-01-14T11:46:34.000-0000'
 
 
 class JiraIssue(object):
@@ -127,9 +128,8 @@ class JiraTests(unittest.TestCase):
     issue = self.issue_tracker.get_issue('VSEC-3112')
     self.assertEqual('VSEC-3112', issue.id)
     self.assertEqual(
-        datetime.datetime(
-            2020, 1, 14, 11, 46, 34, tzinfo=tz.tzoffset(None, -28800)),
-        issue.closed_time)
+        datetime.datetime(2020, 1, 14, 11, 46, 34, tzinfo=pytz.utc).timestamp(),
+        issue.closed_time.timestamp())
 
   def test_modify_labels(self):
     """Test modifying labels."""


### PR DESCRIPTION
This modifies the Jira Issue class to return tz-naive datetime instead as there are areas in ClusterFuzz where tz-naive datetime is expected but the jira integration is returning tz-aware datetime.

Example:
https://github.com/google/clusterfuzz/blob/4f8020c4c7ce73c1da0e68f04943af30bb5f0b32/src/clusterfuzz/_internal/base/dates.py#L43

