### PR TITLE
Rename gae_requirements.txt to requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 /local/bin/android-sdk/*
 /local/storage
 /paramiko.log
-/src/appengine/gae_requirements.txt
+/src/appengine/requirements.txt
 /src/appengine/app.yaml
 /src/appengine/cron-service.yaml
 /src/appengine/cron.yaml

--- a/src/appengine/.gcloudignore
+++ b/src/appengine/.gcloudignore
@@ -22,3 +22,4 @@ __pycache__/
 private/
 _internal/bot/
 _internal/tests/
+third_party/

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -316,7 +316,7 @@ def install_dependencies(platform_name=None, is_reproduce_tool_setup=False):
   _pipfile_to_requirements('src', 'src/requirements.txt')
   # Hack: Use "dev-packages" to specify App Engine only packages.
   _pipfile_to_requirements(
-      'src', 'src/appengine/gae_requirements.txt', dev=True)
+      'src', 'src/appengine/requirements.txt', dev=True)
 
   _install_pip('src/requirements.txt', 'src/third_party')
   if platform_name:
@@ -325,7 +325,7 @@ def install_dependencies(platform_name=None, is_reproduce_tool_setup=False):
         'src/third_party',
         platform_name=platform_name)
 
-  _install_pip('src/appengine/gae_requirements.txt',
+  _install_pip('src/appengine/requirements.txt',
                'src/appengine/third_party')
 
   # Only the previous dependencies are needed for reproduce tool installation.

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -315,8 +315,7 @@ def install_dependencies(platform_name=None, is_reproduce_tool_setup=False):
   """Install dependencies for bots."""
   _pipfile_to_requirements('src', 'src/requirements.txt')
   # Hack: Use "dev-packages" to specify App Engine only packages.
-  _pipfile_to_requirements(
-      'src', 'src/appengine/requirements.txt', dev=True)
+  _pipfile_to_requirements('src', 'src/appengine/requirements.txt', dev=True)
 
   _install_pip('src/requirements.txt', 'src/third_party')
   if platform_name:
@@ -325,8 +324,7 @@ def install_dependencies(platform_name=None, is_reproduce_tool_setup=False):
         'src/third_party',
         platform_name=platform_name)
 
-  _install_pip('src/appengine/requirements.txt',
-               'src/appengine/third_party')
+  _install_pip('src/appengine/requirements.txt', 'src/appengine/third_party')
 
   # Only the previous dependencies are needed for reproduce tool installation.
   if is_reproduce_tool_setup:


### PR DESCRIPTION
This makes GAE deployment handle the requirements installation, rather
than uploading our vendored third_party.

Fixes #2649.