### PR TITLE
Support mapping crash types to labels

### DIFF
--- a/configs/test/issue_trackers/config.yaml
+++ b/configs/test/issue_trackers/config.yaml
@@ -88,6 +88,10 @@ test-project:
       os: OS-%PLATFORM%
       # Label to apply when adding CCs from owners files.
       auto_cc_from_owners: ClusterFuzz-Auto-CC
+      # Optional: Map crash types to labels.
+      #crash_types:
+      #  stack-buffer-overflow: Memory-Corruption
+      #  stack-overflow: Resource-Exhaustion
     # Optional: For issue trackers where labels need to be mapped to some other
     # representation (e.g. an ID), substitutions from above need to be mapped
     # explicitly.

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -367,6 +367,11 @@ def file_issue(testcase,
   for label in additional_labels:
     issue.labels.add(label)
 
+  # Add crash-type-specific label
+  crash_type_label = policy.label_for_crash_type(testcase.crash_type)
+  if crash_type_label:
+    issue.labels.add(crash_type_label)
+
   # Add additional components from the job definition and fuzzer.
   automatic_components = data_handler.get_additional_values_for_variable(
       'AUTOMATIC_COMPONENTS', testcase.job_type, testcase.fuzzer_name)

--- a/src/appengine/libs/issue_management/issue_tracker_policy.py
+++ b/src/appengine/libs/issue_management/issue_tracker_policy.py
@@ -76,6 +76,18 @@ class IssueTrackerPolicy(object):
 
     return str(label)
 
+  def label_for_crash_type(self, crash_type):
+    """Get the actual label string for the given crash type."""
+    if 'crash_types' not in self._data['labels']:
+      return None
+
+    crash_type = crash_type.splitlines()[0].lower()
+    label = self._data['labels']['crash_types'].get(crash_type)
+    if label is None:
+      return None
+
+    return str(label)
+
   def substitution_mapping(self, label):
     """Get an explicit substitution mapping."""
     if 'substitutions' not in self._data:

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -822,10 +822,9 @@ class IssueFilerTests(unittest.TestCase):
 
     issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
     issue_filer.file_issue(self.testcase1, issue_tracker)
-    self.assertIn('Memory corruption',
-                  issue_tracker._itm.last_issue.labels)
+    self.assertIn('Memory corruption', issue_tracker._itm.last_issue.labels)
     self.assertNotIn('Resource Exhaustion',
-                  issue_tracker._itm.last_issue.labels)
+                     issue_tracker._itm.last_issue.labels)
 
 
 class MemoryToolLabelsTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -794,6 +794,39 @@ class IssueFilerTests(unittest.TestCase):
     self.assertIn('Target: target, Project: proj',
                   issue_tracker._itm.last_issue.body)
 
+  def test_crash_type_labels(self):
+    """Test crash type labels."""
+    policy = issue_tracker_policy.IssueTrackerPolicy({
+        'status': {
+            'assigned': 'Assigned',
+            'duplicate': 'Duplicate',
+            'verified': 'Verified',
+            'new': 'Untriaged',
+            'wontfix': 'WontFix',
+            'fixed': 'Fixed'
+        },
+        'all': {
+            'status': 'new',
+        },
+        'non_security': {},
+        'labels': {
+            'crash_types': {
+                'heap-use-after-free': 'Memory corruption',
+                'stack-overflow': 'Resource Exhaustion',
+            }
+        },
+        'security': {},
+        'existing': {},
+    })
+    self.mock.get.return_value = policy
+
+    issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
+    issue_filer.file_issue(self.testcase1, issue_tracker)
+    self.assertIn('Memory corruption',
+                  issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Resource Exhaustion',
+                  issue_tracker._itm.last_issue.labels)
+
 
 class MemoryToolLabelsTest(unittest.TestCase):
   """Memory tool labels tests."""


### PR DESCRIPTION
This PR adds the ability to tag crashes with a labels based on the crash type. This will enable users to categorize crashes better if they so choose. For instance, they might want to apply the same label to all arithmetic overflow crashes.