### PR TITLE
experimental: Add extra sanitizers strategy.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -122,6 +122,12 @@ class Engine(engine.Engine):
 
     strategy_info = libfuzzer.pick_strategies(strategy_pool, target_path,
                                               corpus_dir, arguments, grammar)
+    if (strategy.USE_EXTRA_SANITIZERS_STRATEGY.name in
+        strategy_info.fuzzing_strategies):
+      # TODO(ochang): Save this as part of any resulting testcases.
+      environment.set_value('USE_EXTRA_SANITIZERS', True)
+    else:
+      environment.set_value('USE_EXTRA_SANITIZERS', False)
 
     arguments.extend(strategy_info.arguments)
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -1670,5 +1670,9 @@ def pick_strategies(strategy_pool,
       use_radamsa_mutator_plugin(extra_env)):
     fuzzing_strategies.append(strategy.MUTATOR_PLUGIN_RADAMSA_STRATEGY.name)
 
+  if (environment.platform() == 'LINUX' and
+      strategy_pool.do_strategy(strategy.USE_EXTRA_SANITIZERS_STRATEGY)):
+    fuzzing_strategies.append(strategy.USE_EXTRA_SANITIZERS_STRATEGY.name)
+
   return StrategyInfo(fuzzing_strategies, arguments, additional_corpus_dirs,
                       extra_env, use_dataflow_tracing, is_mutations_run)

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -1670,7 +1670,7 @@ def pick_strategies(strategy_pool,
       use_radamsa_mutator_plugin(extra_env)):
     fuzzing_strategies.append(strategy.MUTATOR_PLUGIN_RADAMSA_STRATEGY.name)
 
-  if (environment.platform() == 'LINUX' and
+  if (environment.platform() == 'LINUX' and utils.is_oss_fuzz() and
       strategy_pool.do_strategy(strategy.USE_EXTRA_SANITIZERS_STRATEGY)):
     fuzzing_strategies.append(strategy.USE_EXTRA_SANITIZERS_STRATEGY.name)
 

--- a/src/clusterfuzz/_internal/bot/untrusted_runner/environment.py
+++ b/src/clusterfuzz/_internal/bot/untrusted_runner/environment.py
@@ -57,6 +57,7 @@ FORWARDED_ENVIRONMENT_VARIABLES = [
         r'^TSAN_OPTIONS$',
         r'^UBSAN_OPTIONS$',
         r'^UNPACK_ALL_FUZZ_TARGETS_AND_FILES$',
+        r'^USE_EXTRA_SANITIZERS$',
         r'^USE_MINIJAIL$',
         r'^USER$',
     )

--- a/src/clusterfuzz/_internal/fuzzing/strategy.py
+++ b/src/clusterfuzz/_internal/fuzzing/strategy.py
@@ -48,6 +48,8 @@ VALUE_PROFILE_STRATEGY = Strategy(
     name='value_profile', probability=0.33, manually_enable=False)
 PEACH_GRAMMAR_MUTATION_STRATEGY = Strategy(
     name='peach_grammar_mutation', probability=0.90, manually_enable=True)
+USE_EXTRA_SANITIZERS_STRATEGY = Strategy(
+    name='extra_sanitizers', probability=0.10, manually_enable=False)
 
 # Keep this strategy order for strategy combination tracking as strategy
 # combinations are tracked as strings.
@@ -63,6 +65,7 @@ LIBFUZZER_STRATEGY_LIST = [
     MUTATOR_PLUGIN_STRATEGY,
     MUTATOR_PLUGIN_RADAMSA_STRATEGY,
     PEACH_GRAMMAR_MUTATION_STRATEGY,
+    USE_EXTRA_SANITIZERS_STRATEGY,
 ]
 
 # TODO: Add more syzkaller strategies.
@@ -98,6 +101,7 @@ LIBFUZZER_STRATEGIES_WITH_BOOLEAN_VALUE = [
     RANDOM_MAX_LENGTH_STRATEGY,
     RECOMMENDED_DICTIONARY_STRATEGY,
     VALUE_PROFILE_STRATEGY,
+    USE_EXTRA_SANITIZERS_STRATEGY,
 ]
 
 # To ensure that all strategies present in |strategy_list| are parsed for stats.

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -600,6 +600,8 @@ class IntegrationTests(BaseIntegrationTest):
 
   def test_fuzz_crash(self):
     """Tests fuzzing (crash)."""
+    self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
+        self.strategies)
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.Engine()
 
