### PR TITLE
Added Trusty ramdump logcat extraction

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -932,21 +932,48 @@ class AndroidLibFuzzerRunner(new_process.UnicodeProcessRunner, LibFuzzerCommon):
       android.adb.copy_remote_directory_to_local(device_directory,
                                                  local_directory)
 
-  def _prepend_trusty_stacktrace_if_needed(self, output):
-    """Add trusty stacktrace to beginning of output if found in logcat."""
-    logcat = android.logger.log_output()
-    begin, end = '---------', 'Built:'
-    target = 'Backtrace for thread:'
+  def _extract_trusty_stacktrace_from_logcat(self, logcat):
+    """Finds and returns a TA stacktrace from a logcat"""
+    begin, end = 'panic notifier - trusty version', 'Built:'
+    target_idx = logcat.rfind(begin)
 
+    if target_idx != -1:
+      #Logcat contains kernel panic
+      begin = logcat[:target_idx].rfind('\n')
+      end_idx = target_idx + logcat[target_idx:].find('\n')
+      end_idx += logcat[end_idx:].find(end)
+      end_idx += logcat[end_idx:].find('\n')
+
+      ta_stacktrace = []
+      split_marker = 'trusty:log: '
+      for line in logcat[begin:end_idx].splitlines():
+        split_idx = line.find(split_marker) + len(split_marker)
+        ta_stacktrace.append(line[split_idx:])
+
+      return '\n'.join(ta_stacktrace)
+
+    begin = '---------'
+    target = 'Backtrace for thread:'
     target_idx = logcat.rfind(target)
-    if target_idx == -1 or not environment.is_android_emulator():
-      return output
+    if target_idx == -1:
+      return 'No TA crash stacktrace found in logcat.\n'
 
     begin_idx = logcat[:target_idx].rfind(begin)
     end_idx = target_idx + logcat[target_idx:].find(end)
     end_idx += logcat[end_idx:].find('\n')
 
-    ta_stacktrace = logcat[begin_idx:end_idx]
+    return logcat[begin_idx:end_idx]
+
+  def _add_trusty_stacktrace_if_needed(self, output):
+    """Add trusty stacktrace to beginning of output if found in logcat."""
+
+    if android.adb.get_device_state() == 'is-ramdump-mode:yes':
+      logcat = android.adb.extract_logcat_from_ramdump_and_reboot()
+    else:
+      logcat = android.logger.log_output()
+
+    ta_stacktrace = self._extract_trusty_stacktrace_from_logcat(logcat)
+
     # Defer imports since stack_symbolizer pulls in a lot of things.
     from clusterfuzz._internal.crash_analysis.stack_parsing import \
         stack_symbolizer
