### PR TITLE
Set GitHub attributes in Testcase during backfilling

### DIFF
--- a/src/local/butler/scripts/backfiler.py
+++ b/src/local/butler/scripts/backfiler.py
@@ -40,3 +40,4 @@ def execute(args):
       print(f'Back filing testcase id: {testcase.key.id()}')
       if args.non_dry_run:
         oss_fuzz_github.file_issue(testcase)
+        testcase.put()


### PR DESCRIPTION
Bug fix:
  Upload GitHub info to cloud storage during backfiling.