### PR TITLE
Fix errors when updating jira issue

### DIFF
--- a/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
+++ b/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
@@ -82,14 +82,19 @@ class IssueTrackerManager(object):
         'components': components,
     }
 
-    # Only add status if it has changed.
-    # Brittle - we should be pulling the equivalent of 'new' from the policy.
-    if issue.status != 'Open':
-      status = {'name': issue.status}
-      update_fields['status'] = status
+    # This assumes the following:
+    # 1. If issue.status is an instance of Resource, the value comes from
+    #    Jira directly and has not been changed.
+    # 2. If issue.status is not an instance of Resource, the value is a
+    #    string and the issue status should be updated.
+    if not isinstance(issue.status, jira.Resource):
+      self.client.transition_issue(issue.jira_issue, transition=issue.status)
 
     if issue.assignee is not None:
-      assignee = {'name': issue.assignee}
+      if isinstance(issue.assignee, jira.Resource):
+        assignee = {'name': issue.assignee.name}
+      else:
+        assignee = {'name': issue.assignee}
       update_fields['assignee'] = assignee
 
     # Again brittle - need to pull these strings from policy.


### PR DESCRIPTION
The first issue this fixes is a `Object of type Status is not JSON serializable`, this is due to the previous implementation assuming that the status value is always a String. This PR changes the implementation to use the right way of updating status (transitions) as well as to only update when necessary.

Traceback:
```
Traceback (most recent call last):
  File "/srv/handlers/cron/cleanup.py", line 132, in cleanup_testcases_and_issues
    update_os_labels(policy, testcase, issue)
  File "/srv/handlers/cron/cleanup.py", line 954, in update_os_labels
    issue.save(notify=False)
  File "/srv/libs/issue_management/jira/__init__.py", line 137, in save
    self.itm.save(self)
  File "/srv/libs/issue_management/jira/issue_tracker_manager.py", line 91, in save
    self._update(issue)
  File "/srv/libs/issue_management/jira/issue_tracker_manager.py", line 148, in _update
    issue.jira_issue.update(fields=update_fields)
  File "/layers/google.python.pip/pip/lib/python3.7/site-packages/jira/resources.py", line 485, in update
    super(Issue, self).update(async_=async_, jira=jira, notify=notify, fields=data)
  File "/layers/google.python.pip/pip/lib/python3.7/site-packages/jira/resources.py", line 225, in update
    data = json.dumps(data)
  File "/opt/python3.7/lib/python3.7/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/opt/python3.7/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/opt/python3.7/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/opt/python3.7/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Status is not JSON serializable"
```

The second issue this fixes is similar, but for the assignee field, this fixes it by adding a check to see if the value is of the jira.Resource type and to handle accordingly.