### PR TITLE
Added prepending of Trusted App (TA) stacktrace for Trusty fuzzing

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -936,7 +936,7 @@ class AndroidLibFuzzerRunner(new_process.UnicodeProcessRunner, LibFuzzerCommon):
     """Add trusty stacktrace to beginning of output if found in logcat."""
     logcat = android.logger.log_output()
     begin, end = '---------', 'Built:'
-    target = 'Backtrace for thread: trusty'
+    target = 'Backtrace for thread:'
 
     target_idx = logcat.rfind(target)
     if target_idx == -1 or not environment.is_android_emulator():


### PR DESCRIPTION
Crashes from Trusty fuzzing sometimes produce a highly relevant Trusted App (TA) stacktrace in the logcat. This PR finds and adds the relevant logcat entry to the beginning of engine output to distinguish the TA stacktrace in testcase reporting. Additionally, upcoming PRs adding TA stacktrace analysis may refer to this entry to help identify relevant frames.