### PR TITLE
Fix jira integration error where issue id is expected to be integer

### DIFF
--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -43,6 +43,11 @@ class Issue(issue_tracker.Issue):
   @property
   def id(self):
     """The issue identifier."""
+    return int(self.jira_issue.id)
+
+  @property
+  def key(self):
+    """The issue key (e.g. FUZZ-123)."""
     return self.jira_issue.key
 
   @property
@@ -179,8 +184,14 @@ class IssueTracker(issue_tracker.IssueTracker):
 
   def issue_url(self, issue_id):
     """Return the issue URL with the given ID."""
+    issue = self.get_issue(issue_id)
+    if not issue:
+      return None
+
     config = db_config.get()
-    url = urljoin(config.jira_url, f'/browse/{str(issue_id)}')
+    jira_url = local_config.ProjectConfig().get('env.ACTUAL_JIRA_URL',
+                                                config.jira_url)
+    url = urljoin(jira_url, f'/browse/{str(issue.key)}')
     return url
 
   def find_issues_url(self, keywords=None, only_open=None):

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -189,9 +189,7 @@ class IssueTracker(issue_tracker.IssueTracker):
       return None
 
     config = db_config.get()
-    jira_url = local_config.ProjectConfig().get('env.ACTUAL_JIRA_URL',
-                                                config.jira_url)
-    url = urljoin(jira_url, f'/browse/{str(issue.key)}')
+    url = urljoin(config.jira_url, f'/browse/{str(issue.key)}')
     return url
 
   def find_issues_url(self, keywords=None, only_open=None):

--- a/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
+++ b/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
@@ -106,6 +106,7 @@ class IssueTrackerManager(object):
     # Jira weirdness, update watchers this way.
     for watcher in watchers:
       self.client.add_watcher(issue.jira_issue, watcher)
+
     issue.jira_issue.update(fields=update_fields)
 
   def get_watchers(self, issue):

--- a/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
+++ b/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
@@ -82,13 +82,15 @@ class IssueTrackerManager(object):
         'components': components,
     }
 
-    # This assumes the following:
-    # 1. If issue.status is an instance of Resource, the value comes from
-    #    Jira directly and has not been changed.
-    # 2. If issue.status is not an instance of Resource, the value is a
-    #    string and the issue status should be updated.
-    if not isinstance(issue.status, jira.resources.Resource):
-      self.client.transition_issue(issue.jira_issue, transition=issue.status)
+    if issue.status != 'Open':
+      # This assumes the following:
+      # 1. If issue.status is an instance of Resource, the value comes from
+      #    Jira directly and has not been changed.
+      # 2. If issue.status is not an instance of Resource, the value is a
+      #    string and the issue status should be updated.
+      # Brittle - we should be pulling the equivalent of 'new' from the policy.
+      if not isinstance(issue.status, jira.resources.Resource):
+        self.client.transition_issue(issue.jira_issue, transition=issue.status)
 
     if issue.assignee is not None:
       if isinstance(issue.assignee, jira.resources.Resource):

--- a/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
+++ b/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
@@ -87,11 +87,11 @@ class IssueTrackerManager(object):
     #    Jira directly and has not been changed.
     # 2. If issue.status is not an instance of Resource, the value is a
     #    string and the issue status should be updated.
-    if not isinstance(issue.status, jira.Resource):
+    if not isinstance(issue.status, jira.resources.Resource):
       self.client.transition_issue(issue.jira_issue, transition=issue.status)
 
     if issue.assignee is not None:
-      if isinstance(issue.assignee, jira.Resource):
+      if isinstance(issue.assignee, jira.resources.Resource):
         assignee = {'name': issue.assignee.name}
       else:
         assignee = {'name': issue.assignee}
@@ -106,7 +106,6 @@ class IssueTrackerManager(object):
     # Jira weirdness, update watchers this way.
     for watcher in watchers:
       self.client.add_watcher(issue.jira_issue, watcher)
-
     issue.jira_issue.update(fields=update_fields)
 
   def get_watchers(self, issue):

--- a/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
+++ b/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
@@ -82,6 +82,7 @@ class IssueTrackerManager(object):
         'components': components,
     }
 
