### PR TITLE
Add GPU Failure type to variant ignore list.

### DIFF
--- a/src/appengine/handlers/cron/grouper.py
+++ b/src/appengine/handlers/cron/grouper.py
@@ -35,7 +35,7 @@ FORWARDED_ATTRIBUTES = ('crash_state', 'crash_type', 'group_id',
 GROUP_MAX_TESTCASE_LIMIT = 25
 
 VARIANT_CRASHES_IGNORE = re.compile(
-    r'^(Out-of-memory|Timeout|Missing-library|Data race)')
+    r'^(Out-of-memory|Timeout|Missing-library|Data race|GPU failure)')
 
 VARIANT_STATES_IGNORE = re.compile(r'^NULL$')
 


### PR DESCRIPTION
These are almost always issues in the environment rather than real issues.