@@ -954,8 +981,8 @@ class AndroidLibFuzzerRunner(new_process.UnicodeProcessRunner, LibFuzzerCommon):
     ta_stacktrace = loop.process_trusty_stacktrace(ta_stacktrace)
 
     return '+-- Logcat excerpt: Trusted App crash stacktrace --+\
-      \n{ta_stacktrace}\n\n{output}'.format(
-        ta_stacktrace=ta_stacktrace, output=output)
+      \n{ta_stacktrace}\n\n{output}\n\nLogcat:\n{logcat_output}'.format(
+        ta_stacktrace=ta_stacktrace, output=output, logcat_output=logcat)
 
   def _add_logcat_output_if_needed(self, output):
     """Add logcat output to end of output to capture crashes from related
@@ -963,7 +990,8 @@ class AndroidLibFuzzerRunner(new_process.UnicodeProcessRunner, LibFuzzerCommon):
     if 'Sanitizer: ' in output:
       return output
 
-    output = self._prepend_trusty_stacktrace_if_needed(output)
+    if environment.is_android_emulator():
+      return self._add_trusty_stacktrace_if_needed(output)
 
     return '{output}\n\nLogcat:\n{logcat_output}'.format(
         output=output, logcat_output=android.logger.log_output())

--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -540,7 +540,16 @@ class SymbolizationLoop(object):
   def _extract_trusty_app_name(self, stacktrace):
     """Returns the name of the crashed Trusted App."""
     #(app: keymaster)
-    match = re.compile(r'\(app:\s*(\w+)\)').search(stacktrace)
+    match = re.compile(r'\(app:\s(\w+)\)').search(stacktrace)
+    if match:
+      return match.group(1)
+
+    return ''
+
+  def _extract_trusty_bid(self, stacktrace):
+    """Returns the build of the crashed Trusted App."""
+    #, Build: 1234567
+    match = re.compile(r',\sBuild:\s(\d+),\sBuilt:').search(stacktrace)
     if match:
       return match.group(1)
 
@@ -557,9 +566,10 @@ class SymbolizationLoop(object):
     """Adds debug line information to a Trusted App stacktrace."""
     symbols_dir = environment.get_value('SYMBOLS_DIR')
     trusty_app = self._extract_trusty_app_name(unsymbolized_crash_stacktrace)
+    trusty_bid = self._extract_trusty_bid(unsymbolized_crash_stacktrace)
 
     symbols_downloader.download_trusty_symbols_if_needed(
-        symbols_dir, trusty_app)
+        symbols_dir, trusty_app, trusty_bid)
     kernel_binary = f'{symbols_dir}/lk.elf'
     trusty_binary = f'{symbols_dir}/{trusty_app}.syms.elf'
 

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -353,7 +353,7 @@ def hard_reset():
       run_shell_command('recovery --wipe_data')
     if state == 'is-ramdump-mode: yes':
       logs.log('Rebooting ramdump state device.')
-      run_fastboot_command(['reboot'])
+      run_fastboot_command('reboot')
 
 
 def kill_processes_and_children_matching_name(process_name):

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -225,8 +225,8 @@ def get_adb_path():
 def get_device_state():
   """Return the device status."""
   if 'is-ramdump-mode: yes' in run_fastboot_command(
-    ['getvar', 'is-ramdump-mode']):
-  return 'is-ramdump-mode: yes'
+      ['getvar', 'is-ramdump-mode']):
+    return 'is-ramdump-mode: yes'
   state_cmd = get_adb_command_line('get-state')
   return execute_command(state_cmd, timeout=RECOVERY_CMD_TIMEOUT)
 

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -224,6 +224,9 @@ def get_adb_path():
 
 def get_device_state():
   """Return the device status."""
+  if 'is-ramdump-mode: yes' in run_fastboot_command(
+    ['getvar', 'is-ramdump-mode']):
+  return 'is-ramdump-mode: yes'
   state_cmd = get_adb_command_line('get-state')
   return execute_command(state_cmd, timeout=RECOVERY_CMD_TIMEOUT)
 
@@ -348,6 +351,9 @@ def hard_reset():
       logs.log('Rebooting recovery state device with --wipe_data.')
       run_command('root')
       run_shell_command('recovery --wipe_data')
+    if state == 'is-ramdump-mode: yes':
+      logs.log('Rebooting ramdump state device.')
+      run_fastboot_command(['reboot'])
 
 
 def kill_processes_and_children_matching_name(process_name):

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -25,6 +25,7 @@ import time
 
 from clusterfuzz._internal.base import persistent_cache
 from clusterfuzz._internal.base import utils
+from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.system import shell
@@ -57,6 +58,8 @@ LSUSB_SERIAL_RE = re.compile(r'\s+iSerial\s+\d\s+(.*)')
 
 # This is a constant value defined in usbdevice_fs.h in Linux system.
 USBDEVFS_RESET = ord('U') << 8 | 20
+
+RAMOOPS_READER_GCS_PATH = 'gs://haiku-storage/trusty/ramoops_reader.py'
 
 
 def bad_state_reached():
@@ -224,9 +227,11 @@ def get_adb_path():
 
 def get_device_state():
   """Return the device status."""
-  if 'is-ramdump-mode: yes' in run_fastboot_command(
-      ['getvar', 'is-ramdump-mode']):
-    return 'is-ramdump-mode: yes'
+  fastboot_state = run_fastboot_command(
+      ['getvar', 'is-ramdump-mode'], timeout=5)
+  if fastboot_state and 'is-ramdump-mode: yes' in fastboot_state:
+    return 'is-ramdump-mode:yes'
+
   state_cmd = get_adb_command_line('get-state')
   return execute_command(state_cmd, timeout=RECOVERY_CMD_TIMEOUT)
 
@@ -266,6 +271,29 @@ def get_kernel_log_content():
     kernel_log_content += read_data_from_file(kernel_log_file) or ''
 
   return kernel_log_content
+
+
+def extract_logcat_from_ramdump_and_reboot():
+  """Extracts logcat from ramdump kernel log and reboots."""
+  run_fastboot_command(['oem', 'ramdump', 'stage_file', 'kernel.log'])
+  run_fastboot_command(['get_staged', 'kernel.log'])
+
+  storage.copy_file_from(RAMOOPS_READER_GCS_PATH, 'ramoops_reader.py')
+  subprocess.run(
+      'python ramoops_reader.py kernel.log > logcat.log',
+      shell=True,
+      check=False)
+  with open('logcat.log', 'r') as file:
+    logcat = file.read()
+
+  files_to_delete = ['ramoops_reader.py', 'kernel.log', 'logcat.log']
+  for filepath in files_to_delete:
+    os.remove(filepath)
+
+  run_fastboot_command('reboot')
+  wait_until_fully_booted()
+
+  return logcat
 
 
 def get_ps_output():
@@ -351,9 +379,6 @@ def hard_reset():
       logs.log('Rebooting recovery state device with --wipe_data.')
       run_command('root')
       run_shell_command('recovery --wipe_data')
-    if state == 'is-ramdump-mode: yes':
-      logs.log('Rebooting ramdump state device.')
-      run_fastboot_command('reboot')
 
 
 def kill_processes_and_children_matching_name(process_name):
@@ -824,6 +849,9 @@ def wait_until_fully_booted():
     time.sleep(BOOT_WAIT_INTERVAL)
 
   factory_reset()
+  if environment.is_android_emulator():
+    #Device may be in recovery mode
+    hard_reset()
   logs.log_fatal_and_exit(
       'Device failed to finish boot. Reset to factory settings and exited.')
 

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -228,7 +228,7 @@ def get_adb_path():
 def get_device_state():
   """Return the device status."""
   fastboot_state = run_fastboot_command(
-      ['getvar', 'is-ramdump-mode'], timeout=5)
+      ['getvar', 'is-ramdump-mode'], timeout=RECOVERY_CMD_TIMEOUT)
   if fastboot_state and 'is-ramdump-mode: yes' in fastboot_state:
     return 'is-ramdump-mode:yes'
 

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -180,7 +180,7 @@ def download_system_symbols_if_needed(symbols_directory):
   utils.write_data_to_file(build_params, build_params_check_path)
 
 
-def download_trusty_symbols_if_needed(symbols_directory, app_name):
+def download_trusty_symbols_if_needed(symbols_directory, app_name, bid):
   """Downloads and extracts Trusted App ELF files"""
   ab_target = ''
   device = settings.get_build_parameters().get('target')
@@ -190,7 +190,8 @@ def download_trusty_symbols_if_needed(symbols_directory, app_name):
     ab_target = 'slider-fuzz-test-debug'
 
   branch = 'polygon-trusty-whitechapel-master'
-  bid = fetch_artifact.get_latest_artifact_info(branch, ab_target)['bid']
+  if not bid:
+    bid = fetch_artifact.get_latest_artifact_info(branch, ab_target)['bid']
 
   artifact_filename = f'{ab_target}-{bid}.syms.zip'
   symbols_archive_path = os.path.join(symbols_directory, artifact_filename)


### PR DESCRIPTION
Trusty fuzzing sometimes causes devices to crash into ramdump state. This PR enables Clusterfuzz to download `kernel.log` from ramdumps and to desymbolize it into a logcat using the `ramoops_reader.py` script. The desymbolized logcat will contain a Kernel Panic stacktrace. This PR adds the KP stacktrace and logcat to the crash output, and resets the device.