### PR TITLE
Strip reserved characters when generating JQL for jira search

### DIFF
--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -224,7 +224,8 @@ def _get_search_text(keywords):
   jira_special_characters = '+-&|!(){}[]^~*?\\:'
   search_text = ''
   for keyword in keywords:
-    # Replace special characters with whitespace as they are not allowed and can't be searched for.
+    # Replace special characters with whitespace as they are not allowed and
+    # can't be searched for.
     stripped_keyword = keyword
     for special_character in jira_special_characters:
       stripped_keyword = stripped_keyword.replace(special_character, ' ')

--- a/src/appengine/libs/issue_management/jira/__init__.py
+++ b/src/appengine/libs/issue_management/jira/__init__.py
@@ -221,8 +221,15 @@ def get_issue_tracker(project_name, config):  # pylint: disable=unused-argument
 
 def _get_search_text(keywords):
   """Get search text."""
+  jira_special_characters = '+-&|!(){}[]^~*?\\:'
   search_text = ''
   for keyword in keywords:
-    search_text += ' AND text ~ "%s"' % keyword
+    # Replace special characters with whitespace as they are not allowed and can't be searched for.
+    stripped_keyword = keyword
+    for special_character in jira_special_characters:
+      stripped_keyword = stripped_keyword.replace(special_character, ' ')
+    # coalesce multiple spaces into one.
+    stripped_keyword = ' '.join(stripped_keyword.split())
+    search_text += f' AND text ~ "{stripped_keyword}"'
 
   return search_text

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
@@ -166,6 +166,12 @@ class JiraTests(unittest.TestCase):
     issue_url = self.issue_tracker.issue_url('VSEC-3112')
     self.assertEqual('https://jira.company.com/browse/VSEC-3112', issue_url)
 
+  def test_find_issues_url(self):
+    """Test find_issues_url."""
+    self.mock.get.return_value = Config()
+    issue_url = self.issue_tracker.find_issues_url(keywords=['keyword+-&|!(){}[]^~*?:+-&|!(){}[]^~*?:test'])
+    self.assertEqual('https://jira.company.com/issues/?jql=project = VSEC AND text ~ "keyword test"', issue_url)
+
   def test_issue_save(self):
     """Test save."""
     self.mock.get_issue.return_value = self.mock_issue

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/jira/jira_test.py
@@ -169,8 +169,11 @@ class JiraTests(unittest.TestCase):
   def test_find_issues_url(self):
     """Test find_issues_url."""
     self.mock.get.return_value = Config()
-    issue_url = self.issue_tracker.find_issues_url(keywords=['keyword+-&|!(){}[]^~*?:+-&|!(){}[]^~*?:test'])
-    self.assertEqual('https://jira.company.com/issues/?jql=project = VSEC AND text ~ "keyword test"', issue_url)
+    issue_url = self.issue_tracker.find_issues_url(
+        keywords=['keyword+-&|!(){}[]^~*?:+-&|!(){}[]^~*?:test'])
+    self.assertEqual(
+        'https://jira.company.com/issues/?jql=project = VSEC AND text ~ "keyword test"',
+        issue_url)
 
   def test_issue_save(self):
     """Test save."""


### PR DESCRIPTION
Jira JQL doesn't allow for certain reserved special characters and having them can cause errors, this change solves that by replacing the characters with white space.