### PR TITLE
Capture centipede timeout & OOM

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/centipede_oom.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/centipede_oom.txt
@@ -1,0 +1,75 @@
+I0930 10:42:58.663538   11110 centipede_interface.cc:138] Coverage dir ./workdir/oom-51745151a002e10f17f77161aba8ac248b720ca0
+I0930 10:42:58.663746   11110 command.cc:78] Starting fork server for ./oom
+I0930 10:42:58.663997   11110 command.cc:93] Fork server command:
+CENTIPEDE_FORK_SERVER_FIFO0=/tmp/centipede-11110-139994428811072/f428f52ea71a391b4068b61cd036d8479eb049e8_FIFO0 \
+CENTIPEDE_FORK_SERVER_FIFO1=/tmp/centipede-11110-139994428811072/f428f52ea71a391b4068b61cd036d8479eb049e8_FIFO1 \
+CENTIPEDE_RUNNER_FLAGS=:timeout_in_seconds=60::address_space_limit_mb=5024::rss_limit_mb=2048::use_pc_features::path_level=0::use_cmp_features::use_dataflow_features::crossover_level=50::shmem:arg1=/centipede-shm1-11110-139994428811072:arg2=/centipede-shm2-11110-139994428811072:failure_description_path=/tmp/centipede-11110-139994428811072/failure_description: \
+./oom \
+/centipede-shm1-11110-139994428811072 \
+/centipede-shm2-11110-139994428811072 \
+> /tmp/centipede-11110-139994428811072/log \
+2>&1 &
+I0930 10:42:58.668708   11110 centipede_default_callbacks.cc:41] No custom mutator detected in the target
+I0930 10:42:58.677653   11119 command.cc:78] Starting fork server for ./oom
+I0930 10:42:58.677780   11119 command.cc:93] Fork server command:
+CENTIPEDE_FORK_SERVER_FIFO0=/tmp/centipede-11110-139994402658048/f428f52ea71a391b4068b61cd036d8479eb049e8_FIFO0 \
+CENTIPEDE_FORK_SERVER_FIFO1=/tmp/centipede-11110-139994402658048/f428f52ea71a391b4068b61cd036d8479eb049e8_FIFO1 \
+CENTIPEDE_RUNNER_FLAGS=:timeout_in_seconds=60::address_space_limit_mb=5024::rss_limit_mb=2048::use_pc_features::path_level=0::use_cmp_features::use_dataflow_features::crossover_level=50::shmem:arg1=/centipede-shm1-11110-139994402658048:arg2=/centipede-shm2-11110-139994402658048:failure_description_path=/tmp/centipede-11110-139994402658048/failure_description: \
+./oom \
+/centipede-shm1-11110-139994402658048 \
+/centipede-shm2-11110-139994402658048 \
+> /tmp/centipede-11110-139994402658048/log \
+2>&1 &
+I0930 10:42:58.681706   11119 centipede_default_callbacks.cc:41] No custom mutator detected in the target
+I0930 10:42:58.776552   11119 centipede.cc:419] Shard: 0/1 /tmp/centipede-11110-139994402658048 seed: 139996067203736
+
+
+
+I0930 10:42:58.778316   11119 centipede.cc:181] [0] begin-fuzz: ft: 0 cov: 0 cnt: 0 df: 0 cmp: 0 path: 0 pair: 0 corp: 0/0 fr: 0 max/avg 0 0 d0/f0 exec/s: 0 mb: 260
+I0930 10:42:58.778929   11119 centipede.cc:203] FUNC: LLVMFuzzerTestOneInput /src/centipede/puzzles/./oom.cc:22:0
+I0930 10:42:58.778941   11119 centipede.cc:203] EDGE: LLVMFuzzerTestOneInput /src/centipede/puzzles/./oom.cc:23:17
+I0930 10:42:58.778949   11119 centipede.cc:203] EDGE: LLVMFuzzerTestOneInput /src/centipede/puzzles/./oom.cc:23:35
+I0930 10:42:58.779028   11119 centipede.cc:203] EDGE: LLVMFuzzerTestOneInput /src/centipede/puzzles/./oom.cc:23:53
+I0930 10:42:58.779043   11119 centipede.cc:203] EDGE: LLVMFuzzerTestOneInput /src/centipede/puzzles/./oom.cc:23:7
+I0930 10:42:58.779145   11119 centipede.cc:203] EDGE: LLVMFuzzerTestOneInput /src/centipede/puzzles/./oom.cc:25:17
+I0930 10:42:58.779198   11119 centipede.cc:181] [0] load-shard: ft: 261 cov: 6 cnt: 6 df: 0 cmp: 255 path: 0 pair: 0 corp: 255/255 fr: 0 max/avg 60 5 d0/f0 exec/s: 0 mb: 260
+I0930 10:42:58.779282   11119 centipede.cc:181] [0] init-done: ft: 261 cov: 6 cnt: 6 df: 0 cmp: 255 path: 0 pair: 0 corp: 255/255 fr: 0 max/avg 60 5 d0/f0 exec/s: 0 mb: 260
+I0930 10:42:58.779320   11119 centipede.cc:377] GenerateCoverageReport: ./workdir/coverage-report-oom.000000.txt
+I0930 10:42:58.782042   11119 centipede.cc:545] Batch execution failed; exit code: 6
+Log of batch follows: [[[==================
+Centipede fuzz target runner; argv[0]: ./oom flags: :timeout_in_seconds=60::address_space_limit_mb=5024::rss_limit_mb=2048::use_pc_features::path_level=0::use_cmp_features::use_dataflow_features::crossover_level=50::shmem:arg1=/centipede-shm1-11110-139994402658048:arg2=/centipede-shm2-11110-139994402658048:failure_description_path=/tmp/centipede-11110-139994402658048/failure_description:
+timeout_in_seconds: 60 rss_limit_mb: 2048
+libc++abi: terminating with uncaught exception of type std::bad_alloc: std::bad_alloc
+==================]]]
+I0930 10:42:58.782092   11119 centipede.cc:554] ReportCrash[0]: The crash occurred when running ./oom on 1000 inputs
+I0930 10:42:58.782097   11119 centipede.cc:590] ReportCrash[0]: Executing input 68 out of 1000
+I0930 10:42:58.783806   11119 centipede.cc:574] ReportCrash[0]: Crash detected, saving input to ./workdir/crashes/860ba15ab431851438af3c37ba32c043364f6504
+I0930 10:42:58.783819   11119 centipede.cc:575] Input bytes: OOM
+I0930 10:42:58.783824   11119 centipede.cc:576] Exit code: 6
+I0930 10:42:58.783829   11119 centipede.cc:577] Failure description: 
+I0930 10:42:58.784033   11119 command.cc:78] Starting fork server for ./oom_asan
+I0930 10:42:58.784145   11119 command.cc:93] Fork server command:
+CENTIPEDE_FORK_SERVER_FIFO0=/tmp/centipede-11110-139994402658048/d8207296173f3e6f2f94c09a5092864f9c00564a_FIFO0 \
+CENTIPEDE_FORK_SERVER_FIFO1=/tmp/centipede-11110-139994402658048/d8207296173f3e6f2f94c09a5092864f9c00564a_FIFO1 \
+CENTIPEDE_RUNNER_FLAGS=:timeout_in_seconds=60::address_space_limit_mb=5024::rss_limit_mb=2048::crossover_level=50::shmem:arg1=/centipede-shm1-11110-139994402658048:arg2=/centipede-shm2-11110-139994402658048:failure_description_path=/tmp/centipede-11110-139994402658048/failure_description: \
+./oom_asan \
+/centipede-shm1-11110-139994402658048 \
+/centipede-shm2-11110-139994402658048 \
+> /tmp/centipede-11110-139994402658048/log \
+2>&1 &
+I0930 10:43:00.806648   11119 centipede.cc:545] Batch execution failed; exit code: 1
+Log of batch follows: [[[==================
+Centipede fuzz target runner; argv[0]: ./oom_asan flags: :timeout_in_seconds=60::address_space_limit_mb=5024::rss_limit_mb=2048::crossover_level=50::shmem:arg1=/centipede-shm1-11110-139994402658048:arg2=/centipede-shm2-11110-139994402658048:failure_description_path=/tmp/centipede-11110-139994402658048/failure_description:
+timeout_in_seconds: 60 rss_limit_mb: 2048
+Not using RLIMIT_AS; VmSize is 20480Gb, suspecting ASAN/MSAN/TSAN
+========= OOM, RSS limit of 2048Mb exceeded (3497Mb); exiting
+==================]]]
+I0930 10:43:00.806711   11119 centipede.cc:554] ReportCrash[1]: The crash occurred when running ./oom_asan on 1000 inputs
+I0930 10:43:00.806718   11119 centipede.cc:590] ReportCrash[1]: Executing input 68 out of 1000
+I0930 10:43:02.828612   11119 centipede.cc:574] ReportCrash[1]: Crash detected, saving input to ./workdir/crashes/860ba15ab431851438af3c37ba32c043364f6504
+I0930 10:43:02.828642   11119 centipede.cc:575] Input bytes: OOM
+I0930 10:43:02.828649   11119 centipede.cc:576] Exit code: 1
+I0930 10:43:02.828663   11119 centipede.cc:577] Failure description: out-of-memory
+I0930 10:43:02.828781   11119 centipede.cc:279] --exit_on_crash is enabled; exiting soon
+I0930 10:43:02.829782   11119 centipede.cc:181] [0] pulse: ft: 261 cov: 6 cnt: 6 df: 0 cmp: 255 path: 0 pair: 0 corp: 255/255 fr: 0 max/avg 60 5 d0/f0 exec/s: 0 mb: 260
+I0930 10:43:02.829949   11119 centipede.cc:181] [0] end-fuzz: ft: 261 cov: 6 cnt: 6 df: 0 cmp: 255 path: 0 pair: 0 corp: 255/255 fr: 0 max/avg 60 5 d0/f0 exec/s: 0 mb: 260

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/centipede_timeout.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/centipede_timeout.txt
@@ -1,0 +1,53 @@
+I0930 17:17:22.296600  834976 centipede_interface.cc:138] Coverage dir ./workdir/scarecrow-bf6e41ee7d3a63db00c65df41ef415eeb26dba4c
+I0930 17:17:22.296792  834976 command.cc:78] Starting fork server for ./scarecrow
+I0930 17:17:22.297036  834976 command.cc:93] Fork server command:
+CENTIPEDE_FORK_SERVER_FIFO0=/tmp/centipede-834976-140692624531584/be9ec219d639cce3b0f030fada9fda81573f6ee0_FIFO0 \
+CENTIPEDE_FORK_SERVER_FIFO1=/tmp/centipede-834976-140692624531584/be9ec219d639cce3b0f030fada9fda81573f6ee0_FIFO1 \
+CENTIPEDE_RUNNER_FLAGS=:timeout_in_seconds=20::address_space_limit_mb=0::rss_limit_mb=0::use_pc_features::path_level=0::use_cmp_features::use_dataflow_features::crossover_level=50::shmem:arg1=/centipede-shm1-834976-140692624531584:arg2=/centipede-shm2-834976-140692624531584:failure_description_path=/tmp/centipede-834976-140692624531584/failure_description: \
+./scarecrow \
+/centipede-shm1-834976-140692624531584 \
+/centipede-shm2-834976-140692624531584 \
+> /tmp/centipede-834976-140692624531584/log \
+2>&1 &
+I0930 17:17:22.303943  834976 centipede_default_callbacks.cc:41] No custom mutator detected in the target
+sh: line 2: llvm-symbolizer: command not found
+E0930 17:17:22.311125  834976 symbol_table.cc:77] system() failed: cmd.ToString()=llvm-symbolizer \
+--no-inlines \
+-e \
+./scarecrow \
+< \
+/tmp/centipede-834976-140692624531584/sym-tmp1 \
+> /tmp/centipede-834976-140692624531584/sym-tmp2 exit_code=127 
+I0930 17:17:22.311646  834985 command.cc:78] Starting fork server for ./scarecrow
+I0930 17:17:22.311739  834985 command.cc:93] Fork server command:
+CENTIPEDE_FORK_SERVER_FIFO0=/tmp/centipede-834976-140692613654080/be9ec219d639cce3b0f030fada9fda81573f6ee0_FIFO0 \
+CENTIPEDE_FORK_SERVER_FIFO1=/tmp/centipede-834976-140692613654080/be9ec219d639cce3b0f030fada9fda81573f6ee0_FIFO1 \
+CENTIPEDE_RUNNER_FLAGS=:timeout_in_seconds=20::address_space_limit_mb=0::rss_limit_mb=0::use_pc_features::path_level=0::use_cmp_features::use_dataflow_features::crossover_level=50::shmem:arg1=/centipede-shm1-834976-140692613654080:arg2=/centipede-shm2-834976-140692613654080:failure_description_path=/tmp/centipede-834976-140692613654080/failure_description: \
+./scarecrow \
+/centipede-shm1-834976-140692613654080 \
+/centipede-shm2-834976-140692613654080 \
+> /tmp/centipede-834976-140692613654080/log \
+2>&1 &
+I0930 17:17:22.317210  834985 centipede_default_callbacks.cc:41] No custom mutator detected in the target
+I0930 17:17:22.405821  834985 centipede.cc:419] Shard: 0/1 /tmp/centipede-834976-140692613654080 seed: 14758258457571676168
+
+
+
+I0930 17:17:43.409854  834985 centipede.cc:181] [0] begin-fuzz: ft: 0 cov: 0 cnt: 0 df: 0 cmp: 0 path: 0 pair: 0 corp: 0/0 fr: 0 max/avg 0 0 d0/f0 exec/s: 0 mb: 263
+I0930 17:17:43.410085  834985 centipede.cc:181] [0] init-done: ft: 0 cov: 0 cnt: 0 df: 0 cmp: 0 path: 0 pair: 0 corp: 1/1 fr: 0 max/avg 1 1 d0/f0 exec/s: 0 mb: 263
+I0930 17:17:43.410127  834985 centipede.cc:377] GenerateCoverageReport: ./workdir/coverage-report-scarecrow.000000.txt
+I0930 17:18:04.414451  834985 centipede.cc:545] Batch execution failed; exit code: 1
+Log of batch follows: [[[==================
+Centipede fuzz target runner; argv[0]: ./scarecrow flags: :timeout_in_seconds=20::address_space_limit_mb=0::rss_limit_mb=0::use_pc_features::path_level=0::use_cmp_features::use_dataflow_features::crossover_level=50::shmem:arg1=/centipede-shm1-834976-140692613654080:arg2=/centipede-shm2-834976-140692613654080:failure_description_path=/tmp/centipede-834976-140692613654080/failure_description:
+timeout_in_seconds: 20 rss_limit_mb: 0
+========= Timeout of 20 seconds exceeded; exiting
+==================]]]
+I0930 17:18:04.414536  834985 centipede.cc:554] ReportCrash[0]: The crash occurred when running ./scarecrow on 1000 inputs
+I0930 17:18:04.414542  834985 centipede.cc:590] ReportCrash[0]: Executing input 0 out of 1000
+I0930 17:18:25.418748  834985 centipede.cc:574] ReportCrash[0]: Crash detected, saving input to ./workdir/crashes/1489f923c4dca729178b3e3233458550d8dddf29
+I0930 17:18:25.418785  834985 centipede.cc:575] Input bytes: \x0\x0
+I0930 17:18:25.418808  834985 centipede.cc:576] Exit code: 1
+I0930 17:18:25.418823  834985 centipede.cc:577] Failure description: timeout-exceeded
+I0930 17:18:25.419847  834985 centipede.cc:279] --exit_on_crash is enabled; exiting soon
+I0930 17:18:25.419885  834985 centipede.cc:181] [0] pulse: ft: 0 cov: 0 cnt: 0 df: 0 cmp: 0 path: 0 pair: 0 corp: 1/1 fr: 0 max/avg 1 1 d0/f0 exec/s: 0 mb: 264
+I0930 17:18:25.419998  834985 centipede.cc:181] [0] end-fuzz: ft: 0 cov: 0 cnt: 0 df: 0 cmp: 0 path: 0 pair: 0 corp: 1/1 fr: 0 max/avg 1 1 d0/f0 exec/s: 0 mb: 264

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2386,6 +2386,50 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_centipede_oom(self):
+    """Test centipede's out of memory stacktrace."""
+    os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
+
+    data = self._read_test_data('centipede_oom.txt')
+    expected_type = 'Out-of-memory'
+    expected_address = ''
+    expected_state = 'NULL'
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_centipede_timeout_enabled(self):
+    """Test a centipede timeout stacktrace (with reporting enabled)."""
+    os.environ['FUZZ_TARGET'] = 'pdfium_fuzzer'
+    os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
+
+    data = self._read_test_data('centipede_timeout.txt')
+    expected_type = 'Timeout'
+    expected_address = ''
+    expected_state = 'pdfium_fuzzer\n'
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_centipede_timeout_disabled(self):
+    """Test a centipede timeout stacktrace (with reporting disabled)."""
+    data = self._read_test_data('centipede_timeout.txt')
+    expected_type = ''
+    expected_address = ''
+    expected_state = ''
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_libfuzzer_timeout_enabled(self):
     """Test a libFuzzer timeout stacktrace (with reporting enabled)."""
     os.environ['FUZZ_TARGET'] = 'pdfium_fuzzer'

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2401,15 +2401,14 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
-  def test_centipede_timeout_enabled(self):
+  def test_centipede_timeout(self):
     """Test a centipede timeout stacktrace (with reporting enabled)."""
