### PR TITLE
Expose crash comparer

### DIFF
--- a/src/clusterfuzz/stacktraces/crash_comparer.py
+++ b/src/clusterfuzz/stacktraces/crash_comparer.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Expose crash comparer to external users."""
+from clusterfuzz._internal.crash_analysis import crash_comparer
+
+crash_comparer = CrashComparer()

--- a/src/clusterfuzz/stacktraces/crash_comparer.py
+++ b/src/clusterfuzz/stacktraces/crash_comparer.py
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Expose crash comparer to external users."""
-from clusterfuzz._internal.crash_analysis import crash_comparer
-
-crash_comparer = crash_comparer.CrashComparer()
+# pylint: disable=unused-import
+from clusterfuzz._internal.crash_analysis.crash_comparer import CrashComparer

--- a/src/clusterfuzz/stacktraces/crash_comparer.py
+++ b/src/clusterfuzz/stacktraces/crash_comparer.py
@@ -14,4 +14,4 @@
 """Expose crash comparer to external users."""
 from clusterfuzz._internal.crash_analysis import crash_comparer
 
-crash_comparer = CrashComparer()
+crash_comparer = crash_comparer.CrashComparer()

--- a/src/setup.py
+++ b/src/setup.py
@@ -19,7 +19,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='clusterfuzz',
-    version='2.5.9',
+    version='2.6.0',
     author='ClusterFuzz authors',
     author_email='clusterfuzz-dev@googlegroups.com',
     description='ClusterFuzz',


### PR DESCRIPTION
Expose `CrashComparer` so that users of `ClusterFuzz`'s `PythonAPI` can access it.
For example, `FuzzBench` will use it to group crashes.