@@ -637,7 +639,7 @@ class IntegrationTests(BaseIntegrationTest):
   def test_fuzz_from_subset(self):
     """Tests fuzzing from corpus subset."""
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
-        [strategy.CORPUS_SUBSET_STRATEGY])
+        self.strategies + [strategy.CORPUS_SUBSET_STRATEGY])
 
     _, corpus_path = setup_testcase_and_corpus('empty',
                                                'corpus_with_some_files')
@@ -916,7 +918,12 @@ class ExtraSanitizerIntegrationTests(IntegrationTests):
   def setUp(self):
     super().setUp()
     os.environ['ASAN_OPTIONS'] = 'detect_leaks=0'
+    os.environ['USE_EXTRA_SANITIZERS'] = 'True'
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.base.utils.is_oss_fuzz',
+    ])
 
+    self.mock.is_oss_fuzz.return_value = True
     self.strategies = [strategy.USE_EXTRA_SANITIZERS_STRATEGY]
 
   def compare_arguments(self, target_path, arguments, corpora_or_testcase,

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -384,6 +384,7 @@ class FuzzTest(fake_fs_unittest.TestCase):
         'strategy_corpus_mutations_radamsa': 0,
         'strategy_corpus_subset': 0,
         'strategy_dataflow_tracing': 0,
+        'strategy_extra_sanitizers': 0,
         'strategy_fork': 0,
         'strategy_mutator_plugin': 0,
         'strategy_mutator_plugin_radamsa': 0,

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -490,6 +490,8 @@ class BaseIntegrationTest(unittest.TestCase):
     self.mock.get_merge_timeout.return_value = 10
     self.mock.random_choice.side_effect = mock_random_choice
 
+    self.strategies = []
+
 
 @test_utils.integration
 class IntegrationTests(BaseIntegrationTest):
@@ -532,7 +534,7 @@ class IntegrationTests(BaseIntegrationTest):
   def test_fuzz_no_crash(self):
     """Tests fuzzing (no crash)."""
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
-        [strategy.VALUE_PROFILE_STRATEGY])
+        self.strategies + [strategy.VALUE_PROFILE_STRATEGY])
 
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.Engine()
@@ -566,7 +568,7 @@ class IntegrationTests(BaseIntegrationTest):
   def test_fuzz_no_crash_with_old_libfuzzer(self):
     """Tests fuzzing (no crash) with an old version of libFuzzer."""
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
-        [strategy.VALUE_PROFILE_STRATEGY])
+        self.strategies + [strategy.VALUE_PROFILE_STRATEGY])
 
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.Engine()
@@ -913,8 +915,9 @@ class ExtraSanitizerIntegrationTests(IntegrationTests):
 
   def setUp(self):
     super().setUp()
-    os.environ['USE_EXTRA_SANITIZERS'] = 'True'
     os.environ['ASAN_OPTIONS'] = 'detect_leaks=0'
+
+    self.strategies = [strategy.USE_EXTRA_SANITIZERS_STRATEGY]
 
   def compare_arguments(self, target_path, arguments, corpora_or_testcase,
                         actual):
@@ -1180,7 +1183,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
   def test_fuzz_no_crash(self):
     """Tests fuzzing (no crash)."""
     self.mock.generate_weighted_strategy_pool.return_value = set_strategy_pool(
-        [strategy.VALUE_PROFILE_STRATEGY])
+        self.strategies + [strategy.VALUE_PROFILE_STRATEGY])
 
     _, corpus_path = setup_testcase_and_corpus('empty', 'corpus')
     engine_impl = engine.Engine()

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/libfuzzer_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/libfuzzer_stats_test.py
@@ -95,6 +95,7 @@ class PerformanceStatsTest(unittest.TestCase):
         'slow_units_count': 0,
         'startup_crash_count': 0,
         'strategy_dataflow_tracing': 0,
+        'strategy_extra_sanitizers': 0,
         'strategy_corpus_mutations_radamsa': 1,
         'strategy_corpus_mutations_ml_rnn': 0,
         'strategy_corpus_subset': 50,


### PR DESCRIPTION
This will be turned on in 10% of all libFuzzer runs.

Note that this flag does not propagate to any testcases yet, so any
found bugs will be marked as unreproducible for now.