### PR TITLE
Fix remove file on hang afl device

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
@@ -1284,6 +1284,7 @@ class AflAndroidRunner(AflRunnerCommon, new_process.UnicodeProcessRunner):
     afl-showmap."""
     # TODO(metzman): Figure out if we should worry about CPU affinity errors
     # here.
+
     filename = os.path.basename(input_file_path)
     intput_file_showmap_results_file = os.path.join(self._showmap_results_dir,
                                                     filename)
@@ -1360,6 +1361,7 @@ class AflAndroidRunner(AflRunnerCommon, new_process.UnicodeProcessRunner):
         android.util.get_device_path(self.stderr_file_path),
         self.stderr_file_path)
     return fuzz_result
+
 
 class UnshareAflRunner(new_process.ModifierProcessRunnerMixin, AflRunner):
   """AFL runner which unshares."""

--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
@@ -254,7 +254,9 @@ class AflAndroidFuzzOutputDirectory(AflFuzzOutputDirectory):
     """Removes the hanging testcase from queue."""
     queue_paths = list_full_file_paths_device(self.queue)
 
-    hang_queue_path = [path for path in queue_paths if path.endswith(hang_filename)][0]
+    hang_queue_path = [
+        path for path in queue_paths if path.endswith(hang_filename)][0]
+
     hang_queue_path_device = android.util.get_device_path(hang_queue_path)
 
     android.adb.remove_file(hang_queue_path_device)
@@ -1115,7 +1117,7 @@ class AflRunnerCommon(object):
         logs.log_warn('Timed out in merge while processing initial corpus.')
         return 0
 
-      if file_features == None:
+      if file_features is None:
         continue
 
       input_inodes.add(os.stat(file_path).st_ino)
@@ -1140,7 +1142,7 @@ class AflRunnerCommon(object):
         logs.log_warn('Timed out in merge while processing output.')
         break
 
-      if file_features == None:
+      if file_features is None:
         continue
 
       corpus.associate_features_with_file(file_features, file_path)
@@ -1284,7 +1286,6 @@ class AflAndroidRunner(AflRunnerCommon, new_process.UnicodeProcessRunner):
     afl-showmap."""
     # TODO(metzman): Figure out if we should worry about CPU affinity errors
     # here.
-
     filename = os.path.basename(input_file_path)
     intput_file_showmap_results_file = os.path.join(self._showmap_results_dir,
                                                     filename)
@@ -1361,7 +1362,6 @@ class AflAndroidRunner(AflRunnerCommon, new_process.UnicodeProcessRunner):
         android.util.get_device_path(self.stderr_file_path),
         self.stderr_file_path)
     return fuzz_result
-
 
 class UnshareAflRunner(new_process.ModifierProcessRunnerMixin, AflRunner):
   """AFL runner which unshares."""
@@ -1488,9 +1488,13 @@ def remove_path(path):
   # Else path doesn't exist. Do nothing.
 
 def list_full_file_paths_device(directory):
+  """List the absolute paths of files in |directory| on Android device."""
   directory_absolute_path = os.path.abspath(directory)
-  directory_absolute_path = android.util.get_device_path(directory_absolute_path)
-  dir_contents = android.adb.run_command(['shell', 'ls', directory_absolute_path])
+  directory_absolute_path = android.util.get_device_path(
+      directory_absolute_path)
+
+  dir_contents = android.adb.run_command(
+      ['shell', 'ls', directory_absolute_path])
 
   paths = []
   for rel_path in dir_contents.split():

--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
@@ -250,6 +250,15 @@ class AflAndroidFuzzOutputDirectory(AflFuzzOutputDirectory):
   and help copy contents from device to local.
   """
 
+  def remove_hang_in_queue(self, hang_filename):
+    """Removes the hanging testcase from queue."""
+    queue_paths = list_full_file_paths_device(self.queue)
+
+    hang_queue_path = [path for path in queue_paths if path.endswith(hang_filename)][0]
+    hang_queue_path_device = android.util.get_device_path(hang_queue_path)
+
+    android.adb.remove_file(hang_queue_path_device)
+
   def copy_crash_if_needed(self, testcase_path):
     """Copy the first crash found by AFL. Before calling super method
     copy the crashes directory from device to local.
