### PR TITLE
Add customize-able project labels applying to all fuzz targets in a Project

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -790,11 +790,14 @@ class ProjectSetup(object):
             backup_bucket=backup_bucket_name)
 
       if self._add_info_labels:
-        job.environment_string += (
-            'AUTOMATIC_LABELS = Proj-{project},Engine-{engine}\n'.format(
-                project=project,
-                engine=template.engine,
-            ))
+        automatic_labels = 'Proj-{project},Engine-{engine}'.format(
+            project=project,
+            engine=template.engine,
+        )
+        labels = info.get('labels')
+        if labels and '*' in labels:
+          automatic_labels += ',%s' % ','.join(labels['*'])
+        job.environment_string += ('AUTOMATIC_LABELS = %s\n' % automatic_labels)
 
       help_url = info.get('help_url')
       if help_url:

--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -790,14 +790,12 @@ class ProjectSetup(object):
             backup_bucket=backup_bucket_name)
 
       if self._add_info_labels:
-        automatic_labels = 'Proj-{project},Engine-{engine}'.format(
-            project=project,
-            engine=template.engine,
-        )
+        automatic_labels = [f'Proj-{project}', f'Engine-{template.engine}']
         labels = info.get('labels')
         if labels and '*' in labels:
-          automatic_labels += ',%s' % ','.join(labels['*'])
-        job.environment_string += ('AUTOMATIC_LABELS = %s\n' % automatic_labels)
+          automatic_labels.extend(labels['*'])
+        automatic_labels = ','.join(automatic_labels)
+        job.environment_string += f'AUTOMATIC_LABELS = {automatic_labels}\n'
 
       help_url = info.get('help_url')
       if help_url:

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -295,12 +295,13 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         ('lib7', {
             'homepage': 'http://example.com',
             'primary_contact': 'primary@example.com',
-            'auto_ccs': [
-                'User@example.com',
-            ],
+            'auto_ccs': ['User@example.com',],
             'fuzzing_engines': ['libfuzzer',],
             'sanitizers': ['address'],
-            'labels': {'*': ['custom'], 'per-target': ['ignore']},
+            'labels': {
+                '*': ['custom'],
+                'per-target': ['ignore']
+            },
         }),
     ]
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -292,6 +292,16 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'auto_ccs': 'User@example.com',
             'vendor_ccs': ['vendor1@example.com', 'vendor2@example.com'],
         }),
+        ('lib7', {
+            'homepage': 'http://example.com',
+            'primary_contact': 'primary@example.com',
+            'auto_ccs': [
+                'User@example.com',
+            ],
+            'fuzzing_engines': ['libfuzzer',],
+            'sanitizers': ['address'],
+            'labels': {'*': ['custom'], 'per-target': ['ignore']},
+        }),
     ]
 
     mock_storage.buckets().get.side_effect = mock_bucket_get
@@ -477,6 +487,27 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         'DATAFLOW_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds-dataflow/lib6/lib6-dataflow-([0-9]+).zip\n')
 
+    job = data_types.Job.query(
+        data_types.Job.name == 'libfuzzer_asan_lib7').get()
+    self.assertIsNotNone(job)
+    self.assertEqual(job.project, 'lib7')
+    self.assertEqual(job.platform, 'LIB7_LINUX')
+    six.assertCountEqual(self, job.templates,
+                         ['engine_asan', 'libfuzzer', 'prune'])
+    self.assertEqual(
+        job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
+        'gs://clusterfuzz-builds/lib7/lib7-address-([0-9]+).zip\n'
+        'PROJECT_NAME = lib7\n'
+        'SUMMARY_PREFIX = lib7\n'
+        'MANAGED = True\n'
+        'REVISION_VARS_URL = https://commondatastorage.googleapis.com/'
+        'clusterfuzz-builds/lib7/lib7-address-%s.srcmap.json\n'
+        'FUZZ_LOGS_BUCKET = lib7-logs.clusterfuzz-external.appspot.com\n'
+        'CORPUS_BUCKET = lib7-corpus.clusterfuzz-external.appspot.com\n'
+        'QUARANTINE_BUCKET = lib7-quarantine.clusterfuzz-external.appspot.com\n'
+        'BACKUP_BUCKET = lib7-backup.clusterfuzz-external.appspot.com\n'
+        'AUTOMATIC_LABELS = Proj-lib7,Engine-libfuzzer,custom\n')
+
     self.maxDiff = None  # pylint: disable=invalid-name
 
     libfuzzer = data_types.Fuzzer.query(
@@ -492,6 +523,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         'libfuzzer_asan_lib6',
         'libfuzzer_msan_lib6',
         'libfuzzer_ubsan_lib6',
+        'libfuzzer_asan_lib7',
     ])
 
     afl = data_types.Fuzzer.query(data_types.Fuzzer.name == 'afl').get()
@@ -1311,6 +1343,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         ('LIB6_LINUX', 'libFuzzer', 'libfuzzer_ubsan_lib6'),
         ('LIB6_LINUX', 'afl', 'afl_asan_lib6'),
         ('LIB1_LINUX', 'honggfuzz', 'honggfuzz_asan_lib1'),
+        ('LIB7_LINUX', 'libFuzzer', 'libfuzzer_asan_lib7'),
     ])
 
     all_permissions = [
@@ -1492,6 +1525,18 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         'email': u'user2@googlemail.com',
         'entity_name': u'honggfuzz_asan_lib1',
         'auto_cc': 1
+    }, {
+        'entity_kind': 1,
+        'is_prefix': False,
+        'email': u'primary@example.com',
+        'entity_name': u'libfuzzer_asan_lib7',
+        'auto_cc': 1
+    }, {
+        'entity_kind': 1,
+        'is_prefix': False,
+        'email': u'user@example.com',
+        'entity_name': u'libfuzzer_asan_lib7',
+        'auto_cc': 1
     }])
 
     expected_topics = [
@@ -1502,6 +1547,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         'projects/clusterfuzz-external/topics/jobs-lib4-linux',
         'projects/clusterfuzz-external/topics/jobs-lib5-linux',
         'projects/clusterfuzz-external/topics/jobs-lib6-linux',
+        'projects/clusterfuzz-external/topics/jobs-lib7-linux',
     ]
     six.assertCountEqual(self, expected_topics,
                          list(pubsub_client.list_topics('projects/' + app_id)))


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Part of https://github.com/google/oss-fuzz/issues/7318

In Project setup, checks for a wildcard label defined in the `project.yaml`'s `labels` field to apply project-wide labels when filing issues. (Previously only per-fuzz target labels were supported). See issue for use-case. 