### PR TITLE
Fix search for sanitizer deps

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -26,6 +26,8 @@ DEVICE_TMP_DIR = '/data/local/tmp'
 # Directory to keep fuzzing artifacts for grey-box fuzzers e.g. corpus.
 DEVICE_FUZZING_DIR = '/data/fuzz'
 
+DEVICE_SANITIZER_DIR = '/system/lib64'
+
 # The format of logcat when lowmemorykiller kills a process. See:
 # https://android.googlesource.com/platform/system/core/+/master/lmkd/lmkd.c#586
 LOW_MEMORY_REGEX = re.compile(

--- a/src/clusterfuzz/_internal/platforms/android/sanitizer.py
+++ b/src/clusterfuzz/_internal/platforms/android/sanitizer.py
@@ -39,13 +39,7 @@ def get_ld_library_path_for_sanitizers():
   if not settings.get_sanitizer_tool_name():
     return None
 
-  sanitizer_libs = adb.run_shell_command(
-      ['find', '/system/lib64/', '-name', '*san_standalone*'])
-  if not sanitizer_libs:
-    return None
-
-  sanitizer_lib_directory = os.path.dirname(sanitizer_libs.splitlines()[0])
-  return '/system/lib64:' + sanitizer_lib_directory
+  return constants.DEVICE_SANITIZER_DIR
 
 
 def get_options_file_path(sanitizer_tool_name):


### PR DESCRIPTION
Existing search is both redundant and buddy.

Note how currently we search in `/system/lib64` path and then, if found, strip the file and append `/system/lib64`. It's  a useless search scenario.

Also note how this adb command was buggy, sometimes a race condition appears to happen and the adb command gets appended as a path. This causes the fuzzer to crash with the error below (note the `LD_LIBRARY_PATH`):

```
Command: /usr/local/google/home/mteffeteller/Android/Sdk/platform-tools/adb shell 'LD_LIBRARY_PATH=/data/fuzz/bot/builds/test-blobs-bucket_fuzzers_target-local_hwasan_libosi_fuzz_buffer_77651789446b3c3a04b9f492ff141f003d437347/revisions/lib:/system/lib64:find: '"'"'/system/lib64' HWASAN_OPTIONS=alloc_dealloc_mismatch=0:allocator_may_return_null=1:allow_user_segv_handler=1:check_malloc_usable_size=0:detect_container_overflow=0:detect_leaks=0:detect_odr_violation=0:detect_stack_use_after_return=1:fast_unwind_on_fatal=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:max_uar_stack_size_log=16:print_scariness=1:print_summary=1:print_suppressions=0:redzone=32:strict_memcmp=0:symbolize=0:use_sigaltstack=1 UBSAN_OPTIONS=halt_on_error=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:print_stacktrace=1:print_summary=1:print_suppressions=0:silence_unsigned_overflow=1:use_sigaltstack=1 /data/fuzz/bot/builds/test-blobs-bucket_fuzzers_target-local_hwasan_libosi_fuzz_buffer_77651789446b3c3a04b9f492ff141f003d437347/revisions/libosi_fuzz_buffer -timeout=25 -rss_limit_mb=2560 -max_len=4193 -artifact_prefix=/data/fuzz/bot/inputs/fuzzer-testcases/ -max_total_time=60 -print_final_stats=1 /data/fuzz/bot/inputs/fuzzer-testcases-disk/temp-458770/new /data/fuzz/bot/inputs/data-bundles/android_libosi_fuzz_buffer
Time ran: 0.08114051818847656

/system/bin/sh: no closing quote
```