-    os.environ['FUZZ_TARGET'] = 'pdfium_fuzzer'
     os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
 
     data = self._read_test_data('centipede_timeout.txt')
     expected_type = 'Timeout'
     expected_address = ''
-    expected_state = 'pdfium_fuzzer\n'
+    expected_state = 'NULL'
     expected_stacktrace = data
     expected_security_flag = False
 

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2417,19 +2417,6 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
-  def test_centipede_timeout_disabled(self):
-    """Test a centipede timeout stacktrace (with reporting disabled)."""
-    data = self._read_test_data('centipede_timeout.txt')
-    expected_type = ''
-    expected_address = ''
-    expected_state = ''
-    expected_stacktrace = data
-    expected_security_flag = False
-
-    self._validate_get_crash_data(data, expected_type, expected_address,
-                                  expected_state, expected_stacktrace,
-                                  expected_security_flag)
-
   def test_libfuzzer_timeout_enabled(self):
     """Test a libFuzzer timeout stacktrace (with reporting enabled)."""
     os.environ['FUZZ_TARGET'] = 'pdfium_fuzzer'

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -869,12 +869,12 @@ class StackParser:
               state,
               new_type='Timeout',
               reset=True)
-          self.update_state_on_match(
-              OUT_OF_MEMORY_REGEX,
-              line,
-              state,
-              new_type='Out-of-memory',
-              reset=True)
+        self.update_state_on_match(
+            OUT_OF_MEMORY_REGEX,
+            line,
+            state,
+            new_type='Out-of-memory',
+            reset=True)
 
       # The following parsing signatures don't lead to crash state overwrites.
       if not state.crash_type:

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -864,11 +864,7 @@ class StackParser:
       if self.detect_ooms_and_hangs:
         for timeout_regex in [LIBFUZZER_TIMEOUT_REGEX, CENTIPEDE_TIMEOUT_REGEX]:
           self.update_state_on_match(
-              timeout_regex,
-              line,
-              state,
-              new_type='Timeout',
-              reset=True)
+              timeout_regex, line, state, new_type='Timeout', reset=True)
         self.update_state_on_match(
             OUT_OF_MEMORY_REGEX,
             line,

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -860,35 +860,21 @@ class StackParser:
       self.update_state_on_check_failure(
           state, line, SECURITY_DCHECK_FAILURE_REGEX, 'Security DCHECK failure')
 
-      # Timeout/OOM detected by libFuzzer.
+      # Timeout/OOM detected by libFuzzer and Centipede.
       if self.detect_ooms_and_hangs:
-        self.update_state_on_match(
-            LIBFUZZER_TIMEOUT_REGEX,
-            line,
-            state,
-            new_type='Timeout',
-            reset=True)
-        self.update_state_on_match(
-            OUT_OF_MEMORY_REGEX,
-            line,
-            state,
-            new_type='Out-of-memory',
-            reset=True)
-
-      # Timeout/OOM detected by Centipede.
-      if self.detect_ooms_and_hangs:
-        self.update_state_on_match(
-            CENTIPEDE_TIMEOUT_REGEX,
-            line,
-            state,
-            new_type='Timeout',
-            reset=True)
-        self.update_state_on_match(
-            OUT_OF_MEMORY_REGEX,
-            line,
-            state,
-            new_type='Out-of-memory',
-            reset=True)
+        for timeout_regex in [LIBFUZZER_TIMEOUT_REGEX, CENTIPEDE_TIMEOUT_REGEX]:
+          self.update_state_on_match(
+              timeout_regex,
+              line,
+              state,
+              new_type='Timeout',
+              reset=True)
+          self.update_state_on_match(
+              OUT_OF_MEMORY_REGEX,
+              line,
+              state,
+              new_type='Out-of-memory',
+              reset=True)
 
       # The following parsing signatures don't lead to crash state overwrites.
       if not state.crash_type:

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -875,6 +875,21 @@ class StackParser:
             new_type='Out-of-memory',
             reset=True)
 
