### PR TITLE
Cast `reproducer_path` as a `str` from `PosixPath`

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -143,8 +143,9 @@ class Engine(engine.Engine):
     crashes = []
     if reproducer_path:
       crashes.append(
-          engine.Crash(str(reproducer_path), fuzz_result.output, [],
-                       int(fuzz_result.time_executed)))
+          engine.Crash(
+              str(reproducer_path), fuzz_result.output, [],
+              int(fuzz_result.time_executed)))
 
     # Stats report is not available in Centipede yet.
     stats = None

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -143,7 +143,7 @@ class Engine(engine.Engine):
     crashes = []
     if reproducer_path:
       crashes.append(
-          engine.Crash(reproducer_path, fuzz_result.output, [],
+          engine.Crash(str(reproducer_path), fuzz_result.output, [],
                        int(fuzz_result.time_executed)))
 
     # Stats report is not available in Centipede yet.


### PR DESCRIPTION
`engine.Crash()` expects the `reproducer_path` to be a `str` instead of `Path`.
This was not captured by the test cases but was discovered via this error after deployment:
```
TypeError: PosixPath('/path/to/inputs/fuzzer-testcases/1489f923c4dca729178b3e3233458550d8d has type PosixPath, but expected one of: bytes, unicode
```