### PR TITLE
[rearchitecture] Add tooling for dealing with signed URLs.

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -91,7 +91,7 @@ OBJECT_URL = 'https://storage.cloud.google.com'
 DIRECTORY_URL = 'https://console.cloud.google.com/storage/browser'
 
 # Expiration in minutes for signed URL.
-SIGNED_EXPIRATION_MINUTES = 24 * 60
+SIGNED_URL_EXPIRATION_MINUTES = 24 * 60
 
 
 class StorageProvider(object):
@@ -137,11 +137,13 @@ class StorageProvider(object):
     """Delete a remote file."""
     raise NotImplementedError
 
-  def sign_download_url(self, remote_path, minutes=SIGNED_EXPIRATION_MINUTES):
+  def sign_download_url(self,
+                        remote_path,
+                        minutes=SIGNED_URL_EXPIRATION_MINUTES):
     """Signs a download URL for a remote file."""
     raise NotImplementedError
 
-  def sign_upload_url(self, remote_path, minutes=SIGNED_EXPIRATION_MINUTES):
+  def sign_upload_url(self, remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES):
     """Signs an upload URL for a remote file."""
     raise NotImplementedError
 
@@ -343,11 +345,13 @@ class GcsProvider(StorageProvider):
 
     return True
 
-  def sign_download_url(self, remote_path, minutes=SIGNED_EXPIRATION_MINUTES):
+  def sign_download_url(self,
+                        remote_path,
+                        minutes=SIGNED_URL_EXPIRATION_MINUTES):
     """Signs a download URL for a remote file."""
     return _sign_url(remote_path, method='GET', minutes=minutes)
 
-  def sign_upload_url(self, remote_path, minutes=SIGNED_EXPIRATION_MINUTES):
+  def sign_upload_url(self, remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES):
     """Signs an upload URL for a remote file."""
     return _sign_url(remote_path, method='PUT', minutes=minutes)
 
@@ -364,7 +368,7 @@ class GcsProvider(StorageProvider):
     retries=DEFAULT_FAIL_RETRIES,
     delay=DEFAULT_FAIL_WAIT,
     function='google_cloud_utils.storage._sign_url')
-def _sign_url(remote_path, minutes=SIGNED_EXPIRATION_MINUTES, method='GET'):
+def _sign_url(remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES, method='GET'):
   """Returns a signed URL for |remote_path| with |method|."""
   minutes = datetime.timedelta(minutes=minutes)
   bucket_name, object_path = get_bucket_name_and_path(remote_path)
@@ -567,13 +571,15 @@ class FileSystemProvider(StorageProvider):
     shell.remove_file(fs_metadata_path)
     return True
 
-  def sign_download_url(self, remote_path, minutes=SIGNED_EXPIRATION_MINUTES):
+  def sign_download_url(self,
+                        remote_path,
+                        minutes=SIGNED_URL_EXPIRATION_MINUTES):
     """Returns remote_path since we are pretending to sign a URL for
     download."""
     del minutes
     return self.convert_path(remote_path)
 
-  def sign_upload_url(self, remote_path, minutes=SIGNED_EXPIRATION_MINUTES):
+  def sign_upload_url(self, remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES):
     """Returns remote_path since we are pretending to sign a URL for
     upload."""
     del minutes
@@ -1278,14 +1284,14 @@ def download_signed_url(url, local_path=None):
   return contents
 
 
-def get_signed_upload_url(remote_path, minutes=SIGNED_EXPIRATION_MINUTES):
+def get_signed_upload_url(remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES):
   """Returns a signed upload URL for |remote_path|. Does not download the
   contents."""
   provider = _provider()
   return provider.sign_upload_url(remote_path, minutes=minutes)
 
 
-def get_signed_download_url(remote_path, minutes=SIGNED_EXPIRATION_MINUTES):
+def get_signed_download_url(remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES):
   """Returns a signed download URL for |remote_path|. Does not download the
   contents."""
   provider = _provider()

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -353,7 +353,6 @@ class GcsProvider(StorageProvider):
 
   def download_signed_url(self, signed_url):
     """Downloads |signed_url|."""
