### PR TITLE
Add SIGTERM cancellation to list of non-error return codes

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/constants.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/constants.py
@@ -75,6 +75,8 @@ RUNS_TO_REPRODUCE = 100
 TARGET_ERROR_EXITCODE = 77
 
 NONCRASH_RETURN_CODES = {
+    # Code when LibFuzzer exits due to SIGTERM cancellation (timeout exceeded)
+    -15,
     0,
     # pylint: disable=line-too-long
     # Code when we interrupt libFuzzer (https://github.com/llvm/llvm-project/blob/1f161919065fbfa2b39b8f373553a64b89f826f8/compiler-rt/lib/fuzzer/FuzzerOptions.h#L25)


### PR DESCRIPTION
Below is a log example.

When the `max_total_time` variable is exceeded, SIGTERM kills the LibFuzzer process. The error exit code is -15, and an empty testcase is generated due to the crash.

```
2023-05-03 19:09:50,822 - run_bot - INFO - ['/usr/local/google/home/mteffeteller/Android/Sdk/platform-tools/adb', 'shell', 'LD_LIBRARY_PATH=/data/fuzz/bot/builds/test-blobs-bucket_fuzzers_target-local_hwasan_libosi_fuzz_buffer_77651789446b3c3a04b9f492ff141f003d437347/revisions/lib:/system/lib64:/system/lib64', 'HWASAN_OPTIONS=alloc_dealloc_mismatch=0:allocator_may_return_null=1:allow_user_segv_handler=1:check_malloc_usable_size=0:detect_container_overflow=0:detect_leaks=0:detect_odr_violation=0:detect_stack_use_after_return=1:fast_unwind_on_fatal=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:max_uar_stack_size_log=16:print_scariness=1:print_summary=1:print_suppressions=0:redzone=32:strict_memcmp=0:symbolize=0:use_sigaltstack=1', 'UBSAN_OPTIONS=halt_on_error=0:print_stacktrace=0:print_suppressions=0', '/data/fuzz/bot/builds/test-blobs-bucket_fuzzers_target-local_hwasan_libosi_fuzz_buffer_77651789446b3c3a04b9f492ff141f003d437347/revisions/libosi_fuzz_buffer', '-timeout=25', '-rss_limit_mb=2560', '-artifact_prefix=/data/fuzz/bot/inputs/fuzzer-testcases/', '-max_total_time=60', '-print_final_stats=1', '/data/fuzz/bot/inputs/fuzzer-testcases-disk/temp-458770/new', '/data/fuzz/bot/inputs/fuzzer-testcases-disk/temp-458770/subset']
2023-05-03 19:09:50,822 - run_bot - INFO - ********HWASAN_OPTIONS***********:
2023-05-03 19:09:50,822 - run_bot - INFO - alloc_dealloc_mismatch=0:allocator_may_return_null=1:allow_user_segv_handler=1:check_malloc_usable_size=0:detect_container_overflow=0:detect_leaks=0:detect_odr_violation=0:detect_stack_use_after_return=1:exitcode=77:fast_unwind_on_fatal=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:max_uar_stack_size_log=16:print_scariness=1:print_summary=1:print_suppressions=0:redzone=32:strict_memcmp=0:symbolize=0:use_sigaltstack=1
2023-05-03 19:09:50,829 - run_bot - INFO - process started
2023-05-03 19:09:50,830 - run_bot - INFO - about to call wait_process..
2023-05-03 19:09:50,830 - run_bot - INFO - INSIDE wait_process
2023-05-03 19:10:50,831 - run_bot - INFO - about to return result....
2023-05-03 19:10:50,832 - run_bot - INFO - None
2023-05-03 19:10:50,832 - run_bot - INFO - -15
```