### PR TITLE
Add rule to capture suffixed glibc-like assertion failure

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/suffixed_glibc_assert.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/suffixed_glibc_assert.txt
@@ -1,0 +1,37 @@
+
+[Environment] ASAN_OPTIONS=exitcode=234:fast_unwind_on_fatal=0
++----------------------------------------Release Build Stacktrace----------------------------------------+
+Command:
+/scratch0/clusterfuzz/bot/builds/clusterfuzz-g3-builds-opt_learning-brain-kernels-fuzzing_libfuzzer_address_sample_target_142857142857142857/revisions/sample_target
+-fake_flag_1=20 -fake_flag_2=40
+/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/asklfjaslkfjasdklfj38kl23jkljklsdf8
+Time ran: 2.289742389042378942897
+INFO: google3-libFuzzer:
+some fake fuzzer info
+INFO: Running in fuzzing mode, google3 logging disabled
+INFO: Running with fake mode schedule (0xA2, 010).
+INFO: Seed:234234324
+INFO: Loaded 1 modules   (09908234 inline 8-bit counters): 09908234
+[0x23sf09sf09, 0x23j23l23klj),
+INFO: Loaded 1 PC tables (23423 PCs): 23423 [0xsdfsdfsdf8907890,0x78978dsdf),
+/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-g3-builds-opt_learning-brain-kernels-fuzzing_libfuzzer_address_sample_target_142857142857142857/revisions/sample_target: Running 1 inputs 10 time(s) each.
+Running:
+/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/3232897fsdf7s890cb89789dfg87ds897d897fg
+third_party/crosstool/v18/stable/toolchain/bin/../include/c++/v1/vector:559:assertion !full() failed: sample_function() called on an empty vectorAddressSanitizer:DEADLYSIGNAL
+=================================================================
+==554804==kljsdklfjsdl: slkdfjsdklj: sdfsd on sfsdfsdfkjl:k lkjlkjs 0x88823909 (pc
+0x089237489237 bp 0x9809sdfssdw sp 0x90889svsxcvcc F2)
+    #0 0xsfsdf908908 in raise (/usr/sdfsd/v5/lib64/libc.so.6+0x90890sdf)
+    (BuildId: 87sfsd890df7s8ad90f7sd0987sad98fasd890f789)
+    #1 0x7fd666828816 in abort (/usr/sdfsd/v5/lib64/libc.so.6+0xsfsd89)
+    (BuildId: s90sdf8sd908cbc9v8bc90vb)
+    #18 0x90s8df90sd89 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned
+    char const*, unsigned long))
+    third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:223:3
+    #19 0x908sf90sd in main
+    third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:82:234
+    #20 0x90908f90sd8f90sd8f in opiopfdssdfsdf
+    (/usr/opsdf/v5/lib64/libc.so.6+0xsfsd9) (BuildId:
+    908s09fsd90f8sd90f8sd90f90sdfsd908)
+    #21 0x908s90fsdfsdf098 in _start iuoi-sdpiops/BUILD/src/csu/../sysdeps/908/start.S:993
+==0983290==ABORTING

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -628,8 +628,8 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
-  def test_assert_disengaged_value(self):
-    """Test the disengaged value assertion failure format."""
+  def test_assert_glibc_suffixed(self):
+    """Test the glibc-like assertion failure format but with suffix."""
     environment.set_value('ASSERTS_HAVE_SECURITY_IMPLICATION', False)
 
     data = self._read_test_data('erroneous_stacktrace.txt')

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -653,6 +653,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
+
   def test_stack_filtering(self):
     """Test ignore lists and stack frame filtering."""
     data = self._read_test_data('stack_filtering.txt')

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -632,6 +632,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     """Test the glibc-like assertion failure format but with suffix."""
     environment.set_value('ASSERTS_HAVE_SECURITY_IMPLICATION', False)
 
+    # Common case 1.
     data = self._read_test_data('erroneous_stacktrace.txt')
     expected_type = 'ASSERT'
     expected_address = ''
@@ -642,6 +643,16 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+    # Common case 2.
+    data = self._read_test_data('suffixed_glibc_assert.txt')
+    expected_type = 'ASSERT'
+    expected_address = ''
+    expected_state = 'sample_function() called on an empty vector\n'
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
   def test_stack_filtering(self):
     """Test ignore lists and stack frame filtering."""
     data = self._read_test_data('stack_filtering.txt')

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -628,6 +628,20 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_assert_disengaged_value(self):
+    """Test the disengaged value assertion failure format."""
+    environment.set_value('ASSERTS_HAVE_SECURITY_IMPLICATION', False)
+
+    data = self._read_test_data('erroneous_stacktrace.txt')
+    expected_type = 'ASSERT'
+    expected_address = ''
+    expected_state = 'optional operator* called on a disengaged value\n'
+    expected_stacktrace = data
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_stack_filtering(self):
     """Test ignore lists and stack frame filtering."""
     data = self._read_test_data('stack_filtering.txt')

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -432,6 +432,7 @@ class StackParser:
       # However if we already have a kernel crash, we don't want to
       # replace it with the ASSERT.
       if not state.crash_type.startswith('Kernel failure'):
