### PR TITLE
Improve centipede's tests

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
@@ -154,7 +154,7 @@ class IntegrationTest(unittest.TestCase):
     testcase_path = setup_testcase('oom', self.test_paths)
     existing_runner_flags = os.environ.get('CENTIPEDE_RUNNER_FLAGS')
     # For testing oom only.
-    os.environ['CENTIPEDE_RUNNER_FLAGS'] = (f':rss_limit_mb={_RSS_LIMIT_TEST}:')
+    os.environ['CENTIPEDE_RUNNER_FLAGS'] = f':rss_limit_mb={_RSS_LIMIT_TEST}:'
     self._test_reproduce(constants.OUT_OF_MEMORY_REGEX, testcase_path)
     if existing_runner_flags:
       os.environ['CENTIPEDE_RUNNER_FLAGS'] = existing_runner_flags


### PR DESCRIPTION
Previously centipede's tests write to the source repo, hoping that they can undo it after running.
This is an incorrect assumption, as Ctrl-C or exceptions can prevent this from happening, leading to
modifications being made to the repo during development (I noticed this after centipede and centipede-old kept being modified according to git :-)
Replace it with temporary directories that wont replace tracked files or add files to tracked directories (which makes it impossible to deploy).