### PR TITLE
Add additional logging for test_reproduce_reliability.

### DIFF
--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -714,6 +714,7 @@ class TestcaseRunner(object):
   def test_reproduce_reliability(self, retries, expected_state,
                                  expected_security_flag) -> bool:
     """Test to see if a crash is fully reproducible or is a one-time crasher."""
+    logs.log("Beginning a reproducibility test.")
     self._pre_run_cleanup()
 
     reproducible_crash_target_count = retries * REPRODUCIBILITY_FACTOR


### PR DESCRIPTION
We're trying to better understand the performance of the reproduction tasks, and this additional logging will make it simpler to filter/understand the relevant data.