### PR TITLE
Fix App Engine dependency breakage.

### DIFF
--- a/src/appengine/gae_requirements.txt
+++ b/src/appengine/gae_requirements.txt
@@ -1,8 +1,10 @@
 cryptography==3.4.8
 firebase-admin==2.16.0
 Flask==1.1.2
+itsdangerous==2.0.1
 Jinja2==2.11.3
 jira==2.0.0
+markupsafe==2.0.1
 PyJWT==1.7.1
 pyOpenSSL==19.1.0
 python-dateutil==2.8.1


### PR DESCRIPTION
Pin markupsafe, itsdangerous to older versions.

All dependencies will be pinned in a later PR.