### PR TITLE
Update container image tag

### DIFF
--- a/configs/test/gce/clusters.yaml
+++ b/configs/test/gce/clusters.yaml
@@ -88,7 +88,7 @@ test-clusterfuzz:
         metadata:
           items:
             - key: docker-image
-              value: gcr.io/clusterfuzz-images/base:ce67e3c-202004060711
+              value: gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654
             - key: user-data
               value: file://linux-init.yaml
         serviceAccounts:
@@ -116,7 +116,7 @@ test-clusterfuzz:
         metadata:
           items:
             - key: docker-image
-              value: gcr.io/clusterfuzz-images/base:ce67e3c-202004060711
+              value: gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654
             - key: user-data
               value: file://linux-init.yaml
         serviceAccounts:
@@ -146,7 +146,7 @@ test-clusterfuzz:
         metadata:
           items:
             - key: docker-image
-              value: gcr.io/clusterfuzz-images/high-end:ce67e3c-202004060711
+              value: gcr.io/clusterfuzz-images/high-end:a2f4dd6-202202070654
             - key: user-data
               value: file://linux-init.yaml
         serviceAccounts:
@@ -174,7 +174,7 @@ test-clusterfuzz:
         metadata:
           items:
             - key: docker-image
-              value: gcr.io/clusterfuzz-images/ml-with-gpu:ce67e3c-202004060711
+              value: gcr.io/clusterfuzz-images/ml-with-gpu:a2f4dd6-202202070654
             - key: user-data
               value: file://linux-init-ml-with-gpu.yaml
         serviceAccounts:


### PR DESCRIPTION
The original container image tags (`ce67e3c-202004060711`) pull down Ubuntu 16.04 UTS.  The replacement (`a2f4dd6-202202070654`) is 20.04 LTS.

I notice the sample / proof of concept Heartbleed test case works with both.

However, the real life example binaries I used to test the clusterfuzz instance are more particular in other libraries between the two LTS releases and failed to run without updating to a newer base image.

I expect this small patch will help others out as they get their instance operational.
