### PR TITLE
fix alf EXPAND_HAVOC randomness strategy

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
@@ -566,7 +566,6 @@ class AflRunnerCommon(object):
     environment.set_value(constants.SKIP_CRASHES_ENV_VAR, 1)
     environment.set_value(constants.SKIP_CPUFREQ_ENV_VAR, 1)
     environment.set_value(constants.BENCH_UNTIL_CRASH_ENV_VAR, 1)
-    environment.set_value(constants.EXPAND_HAVOC_NOW_VAR, 1)
     environment.set_value(constants.STDERR_FILENAME_ENV_VAR,
                           self.stderr_file_path)
 


### PR DESCRIPTION
Expanded havoc mutation is always enabled.
https://github.com/google/clusterfuzz/blob/cd9c586adfeb585df7b7e7f3a6bb8f2297e5061e/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py#L764
https://github.com/google/clusterfuzz/blob/cd9c586adfeb585df7b7e7f3a6bb8f2297e5061e/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py#L573-L577
https://github.com/google/clusterfuzz/blob/cd9c586adfeb585df7b7e7f3a6bb8f2297e5061e/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py#L558-L569
It breaks the randomness strategy:
https://github.com/google/clusterfuzz/blob/cd9c586adfeb585df7b7e7f3a6bb8f2297e5061e/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py#L793-L796