### PR TITLE
strip the .git suffix when necessary

### DIFF
--- a/src/appengine/libs/issue_management/oss_fuzz_github.py
+++ b/src/appengine/libs/issue_management/oss_fuzz_github.py
@@ -21,6 +21,7 @@ from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.metrics import logs
 
 GITHUB_PREFIX = 'https://github.com/'
+GITHUB_SUFFIX = '.git'
 
 TESTCASE_REPORT_URL = 'https://{domain}/testcase?key={testcase_id}'
 
@@ -94,6 +95,8 @@ def _get_repo(testcase, access):
     logs.log(f'MAIN REPO is not a GitHub url: {repo_url}.')
     return None
   repo_name = repo_url[len(GITHUB_PREFIX):]
+  if repo_url[-len(GITHUB_SUFFIX):] == GITHUB_SUFFIX:
+    repo_name = repo_name[:-len(GITHUB_SUFFIX)]
 
   try:
     target_repo = access.get_repo(repo_name)

--- a/src/appengine/libs/issue_management/oss_fuzz_github.py
+++ b/src/appengine/libs/issue_management/oss_fuzz_github.py
@@ -21,7 +21,7 @@ from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.metrics import logs
 
 GITHUB_PREFIX = 'https://github.com/'
-GITHUB_SUFFIX = '.git'
+GIT_SUFFIX = '.git'
 
 TESTCASE_REPORT_URL = 'https://{domain}/testcase?key={testcase_id}'
 
@@ -95,8 +95,8 @@ def _get_repo(testcase, access):
     logs.log(f'MAIN REPO is not a GitHub url: {repo_url}.')
     return None
   repo_name = repo_url[len(GITHUB_PREFIX):]
-  if repo_url[-len(GITHUB_SUFFIX):] == GITHUB_SUFFIX:
-    repo_name = repo_name[:-len(GITHUB_SUFFIX)]
+  if repo_url.endswith(GIT_SUFFIX):
+    repo_name = repo_name[:-len(GIT_SUFFIX)]
 
   try:
     target_repo = access.get_repo(repo_name)

--- a/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
@@ -22,8 +22,9 @@ from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 from libs.issue_management import oss_fuzz_github
 
-REPO_NAME = 'sample/sample.git'
+REPO_NAME = 'sample/sample'
 MAIN_REPO = f'https://github.com/{REPO_NAME}'
+MAIN_REPO_SUFFIX = f'https://github.com/{REPO_NAME}.git'
 JOB1_ENVIRONMENT = f'MAIN_REPO = {MAIN_REPO}\n' \
                    'FILE_GITHUB_ISSUE = True'
 
@@ -31,6 +32,9 @@ JOB2_ENVIRONMENT = f'MAIN_REPO = {MAIN_REPO}\n' \
                    'FILE_GITHUB_ISSUE = False'
 
 JOB3_ENVIRONMENT = f'MAIN_REPO = {MAIN_REPO}\n'
+
+JOB4_ENVIRONMENT = f'MAIN_REPO = {MAIN_REPO_SUFFIX}\n' \
+                  'FILE_GITHUB_ISSUE = True'
 
 GITHUB_REPO_ID = 100
 GITHUB_ISSUE_NUM = 200
@@ -55,6 +59,10 @@ class OSSFuzzGithubTests(unittest.TestCase):
         name='job3', environment_string=JOB3_ENVIRONMENT,
         platform='linux').put()
 
+    data_types.Job(
+        name='job4', environment_string=JOB4_ENVIRONMENT,
+        platform='linux').put()
+
     testcase_args1 = {
         'bug_information': '300',
     }
@@ -77,6 +85,9 @@ class OSSFuzzGithubTests(unittest.TestCase):
     self.testcase4 = data_types.Testcase(job_type='job1', **testcase_args2)
     self.testcase4.put()
 
+    self.testcase5 = data_types.Testcase(job_type='job4', **testcase_args1)
+    self.testcase5.put()
+
     test_helpers.patch(self, [
         'clusterfuzz._internal.config.db_config.get_value',
     ])
@@ -90,15 +101,17 @@ class OSSFuzzGithubTests(unittest.TestCase):
     mock_github.Github().get_repo().create_issue.return_value = mock.MagicMock(
         number=GITHUB_ISSUE_NUM)
 
-    oss_fuzz_github.file_issue(self.testcase1)
+    for testcase in [self.testcase1, self.testcase5]:
+      oss_fuzz_github.file_issue(testcase)
 
-    mock_github.Github.assert_called_with(GITHUB_ACCESS_TOKEN)
-    mock_github.Github().get_repo.assert_called_with(REPO_NAME)
-    mock_github.Github().get_repo().create_issue.assert_called_once_with(
-        title=oss_fuzz_github.get_issue_title(self.testcase1),
-        body=oss_fuzz_github.get_issue_body(self.testcase1))
-    self.assertEqual(self.testcase1.github_repo_id, GITHUB_REPO_ID)
-    self.assertEqual(self.testcase1.github_issue_num, GITHUB_ISSUE_NUM)
+      mock_github.Github.assert_called_with(GITHUB_ACCESS_TOKEN)
+      mock_github.Github().get_repo.assert_called_with(REPO_NAME)
+      mock_github.Github().get_repo().create_issue.assert_called_once_with(
+          title=oss_fuzz_github.get_issue_title(testcase),
+          body=oss_fuzz_github.get_issue_body(testcase))
+      self.assertEqual(testcase.github_repo_id, GITHUB_REPO_ID)
+      self.assertEqual(testcase.github_issue_num, GITHUB_ISSUE_NUM)
+      mock_github.reset_mock()
 
   @mock.patch('libs.issue_management.oss_fuzz_github.github')
   def test_not_file_issue(self, mock_github):


### PR DESCRIPTION
Some project's `main_repo` URL ends with a `.git` suffix.
Remove that suffix when necessary to avoid confusion when filing issues.