### PR TITLE
Fix: enabling jira token auth

### DIFF
--- a/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
+++ b/src/appengine/libs/issue_management/jira/issue_tracker_manager.py
@@ -42,7 +42,7 @@ class IssueTrackerManager(object):
     credentials = json.loads(config.jira_credentials)
     jira_url = config.jira_url
     jira_client = jira.JIRA(
-        jira_url, auth=(credentials['username'], credentials['password']))
+        jira_url, basic_auth=(credentials['user_email'], credentials['auth_token']))
     return jira_client
 
   def save(self, issue):


### PR DESCRIPTION
Jira Cloud [no longer supports](https://jira.readthedocs.io/examples.html#authentication) username:password authentification.
This is to enable the use of auth token in issue tracker manager 