### PR TITLE
Create FuzzTarget from Testcase when it does not exist.

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -721,7 +721,8 @@ class Testcase(Model):
     if not target:
       binary = self.get_metadata('fuzzer_binary_name')
       if not binary:
-        raise ValueError('Fuzzer binary name not found')
+        # Not applicable.
+        return None
 
       target = FuzzTarget(
           engine=self.fuzzer_name, project=self.project_name, binary=binary)

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -718,6 +718,14 @@ class Testcase(Model):
       return None
 
     target = ndb.Key(FuzzTarget, name).get()
+    if not target:
+      binary = self.get_metadata('fuzzer_binary_name')
+      if not binary:
+        raise ValueError('Fuzzer binary name not found')
+
+      target = FuzzTarget(
+          engine=self.fuzzer_name, project=self.project_name, binary=binary)
+
     if environment.get_value('ORIGINAL_JOB_NAME'):
       # Overridden engine (e.g. for minimization).
       target.engine = environment.get_engine_for_job()


### PR DESCRIPTION
This is an edge case that can happen when a fuzz target hasn't run for a
very long time, but some other non-preemptible task is still getting
scheduled to run.

Fixes #2769