### PR TITLE
Update `yapf`

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,5 +1,5 @@
 [style]
-based_on_style = chromium
+based_on_style = google
 column_limit = 80
 indent_width = 2
 split_before_named_assigns = true


### PR DESCRIPTION
Not sure if I misinterpreted this, but I reckon [`chromium` has been changed to `pep8`](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/python/python.md#yapf)?
Alternatively, it can be [`google` or `yapf`](https://github.com/google/yapf/blob/main/README.rst#formatting-style).
`yapf` has an error, though.