### PR TITLE
fixes jira actions and is_open property

### DIFF
--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -65,7 +65,7 @@ class Issue(issue_tracker.Issue):
   @property
   def is_open(self):
     """Whether the issue is open."""
-    return self.jira_issue.resolution not in ['Closed', 'Done', 'Resolved']
+    return self.jira_issue.fields.resolution is None
 
   @property
   def closed_time(self):
@@ -138,7 +138,7 @@ class Issue(issue_tracker.Issue):
 
   @property
   def actions(self):
-    pass
+    return ()
 
   @property
   def merged_into(self):


### PR DESCRIPTION
Fixes an issue where actions was expected to be iterable, this makes it return an empty tuple as default.
Example:
https://github.com/google/clusterfuzz/blob/4f8020c4c7ce73c1da0e68f04943af30bb5f0b32/src/appengine/libs/issue_management/issue_tracker_utils.py#L181

Also fixes the is_open property by checking if resolution is None (I think its safe to assume that if there is a resolution that the issue is closed).