### PR TITLE
Centipede integration setup

### DIFF
--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -871,19 +871,6 @@ class ProjectSetup(object):
         job.environment_string += (
             f'DATAFLOW_BUILD_BUCKET_PATH = {dataflow_build_bucket_path}\n')
 
-      # Centipede requires separate binaries for sanitized targets.
-      if (template.engine == 'centipede' and
-          template.architecture == 'x86_64' and
-          template.sanitizer == 'address'):
-        sanitized_target_bucket_path = self._get_build_bucket_path(
-            project_name=project,
-            info=info,
-            engine='centipede',
-            memory_tool='address',
-            architecture=template.architecture)
-        job.environment_string += ('SANITIZED_TARGET_BUILD_BUCKET_PATH = '
-                                   f'{sanitized_target_bucket_path}\n')
-
       if self._additional_vars:
         additional_vars = {}
         additional_vars.update(self._additional_vars.get('all', {}))

--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -137,6 +137,9 @@ GFT_MSAN_JOB = JobInfo('googlefuzztest_msan_', 'googlefuzztest', 'memory',
 GFT_UBSAN_JOB = JobInfo('googlefuzztest_ubsan_', 'googlefuzztest', 'undefined',
                         ['googlefuzztest', 'engine_ubsan'])
 
+CENTIPEDE_ASAN_JOB = JobInfo('centipede_asan_', 'centipede', 'address',
+                             ['centipede', 'engine_asan'])
+
 LIBFUZZER_NONE_JOB = JobInfo('libfuzzer_nosanitizer_', 'libfuzzer', 'none',
                              ['libfuzzer'])
 LIBFUZZER_NONE_I386_JOB = JobInfo(
@@ -144,6 +147,9 @@ LIBFUZZER_NONE_I386_JOB = JobInfo(
     'libfuzzer',
     'none', ['libfuzzer'],
     architecture='i386')
+
+CENTIPEDE_NONE_JOB = JobInfo('centipede_nosanitizer_', 'centipede', 'none',
+                             ['centipede'])
 
 JOB_MAP = {
     'libfuzzer': {
@@ -179,7 +185,13 @@ JOB_MAP = {
         'x86_64': {
             'address': NO_ENGINE_ASAN_JOB,
         }
-    }
+    },
+    'centipede': {
+        'x86_64': {
+            'address': CENTIPEDE_ASAN_JOB,
+            'none': CENTIPEDE_NONE_JOB,
+        },
+    },
 }
 
 DEFAULT_ARCHITECTURES = ['x86_64']

--- a/src/appengine/handlers/cron/project_setup.py
+++ b/src/appengine/handlers/cron/project_setup.py
@@ -148,9 +148,6 @@ LIBFUZZER_NONE_I386_JOB = JobInfo(
     'none', ['libfuzzer'],
     architecture='i386')
 
-CENTIPEDE_NONE_JOB = JobInfo('centipede_nosanitizer_', 'centipede', 'none',
-                             ['centipede'])
-
 JOB_MAP = {
     'libfuzzer': {
         'x86_64': {
@@ -189,7 +186,6 @@ JOB_MAP = {
     'centipede': {
         'x86_64': {
             'address': CENTIPEDE_ASAN_JOB,
-            'none': CENTIPEDE_NONE_JOB,
         },
     },
 }

--- a/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
@@ -1803,6 +1803,13 @@ class FuzzingSession(object):
           [dataflow_bucket_path], build_prefix='DATAFLOW'):
         logs.log_error('Failed to set up dataflow build.')
 
+    # Centipede requires separate binaries for sanitized targets.
+    if environment.is_centipede_fuzzer_job():
+      sanitized_target_bucket_path = environment.get_value(
+          'SANITIZED_TARGET_BUILD_BUCKET_PATH')
+      if sanitized_target_bucket_path:
+        logs.log_error('Failed to set up sanitized_target_build.')
+
     # Save fuzz targets count to aid with CPU weighting.
     self._save_fuzz_targets_count()
 

--- a/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
@@ -852,8 +852,8 @@ def store_fuzzer_run_results(testcase_file_paths, fuzzer, fuzzer_command,
     fuzzer_return_code_string = 'Fuzzer timed out.'
   truncated_fuzzer_output = truncate_fuzzer_output(fuzzer_output,
                                                    data_types.ENTITY_SIZE_LIMIT)
-  console_output = '%s: %s\n%s\n%s' % (bot_name, fuzzer_return_code_string,
-                                       fuzzer_command, truncated_fuzzer_output)
+  console_output = (f'{bot_name}: {fuzzer_return_code_string}\n{fuzzer_command}'
+                    f'\n{truncated_fuzzer_output}')
 
   # Refresh the fuzzer object.
   fuzzer = data_types.Fuzzer.query(data_types.Fuzzer.name == fuzzer.name).get()

--- a/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
@@ -852,8 +852,8 @@ def store_fuzzer_run_results(testcase_file_paths, fuzzer, fuzzer_command,
     fuzzer_return_code_string = 'Fuzzer timed out.'
   truncated_fuzzer_output = truncate_fuzzer_output(fuzzer_output,
                                                    data_types.ENTITY_SIZE_LIMIT)
-  console_output = u'%s: %s\n%s\n%s' % (bot_name, fuzzer_return_code_string,
-                                        fuzzer_command, truncated_fuzzer_output)
+  console_output = '%s: %s\n%s\n%s' % (bot_name, fuzzer_return_code_string,
+                                       fuzzer_command, truncated_fuzzer_output)
 
   # Refresh the fuzzer object.
   fuzzer = data_types.Fuzzer.query(data_types.Fuzzer.name == fuzzer.name).get()
@@ -1463,7 +1463,7 @@ class FuzzingSession(object):
     if fuzzer_output:
       fuzzer_output = utils.decode_to_unicode(fuzzer_output)
     else:
-      fuzzer_output = u'No output!'
+      fuzzer_output = 'No output!'
 
     # Get the list of generated testcases.
     testcase_file_paths, generated_testcase_count, generated_testcase_string = (

--- a/src/clusterfuzz/_internal/fuzzing/__init__.py
+++ b/src/clusterfuzz/_internal/fuzzing/__init__.py
@@ -18,6 +18,7 @@ PUBLIC_ENGINES = (
     'afl',
     'honggfuzz',
     'googlefuzztest',
+    'centipede',
 )
 
 PRIVATE_ENGINES = ('syzkaller',)

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -631,7 +631,7 @@ def _job_substring_match(search_string, job_name):
 
 
 def is_afl_job(job_name=None):
-  """Return true if the current job uses AFL."""
+  """Return True if the current job uses AFL."""
   return get_engine_for_job(job_name) == 'afl'
 
 
@@ -657,27 +657,27 @@ def is_chromeos_system_job(job_name=None):
 
 
 def is_libfuzzer_job(job_name=None):
-  """Return true if the current job uses libFuzzer."""
+  """Return True if the current job uses libFuzzer."""
   return get_engine_for_job(job_name) == 'libFuzzer'
 
 
 def is_honggfuzz_job(job_name=None):
-  """Return true if the current job uses honggfuzz."""
+  """Return True if the current job uses honggfuzz."""
   return get_engine_for_job(job_name) == 'honggfuzz'
 
 
 def is_kernel_fuzzer_job(job_name=None):
-  """Return true if the current job uses syzkaller."""
+  """Return True if the current job uses syzkaller."""
   return get_engine_for_job(job_name) == 'syzkaller'
 
 
 def is_centipede_fuzzer_job(job_name=None):
-  """Return true if the current job uses Centipede."""
+  """Return True if the current job uses Centipede."""
   return get_engine_for_job(job_name) == 'centipede'
 
 
 def is_engine_fuzzer_job(job_name=None):
-  """Return true if this is an engine fuzzer."""
+  """Return True if this is an engine fuzzer."""
   return bool(get_engine_for_job(job_name))
 
 
@@ -694,7 +694,7 @@ def get_engine_for_job(job_name=None):
 
 
 def is_posix():
-  """Return true if we are on a posix platform (linux/unix and mac os)."""
+  """Return True if we are on a posix platform (linux/unix and mac os)."""
   return os.name == 'posix'
 
 
@@ -1055,7 +1055,7 @@ def bot_noop(func):
 
 
 def is_local_development():
-  """Return true if running in local development environment (e.g. running
+  """Return True if running in local development environment (e.g. running
   a bot locally, excludes tests)."""
   return bool(get_value('LOCAL_DEVELOPMENT') and not get_value('PY_UNITTESTS'))
 
@@ -1080,22 +1080,22 @@ def is_ephemeral():
 
 
 def is_android(plt=None):
-  """Return true if we are on android platform."""
+  """Return True if we are on android platform."""
   return 'ANDROID' in (plt or platform())
 
 
 def is_android_cuttlefish(plt=None):
-  """Return true if we are on android cuttlefish platform."""
+  """Return True if we are on android cuttlefish platform."""
   return 'ANDROID_X86' in (plt or platform())
 
 
 def is_android_emulator(plt=None):
-  """Return true if we are on android emulator platform."""
+  """Return True if we are on android emulator platform."""
   return 'ANDROID_EMULATOR' == (plt or platform())
 
 
 def is_android_kernel(plt=None):
-  """Return true if we are on android kernel platform groups."""
+  """Return True if we are on android kernel platform groups."""
   return 'ANDROID_KERNEL' in (plt or get_platform_group())
 
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -671,6 +671,11 @@ def is_kernel_fuzzer_job(job_name=None):
   return get_engine_for_job(job_name) == 'syzkaller'
 
 
+def is_centipede_fuzzer_job(job_name=None):
+  """Return true if the current job uses Centipede."""
+  return get_engine_for_job(job_name) == 'centipede'
+
+
 def is_engine_fuzzer_job(job_name=None):
   """Return true if this is an engine fuzzer."""
   return bool(get_engine_for_job(job_name))

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -320,13 +320,13 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'architectures': ['i386', 'x86_64'],
         }),
         ('lib9', {
-           'homepage:': 'http://example.com',
-           'primary_contact': 'primary@example.com',
-           'auto_ccs': ['User@example.com',],
-           'main_repo': 'https://github.com/google/main-repo',
-           'fuzzing_engines': ['centipede',],
-           'sanitizers:': ['address',],
-           'architectures': ['x86_64',],
+            'homepage:': 'http://example.com',
+            'primary_contact': 'primary@example.com',
+            'auto_ccs': ['User@example.com',],
+            'main_repo': 'https://github.com/google/main-repo',
+            'fuzzing_engines': ['centipede',],
+            'sanitizers:': ['address',],
+            'architectures': ['x86_64',],
         }),
     ]
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -1419,229 +1419,288 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         for entity in data_types.ExternalUserPermission.query()
     ]
 
-    six.assertCountEqual(self, all_permissions, [{
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_asan_lib1',
-        'email': 'primary@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_ubsan_lib1',
-        'email': 'primary@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_ubsan_lib1',
-        'email': 'user@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_ubsan_lib1',
-        'email': 'user2@googlemail.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_asan_lib1',
-        'email': 'user@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_asan_lib1',
-        'email': 'user2@googlemail.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'afl_asan_lib1',
-        'email': 'primary@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'afl_asan_lib1',
-        'email': 'user@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'afl_asan_lib1',
-        'email': 'user2@googlemail.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_msan_lib3',
-        'email': 'user@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_ubsan_lib3',
-        'email': 'user@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'libfuzzer_asan_lib3',
-        'email': 'user@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'auto_cc': 1,
-        'entity_name': 'asan_lib4',
-        'email': 'user@example.com'
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'libfuzzer_asan_i386_lib3',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'libfuzzer_msan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'libfuzzer_ubsan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'libfuzzer_asan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'afl_asan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'vendor1@example.com',
-        'entity_name': 'libfuzzer_msan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'vendor1@example.com',
-        'entity_name': 'libfuzzer_ubsan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'vendor1@example.com',
-        'entity_name': 'libfuzzer_asan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'vendor1@example.com',
-        'entity_name': 'afl_asan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'vendor2@example.com',
-        'entity_name': 'libfuzzer_msan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'vendor2@example.com',
-        'entity_name': 'libfuzzer_ubsan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'vendor2@example.com',
-        'entity_name': 'libfuzzer_asan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'vendor2@example.com',
-        'entity_name': 'afl_asan_lib6',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'primary@example.com',
-        'entity_name': 'honggfuzz_asan_lib1',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'honggfuzz_asan_lib1',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user2@googlemail.com',
-        'entity_name': 'honggfuzz_asan_lib1',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'primary@example.com',
-        'entity_name': 'libfuzzer_asan_lib7',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'libfuzzer_asan_lib7',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'libfuzzer_nosanitizer_lib8',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'primary@example.com',
-        'entity_name': 'libfuzzer_nosanitizer_lib8',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'primary@example.com',
-        'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'primary@example.com',
-        'entity_name': 'centipede_asan_lib1',
-        'auto_cc': 1
-    }, {
-        'entity_kind': 1,
-        'is_prefix': False,
-        'email': 'user@example.com',
-        'entity_name': 'centipede_nosanitizer_lib8',
-        'auto_cc': 1
-    }])
+    six.assertCountEqual(self, all_permissions, [
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_asan_lib1',
+            'email': 'primary@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_ubsan_lib1',
+            'email': 'primary@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_ubsan_lib1',
+            'email': 'user@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_ubsan_lib1',
+            'email': 'user2@googlemail.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_asan_lib1',
+            'email': 'user@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_asan_lib1',
+            'email': 'user2@googlemail.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'afl_asan_lib1',
+            'email': 'primary@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'afl_asan_lib1',
+            'email': 'user@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'afl_asan_lib1',
+            'email': 'user2@googlemail.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_msan_lib3',
+            'email': 'user@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_ubsan_lib3',
+            'email': 'user@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'libfuzzer_asan_lib3',
+            'email': 'user@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'asan_lib4',
+            'email': 'user@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'libfuzzer_asan_i386_lib3',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'libfuzzer_msan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'libfuzzer_ubsan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'libfuzzer_asan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'afl_asan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'vendor1@example.com',
+            'entity_name': 'libfuzzer_msan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'vendor1@example.com',
+            'entity_name': 'libfuzzer_ubsan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'vendor1@example.com',
+            'entity_name': 'libfuzzer_asan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'vendor1@example.com',
+            'entity_name': 'afl_asan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'vendor2@example.com',
+            'entity_name': 'libfuzzer_msan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'vendor2@example.com',
+            'entity_name': 'libfuzzer_ubsan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'vendor2@example.com',
+            'entity_name': 'libfuzzer_asan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'vendor2@example.com',
+            'entity_name': 'afl_asan_lib6',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'primary@example.com',
+            'entity_name': 'honggfuzz_asan_lib1',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'honggfuzz_asan_lib1',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user2@googlemail.com',
+            'entity_name': 'honggfuzz_asan_lib1',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'primary@example.com',
+            'entity_name': 'centipede_asan_lib1',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'centipede_asan_lib1',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user2@googlemail.com',
+            'entity_name': 'centipede_asan_lib1',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'primary@example.com',
+            'entity_name': 'libfuzzer_asan_lib7',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'libfuzzer_asan_lib7',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'libfuzzer_nosanitizer_lib8',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'primary@example.com',
+            'entity_name': 'libfuzzer_nosanitizer_lib8',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'primary@example.com',
+            'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'primary@example.com',
+            'entity_name': 'centipede_asan_lib9',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'centipede_nosanitizer_lib9',
+            'auto_cc': 1
+        },
+    ])
 
     expected_topics = [
         'projects/clusterfuzz-external/topics/jobs-linux',

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -182,6 +182,10 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.gft = data_types.Fuzzer(name='googlefuzztest', jobs=[])
     self.gft.put()
 
+    self.centipede = data_types.Fuzzer(name='centipede', jobs=[])
+    self.centipede.data_bundle_name = 'global'
+    self.centipede.put()
+
     helpers.patch(self, [
         'clusterfuzz._internal.config.local_config.ProjectConfig',
         ('get_application_id_2',
@@ -207,6 +211,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'add_revision_mappings': True,
             'build_buckets': {
                 'afl': 'clusterfuzz-builds-afl',
+                'centipede': 'clusterfuzz-builds-centipede',
                 'dataflow': 'clusterfuzz-builds-dataflow',
                 'honggfuzz': 'clusterfuzz-builds-honggfuzz',
                 'libfuzzer': 'clusterfuzz-builds',
@@ -1370,6 +1375,8 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         ('LIB7_LINUX', 'libFuzzer', 'libfuzzer_asan_lib7'),
         ('LIB8_LINUX', 'libFuzzer', 'libfuzzer_nosanitizer_i386_lib8'),
         ('LIB8_LINUX', 'libFuzzer', 'libfuzzer_nosanitizer_lib8'),
+        ('LIB1_LINUX', 'centipede', 'centipede_asan_lib1'),
+        ('LIB8_LINUX', 'centipede', 'centipede_nosanitizer_lib8'),
     ])
 
     all_permissions = [
@@ -1587,6 +1594,18 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         'email': 'primary@example.com',
         'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
         'auto_cc': 1
+    }, {
+        'entity_kind': 1,
+        'is_prefix': False,
+        'email': 'primary@example.com',
+        'entity_name': 'centipede_asan_lib1',
+        'auto_cc': 1
+    }, {
+        'entity_kind': 1,
+        'is_prefix': False,
+        'email': 'user@example.com',
+        'entity_name': 'centipede_nosanitizer_lib8',
+        'auto_cc': 1
     }])
 
     expected_topics = [
@@ -1737,6 +1756,9 @@ class GenericProjectSetupTest(unittest.TestCase):
 
     self.gft = data_types.Fuzzer(name='googlefuzztest', jobs=[])
     self.gft.put()
+
+    self.centipede = data_types.Fuzzer(name='centipede', jobs=[])
+    self.centipede.put()
 
     helpers.patch(self, [
         'clusterfuzz._internal.config.local_config.ProjectConfig',

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -1757,9 +1757,6 @@ class GenericProjectSetupTest(unittest.TestCase):
     self.gft = data_types.Fuzzer(name='googlefuzztest', jobs=[])
     self.gft.put()
 
-    self.centipede = data_types.Fuzzer(name='centipede', jobs=[])
-    self.centipede.put()
-
     helpers.patch(self, [
         'clusterfuzz._internal.config.local_config.ProjectConfig',
         ('get_application_id_2',

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -320,11 +320,13 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'architectures': ['i386', 'x86_64'],
         }),
         ('lib9', {
-            'homepage': 'http://example.com',
-            'primary_contact': 'primary@example.com',
-            'main_repo': 'https://github.com/google/main-repo',
-            'fuzzing_engines': ['centipede',],
-            'sanitizers': ['addres',],
+           'homepage:': 'http://example.com',
+           'primary_contact': 'primary@example.com',
+           'auto_ccs': ['User@example.com',],
+           'main_repo': 'https://github.com/google/main-repo',
+           'fuzzing_engines': ['centipede',],
+           'sanitizers:': ['address',],
+           'architectures': ['x86_64',],
         }),
     ]
 
@@ -550,17 +552,18 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     six.assertCountEqual(self, job.templates, ['engine_asan', 'centipede'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
-        'gs://clusterfuzz-builds/lib9/lib9-address-([0-9]+).zip\n'
+        'gs://clusterfuzz-builds-centipede/lib9/lib9-address-([0-9]+).zip\n'
         'PROJECT_NAME = lib9\n'
         'SUMMARY_PREFIX = lib9\n'
         'MANAGED = True\n'
         'REVISION_VARS_URL = https://commondatastorage.googleapis.com/'
-        'clusterfuzz-builds/lib9/lib9-address-%s.srcmap.json\n'
+        'clusterfuzz-builds-centipede/lib9/lib9-address-%s.srcmap.json\n'
         'FUZZ_LOGS_BUCKET = lib9-logs.clusterfuzz-external.appspot.com\n'
         'CORPUS_BUCKET = lib9-corpus.clusterfuzz-external.appspot.com\n'
         'QUARANTINE_BUCKET = lib9-quarantine.clusterfuzz-external.appspot.com\n'
         'BACKUP_BUCKET = lib9-backup.clusterfuzz-external.appspot.com\n'
         'AUTOMATIC_LABELS = Proj-lib9,Engine-centipede\n'
+        'MAIN_REPO = https://github.com/google/main-repo\n'
         'FILE_GITHUB_ISSUE = False\n')
 
     self.maxDiff = None  # pylint: disable=invalid-name
@@ -1625,27 +1628,6 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'primary@example.com',
-            'entity_name': 'centipede_asan_lib1',
-            'auto_cc': 1
-        },
-        {
-            'entity_kind': 1,
-            'is_prefix': False,
-            'email': 'user@example.com',
-            'entity_name': 'centipede_asan_lib1',
-            'auto_cc': 1
-        },
-        {
-            'entity_kind': 1,
-            'is_prefix': False,
-            'email': 'user2@googlemail.com',
-            'entity_name': 'centipede_asan_lib1',
-            'auto_cc': 1
-        },
-        {
-            'entity_kind': 1,
-            'is_prefix': False,
-            'email': 'primary@example.com',
             'entity_name': 'libfuzzer_asan_lib7',
             'auto_cc': 1
         },
@@ -1682,6 +1664,13 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'is_prefix': False,
             'email': 'primary@example.com',
             'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
+            'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'email': 'user@example.com',
+            'entity_name': 'centipede_asan_lib9',
             'auto_cc': 1
         },
         {
@@ -1689,13 +1678,6 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'is_prefix': False,
             'email': 'primary@example.com',
             'entity_name': 'centipede_asan_lib9',
-            'auto_cc': 1
-        },
-        {
-            'entity_kind': 1,
-            'is_prefix': False,
-            'email': 'user@example.com',
-            'entity_name': 'centipede_nosanitizer_lib9',
             'auto_cc': 1
         },
     ])

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -1832,6 +1832,9 @@ class GenericProjectSetupTest(unittest.TestCase):
     self.gft = data_types.Fuzzer(name='googlefuzztest', jobs=[])
     self.gft.put()
 
+    self.centipede = data_types.Fuzzer(name='centipede', jobs=[])
+    self.centipede.put()
+
     helpers.patch(self, [
         'clusterfuzz._internal.config.local_config.ProjectConfig',
         ('get_application_id_2',

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -592,7 +592,6 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     centipede = data_types.Fuzzer.query(
         data_types.Fuzzer.name == 'centipede').get()
     six.assertCountEqual(self, centipede.jobs, [
-        'centipede_nosanitizer_lib9',
         'centipede_asan_lib9',
     ])
 
@@ -1411,7 +1410,6 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         ('LIB8_LINUX', 'libFuzzer', 'libfuzzer_nosanitizer_i386_lib8'),
         ('LIB8_LINUX', 'libFuzzer', 'libfuzzer_nosanitizer_lib8'),
         ('LIB9_LINUX', 'centipede', 'centipede_asan_lib9'),
-        ('LIB9_LINUX', 'centipede', 'centipede_nosanitizer_lib9'),
     ])
 
     all_permissions = [

--- a/src/local/butler/scripts/setup.py
+++ b/src/local/butler/scripts/setup.py
@@ -84,6 +84,18 @@ ENABLE_GESTURES = False
 THREAD_DELAY = 30.0
 """
 
+CENTIPEDE_TEMPLATE = """MAX_FUZZ_THREADS = 1
+MAX_TESTCASES = 2
+FUZZ_TEST_TIMEOUT = 8400
+TEST_TIMEOUT = 65
+WARMUP_TIMEOUT = 65
+BAD_BUILD_CHECK = False
+THREAD_ALIVE_CHECK_INTERVAL = 1
+REPORT_OOMS_AND_HANGS = True
+ENABLE_GESTURES = False
+THREAD_DELAY = 30.0
+"""
+
 ENGINE_ASAN_TEMPLATE = ('LSAN = True\n'
                         'ADDITIONAL_ASAN_OPTIONS = '
                         'symbolize=0:'
@@ -122,6 +134,7 @@ PRUNE_TEMPLATE = 'CORPUS_PRUNE = True'
 
 TEMPLATES = {
     'afl': AFL_TEMPLATE,
+    'centipede': CENTIPEDE_TEMPLATE,
     'engine_asan': ENGINE_ASAN_TEMPLATE,
     'engine_msan': ENGINE_MSAN_TEMPLATE,
     'engine_ubsan': ENGINE_UBSAN_TEMPLATE,
@@ -287,6 +300,15 @@ class GoogleFuzzTestDefaults(BaseBuiltinFuzzerDefaults):
     self.key_id = 1341
 
 
+class CentipedeDefaults(BaseBuiltinFuzzerDefaults):
+  """Default values for Centipede."""
+
+  def __init__(self):
+    super().__init__()
+    self.name = 'centipede'
+    self.key_id = 1342
+
+
 def setup_config(non_dry_run):
   """Set up configuration."""
   config = data_types.Config.query().get()
@@ -307,7 +329,8 @@ def setup_fuzzers(non_dry_run):
       LibFuzzerDefaults(),
       HonggfuzzDefaults(),
       GoogleFuzzTestDefaults(),
-      SyzkallerDefaults()
+      SyzkallerDefaults(),
+      CentipedeDefaults(),
   ]:
     fuzzer = data_types.Fuzzer.query(
         data_types.Fuzzer.name == fuzzer_defaults.name).get()


### PR DESCRIPTION
WIP: Project setups and tests.

The test cases are a bit confusing, particularly about the usage of [buckets `a-b`](https://github.com/google/clusterfuzz/blob/c5d3476ef597addbfc8848b2c0ae1be1e428a55c/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py#L1684), `c-d`, etc.
Is there any hint about how they are used? Thanks!
@jonathanmetzman @oliverchang 

