### PR TITLE
Stop keeping track of whether testcases are binary

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/analyze_task.py
@@ -156,7 +156,6 @@ def execute_task(testcase_id, job_type):
   # Update initial testcase information.
   testcase.absolute_path = testcase_file_path
   testcase.job_type = job_type
-  testcase.binary_flag = utils.is_binary_file(testcase_file_path)
   testcase.queue = tasks.default_queue()
   testcase.crash_state = ''
 

--- a/src/clusterfuzz/_internal/bot/tasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/corpus_pruning_task.py
@@ -780,7 +780,6 @@ def _process_corpus_crashes(context, result):
         job_type=job_type,
         archived=False,
         archive_filename='',
-        binary_flag=True,
         http_flag=False,
         gestures=None,
         redzone=DEFAULT_REDZONE,

--- a/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/fuzz_task.py
@@ -928,7 +928,6 @@ def create_testcase(group, context):
       job_type=context.job_type,
       archived=crash.archived,
       archive_filename=crash.archive_filename,
-      binary_flag=utils.is_binary_file(crash.file_path),
       http_flag=crash.http_flag,
       gestures=crash.gestures,
       redzone=context.redzone,

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -712,7 +712,7 @@ def _get_security_severity(crash, job_type, gestures):
 def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
                    one_time_crasher_flag, crash_revision, comment,
                    absolute_path, fuzzer_name, fully_qualified_fuzzer_name,
-                   job_type, archived, archive_filename, binary_flag, http_flag,
+                   job_type, archived, archive_filename, http_flag,
                    gestures, redzone, disable_ubsan, minidump_keys,
                    window_argument, timeout_multiplier, minimized_arguments):
   """Create a testcase and store it in the datastore using remote api."""
@@ -749,7 +749,6 @@ def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
   testcase.queue = tasks.default_queue()
   testcase.archive_state = archive_state
   testcase.archive_filename = archive_filename
-  testcase.binary_flag = binary_flag
   testcase.http_flag = http_flag
   testcase.timestamp = datetime.datetime.utcnow()
   testcase.gestures = gestures
@@ -770,10 +769,10 @@ def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
   # Get testcase id from newly created testcase.
   testcase_id = testcase.key.id()
   logs.log(
-      ('Created new testcase %d (reproducible:%s, security:%s, binary:%s).\n'
+      ('Created new testcase %d (reproducible:%s, security:%s).\n'
        'crash_type: %s\ncrash_state:\n%s\n') %
       (testcase_id, not testcase.one_time_crasher_flag, testcase.security_flag,
-       testcase.binary_flag, testcase.crash_type, testcase.crash_state))
+       testcase.crash_type, testcase.crash_state))
 
   # Update global blacklist to avoid finding this leak again (if needed).
   is_lsan_enabled = environment.get_value('LSAN')

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -712,9 +712,9 @@ def _get_security_severity(crash, job_type, gestures):
 def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
                    one_time_crasher_flag, crash_revision, comment,
                    absolute_path, fuzzer_name, fully_qualified_fuzzer_name,
-                   job_type, archived, archive_filename, http_flag,
-                   gestures, redzone, disable_ubsan, minidump_keys,
-                   window_argument, timeout_multiplier, minimized_arguments):
+                   job_type, archived, archive_filename, http_flag, gestures,
+                   redzone, disable_ubsan, minidump_keys, window_argument,
+                   timeout_multiplier, minimized_arguments):
   """Create a testcase and store it in the datastore using remote api."""
   # Initialize variable to prevent invalid values.
   if archived:
@@ -768,11 +768,10 @@ def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
 
   # Get testcase id from newly created testcase.
   testcase_id = testcase.key.id()
-  logs.log(
-      ('Created new testcase %d (reproducible:%s, security:%s).\n'
-       'crash_type: %s\ncrash_state:\n%s\n') %
-      (testcase_id, not testcase.one_time_crasher_flag, testcase.security_flag,
-       testcase.crash_type, testcase.crash_state))
+  logs.log(('Created new testcase %d (reproducible:%s, security:%s).\n'
+            'crash_type: %s\ncrash_state:\n%s\n') %
+           (testcase_id, not testcase.one_time_crasher_flag,
+            testcase.security_flag, testcase.crash_type, testcase.crash_state))
 
   # Update global blacklist to avoid finding this leak again (if needed).
   is_lsan_enabled = environment.get_value('LSAN')

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -426,9 +426,6 @@ class Testcase(Model):
   # File name of the original uploaded archive.
   archive_filename = ndb.TextProperty()
 
-  # Is this a binary file?
-  binary_flag = ndb.BooleanProperty(default=False, indexed=False)
-
   # Timestamp.
   timestamp = ndb.DateTimeProperty()
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/upload_testcase_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/upload_testcase_test.py
@@ -149,7 +149,6 @@ class UploadOAuthTest(unittest.TestCase):
         'additional_metadata': '{"fuzzer_binary_name": "target"}',
         'archive_filename': None,
         'archive_state': 0,
-        'binary_flag': False,
         'bug_information': '',
         'comments': '[2021-01-01 00:00:00 UTC] uploader@email: '
                     'External testcase upload.\n',
@@ -255,8 +254,6 @@ class UploadOAuthTest(unittest.TestCase):
             None,
         'archive_state':
             0,
-        'binary_flag':
-            False,
         'bug_information':
             '',
         'comments':
@@ -415,7 +412,6 @@ class UploadOAuthTest(unittest.TestCase):
         'additional_metadata': '{"fuzzer_binary_name": "target"}',
         'archive_filename': None,
         'archive_state': 0,
-        'binary_flag': False,
         'bug_information': '',
         'comments': '[2021-01-01 00:00:00 UTC] uploader@email: '
                     'External testcase upload.\n',


### PR DESCRIPTION
It can be done on the fly (only purpose is determining whether to skip manual minimization (and I'm not sure this is actually a valid reason). And the db column is never read only written.