### PR TITLE
Report V8 API errors correctly

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -977,7 +977,8 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_address = ''
     expected_state = ('Empty MaybeLocal. (v8::ToLocalChecked)\n'
                       'blink::V8ContextSnapshotImpl::CreateContext\n'
-                      'blink::V8ContextSnapshot::CreateContextFromSnapshot\n')
+                      'blink::V8ContextSnapshot::CreateContextFromSnapshot\n'
+                      'blink::LocalWindowProxy::CreateContext\n')
     expected_stacktrace = data
     expected_security_flag = False
 

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -973,11 +973,11 @@ class StackAnalyzerTestcase(unittest.TestCase):
     """Test a failure in ToLocalEmpty, which is actually a bug in the caller
     of that method."""
     data = self._read_test_data('v8_to_local_empty.txt')
-    expected_type = 'Breakpoint'
-    expected_address = '0x7ffe91274242'
-    expected_state = ('blink::V8ContextSnapshotImpl::CreateContext\n'
-                      'blink::V8ContextSnapshot::CreateContextFromSnapshot\n'
-                      'blink::LocalWindowProxy::CreateContext\n')
+    expected_type = 'V8 API error'
+    expected_address = ''
+    expected_state = ('Empty MaybeLocal. (v8::ToLocalChecked)\n'
+                      'blink::V8ContextSnapshotImpl::CreateContext\n'
+                      'blink::V8ContextSnapshot::CreateContextFromSnapshot\n')
     expected_stacktrace = data
     expected_security_flag = False
 

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -971,6 +971,13 @@ class StackParser:
             state.crash_state = abort_error
           state.frame_count = MAX_CRASH_STATE_FRAMES
 
+        # V8 API errors.
+        v8_error_match = self.update_state_on_match(
+            V8_ERROR_REGEX, line, state, new_type='V8 API error', reset=True,
+            new_frame_count=1)
+        if v8_error_match:
+          state.crash_state = v8_error_match.group(1) + '\n'
+
         # V8 correctness failure errors.
         self.update_state_on_match(
             V8_CORRECTNESS_FAILURE_REGEX,

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -973,8 +973,7 @@ class StackParser:
 
         # V8 API errors.
         v8_error_match = self.update_state_on_match(
-            V8_ERROR_REGEX, line, state, new_type='V8 API error', reset=True,
-            new_frame_count=1)
+            V8_ERROR_REGEX, line, state, new_type='V8 API error', reset=True)
         if v8_error_match:
           state.crash_state = v8_error_match.group(1) + '\n'
 

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -268,6 +268,7 @@ V8_ABORT_METADATA_REGEX = re.compile(r'(.*) \[(.*):\d+\]$')
 V8_CORRECTNESS_FAILURE_REGEX = re.compile(r'#\s*V8 correctness failure')
 V8_CORRECTNESS_METADATA_REGEX = re.compile(
     r'#\s*V8 correctness ((configs|sources|suppression): .*)')
+V8_ERROR_REGEX = re.compile(r'\s*\[[^\]]*\] V8 error: (.+)\.$')
 WINDOWS_CDB_STACK_FRAME_REGEX = re.compile(
     r'([0-9a-zA-Z`]+) '  # Child EBP or SP; remove ` if needed (1)
     r'([0-9a-zA-Z`]+) '  # RetAddr; remove ` if needed (2)
@@ -577,6 +578,7 @@ IGNORE_CRASH_TYPES_FOR_ABRT_BREAKPOINT_AND_ILLS = [
     'Fatal error',
     'Security CHECK failure',
     'Security DCHECK failure',
+    'V8 API error',
 ]
 
 STATE_STOP_MARKERS = [


### PR DESCRIPTION
Previously they were reported as 'breakpoint', and the actual error
message was missing.
We now handle them separately, similar to chrome's or v8's check
failures.

This is a follow-up to https://github.com/google/clusterfuzz/pull/2751.