### PR TITLE
Added device resets for adb recovery state in android emulator platform.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -96,7 +96,7 @@ RUN curl -sS https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz | tar -C /
     cd /tmp/Python-3.7.7 && \
     ./configure --enable-optimizations --enable-loadable-sqlite-extensions && make altinstall && \
     rm -rf /tmp/Python-3.7.7
-RUN pip3.7 install pipenv
+RUN pip3.7 install pipenv==2022.8.5
 
 # Install Node.js
 COPY setup_19.x /data

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -338,6 +338,18 @@ def hard_reset():
   soft_reset_cmd = get_adb_command_line('reboot')
   execute_command(soft_reset_cmd, timeout=RECOVERY_CMD_TIMEOUT)
 
+  if environment.is_android_emulator():
+    #For recovery state
+    logs.log('Platform ANDROID_EMULATOR detected.')
+    restart_adb()
+    state = get_device_state()
+
+    logs.log('Device state is: %s' % state)
+    if state == 'recovery':
+      logs.log('Rebooting recovery state device with --wipe_data.')
+      run_command('root')
+      run_shell_command('recovery --wipe_data')
+
 
 def kill_processes_and_children_matching_name(process_name):
   """Kills process along with children matching names."""
@@ -434,6 +446,11 @@ def remount():
   run_command('remount')
   wait_for_device()
   run_as_root()
+
+
+def restart_adb():
+  run_command('kill-server')
+  run_command('start-server')
 
 
 def remove_directory(device_directory, recreate=False):

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1089,6 +1089,11 @@ def is_android_cuttlefish(plt=None):
   return 'ANDROID_X86' in (plt or platform())
 
 
+def is_android_emulator(plt=None):
+  """Return True if we are on android emulator platform."""
+  return 'ANDROID_EMULATOR' in (plt or get_platform_group())
+
+
 def is_android_kernel(plt=None):
   """Return True if we are on android kernel platform groups."""
   return 'ANDROID_KERNEL' in (plt or get_platform_group())

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1089,7 +1089,7 @@ def is_android_cuttlefish(plt=None):
   return 'ANDROID_X86' in (plt or platform())
 
 
-def is_android_emulator(plt=None):
+def is_android_emulator():
   """Return True if we are on android emulator platform."""
   return 'ANDROID_EMULATOR' in get_platform_group()
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1091,7 +1091,7 @@ def is_android_cuttlefish(plt=None):
 
 def is_android_emulator(plt=None):
   """Return True if we are on android emulator platform."""
-  return 'ANDROID_EMULATOR' in (plt or get_platform_group())
+  return 'ANDROID_EMULATOR' in get_platform_group()
 
 
 def is_android_kernel(plt=None):


### PR DESCRIPTION
The android_emulator platform used for Trusty device fuzzing frequently sends devices into adb recovery state. Clusterfuzz does not currently detect or reset devices in adb recovery state so this code adds device reset logic for android_emulator.