### PR TITLE
Properly disable LSan when extra sanitizers are used.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -126,6 +126,7 @@ class Engine(engine.Engine):
         strategy_info.fuzzing_strategies):
       # TODO(ochang): Save this as part of any resulting testcases.
       environment.set_value('USE_EXTRA_SANITIZERS', True)
+      environment.disable_lsan()
     else:
       environment.set_value('USE_EXTRA_SANITIZERS', False)
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -122,6 +122,16 @@ def copy():
   return environment_copy
 
 
+def disable_lsan():
+  """Disable leak detection (if enabled)."""
+  if get_current_memory_tool_var() != 'ASAN_OPTIONS':
+    return
+
+  sanitizer_options = get_memory_tool_options('ASAN_OPTIONS', {})
+  sanitizer_options['detect_leaks'] = 0
+  set_memory_tool_options('ASAN_OPTIONS', sanitizer_options)
+
+
 def get_asan_options(redzone_size, malloc_context_size, quarantine_size_mb,
                      bot_platform, leaks, disable_ubsan):
   """Generates default ASAN options."""


### PR DESCRIPTION
Extra sanitizers are decided later on after the sanitizer options are
initially set.