### PR TITLE
Opt-out of allstar security policy

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Exemption reason: This repo uses binary artifacts that are not practical to
 # build from source (e.g. from LLVM).
 optConfig:

--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,4 @@
+# Exemption reason: This repo uses binary artifacts that are not practical to
+# build from source (e.g. from LLVM).
+optConfig:
+  optOut: true


### PR DESCRIPTION
It's impractical for ClusterFuzz to build every binary it needs from source.
Fixes https://github.com/google/clusterfuzz/issues/2693