### PR TITLE
Add DISABLE_VARIANT option for jobs.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_creation.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_creation.py
@@ -172,6 +172,10 @@ def create_variant_tasks_if_needed(testcase):
     if utils.string_is_true(job_environment.get('EXPERIMENTAL')):
       continue
 
+    # Skip jobs for which variant tasks are disabled.
+    if utils.string_is_true(job_environment.get('DISABLE_VARIANT')):
+      continue
+
     queue = tasks.queue_for_platform(job.platform)
     tasks.add_task('variant', testcase_id, job_type, queue)
 


### PR DESCRIPTION
If set to True, variant tasks will not be created for that job. This is
useful in cases where a project's jobs don't contain the same fuzzers.