### PR TITLE
Use staging assignee over automatic assignee for testcases

### DIFF
--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -391,7 +391,7 @@ def file_issue(testcase,
   if fuzzer_metadata and 'assignee' in fuzzer_metadata:
     issue.status = policy.status('assigned')
     issue.assignee = fuzzer_metadata['assignee']
-    logs.log('Fuzzer testcase has assignee metadata %s.' % issue.assignee)
+    logs.log('Testcase has assignee metadata %s' % issue.assignee)
 
   # Add additional ccs from the job definition and fuzzer.
   ccs = data_handler.get_additional_values_for_variable(

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -391,8 +391,7 @@ def file_issue(testcase,
   if fuzzer_metadata and 'assignee' in fuzzer_metadata:
     issue.status = policy.status('assigned')
     issue.assignee = fuzzer_metadata['assignee']
-    logs.log(
-        'Fuzzer testcase has assignee metadata %s.' % issue.assignee)
+    logs.log('Fuzzer testcase has assignee metadata %s.' % issue.assignee)
 
   # Add additional ccs from the job definition and fuzzer.
   ccs = data_handler.get_additional_values_for_variable(

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -387,6 +387,13 @@ def file_issue(testcase,
   else:
     issue.status = properties.status
 
+  fuzzer_metadata = testcase.get_metadata('issue_metadata')
+  if fuzzer_metadata and 'stagingCc' in fuzzer_metadata:
+    issue.status = policy.status('assigned')
+    issue.assignee = fuzzer_metadata['stagingCc']
+    logs.log(
+        'Fuzzer is under staging. Assigned testcase to %s' % issue.assignee)
+
   # Add additional ccs from the job definition and fuzzer.
   ccs = data_handler.get_additional_values_for_variable(
       'AUTOMATIC_CCS', testcase.job_type, testcase.fuzzer_name)

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -388,9 +388,9 @@ def file_issue(testcase,
     issue.status = properties.status
 
   fuzzer_metadata = testcase.get_metadata('issue_metadata')
-  if fuzzer_metadata and 'stagingCc' in fuzzer_metadata:
+  if fuzzer_metadata and 'issue_assignee_override' in fuzzer_metadata:
     issue.status = policy.status('assigned')
-    issue.assignee = fuzzer_metadata['stagingCc']
+    issue.assignee = fuzzer_metadata['issue_assignee_override']
     logs.log(
         'Fuzzer is under staging. Assigned testcase to %s' % issue.assignee)
 

--- a/src/appengine/libs/issue_management/issue_filer.py
+++ b/src/appengine/libs/issue_management/issue_filer.py
@@ -388,11 +388,11 @@ def file_issue(testcase,
     issue.status = properties.status
 
   fuzzer_metadata = testcase.get_metadata('issue_metadata')
-  if fuzzer_metadata and 'issue_assignee_override' in fuzzer_metadata:
+  if fuzzer_metadata and 'assignee' in fuzzer_metadata:
     issue.status = policy.status('assigned')
-    issue.assignee = fuzzer_metadata['issue_assignee_override']
+    issue.assignee = fuzzer_metadata['assignee']
     logs.log(
-        'Fuzzer is under staging. Assigned testcase to %s' % issue.assignee)
+        'Fuzzer testcase has assignee metadata %s.' % issue.assignee)
 
   # Add additional ccs from the job definition and fuzzer.
   ccs = data_handler.get_additional_values_for_variable(


### PR DESCRIPTION
Haiku is adding a new 'staging' fuzz config field to indicate that fuzzers are under test and not ready to send bugs for triage. Rather, fuzzers under staging will include in a `.issue_metadata` file, `{"issue_assignee_override":"email@email.com"}` to provide an assignee to replace AUTOMATIC_ASSIGNEE.