### PR TITLE
[rearchitecture] Fix run_bot/butler

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -55,7 +55,7 @@ def _setup_args_for_remote(parser):
       '-i',
       '--instance-name',
       required=True,
-      help=('The instance name (e.g. clusterfuzz-linux-0005).'))
+      help='The instance name (e.g. clusterfuzz-linux-0005).')
   parser.add_argument('--project', help='The Project ID.')
   parser.add_argument('--zone', help='The Project Zone.')
 
@@ -211,11 +211,11 @@ def main():
       'running normally.')
 
   parser_remote = subparsers.add_parser(
-      'remote', help=('Run command-line tasks on a remote bot.'))
+      'remote', help='Run command-line tasks on a remote bot.')
   _setup_args_for_remote(parser_remote)
 
   parser_clean_indexes = subparsers.add_parser(
-      'clean_indexes', help=('Clean up undefined indexes (in index.yaml).'))
+      'clean_indexes', help='Clean up undefined indexes (in index.yaml).')
   parser_clean_indexes.add_argument(
       '-c', '--config-dir', required=True, help='Path to application config.')
 
@@ -252,7 +252,7 @@ def main():
   args = parser.parse_args()
   if not args.command:
     parser.print_help()
-    return
+    return 0
 
   _setup()
   command = importlib.import_module(f'local.butler.{args.command}')

--- a/butler.py
+++ b/butler.py
@@ -256,7 +256,7 @@ def main():
 
   _setup()
   command = importlib.import_module(f'local.butler.{args.command}')
-  command.execute(args)
+  return command.execute(args)
 
 
 def _setup():
@@ -270,4 +270,4 @@ def _setup():
 
 
 if __name__ == '__main__':
-  main()
+  sys.exit(main())

--- a/src/local/butler/run_bot.py
+++ b/src/local/butler/run_bot.py
@@ -111,6 +111,7 @@ def execute(args):
   _setup_bot_directory(args)
   _setup_environment_and_configs(args, appengine_path)
 
+  exit_code = 0
   try:
     os.chdir(os.path.join(args.directory, 'clusterfuzz'))
     proc = common.execute_async('python src/python/bot/startup/run_bot.py')
@@ -122,5 +123,8 @@ def execute(args):
     signal.signal(signal.SIGTERM, _stop_handler)
     common.process_proc_output(proc)
     proc.wait()
+    exit_code = proc.wait()
   except KeyboardInterrupt:
     _stop_handler()
+    # exit_code should be 0 when Ctrl-Ced.
+  return exit_code

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -194,6 +194,8 @@ if __name__ == '__main__':
     exit_code = 0
   except Exception:
     traceback.print_exc()
+    sys.stdout.flush()
+    sys.stderr.flush()
     exit_code = 1
 
   monitor.stop()

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -95,7 +95,7 @@ def task_loop():
           commands.process_command(task)
     except SystemExit as e:
       exception_occurred = True
-      clean_exit = (e.code == 0)
+      clean_exit = e.code == 0
       if not clean_exit and not isinstance(e, untrusted.HostException):
         logs.log_error('SystemExit occurred while working on task.')
 


### PR DESCRIPTION
Print stacktraces properly.
Propogate errors so that butler command
fails when run_bot and other commands fails.
Related: #3008