+      # Timeout/OOM detected by Centipede.
+      if self.detect_ooms_and_hangs:
+        self.update_state_on_match(
+            CENTIPEDE_TIMEOUT_REGEX,
+            line,
+            state,
+            new_type='Timeout',
+            reset=True)
+        self.update_state_on_match(
+            OUT_OF_MEMORY_REGEX,
+            line,
+            state,
+            new_type='Out-of-memory',
+            reset=True)
+
       # The following parsing signatures don't lead to crash state overwrites.
       if not state.crash_type:
         # Windows cdb stack overflow.

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -171,7 +171,7 @@ OUT_OF_MEMORY_REGEX = re.compile(r'.*(?:%s).*' % '|'.join([
     r'libFuzzer: out-of-memory \(',
     r'rss limit exhausted',
     r'in rust_oom',
-    r'Failure description: out-of-memory',  # Centipede
+    r'Failure description: out-of-memory',  # Centipede.
 ]))
 RUNTIME_ERROR_REGEX = re.compile(r'#\s*Runtime error in (.*)')
 RUNTIME_ERROR_LINE_REGEX = re.compile(r'#\s*Runtime error in (.*), line [0-9]+')

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -64,6 +64,8 @@ ASSERT_REGEX_GOOGLE = re.compile(GOOGLE_LOG_FATAL_PREFIX +
 ASSERT_REGEX_GLIBC = re.compile(
     r'.*:\s*assertion [`\'"]?(.*?)[`\'"]? failed\.?$', re.IGNORECASE)
 ASSERT_NOT_REACHED_REGEX = re.compile(r'^\s*SHOULD NEVER BE REACHED\s*$')
+CENTIPEDE_TIMEOUT_REGEX = re.compile(
+    r'^========= Timeout of \d+ seconds exceeded; exiting')
 CFI_ERROR_REGEX = re.compile(
     r'(.*): runtime error: control flow integrity check for type (.*) '
     r'failed during (.*vtable address ([xX0-9a-fA-F]+)|.*)')
@@ -168,7 +170,8 @@ OUT_OF_MEMORY_REGEX = re.compile(r'.*(?:%s).*' % '|'.join([
     r'couldnt allocate.*Out of memory',
     r'libFuzzer: out-of-memory \(',
     r'rss limit exhausted',
-    r'in rust_oom'
+    r'in rust_oom',
+    r'Failure description: out-of-memory',  # Centipede
 ]))
 RUNTIME_ERROR_REGEX = re.compile(r'#\s*Runtime error in (.*)')
 RUNTIME_ERROR_LINE_REGEX = re.compile(r'#\s*Runtime error in (.*), line [0-9]+')


### PR DESCRIPTION
Ensure capturing the timeout and OOM error messages from `Centipede`'s output.