### PR TITLE
Fix centipede regression

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -199,7 +199,8 @@ class Engine(engine.Engine):
     if sanitized_target_path.exists():
       sanitized_target = str(sanitized_target_path)
     else:
-      logs.log_warn('Unable to find sanitized target binary.')
+      logs.log_warn(
+          f'Unable to find sanitized target binary: {sanitized_target_path}')
 
     runner = new_process.UnicodeProcessRunner(sanitized_target, [input_path])
     result = runner.run_and_wait(timeout=max_time)

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -196,11 +196,12 @@ class Engine(engine.Engine):
       A ReproduceResult.
     """
     sanitized_target_path = self._get_sanitized_target_path(target_path)
-    if not sanitized_target_path.exists():
+    if sanitized_target_path.exists():
+      sanitized_target = str(sanitized_target_path)
+    else:
       logs.log_warn('Unable to find sanitized target binary.')
 
-    runner = new_process.UnicodeProcessRunner(sanitized_target_path,
-                                              [input_path])
+    runner = new_process.UnicodeProcessRunner(sanitized_target, [input_path])
     result = runner.run_and_wait(timeout=max_time)
     self._trim_logs(result)
 


### PR DESCRIPTION
Fix compatibility error: cast the binary path from a `Path` type to `str`, which is required for production.