-    # TODO(metzman): Add retries.
     return download_url(signed_url)
 
   def upload_signed_url(self, data, signed_url):
@@ -640,8 +639,8 @@ class GcsBlobInfo(object):
 def _provider():
   """Get the current storage provider."""
   local_buckets_path = environment.get_value('LOCAL_GCS_BUCKETS_PATH')
-  # if local_buckets_path:
-  #   return FileSystemProvider(local_buckets_path)
+  if local_buckets_path:
+    return FileSystemProvider(local_buckets_path)
   return GcsProvider()
 
 
@@ -918,11 +917,11 @@ def read_data(cloud_storage_file_path):
   return _provider().read_data(cloud_storage_file_path)
 
 
-# @retry.wrap(
-#     retries=DEFAULT_FAIL_RETRIES,
-#     delay=DEFAULT_FAIL_WAIT,
-#     function='google_cloud_utils.storage.write_data',
-#     exception_type=google.cloud.exceptions.GoogleCloudError)
+@retry.wrap(
+    retries=DEFAULT_FAIL_RETRIES,
+    delay=DEFAULT_FAIL_WAIT,
+    function='google_cloud_utils.storage.write_data',
+    exception_type=google.cloud.exceptions.GoogleCloudError)
 def write_data(data, cloud_storage_file_path, metadata=None):
   """Return content of a cloud storage file."""
   return _provider().write_data(
@@ -1161,10 +1160,10 @@ def store_file_in_cache(file_path,
     logs.log('Completed storing file %s into cache.' % filename)
 
 
-# @retry.wrap(#
-#     retries=DEFAULT_FAIL_RETRIES,
-#     delay=DEFAULT_FAIL_WAIT,
-#     function='google_cloud_utils.storage.get')
+@retry.wrap(
+    retries=DEFAULT_FAIL_RETRIES,
+    delay=DEFAULT_FAIL_WAIT,
+    function='google_cloud_utils.storage.get')
 def get(cloud_storage_file_path):
   """Get GCS object data."""
   return _provider().get(cloud_storage_file_path)

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -1253,7 +1253,10 @@ def uworker_io_bucket():
 
   assert not environment.get_value('PY_UNITTESTS')
   # TODO(metzman): Use local config.
-  return environment.get_value('UWORKER_IO_BUCKET')
+  uworker_io_bucket = environment.get_value('UWORKER_IO_BUCKET')
+  if not uworker_io_bucket:
+    logs.log_error('UWORKER_IO_BUCKET is not defined.')
+  return uworker_io_bucket
 
 
 @retry.wrap(

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -1137,6 +1137,7 @@ def store_file_in_cache(file_path,
 
     def mtime(file_path):
       return os.stat(file_path).st_mtime
+
     last_used_cached_files_list = list(
         sorted(cached_files_list, key=mtime, reverse=True))
     for cached_file_path in (

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -1241,6 +1241,7 @@ def blobs_bucket():
 
 
 def uworker_io_bucket():
+  """Returns the bucket where uworker I/O is done."""
   test_uworker_io_bucket = environment.get_value('TEST_UWORKER_IO_BUCKET')
   if test_uworker_io_bucket:
     return test_uworker_io_bucket
@@ -1271,7 +1272,6 @@ def download_url(url):
     retry_on_false=True)
 def upload_signed_url(data, url):
   """Uploads data to the |signed_url|."""
-  # TODO(metzman): Deal with providers.
   return _provider().upload_signed_url(data, url)
 
 

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -93,6 +93,9 @@ DIRECTORY_URL = 'https://console.cloud.google.com/storage/browser'
 # Expiration in minutes for signed URL.
 SIGNED_URL_EXPIRATION_MINUTES = 24 * 60
 
+# Timeout for HTTP operations.
+HTTP_TIMEOUT_SECONDS = 15
+
 
 class StorageProvider(object):
   """Core storage provider interface."""
@@ -361,7 +364,7 @@ class GcsProvider(StorageProvider):
 
   def upload_signed_url(self, data, signed_url):
     """Uploads |data| to |signed_url|."""
-    requests.put(signed_url, data=data)
+    requests.put(signed_url, data=data, timeout=HTTP_TIMEOUT_SECONDS)
 
 
 @retry.wrap(
@@ -1132,7 +1135,8 @@ def store_file_in_cache(file_path,
       cached_file_path = os.path.join(cache_directory, cached_filename)
       cached_files_list.append(cached_file_path)
 
-    mtime = lambda f: os.stat(f).st_mtime
+    def mtime(file_path):
+      return os.stat(file_path).st_mtime
     last_used_cached_files_list = list(
         sorted(cached_files_list, key=mtime, reverse=True))
     for cached_file_path in (
@@ -1258,7 +1262,7 @@ def uworker_io_bucket():
     exception_type=HttpError)
 def download_url(url):
   """Downloads |url| and returns the contents."""
-  request = requests.get(url)
+  request = requests.get(url, timeout=HTTP_TIMEOUT_SECONDS)
   if not request.ok:
     raise RuntimeError('Request to %s failed. Code: %d. Reason: %s' %
                        (url, request.status_code, request.reason))

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -647,6 +647,7 @@ def _provider():
   local_buckets_path = environment.get_value('LOCAL_GCS_BUCKETS_PATH')
   if local_buckets_path:
     return FileSystemProvider(local_buckets_path)
+
   return GcsProvider()
 
 
@@ -797,6 +798,7 @@ def create_bucket_if_needed(bucket_name, object_lifecycle=None, cors=None):
   return True
 
 
+@environment.local_noop
 def create_discovery_storage_client():
   """Create a storage client using discovery APIs."""
   return build('storage', 'v1', cache_discovery=False)

--- a/src/clusterfuzz/_internal/tests/core/google_cloud_utils/storage_test.py
+++ b/src/clusterfuzz/_internal/tests/core/google_cloud_utils/storage_test.py
@@ -260,3 +260,33 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
     self.provider.delete('gs://test-bucket/a')
     self.assertFalse(os.path.exists('/local/test-bucket/objects/a'))
     self.assertFalse(os.path.exists('/local/test-bucket/metadata/a'))
+
+  def test_sign_upload_url(self):
+    """Tests sign_upload_url."""
+    # The remote_path passed is actually a filesystem path.
+    url = 'gs://test-bucket/upload'
+    return self.assertEqual(
+        self.provider.sign_upload_url(url), '/local/test-bucket/objects/upload')
+
+  def test_sign_download_url(self):
+    """Tests sign_download_url."""
+    # The remote_path passed is actually a filesystem path.
+    url = 'gs://test-bucket/download'
+    return self.assertEqual(
+        self.provider.sign_download_url(url),
+        '/local/test-bucket/objects/download')
+
+  def test_download_signed_url(self):
+    """Tests download_signed_url."""
+    contents = b'aa'
+    self.fs.create_file('/local/test-bucket/objects/a', contents=contents)
+    return self.assertEqual(
+        self.provider.download_signed_url('gs://test-bucket/a'), contents)
+
+  def test_upload_signed_url(self):
+    """Tests upload_signed_url."""
+    contents = b'aa'
+    self.fs.create_file('/local/test-bucket/objects/a', contents=contents)
+    self.provider.upload_signed_url(contents, 'gs://test-bucket/a')
+    with open('/local/test-bucket/objects/a', 'rb') as fp:
+      return self.assertEqual(fp.read(), contents)

--- a/src/clusterfuzz/_internal/tests/core/google_cloud_utils/storage_test.py
+++ b/src/clusterfuzz/_internal/tests/core/google_cloud_utils/storage_test.py
@@ -263,14 +263,12 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
 
   def test_sign_upload_url(self):
     """Tests sign_upload_url."""
-    # The remote_path passed is actually a filesystem path.
     url = 'gs://test-bucket/upload'
     return self.assertEqual(
         self.provider.sign_upload_url(url), '/local/test-bucket/objects/upload')
 
   def test_sign_download_url(self):
     """Tests sign_download_url."""
-    # The remote_path passed is actually a filesystem path.
     url = 'gs://test-bucket/download'
     return self.assertEqual(
         self.provider.sign_download_url(url),


### PR DESCRIPTION
Add functionality for creating signed upload and download URLs and using them, both for the filesystem and GCS storage implementations. Add tests.
For now this is a non-functional change.

Related: https://github.com/google/clusterfuzz/issues/3008