### PR TITLE
Only add to sources.list.d file a single time

### DIFF
--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -105,10 +105,13 @@ if [ ! $only_reproduce ]; then
         stable"
 
     export CLOUD_SDK_REPO="cloud-sdk"
-    echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | \
-        sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+    export APT_FILE=/etc/apt/sources.list.d/google-cloud-sdk.list
+    export APT_LINE="deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main"
+    sudo bash -c "grep -x \"$APT_LINE\" $APT_FILE || (echo $APT_LINE | tee -a $APT_FILE)"
+
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
         sudo apt-key add -
+
   fi
 
   # Install apt-get packages.


### PR DESCRIPTION
The install_deps_bash.sh currently duplicates the lines it adds to /etc/apt/sources.list.d every time it runs.  This patch corrects that.
