### PR TITLE
Added try/catch to killing Popen objects. Added fastboot cmd timeouts.

### DIFF
--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -560,7 +560,10 @@ class SymbolizationLoop(object):
     for pipe in pipes:
       pipe.stdin.close()
       pipe.stdout.close()
-      pipe.kill()
+      try:
+        pipe.kill()
+      except ProcessLookupError:
+        pass
 
   def process_trusty_stacktrace(self, unsymbolized_crash_stacktrace):
     """Adds debug line information to a Trusted App stacktrace."""

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -49,6 +49,7 @@ MONKEY_PROCESS_NAME = 'monkey'
 WAIT_FOR_DEVICE_TIMEOUT = 600
 REBOOT_TIMEOUT = 3600
 RECOVERY_CMD_TIMEOUT = 60
+GET_DEVICE_STATE_TIMEOUT = 3
 STOP_CVD_WAIT = 20
 LAUNCH_CVD_TIMEOUT = 2700
 
@@ -227,10 +228,11 @@ def get_adb_path():
 
 def get_device_state():
   """Return the device status."""
-  fastboot_state = run_fastboot_command(
-      ['getvar', 'is-ramdump-mode'], timeout=RECOVERY_CMD_TIMEOUT)
-  if fastboot_state and 'is-ramdump-mode: yes' in fastboot_state:
-    return 'is-ramdump-mode:yes'
+  if environment.is_android_emulator():
+    fastboot_state = run_fastboot_command(
+        ['getvar', 'is-ramdump-mode'], timeout=GET_DEVICE_STATE_TIMEOUT)
+    if fastboot_state and 'is-ramdump-mode: yes' in fastboot_state:
+      return 'is-ramdump-mode:yes'
 
   state_cmd = get_adb_command_line('get-state')
   return execute_command(state_cmd, timeout=RECOVERY_CMD_TIMEOUT)
@@ -275,8 +277,11 @@ def get_kernel_log_content():
 
 def extract_logcat_from_ramdump_and_reboot():
   """Extracts logcat from ramdump kernel log and reboots."""
-  run_fastboot_command(['oem', 'ramdump', 'stage_file', 'kernel.log'])
-  run_fastboot_command(['get_staged', 'kernel.log'])
+  run_fastboot_command(
+      ['oem', 'ramdump', 'stage_file', 'kernel.log'],
+      timeout=RECOVERY_CMD_TIMEOUT)
+  run_fastboot_command(
+      ['get_staged', 'kernel.log'], timeout=RECOVERY_CMD_TIMEOUT)
 
   storage.copy_file_from(RAMOOPS_READER_GCS_PATH, 'ramoops_reader.py')
   subprocess.run(

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -281,7 +281,7 @@ def extract_logcat_from_ramdump_and_reboot():
       ['oem', 'ramdump', 'stage_file', 'kernel.log'],
       timeout=RECOVERY_CMD_TIMEOUT)
   run_fastboot_command(
-      ['get_staged', 'kernel.log'], timeout=RECOVERY_CMD_TIMEOUT)
+      ['get_staged', 'kernel.log'], timeout=WAIT_FOR_DEVICE_TIMEOUT)
 
   storage.copy_file_from(RAMOOPS_READER_GCS_PATH, 'ramoops_reader.py')
   subprocess.run(


### PR DESCRIPTION
Running `kill()` on `subprocess.Popen` objects throws a ProcessLookupError if the process has already been killed, interrupting bot tasks. This PR puts `kill()` in a try/catch block to handle this case.

`adb.get_device_state()` is called frequently in practice, including during progression tasks. Its call to `run_fastboot_command()` will time out if the device is not already in fastboot mode, thus slowing down the bot as it handles multiple progression tasks. This PR changes this device state check to slow down only android_emulator tasks, and decreases the timeout per check.