### PR TITLE
Fix incorrect logging call.

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1513,7 +1513,7 @@ def setup_build(revision=0, target_weights=None):
     if bucket_path:
       bucket_paths.append(bucket_path)
     else:
-      logs.log('Bucket path not found for %s', env_var)
+      logs.log('Bucket path not found for %s' % env_var)
 
   if len(bucket_paths) == 0:
     logs.log_error('Attempted a trunk build, but no bucket paths were found.')


### PR DESCRIPTION
PR #2685 accidentally added a logging statement that would cause
"TypeError: level must be an integer" to be thrown when reached. This
fixes the syntax to remove the error.