+        self.match_assert(line, state, ASSERT_DISENGAGED_VALUE, group=1)
         self.match_assert(line, state, ASSERT_REGEX)
         self.match_assert(line, state, ASSERT_REGEX_GOOGLE, group=2)
         self.match_assert(line, state, ASSERT_REGEX_GLIBC)

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -432,10 +432,10 @@ class StackParser:
       # However if we already have a kernel crash, we don't want to
       # replace it with the ASSERT.
       if not state.crash_type.startswith('Kernel failure'):
-        self.match_assert(line, state, ASSERT_DISENGAGED_VALUE, group=1)
         self.match_assert(line, state, ASSERT_REGEX)
         self.match_assert(line, state, ASSERT_REGEX_GOOGLE, group=2)
         self.match_assert(line, state, ASSERT_REGEX_GLIBC)
+        self.match_assert(line, state, ASSERT_REGEX_GLIBC_SUFFIXED)
         self.match_assert(line, state, RUST_ASSERT_REGEX)
 
       # ASSERT_NOT_REACHED prints a single line error then triggers a crash. We

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -63,6 +63,10 @@ ASSERT_REGEX_GOOGLE = re.compile(GOOGLE_LOG_FATAL_PREFIX +
                                  r'.*assertion failed at\s.*\sin\s*.*: (.*)')
 ASSERT_REGEX_GLIBC = re.compile(
     r'.*:\s*assertion [`\'"]?(.*?)[`\'"]? failed\.?$', re.IGNORECASE)
+ASSERT_DISENGAGED_VALUE = re.compile(
+    r'.*\S.*\/.*:\d+:\s*assertion .* failed:\s*'
+    r'(optional operator.* called on a disengaged value)'
+)
 ASSERT_NOT_REACHED_REGEX = re.compile(r'^\s*SHOULD NEVER BE REACHED\s*$')
 CENTIPEDE_TIMEOUT_REGEX = re.compile(
     r'^========= Timeout of \d+ seconds exceeded; exiting')

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -63,10 +63,8 @@ ASSERT_REGEX_GOOGLE = re.compile(GOOGLE_LOG_FATAL_PREFIX +
                                  r'.*assertion failed at\s.*\sin\s*.*: (.*)')
 ASSERT_REGEX_GLIBC = re.compile(
     r'.*:\s*assertion [`\'"]?(.*?)[`\'"]? failed\.?$', re.IGNORECASE)
-ASSERT_DISENGAGED_VALUE = re.compile(
-    r'.*\S.*\/.*:\d+:\s*assertion .* failed:\s*'
-    r'(optional operator.* called on a disengaged value)'
-)
+ASSERT_REGEX_GLIBC_SUFFIXED = re.compile(
+    r'.*\S.*\/.*:\d+:\s*assertion .* failed:\s*(\S.*)')
 ASSERT_NOT_REACHED_REGEX = re.compile(r'^\s*SHOULD NEVER BE REACHED\s*$')
 CENTIPEDE_TIMEOUT_REGEX = re.compile(
     r'^========= Timeout of \d+ seconds exceeded; exiting')

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -63,6 +63,9 @@ ASSERT_REGEX_GOOGLE = re.compile(GOOGLE_LOG_FATAL_PREFIX +
                                  r'.*assertion failed at\s.*\sin\s*.*: (.*)')
 ASSERT_REGEX_GLIBC = re.compile(
     r'.*:\s*assertion [`\'"]?(.*?)[`\'"]? failed\.?$', re.IGNORECASE)
+# The 'assertion .* failed' is suffixed with the failure reason. E.g.,
+# 'assertion __dest < len() failed: sample_array[] index out of bounds',
+# 'assertion !full() failed: sample_function() called on an empty vector'
 ASSERT_REGEX_GLIBC_SUFFIXED = re.compile(
     r'.*\S.*\/.*:\d+:\s*assertion .* failed:\s*(\S.*)')
 ASSERT_NOT_REACHED_REGEX = re.compile(r'^\s*SHOULD NEVER BE REACHED\s*$')


### PR DESCRIPTION
1. Add a new rule to capture the assertion error 'optional operator called on a disengaged value'
2. Add a testcase for this new rule.