### PR TITLE
Fix local `clusterfuzz` server error

### DIFF
--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -111,7 +111,7 @@ sudo apt-get update
 sudo apt-get install -y \
     docker-ce \
     google-cloud-sdk \
-    openjdk-8-jdk \
+    openjdk-11-jdk \
     liblzma-dev
 
 # Install patchelf - latest version not available on some older distros so we


### PR DESCRIPTION
Fix #2835 by upgrading `openjdk-8-jdk` to `openjdk-11-jdk`.