### PR TITLE
Mock test GitHub issue

### DIFF
--- a/src/appengine/libs/issue_management/oss_fuzz_github.py
+++ b/src/appengine/libs/issue_management/oss_fuzz_github.py
@@ -71,7 +71,8 @@ def _get_access_token():
   """Get access to GitHub with the oss-fuzz personal access token"""
   token = db_config.get_value('oss_fuzz_robot_github_personal_access_token')
   if not token:
-    raise RuntimeError('Unable to access GitHub account and close the issue.')
+    raise RuntimeError('Unable to access GitHub account to '
+                       'file/close the issue.')
   return github.Github(token)
 
 

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -23,7 +23,6 @@ import mock
 import parameterized
 import six
 
-from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.google_cloud_utils import pubsub
 from clusterfuzz._internal.tests.test_libs import helpers
@@ -32,7 +31,6 @@ from clusterfuzz._internal.tests.test_libs import test_utils
 from libs.issue_management import issue_filer
 from libs.issue_management import issue_tracker_policy
 from libs.issue_management import monorail
-from libs.issue_management import oss_fuzz_github
 from libs.issue_management.issue_tracker import LabelStore
 from libs.issue_management.monorail.issue import Issue as MonorailIssue
 
@@ -195,32 +193,6 @@ QUESTIONS_NOTE = (
     'other feedback, please file an issue at '
     'https://github.com/google/oss-fuzz/issues.')
 
-TESTCASE_REPORT_URL = 'https://{domain}/testcase?key={testcase_id}'
-
-MONORAIL_URL = (
-    'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id={bug_information}')
-
-OSS_FUZZ_ISSUE_URL = 'https://github.com/google/oss-fuzz/issues/new'
-
-GITHUB_ISSUE_TITTLE_TEXT = 'OSS-Fuzz issue {bug_information}'
-
-GITHUB_ISSUE_CONTENT_TEXT = (
-    'OSS-Fuzz has found a bug in this project. Please see '
-    f'{TESTCASE_REPORT_URL} '
-    'for details and reproducers.'
-    '\n\n'
-    'This issue is mirrored from '
-    f'{MONORAIL_URL} '
-    'and will auto-close if the status changes there.'
-    '\n\n'
-    'If you have trouble accessing this report, '
-    f'please file an issue at {OSS_FUZZ_ISSUE_URL}.'
-    '\n')
-
-GITHUB_ISSUE_CLOSE_COMMENT_TEXT = ('OSS-Fuzz has closed this bug. Please see '
-                                   f'{MONORAIL_URL} '
-                                   'for details.')
-
 
 class IssueTrackerManager(object):
   """Mock issue tracker manager."""
@@ -304,16 +276,6 @@ class IssueFilerTests(unittest.TestCase):
 
     self.testcase7 = data_types.Testcase(job_type='ios_job4', **testcase_args)
     self.testcase7.put()
