### PR TITLE
Use RegEx to split unintended concatenated lines in stacktrace

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/corrected_stacktrace.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/corrected_stacktrace.txt
@@ -1,0 +1,38 @@
+
+[Environment] ASAN_OPTIONS=exitcode=234:fast_unwind_on_fatal=0
++----------------------------------------Release Build Stacktrace----------------------------------------+
+Command:
+/scratch0/clusterfuzz/bot/builds/clusterfuzz-g3-builds-opt_learning-brain-kernels-fuzzing_libfuzzer_address_sample_target_142857142857142857/revisions/sample_target
+-fake_flag_1=20 -fake_flag_2=40
+/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/asklfjaslkfjasdklfj38kl23jkljklsdf8
+Time ran: 2.289742389042378942897
+INFO: google3-libFuzzer:
+some fake fuzzer info
+INFO: Running in fuzzing mode, google3 logging disabled
+INFO: Running with fake mode schedule (0xA2, 010).
+INFO: Seed:234234324
+INFO: Loaded 1 modules   (09908234 inline 8-bit counters): 09908234
+[0x23sf09sf09, 0x23j23l23klj),
+INFO: Loaded 1 PC tables (23423 PCs): 23423 [0xsdfsdfsdf8907890,0x78978dsdf),
+/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-g3-builds-opt_learning-brain-kernels-fuzzing_libfuzzer_address_sample_target_142857142857142857/revisions/sample_target: Running 1 inputs 10 time(s) each.
+Running:
+/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/3232897fsdf7s890cb89789dfg87ds897d897fg
+third_party/lkjklcvbdc/v18/stable/toolchain/bin/../include/c++/v1/optional:2343: assertion this->has_value() failed: optional operator* called on a disengaged value
+AddressSanitizer:DEADLYSIGNAL
+=================================================================
+==554804==kljsdklfjsdl: slkdfjsdklj: sdfsd on sfsdfsdfkjl:k lkjlkjs 0x88823909 (pc
+0x089237489237 bp 0x9809sdfssdw sp 0x90889svsxcvcc F2)
+    #0 0xsfsdf908908 in raise (/usr/sdfsd/v5/lib64/libc.so.6+0x90890sdf)
+    (BuildId: 87sfsd890df7s8ad90f7sd0987sad98fasd890f789)
+    #1 0x7fd666828816 in abort (/usr/sdfsd/v5/lib64/libc.so.6+0xsfsd89)
+    (BuildId: s90sdf8sd908cbc9v8bc90vb)
+    #18 0x90s8df90sd89 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned
+    char const*, unsigned long))
+    third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:223:3
+    #19 0x908sf90sd in main
+    third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:82:234
+    #20 0x90908f90sd8f90sd8f in opiopfdssdfsdf
+    (/usr/opsdf/v5/lib64/libc.so.6+0xsfsd9) (BuildId:
+    908s09fsd90f8sd90f8sd90f90sdfsd908)
+    #21 0x908s90fsdfsdf098 in _start iuoi-sdpiops/BUILD/src/csu/../sysdeps/908/start.S:993
+==0983290==ABORTING

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/erroneous_stacktrace.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/erroneous_stacktrace.txt
@@ -1,0 +1,37 @@
+
+[Environment] ASAN_OPTIONS=exitcode=234:fast_unwind_on_fatal=0
++----------------------------------------Release Build Stacktrace----------------------------------------+
+Command:
+/scratch0/clusterfuzz/bot/builds/clusterfuzz-g3-builds-opt_learning-brain-kernels-fuzzing_libfuzzer_address_sample_target_142857142857142857/revisions/sample_target
+-fake_flag_1=20 -fake_flag_2=40
+/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/asklfjaslkfjasdklfj38kl23jkljklsdf8
+Time ran: 2.289742389042378942897
+INFO: google3-libFuzzer:
+some fake fuzzer info
+INFO: Running in fuzzing mode, google3 logging disabled
+INFO: Running with fake mode schedule (0xA2, 010).
+INFO: Seed:234234324
+INFO: Loaded 1 modules   (09908234 inline 8-bit counters): 09908234
+[0x23sf09sf09, 0x23j23l23klj),
+INFO: Loaded 1 PC tables (23423 PCs): 23423 [0xsdfsdfsdf8907890,0x78978dsdf),
+/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-g3-builds-opt_learning-brain-kernels-fuzzing_libfuzzer_address_sample_target_142857142857142857/revisions/sample_target: Running 1 inputs 10 time(s) each.
+Running:
+/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/3232897fsdf7s890cb89789dfg87ds897d897fg
+third_party/lkjklcvbdc/v18/stable/toolchain/bin/../include/c++/v1/optional:2343: assertion this->has_value() failed: optional operator* called on a disengaged valueAddressSanitizer:DEADLYSIGNAL
+=================================================================
+==554804==kljsdklfjsdl: slkdfjsdklj: sdfsd on sfsdfsdfkjl:k lkjlkjs 0x88823909 (pc
+0x089237489237 bp 0x9809sdfssdw sp 0x90889svsxcvcc F2)
+    #0 0xsfsdf908908 in raise (/usr/sdfsd/v5/lib64/libc.so.6+0x90890sdf)
+    (BuildId: 87sfsd890df7s8ad90f7sd0987sad98fasd890f789)
+    #1 0x7fd666828816 in abort (/usr/sdfsd/v5/lib64/libc.so.6+0xsfsd89)
+    (BuildId: s90sdf8sd908cbc9v8bc90vb)
+    #18 0x90s8df90sd89 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned
+    char const*, unsigned long))
+    third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:223:3
+    #19 0x908sf90sd in main
+    third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:82:234
+    #20 0x90908f90sd8f90sd8f in opiopfdssdfsdf
+    (/usr/opsdf/v5/lib64/libc.so.6+0xsfsd9) (BuildId:
+    908s09fsd90f8sd90f8sd90f90sdfsd908)
+    #21 0x908s90fsdfsdf098 in _start iuoi-sdpiops/BUILD/src/csu/../sysdeps/908/start.S:993
+==0983290==ABORTING

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -20,6 +20,7 @@ from clusterfuzz._internal.crash_analysis import crash_analyzer
 from clusterfuzz._internal.crash_analysis.stack_parsing import stack_analyzer
 from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.tests.test_libs import helpers
