### PR TITLE
Comment out corpus-backup/make-public from cron.yaml

### DIFF
--- a/configs/test/gae/prod3/cron.yaml
+++ b/configs/test/gae/prod3/cron.yaml
@@ -34,10 +34,10 @@ cron:
     schedule: every 1 minutes
     target: cron-service
 
-  - description: Make corpus backups public.
-    url: /corpus-backup/make-public
-    schedule: every day 03:00
-    target: cron-service
+  # - description: Make corpus backups public.
+  #  url: /corpus-backup/make-public
+  #  schedule: every day 03:00
+  #  target: cron-service
 
   # Run fuzzer coverage task right before the corpus pruning task.
   - description: Obtain code coverage information from the coverage GCS bucket.


### PR DESCRIPTION
This shouldn't be default behaviour. 
Fixes #2684