### PR TITLE
Disable dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,14 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  open-pull-requests-limit: 0
 - package-ecosystem: pip
   directory: "/src"
   schedule:
     interval: daily
+  open-pull-requests-limit: 0
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "daily"
+  open-pull-requests-limit: 0


### PR DESCRIPTION
To be replaced with https://github.com/google/clusterfuzz/issues/2912 which will allow us to do batched dependency updates much more easily. 