-
-    self.testcases = [
-        self.testcase1,
-        self.testcase2,
-        self.testcase3,
-        self.testcase4,
-        self.testcase5,
-        self.testcase6,
-        self.testcase7,
-    ]
 
     data_types.ExternalUserPermission(
         email='user@example.com',
@@ -681,32 +643,6 @@ class IssueFilerTests(unittest.TestCase):
     issue_filer.file_issue(self.testcase1, issue_tracker)
     self.assertIn('Target: target, Project: proj',
                   issue_tracker._itm.last_issue.body)
-
-  def test_github_issue_title(self):
-    """Test the title format of new GitHub issues."""
-    for testcase in self.testcases:
-      actual_title = oss_fuzz_github.get_issue_title(testcase)
-      expected_title = GITHUB_ISSUE_TITTLE_TEXT.format(
-          bug_information=testcase.bug_information)
-      self.assertEqual(actual_title, expected_title)
-
-  def test_github_issue_body(self):
-    """Test the body format of new GitHub issues."""
-    for testcase in self.testcases:
-      actual_body = oss_fuzz_github.get_issue_body(testcase)
-      expected_body = GITHUB_ISSUE_CONTENT_TEXT.format(
-          domain=data_handler.get_domain(),
-          testcase_id=testcase.key.id(),
-          bug_information=testcase.bug_information)
-      self.assertEqual(actual_body, expected_body)
-
-  def test_github_issue_close(self):
-    """Test the closing message format of GitHub issues filed."""
-    for testcase in self.testcases:
-      actual_comment = oss_fuzz_github.get_issue_close_comment(testcase)
-      expected_comment = GITHUB_ISSUE_CLOSE_COMMENT_TEXT.format(
-          bug_information=testcase.bug_information)
-      self.assertEqual(actual_comment, expected_comment)
 
 
 class MemoryToolLabelsTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
@@ -1,0 +1,153 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GitHub issue filer tests."""
+
+import unittest
+
+import mock
+
+from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
+from clusterfuzz._internal.tests.test_libs import test_utils
+from libs.issue_management import oss_fuzz_github
+
+REPO_NAME = 'sample/sample.git'
+MAIN_REPO = f'https://github.com/{REPO_NAME}'
+JOB1_ENVIRONMENT = f"MAIN_REPO = {MAIN_REPO}\n" \
+                   "FILE_GITHUB_ISSUE = True"
+
+JOB2_ENVIRONMENT = f"MAIN_REPO = {MAIN_REPO}\n" \
+                   "FILE_GITHUB_ISSUE = False"
+
+JOB3_ENVIRONMENT = f"MAIN_REPO = {MAIN_REPO}\n"
+
+GITHUB_REPO_ID = 100
+GITHUB_ISSUE_NUM = 200
+GITHUB_ACCESS_TOKEN = "SECRET"
+
+
+@test_utils.with_cloud_emulators('datastore')
+class OSSFuzzGithubTests(unittest.TestCase):
+  """Tests for the GitHub issue filer."""
+
+  def setUp(self):
+    """Prepare testcases to file to GitHub."""
+    data_types.Job(
+        name='job1', environment_string=JOB1_ENVIRONMENT,
+        platform='linux').put()
+
+    data_types.Job(
+        name='job2', environment_string=JOB2_ENVIRONMENT,
+        platform='linux').put()
+
+    data_types.Job(
+        name='job3', environment_string=JOB3_ENVIRONMENT,
+        platform='linux').put()
+
+    testcase_args1 = {
+        'bug_information': '300',
+    }
+
+    testcase_args2 = {
+        'bug_information': '300',
+        'github_repo_id': GITHUB_REPO_ID,
+        'github_issue_num': GITHUB_ISSUE_NUM,
+    }
+
+    self.testcase1 = data_types.Testcase(job_type='job1', **testcase_args1)
+    self.testcase1.put()
+
+    self.testcase2 = data_types.Testcase(job_type='job2', **testcase_args1)
+    self.testcase2.put()
+
+    self.testcase3 = data_types.Testcase(job_type='job3', **testcase_args1)
+    self.testcase3.put()
+
+    self.testcase4 = data_types.Testcase(job_type='job1', **testcase_args2)
+    self.testcase4.put()
+
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.config.db_config.get_value',
+    ])
+    self.mock.get_value.return_value = GITHUB_ACCESS_TOKEN
+
+  @mock.patch('libs.issue_management.oss_fuzz_github.github')
+  def test_file_issue(self, mock_github):
+    """File testcase to GitHub."""
+    mock_github.Github().get_repo.return_value = mock.MagicMock(
+        id=GITHUB_REPO_ID)
+    mock_github.Github().get_repo().create_issue.return_value = mock.MagicMock(
+        number=GITHUB_ISSUE_NUM)
+
+    oss_fuzz_github.file_issue(self.testcase1)
+
+    mock_github.Github.assert_called_with(GITHUB_ACCESS_TOKEN)
+    mock_github.Github().get_repo.assert_called_with(REPO_NAME)
+    mock_github.Github().get_repo().create_issue.assert_called_once_with(
+        title=oss_fuzz_github.get_issue_title(self.testcase1),
+        body=oss_fuzz_github.get_issue_body(self.testcase1))
+    self.assertEqual(self.testcase1.github_repo_id, GITHUB_REPO_ID)
+    self.assertEqual(self.testcase1.github_issue_num, GITHUB_ISSUE_NUM)
+
+  @mock.patch('libs.issue_management.oss_fuzz_github.github')
+  def test_not_file_issue(self, mock_github):
+    """Disable file testcase to GitHub with environment setting."""
+    oss_fuzz_github.file_issue(self.testcase2)
+    # TODO (Dongge):
+    # Move testcase3 to test_file_issue after roll out
+    oss_fuzz_github.file_issue(self.testcase3)
+
+    mock_github.Github().get_repo().create_issue.assert_not_called()
+
+  @mock.patch('libs.issue_management.oss_fuzz_github.github')
+  def test_close_issue(self, mock_github):
+    """Close GitHub testcase."""
+    mock_github.Github().get_repo.return_value = mock.MagicMock(
+        id=GITHUB_REPO_ID)
+    mock_github.Github().get_repo().get_issue.return_value = mock.MagicMock(
+        number=GITHUB_ISSUE_NUM, state='open')
+
+    oss_fuzz_github.close_issue(self.testcase4)
+
+    mock_github.Github().get_repo().get_issue(
+    ).create_comment.assert_called_once_with(
+        oss_fuzz_github.get_issue_close_comment(self.testcase4))
+    mock_github.Github().get_repo().get_issue().edit.assert_called_once_with(
+        state='closed')
+
+  @mock.patch('libs.issue_management.oss_fuzz_github.github')
+  def test_close_closed_issue(self, mock_github):
+    """Not close GitHub testcases that have been closed."""
+    mock_github.Github().get_repo.return_value = mock.MagicMock(
+        id=GITHUB_REPO_ID)
+    mock_github.Github().get_repo().get_issue.return_value = mock.MagicMock(
+        number=GITHUB_ISSUE_NUM, state='closed')
+
+    oss_fuzz_github.close_issue(self.testcase4)
+
+    mock_github.Github().get_repo().get_issue(
+    ).create_comment.assert_not_called()
+
+  @mock.patch('libs.issue_management.oss_fuzz_github.github')
+  def test_close_unrecorded_issue(self, mock_github):
+    """Not close GitHub testcases that are not recorded."""
+    mock_github.Github().get_repo.return_value = mock.MagicMock(
+        id=GITHUB_REPO_ID)
+    mock_github.Github().get_repo().get_issue.return_value = mock.MagicMock(
+        number=GITHUB_ISSUE_NUM, state='open')
+
+    oss_fuzz_github.close_issue(self.testcase1)
+
+    mock_github.Github().get_repo().get_issue(
+    ).create_comment.assert_not_called()

--- a/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
@@ -24,17 +24,17 @@ from libs.issue_management import oss_fuzz_github
 
 REPO_NAME = 'sample/sample.git'
 MAIN_REPO = f'https://github.com/{REPO_NAME}'
-JOB1_ENVIRONMENT = f"MAIN_REPO = {MAIN_REPO}\n" \
-                   "FILE_GITHUB_ISSUE = True"
+JOB1_ENVIRONMENT = f'MAIN_REPO = {MAIN_REPO}\n' \
+                   'FILE_GITHUB_ISSUE = True'
 
-JOB2_ENVIRONMENT = f"MAIN_REPO = {MAIN_REPO}\n" \
-                   "FILE_GITHUB_ISSUE = False"
+JOB2_ENVIRONMENT = f'MAIN_REPO = {MAIN_REPO}\n' \
+                   'FILE_GITHUB_ISSUE = False'
 
-JOB3_ENVIRONMENT = f"MAIN_REPO = {MAIN_REPO}\n"
+JOB3_ENVIRONMENT = f'MAIN_REPO = {MAIN_REPO}\n'
 
 GITHUB_REPO_ID = 100
 GITHUB_ISSUE_NUM = 200
-GITHUB_ACCESS_TOKEN = "SECRET"
+GITHUB_ACCESS_TOKEN = 'SECRET'
 
 
 @test_utils.with_cloud_emulators('datastore')


### PR DESCRIPTION
Replace old temporary unittests with a new file dedicated to test GitHub issue mirrorer.
New tests mock `pygithub` package and verify its functions are invoked correctly.