+    # Brittle - we should be pulling the equivalent of 'new' from the policy.
     if issue.status != 'Open':
       # This assumes the following:
       # 1. If issue.status is an instance of Resource, the value comes from

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
@@ -67,6 +67,7 @@ class JiraIssue(object):
 
   def __init__(self, key):
     self.key = key
+    self.id = key.split('-')[-1]
     self.fields = Fields()
 
 
@@ -105,7 +106,8 @@ class JiraTests(unittest.TestCase):
     self.mock.get_issue.return_value = self.mock_issue
     issue = self.issue_tracker.get_issue('VSEC-3112')
 
-    self.assertEqual('VSEC-3112', issue.id)
+    self.assertEqual(3112, issue.id)
+    self.assertEqual('VSEC-3112', issue.key)
     self.assertEqual('summary', issue.title)
     self.assertEqual('body', issue.body)
     self.assertEqual('Unassigned', issue.assignee)
@@ -125,7 +127,7 @@ class JiraTests(unittest.TestCase):
     ], issue.ccs)
 
     issue = self.issue_tracker.get_issue('VSEC-3112')
-    self.assertEqual('VSEC-3112', issue.id)
+    self.assertEqual('VSEC-3112', issue.key)
     self.assertEqual(
         datetime.datetime(2020, 1, 14, 11, 46, 34, tzinfo=pytz.utc).timestamp(),
         issue.closed_time.timestamp())
@@ -150,10 +152,11 @@ class JiraTests(unittest.TestCase):
     """Test find_issues."""
     self.mock.get_issues.return_value = [self.jira_issue]
     issues = self.issue_tracker.find_issues(keywords=['body'], only_open=True)
-    six.assertCountEqual(self, ['VSEC-3112'], [issue.id for issue in issues])
+    six.assertCountEqual(self, ['VSEC-3112'], [issue.key for issue in issues])
 
   def test_issue_url(self):
     """Test issue_url."""
     self.mock.get.return_value = Config()
+    self.mock.get_issue.return_value = self.mock_issue
     issue_url = self.issue_tracker.issue_url('VSEC-3112')
     self.assertEqual('https://jira.company.com/browse/VSEC-3112', issue_url)

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
@@ -70,6 +70,9 @@ class JiraIssue(object):
     self.id = key.split('-')[-1]
     self.fields = Fields()
 
+  def update(self, **kwargs):
+    pass
+
 
 class JiraTests(unittest.TestCase):
   """Tests for the jira issue tracker."""
@@ -82,7 +85,9 @@ class JiraTests(unittest.TestCase):
         'IssueTrackerManager.get_issues',
         'libs.issue_management.jira.IssueTracker.get_issue',
         'libs.issue_management.jira.IssueTracker.new_issue',
-        'clusterfuzz._internal.config.db_config.get'
+        'clusterfuzz._internal.config.db_config.get',
+        'libs.issue_management.jira.issue_tracker_manager.'
+        'IssueTrackerManager.client'
     ])
 
     self.itm = issue_tracker_manager.IssueTrackerManager('VSEC')
@@ -160,3 +165,11 @@ class JiraTests(unittest.TestCase):
     self.mock.get_issue.return_value = self.mock_issue
     issue_url = self.issue_tracker.issue_url('VSEC-3112')
     self.assertEqual('https://jira.company.com/browse/VSEC-3112', issue_url)
+
+  def test_issue_save(self):
+    """Test save."""
+    self.mock.get_issue.return_value = self.mock_issue
+    issue = self.issue_tracker.get_issue('VSEC-3112')
+    issue.status = 'Closed'
+    issue.save()
+    self.assertEqual(issue.status, 'Closed')


### PR DESCRIPTION
**Context**
Clusterfuzz expects issue.id to be integer in various parts of the code, however, the current implementation of the jira integration returns a string value that is not int-parseable (e.g. fuzz-123), this results in exceptions thrown during cronjobs that fails.

This PR fixes that by returning the id of an issue instead of the key, however, doing this requires making a call to the Jira instance to fetch the key value in order to craft the issue URL (which we memoize for 24 hours after).

Additionally this PR also fixes an issue that I introduced in a previous PR due to an invalid module path: https://github.com/google/clusterfuzz/blob/master/src/appengine/libs/issue_management/jira/issue_tracker_manager.py#L90 (also added a unit test to catch this)
