### PR TITLE
Handle repos that disable issues

### DIFF
--- a/src/appengine/libs/issue_management/oss_fuzz_github.py
+++ b/src/appengine/libs/issue_management/oss_fuzz_github.py
@@ -145,6 +145,10 @@ def file_issue(testcase):
     logs.log('Unable to file issues to the main repo of the project')
     return
 
+  if not repo.has_issues:
+    logs.log_warn('Unable to file issues to the main repo: '
+                  'Repo has disabled issues.')
+
   issue = _post_issue(repo, testcase)
   _update_testcase_properties(testcase, repo, issue)
 

--- a/src/appengine/libs/issue_management/oss_fuzz_github.py
+++ b/src/appengine/libs/issue_management/oss_fuzz_github.py
@@ -169,6 +169,11 @@ def _get_issue(testcase, access):
     logs.log_error(f'Unable to locate the GitHub repository id {repo_id}.')
     return None
 
+  if not repo.has_issues:
+    logs.log_warn('Unable to close issues of the main repo: '
+                  'Repo has disabled issues.')
+    return None
+
   try:
     target_issue = repo.get_issue(issue_num)
   except github.UnknownObjectException:

--- a/src/appengine/libs/issue_management/oss_fuzz_github.py
+++ b/src/appengine/libs/issue_management/oss_fuzz_github.py
@@ -148,6 +148,7 @@ def file_issue(testcase):
   if not repo.has_issues:
     logs.log_warn('Unable to file issues to the main repo: '
                   'Repo has disabled issues.')
+    return
 
   issue = _post_issue(repo, testcase)
   _update_testcase_properties(testcase, repo, issue)

--- a/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
@@ -111,6 +111,16 @@ class OSSFuzzGithubTests(unittest.TestCase):
     mock_github.Github().get_repo().create_issue.assert_not_called()
 
   @mock.patch('libs.issue_management.oss_fuzz_github.github')
+  def test_file_issue_to_repo_disabled_issues(self, mock_github):
+    """File an issue to a repo that has disabled issues."""
+    mock_github.Github().get_repo.return_value = mock.MagicMock(
+        has_issues=False)
+
+    oss_fuzz_github.file_issue(self.testcase1)
+
+    mock_github.Github().get_repo().create_issue.assert_not_called()
+
+  @mock.patch('libs.issue_management.oss_fuzz_github.github')
   def test_close_issue(self, mock_github):
     """Close GitHub testcase."""
     mock_github.Github().get_repo.return_value = mock.MagicMock(
@@ -125,6 +135,16 @@ class OSSFuzzGithubTests(unittest.TestCase):
         oss_fuzz_github.get_issue_close_comment(self.testcase4))
     mock_github.Github().get_repo().get_issue().edit.assert_called_once_with(
         state='closed')
+
+  @mock.patch('libs.issue_management.oss_fuzz_github.github')
+  def test_close_issue_of_repo_disabled_issues(self, mock_github):
+    """Close an issue of a repo that has disabled issues."""
+    mock_github.Github().get_repo.return_value = mock.MagicMock(
+        has_issues=False)
+
+    oss_fuzz_github.file_issue(self.testcase1)
+
+    mock_github.Github().get_repo().get_issue.assert_not_called()
 
   @mock.patch('libs.issue_management.oss_fuzz_github.github')
   def test_close_closed_issue(self, mock_github):


### PR DESCRIPTION
If a repo has disabled issues:
1.  Do not file new issues + a test;
2.  Do not get old issues + a test.

Fixes https://github.com/google/clusterfuzz/issues/2612.