### PR TITLE
Fix stacktrace parsing for command injection.

### DIFF
--- a/src/clusterfuzz/_internal/crash_analysis/crash_analyzer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/crash_analyzer.py
@@ -98,6 +98,9 @@ GOLANG_CRASH_TYPES_NON_SECURITY = [
     'Slice bounds out of range',
     'Stack overflow',
 ]
+EXTRA_SANITIZERS_SECURITY = [
+    'Command injection',
+]
 
 # Default page size of 4KB.
 NULL_DEREFERENCE_BOUNDARY = 0x1000
@@ -346,6 +349,9 @@ def is_security_issue(crash_stacktrace, crash_type, crash_address):
 
   # Kernel Failures are security bugs
   if crash_type.startswith('Kernel failure'):
+    return True
+
+  if crash_type in EXTRA_SANITIZERS_SECURITY:
     return True
 
   # No crash type, can't process.

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/command_injection_bug.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/command_injection_bug.txt
@@ -1,53 +1,24 @@
-rm -f execSan /tmp/tripwire target
-clang++ -std=c++17 -Wall -Wextra -O3 -g3 -lpthread -o execSan execSan.cpp
-clang++ -std=c++17 -Wall -Wextra -O3 -g3 -fsanitize=address,fuzzer -o target target.cpp
-./execSan ./target -dict=vuln.dict
-Dictionary: 1 entries
-INFO: Running with entropic power schedule (0xFF, 100).
-INFO: Seed: 1387145185
-INFO: Loaded 1 modules   (18 inline 8-bit counters): 18 [0x54cf70, 0x54cf82),
-INFO: Loaded 1 PC tables (18 PCs): 18 [0x525168,0x525288),
-INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
-INPUT
-INFO: A corpus is not provided, starting from an empty corpus
-INPUT
-
-#2	INITED cov: 7 ft: 7 corp: 1/1b exec/s: 0 rss: 30Mb
-INPUT
-
-
-#3	NEW    cov: 8 ft: 8 corp: 2/3b lim: 4 exec/s: 0 rss: 31Mb L: 2/2 MS: 1 CrossOver-
-INPUT`
-
-sh: -c: line 1: unexpected EOF while looking for matching ``'
 --- Found a sign of shell corruption ---
-sh: -c: line 2: syntax error: unexpected end of file
-
+Syntax error: Unterminated quoted string
 ----------------------------------------
 ===BUG DETECTED: Shell corruption===
-==2107637== ERROR: libFuzzer: deadly signal
-sh: -c: line 2: syntax error: unexpected end of file
-#0 0x4e0861 in __sanitizer_print_stack_trace (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x4e0861)
-    #1 0x45ae07 in fuzzer::PrintStackTrace() (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x45ae07)
-    #2 0x43f183 in fuzzer::Fuzzer::CrashCallback() (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x43f183)
-    #3 0x7f7fba16f1ff  (/lib/x86_64-linux-gnu/libpthread.so.0+0x121ff)
-    #4 0x7f7fba018a66 in wait4 posix/../sysdeps/unix/sysv/linux/wait4.c:30:10
-    #5 0x7f7fb9f974b2 in do_system stdlib/../sysdeps/posix/system.c:172:11
-    #6 0x50d01f in LLVMFuzzerTestOneInput /usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target.cpp:26:3
-    #7 0x440a53 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x440a53)
-    #8 0x43fe6d in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x43fe6d)
-    #9 0x441b0b in fuzzer::Fuzzer::MutateAndTestOne() (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x441b0b)
-    #10 0x442735 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x442735)
-    #11 0x42f9cd in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x42f9cd)
-    #12 0x45b742 in main (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x45b742)
-    #13 0x7f7fb9f757fc in __libc_start_main csu/../csu/libc-start.c:332:16
-    #14 0x423979 in _start (/usr/local/google/home/donggeliu/Code/oss-fuzz/infra/experimental/sanitizers/ExecSan/target+0x423979)
-
-NOTE: libFuzzer has rudimentary signal handlers.
-      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
-SUMMARY: libFuzzer: deadly signal
-MS: 1 ChangeByte-; base unit: 71853c6197a6a7f222db0f1978c7cb232b87c5ee
-0x60,0xa,
-`\x0a
-artifact_prefix='./'; Test unit written to ./crash-f6460d7d9d2b32d0dbd200d75a696a0a3e3a09e1
-Base64: YAo=
+AddressSanitizer:DEADLYSIGNAL
+=================================================================
+==493018==ERROR: AddressSanitizer: ABRT on unknown address 0x0539000785d7 (pc 0x7f83920d7dff bp 0x7fff7994c5b8 sp 0x7fff7994c580 T0)
+SCARINESS: 10 (signal)
+    #0 0x7f83920d7dff in wait4 /build/glibc-eX1tMB/glibc-2.31/sysdeps/unix/sysv/linux/wait4.c:27:10
+    #1 0x7f83920470e6 in do_system /build/glibc-eX1tMB/glibc-2.31/sysdeps/posix/system.c:172:11
+    #2 0x7f83920d7dff in Foo foo.c:27:10
+    #3 0x7f83920470e6 in Bar bar.c:172:11
+    #4 0x46eca3 in fuzzer::ExecuteCommand(fuzzer::Command const&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerUtilLinux.cpp:25:19
+    #5 0x461537 in fuzzer::CrashResistantMerge(std::__Fuzzer::vector<std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> >, std::__Fuzzer::allocator<std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> > > > const&, std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile> > const&, std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile> > const&, std::__Fuzzer::vector<std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> >, std::__Fuzzer::allocator<std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> > > >*, std::__Fuzzer::set<unsigned int, std::__Fuzzer::less<unsigned int>, std::__Fuzzer::allocator<unsigned int> > const&, std::__Fuzzer::set<unsigned int, std::__Fuzzer::less<unsigned int>, std::__Fuzzer::allocator<unsigned int> >*, std::__Fuzzer::set<unsigned int, std::__Fuzzer::less<unsigned int>, std::__Fuzzer::allocator<unsigned int> > const&, std::__Fuzzer::set<unsigned int, std::__Fuzzer::less<unsigned int>, std::__Fuzzer::allocator<unsigned int> >*, std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> > const&, bool, bool) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMerge.cpp:506:21
+    #6 0x44a282 in fuzzer::FuzzWithFork(fuzzer::Random&, fuzzer::FuzzingOptions const&, std::__Fuzzer::vector<std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> >, std::__Fuzzer::allocator<std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> > > > const&, std::__Fuzzer::vector<std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> >, std::__Fuzzer::allocator<std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char> > > > const&, int) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerFork.cpp:348:5
+    #7 0x446399 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:875:5
+    #8 0x46f2f2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
+    #9 0x7f83920190b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/libc-start.c:308:16
+    #10 0x41f6dd in _start
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: ABRT (/lib/x86_64-linux-gnu/libc.so.6+0xe5dff)
+==493018==ABORTING
+MS: 0 ; base unit: 0000000000000000000000000000000000000000
+artifact_prefix='/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/'; Test unit written to /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/crash-da39a3ee5e6b4b0d3255bfef95601890afd80709

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -3262,7 +3262,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('command_injection_bug.txt')
     expected_type = 'Command injection'
     expected_address = ''
-    expected_state = 'wait4\ndo_system\ntarget.cpp\n'
+    expected_state = 'Foo\nBar\n'
     expected_stacktrace = data
     expected_security_flag = True
     self._validate_get_crash_data(data, expected_type, expected_address,

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -566,6 +566,7 @@ STACK_FRAME_IGNORE_REGEXES_IF_SYMBOLIZED = [
 IGNORE_CRASH_TYPES_FOR_ABRT_BREAKPOINT_AND_ILLS = [
     'ASSERT',
     'CHECK failure',
+    'Command injection',
     'DCHECK failure',
     'Fatal error',
     'Security CHECK failure',


### PR DESCRIPTION
- Don't replace the crash type with the sanitizer signal crash type.
- Explicitly set 'Command injection' as a security bug.