### PR TITLE
Make libFuzzer use env variables from fuzzer.options

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -132,9 +132,10 @@ class Engine(engine.Engine):
 
     arguments.extend(strategy_info.arguments)
     # Update strategy info with environment variables from fuzzer's options.
-    for env_var_name, value in extra_env:
-      if env_var_name not in strategy_info.extra_env:
-        strategy_info.extra_env[env_var_name] = value
+    if extra_env is not None:
+      for env_var_name, value in extra_env:
+        if env_var_name not in strategy_info.extra_env:
+          strategy_info.extra_env[env_var_name] = value
 
     # Check for seed corpus and add it into corpus directory.
     engine_common.unpack_seed_corpus_if_needed(target_path, corpus_dir)

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -111,6 +111,7 @@ class Engine(engine.Engine):
     del build_dir
     arguments = fuzzer.get_arguments(target_path)
     grammar = fuzzer.get_grammar(target_path)
+    extra_env = fuzzer.get_extra_env(target_path)
 
     if self.do_strategies:
       strategy_pool = strategy_selection.generate_weighted_strategy_pool(
@@ -130,6 +131,10 @@ class Engine(engine.Engine):
       environment.set_value('USE_EXTRA_SANITIZERS', False)
 
     arguments.extend(strategy_info.arguments)
+    # Update strategy info with environment variables from fuzzer's options.
+    for env_var_name, value in extra_env:
+      if env_var_name not in strategy_info.extra_env:
+        strategy_info.extra_env[env_var_name] = value
 
     # Check for seed corpus and add it into corpus directory.
     engine_common.unpack_seed_corpus_if_needed(target_path, corpus_dir)

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py
@@ -27,6 +27,7 @@ def get_grammar(fuzzer_path):
 
   return None
 
+
 def get_extra_env(fuzzer_path):
   """Get environment variables for a given fuzz target if any (or None)."""
   fuzzer_options = options.get_fuzz_target_options(fuzzer_path)

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py
@@ -27,6 +27,13 @@ def get_grammar(fuzzer_path):
 
   return None
 
+def get_extra_env(fuzzer_path):
+  """Get environment variables for a given fuzz target. Return none if there isn't one."""
+  fuzzer_options = options.get_fuzz_target_options(fuzzer_path)
+  if fuzzer_options:
+    return fuzzer_options.get_env()
+
+  return None
 
 def get_arguments(fuzzer_path):
   """Get arguments for a given fuzz target."""

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py
@@ -28,12 +28,13 @@ def get_grammar(fuzzer_path):
   return None
 
 def get_extra_env(fuzzer_path):
-  """Get environment variables for a given fuzz target. Return none if there isn't one."""
+  """Get environment variables for a given fuzz target if any (or None)."""
   fuzzer_options = options.get_fuzz_target_options(fuzzer_path)
   if fuzzer_options:
     return fuzzer_options.get_env()
 
   return None
+
 
 def get_arguments(fuzzer_path):
   """Get arguments for a given fuzz target."""


### PR DESCRIPTION
@oliverchang this completes https://github.com/google/clusterfuzz/pull/2874

Before that commit, Only AFL can use env variables from fuzzer.options
And I would like to have it for libFuzzer as it is the engine used with golang to get `GODEBUG` set before running my target