### PR TITLE
Fix centipede reproduction

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -195,7 +195,12 @@ class Engine(engine.Engine):
     Returns:
       A ReproduceResult.
     """
-    runner = new_process.UnicodeProcessRunner(target_path, [input_path])
+    sanitized_target_path = self._get_sanitized_target_path(target_path)
+    if not sanitized_target_path.exists():
+      logs.log_warn('Unable to find sanitized target binary.')
+
+    runner = new_process.UnicodeProcessRunner(sanitized_target_path,
+                                              [input_path])
     result = runner.run_and_wait(timeout=max_time)
     self._trim_logs(result)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
@@ -87,8 +87,9 @@ class IntegrationTest(unittest.TestCase):
     """Tests reproducing a crash."""
     testcase_path = setup_testcase('crash')
     engine_impl = engine.Engine()
+    target_path = DATA_DIR / 'test_fuzzer'
+    result = engine_impl.reproduce(target_path, testcase_path, [], 10)
     sanitized_target_path = DATA_DIR / fuzzer_utils.EXTRA_BUILD_DIR / 'test_fuzzer'
-    result = engine_impl.reproduce(sanitized_target_path, testcase_path, [], 10)
     self.assertListEqual([sanitized_target_path, testcase_path], result.command)
     self.assertIn('ERROR: AddressSanitizer: heap-use-after-free', result.output)
 


### PR DESCRIPTION
`Centipede`'s testcases were not considered reproducible because reproduction uses unsanitized binaries.
This PR address it by:
1. Finding and using the sanitized binary based on the unsanitized binary's path during reproduction.
2. Making the corresponding unit test reflect actual usage: now it passes the unsanitized binary to `reproduce()`.