### PR TITLE
Added Android device ramdump detection and reset

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -353,7 +353,7 @@ def hard_reset():
       run_shell_command('recovery --wipe_data')
     if state == 'is-ramdump-mode: yes':
       logs.log('Rebooting ramdump state device.')
-      run_fastboot_command(['reboot'])
+      run_fastboot_command('reboot')
 
 
 def kill_processes_and_children_matching_name(process_name):

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -225,8 +225,8 @@ def get_adb_path():
 def get_device_state():
   """Return the device status."""
   if 'is-ramdump-mode: yes' in run_fastboot_command(
-    ['getvar', 'is-ramdump-mode']):
-  return 'is-ramdump-mode: yes'
+      ['getvar', 'is-ramdump-mode']):
+    return 'is-ramdump-mode: yes'
   state_cmd = get_adb_command_line('get-state')
   return execute_command(state_cmd, timeout=RECOVERY_CMD_TIMEOUT)
 

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -224,6 +224,9 @@ def get_adb_path():
 
 def get_device_state():
   """Return the device status."""
+  if 'is-ramdump-mode: yes' in run_fastboot_command(
+    ['getvar', 'is-ramdump-mode']):
+  return 'is-ramdump-mode: yes'
   state_cmd = get_adb_command_line('get-state')
   return execute_command(state_cmd, timeout=RECOVERY_CMD_TIMEOUT)
 
@@ -348,6 +351,9 @@ def hard_reset():
       logs.log('Rebooting recovery state device with --wipe_data.')
       run_command('root')
       run_shell_command('recovery --wipe_data')
+    if state == 'is-ramdump-mode: yes':
+      logs.log('Rebooting ramdump state device.')
+      run_fastboot_command(['reboot'])
 
 
 def kill_processes_and_children_matching_name(process_name):


### PR DESCRIPTION
Crashes from Trusty fuzzers often send Android devices into a ramdump state that prevents any further fuzzing. In such ramdump crashes, the stacktrace is left in the ramdump files and is not currently detected by Clusterfuzz. 

This PR detects and resets devices in ramdump state and is intended act as an entry point for future changes to extract ramdump data to generate a new crash object.