@@ -1106,6 +1115,9 @@ class AflRunnerCommon(object):
         logs.log_warn('Timed out in merge while processing initial corpus.')
         return 0
 
+      if file_features == None:
+        continue
+
       input_inodes.add(os.stat(file_path).st_ino)
       input_filenames.add(os.path.basename(file_path))
       corpus.associate_features_with_file(file_features, file_path)
@@ -1127,6 +1139,9 @@ class AflRunnerCommon(object):
       if timed_out:
         logs.log_warn('Timed out in merge while processing output.')
         break
+
+      if file_features == None:
+        continue
 
       corpus.associate_features_with_file(file_features, file_path)
 
@@ -1269,10 +1284,16 @@ class AflAndroidRunner(AflRunnerCommon, new_process.UnicodeProcessRunner):
     afl-showmap."""
     # TODO(metzman): Figure out if we should worry about CPU affinity errors
     # here.
-
     filename = os.path.basename(input_file_path)
     intput_file_showmap_results_file = os.path.join(self._showmap_results_dir,
                                                     filename)
+
+    if not os.path.exists(intput_file_showmap_results_file):
+      logs.log_error('Cannot merge corpus. Most likely reason is AFL_MAP_SIZE'
+                     'required is very large for fuzzing target.')
+
+      return None, False
+
     showmap_output = engine_common.read_data_from_file(
         intput_file_showmap_results_file)
     return self.get_feature_tuple(showmap_output), False
@@ -1339,7 +1360,6 @@ class AflAndroidRunner(AflRunnerCommon, new_process.UnicodeProcessRunner):
         android.util.get_device_path(self.stderr_file_path),
         self.stderr_file_path)
     return fuzz_result
-
 
 class UnshareAflRunner(new_process.ModifierProcessRunnerMixin, AflRunner):
   """AFL runner which unshares."""
@@ -1464,6 +1484,19 @@ def remove_path(path):
   elif os.path.isdir(path):
     shutil.rmtree(path)
   # Else path doesn't exist. Do nothing.
+
+def list_full_file_paths_device(directory):
+  directory_absolute_path = os.path.abspath(directory)
+  directory_absolute_path = android.util.get_device_path(directory_absolute_path)
+  dir_contents = android.adb.run_command(['shell', 'ls', directory_absolute_path])
+
+  paths = []
+  for rel_path in dir_contents.split():
+    full_path = os.path.join(directory_absolute_path, rel_path)
+    if android.adb.file_exists(full_path):
+      paths.append(full_path)
+
+  return paths
 
 
 def list_full_file_paths(directory):

--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
@@ -255,7 +255,8 @@ class AflAndroidFuzzOutputDirectory(AflFuzzOutputDirectory):
     queue_paths = list_full_file_paths_device(self.queue)
 
     hang_queue_path = [
-        path for path in queue_paths if path.endswith(hang_filename)][0]
+        path for path in queue_paths if path.endswith(hang_filename)
+    ][0]
 
     hang_queue_path_device = android.util.get_device_path(hang_queue_path)
 
@@ -1363,6 +1364,7 @@ class AflAndroidRunner(AflRunnerCommon, new_process.UnicodeProcessRunner):
         self.stderr_file_path)
     return fuzz_result
 
+
 class UnshareAflRunner(new_process.ModifierProcessRunnerMixin, AflRunner):
   """AFL runner which unshares."""
 
@@ -1486,6 +1488,7 @@ def remove_path(path):
   elif os.path.isdir(path):
     shutil.rmtree(path)
   # Else path doesn't exist. Do nothing.
+
 
 def list_full_file_paths_device(directory):
   """List the absolute paths of files in |directory| on Android device."""

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -30,7 +30,7 @@ from clusterfuzz._internal.metrics import logs
 DEFAULT_CHUNK_SIZE = 20 * 1024 * 1024
 
 # Maximum number of retries for artifact access.
-MAX_RETRIES = 20
+MAX_RETRIES = 5
 
 
 def execute_request_with_retries(request):


### PR DESCRIPTION
When AFL++ fuzz run is initializing and running through the corpus inputs, if one of those corpus files hangs then ClusterFuzz needs to remove that file from the input. It tries to remove this file from the host machine for Android, but needs to remove the file from the Android device instead. This PR is to update that.