+from clusterfuzz.stacktraces import StackParser
 
 DATA_DIRECTORY = os.path.join(os.path.dirname(__file__), 'stack_analyzer_data')
 TEST_JOB_NAME = 'test'
@@ -3453,3 +3454,13 @@ class StackAnalyzerTestcase(unittest.TestCase):
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
+
+  def test_split_stacktrace(self):
+    """Test if unintentionally concatenated lines in stracktraces can be split correctly."""
+    erroneous_stacktrace = self._read_test_data('erroneous_stacktrace.txt')
+    corrected_stacktrace = self._read_test_data('corrected_stacktrace.txt')
+
+    actual_split_stacktrace = StackParser.split_stacktrace(erroneous_stacktrace)
+    expected_split_stacktrace = corrected_stacktrace.splitlines()
+
+    self.assertEqual(actual_split_stacktrace, expected_split_stacktrace)

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -382,7 +382,6 @@ class StackParser:
     """Split stacktrace by line, and handle special cases with regex."""
     stacktrace = re.sub(CONCATENATED_SAN_DEADLYSIGNAL_REGEX,
                         SPLIT_CONCATENATED_SAN_DEADLYSIGNAL_REGEX, stacktrace)
-    print(stacktrace)
     return stacktrace.splitlines()
 
   def parse(self, stacktrace: str) -> CrashInfo:

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -377,6 +377,14 @@ class StackParser:
           state.lkl_kernel_build_id = match.group(2)
     return result
 
