### PR TITLE
disable uniform bucket-level access for GCS buckets

### DIFF
--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -218,6 +218,10 @@ def create_buckets(project_id, buckets):
     except common.GsutilError:
       # Create the bucket if it does not exist.
       gsutil.run('mb', '-p', project_id, 'gs://' + bucket)
+    finally:
+      # Disable uniform bucket-level access. Otherwise setting legacy fine
+      # grained ACLs will fail.
+      gsutil.run('bucketpolicyonly', 'set', 'off', 'gs://' + bucket)
 
 
 def set_cors(config_dir, buckets):


### PR DESCRIPTION
Without getting into too much detail here, this is possibly a fix that's only required for Google corp users. However, it should also not negatively impact non-Googler users. Happy to chat directly for any questions.