### PR TITLE
add missing GCP API: cloudscheduler.googleapis.com

### DIFF
--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -36,6 +36,7 @@ _REQUIRED_SERVICES = (
     'clouderrorreporting.googleapis.com',
     'cloudprofiler.googleapis.com',
     'cloudresourcemanager.googleapis.com',
+    'cloudscheduler.googleapis.com',
     'compute.googleapis.com',
     'containerregistry.googleapis.com',
     'datastore.googleapis.com',


### PR DESCRIPTION
Adds Cloud Scheduler to list of required GCP APIs. Installation now fails without enabling this API. 