### PR TITLE
Fix for using dictionary when fuzzing AFL on Android device

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
@@ -154,7 +154,11 @@ class AflConfig(object):
     if not os.path.exists(default_dict_path):
       return
 
-    self.dict_path = default_dict_path
+    if not environment.is_android():
+      self.dict_path = default_dict_path
+    else:
+      self.dict_path = android.util.get_device_path(default_dict_path)
+
     self.additional_afl_arguments.append(constants.DICT_FLAG + self.dict_path)
 
 


### PR DESCRIPTION
When fuzzing AFL on Android, the dictionary is getting pushed to device but the path to the dictionary is incorrect