+  @staticmethod
+  def split_stacktrace(stacktrace: str):
+    """Split stacktrace by line, and handle special cases with regex."""
+    stacktrace = re.sub(CONCATENATED_SAN_DEADLYSIGNAL_REGEX,
+                        SPLIT_CONCATENATED_SAN_DEADLYSIGNAL_REGEX, stacktrace)
+    print(stacktrace)
+    return stacktrace.splitlines()
+
   def parse(self, stacktrace: str) -> CrashInfo:
     """Parse a stacktrace."""
     state = CrashInfo()
@@ -395,7 +403,7 @@ class StackParser:
       stacktrace = self.remove_lkl_kernel_times_and_set_params(
           state, stacktrace)
 
-    split_crash_stacktrace = stacktrace.splitlines()
+    split_crash_stacktrace = StackParser.split_stacktrace(stacktrace)
 
     if state.is_python:
       split_crash_stacktrace = reverse_python_stacktrace(split_crash_stacktrace)

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -379,7 +379,12 @@ class StackParser:
 
   @staticmethod
   def split_stacktrace(stacktrace: str):
-    """Split stacktrace by line, and handle special cases with regex."""
+    """Split stacktrace by line, and handle special cases."""
+    # Fix a known malformed traceback pattern:
+    # A newline character is missing between the important crash info line and
+    # an ignorable sanitizer output line.
+    # Insert the newline char back between them so that the crash info can be
+    # preserved for parsing later.
     stacktrace = re.sub(CONCATENATED_SAN_DEADLYSIGNAL_REGEX,
                         SPLIT_CONCATENATED_SAN_DEADLYSIGNAL_REGEX, stacktrace)
     return stacktrace.splitlines()

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -185,7 +185,11 @@ SAN_CHECK_FAILURE_REGEX = re.compile(
     r'.*Sanitizer CHECK failed[:]\s*[^ ]*\s*(.*)')
 SAN_CRASH_TYPE_ADDRESS_REGEX = re.compile(
     r'[ ]*([^ ]*|Atomic [^ ]*) of size ([^ ]*) at ([^ ]*)')
-SAN_DEADLYSIGNAL_REGEX = re.compile(r'.*:DEADLYSIGNAL')
+SAN_DEADLYSIGNAL_REGEX = re.compile(
+    r'(Address|Leak|Memory|UndefinedBehavior|Thread)Sanitizer:DEADLYSIGNAL')
+CONCATENATED_SAN_DEADLYSIGNAL_REGEX = re.compile(
+    r'\n(.+)(' + SAN_DEADLYSIGNAL_REGEX.pattern + r')\n')
+SPLIT_CONCATENATED_SAN_DEADLYSIGNAL_REGEX = r'\n\1\n\2\n'
 SAN_FPE_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: FPE ')
 SAN_ILL_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: ILL ')
 SAN_TRAP_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: TRAP ')

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -188,7 +188,7 @@ SAN_CRASH_TYPE_ADDRESS_REGEX = re.compile(
 SAN_DEADLYSIGNAL_REGEX = re.compile(
     r'(Address|Leak|Memory|UndefinedBehavior|Thread)Sanitizer:DEADLYSIGNAL')
 CONCATENATED_SAN_DEADLYSIGNAL_REGEX = re.compile(
-    r'\n(.+)(' + SAN_DEADLYSIGNAL_REGEX.pattern + r')\n')
+    r'\n([^\n]*\S[^\n]*)(' + SAN_DEADLYSIGNAL_REGEX.pattern + r')\n')
 SPLIT_CONCATENATED_SAN_DEADLYSIGNAL_REGEX = r'\n\1\n\2\n'
 SAN_FPE_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: FPE ')
 SAN_ILL_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: ILL ')


### PR DESCRIPTION
Missing `\n` chars in stacktrace will concatenate adjacent lines into one, which sometimes misleads the stracktrace parser to ignore important error messages.
This PR captures one such case and split the lines with RegEx.
It also comes with an obfuscated testcase for this.