### PR TITLE
load_bigquery_stats: Create empty table with schema.

### DIFF
--- a/src/appengine/handlers/cron/load_bigquery_stats.py
+++ b/src/appengine/handlers/cron/load_bigquery_stats.py
@@ -77,7 +77,7 @@ class Handler(base_handler.Handler):
 
     return self._execute_insert_request(dataset_insert)
 
-  def _create_table_if_needed(self, bigquery, dataset_id, table_id):
+  def _create_table_if_needed(self, bigquery, dataset_id, table_id, schema):
     """Create a new table if needed."""
     project_id = utils.get_application_id()
     table_body = {
@@ -89,6 +89,7 @@ class Handler(base_handler.Handler):
         'timePartitioning': {
             'type': 'DAY',
         },
+        'schema': schema,
     }
 
     table_insert = bigquery.tables().insert(
@@ -110,13 +111,15 @@ class Handler(base_handler.Handler):
     for kind in STATS_KINDS:
       kind_name = kind.__name__
       table_id = kind_name
-      if not self._create_table_if_needed(bigquery, dataset_id, table_id):
-        continue
 
       if kind == fuzzer_stats.TestcaseRun:
         schema = fuzzer_stats_schema.get(fuzzer)
       else:
         schema = kind.SCHEMA
+
+      if not self._create_table_if_needed(bigquery, dataset_id, table_id,
+                                          schema):
+        continue
 
       gcs_path = fuzzer_stats.get_gcs_stats_path(kind_name, fuzzer, timestamp)
       load = {

--- a/src/appengine/handlers/cron/load_bigquery_stats.py
+++ b/src/appengine/handlers/cron/load_bigquery_stats.py
@@ -89,8 +89,10 @@ class Handler(base_handler.Handler):
         'timePartitioning': {
             'type': 'DAY',
         },
-        'schema': schema,
     }
+
+    if schema is not None:
+      table_body['schema'] = schema
 
     table_insert = bigquery.tables().insert(
         projectId=project_id, datasetId=dataset_id, body=table_body)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -20,9 +20,9 @@ import mock
 import webtest
 
 from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.metrics import fuzzer_stats
 from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
-from clusterfuzz._internal.metrics import fuzzer_stats
 from handlers.cron import load_bigquery_stats
 
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -22,6 +22,7 @@ import webtest
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
+from clusterfuzz._internal.metrics import fuzzer_stats
 from handlers.cron import load_bigquery_stats
 
 
@@ -76,6 +77,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                     'tableId': 'JobRun',
                     'datasetId': 'fuzzer_stats',
                 },
+                'schema': fuzzer_stats.JobRun.SCHEMA,
             },
             datasetId='fuzzer_stats',
             projectId='test-clusterfuzz'),


### PR DESCRIPTION
Previously the schema was only set on load. If an engine isn't running
(and therefore no stats are output), the schema on the table is never
set, leading to exceptions in /fuzz-strategy-selection.

Fixes #2629.