### PR TITLE
Log output to ADB commands when pushing large files to avoid 'file no…

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -82,13 +82,13 @@ def copy_local_directory_to_remote(local_directory, remote_directory):
   """Copies local directory contents to a device directory."""
   create_directory_if_needed(remote_directory)
   if os.listdir(local_directory):
-    run_command(['push', '%s/.' % local_directory, remote_directory])
+    run_command(['push', '%s/.' % local_directory, remote_directory], True, True)
 
 
 def copy_local_file_to_remote(local_file_path, remote_file_path):
   """Copies local file to a device file."""
   create_directory_if_needed(os.path.dirname(remote_file_path))
-  run_command(['push', local_file_path, remote_file_path])
+  run_command(['push', local_file_path, remote_file_path], True, True)
 
 
 def copy_remote_directory_to_local(remote_directory, local_directory):

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -82,15 +82,14 @@ def copy_local_directory_to_remote(local_directory, remote_directory):
   """Copies local directory contents to a device directory."""
   create_directory_if_needed(remote_directory)
   if os.listdir(local_directory):
-    run_command(['push', '%s/.' % local_directory, remote_directory],
-                True, True)
+    run_command(['push', '%s/.' % local_directory, remote_directory], True,
+                True)
 
 
 def copy_local_file_to_remote(local_file_path, remote_file_path):
   """Copies local file to a device file."""
   create_directory_if_needed(os.path.dirname(remote_file_path))
-  run_command(['push', local_file_path, remote_file_path],
-              True,True)
+  run_command(['push', local_file_path, remote_file_path], True, True)
 
 
 def copy_remote_directory_to_local(remote_directory, local_directory):

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -82,13 +82,15 @@ def copy_local_directory_to_remote(local_directory, remote_directory):
   """Copies local directory contents to a device directory."""
   create_directory_if_needed(remote_directory)
   if os.listdir(local_directory):
-    run_command(['push', '%s/.' % local_directory, remote_directory], True, True)
+    run_command(['push', '%s/.' % local_directory, remote_directory],
+                True, True)
 
 
 def copy_local_file_to_remote(local_file_path, remote_file_path):
   """Copies local file to a device file."""
   create_directory_if_needed(os.path.dirname(remote_file_path))
-  run_command(['push', local_file_path, remote_file_path], True, True)
+  run_command(['push', local_file_path, remote_file_path],
+              True,True)
 
 
 def copy_remote_directory_to_local(remote_directory, local_directory):


### PR DESCRIPTION
…t found' race condition

Many of our bots are failing to execute commands because of a 'file not found' error (below). Adding this flag causes the command to be synchronous and therefore the files will copy over fully before the device calls fuzzer executable.

```
Command: /usr/local/google/mobileharness/mh_res_files/devtools/mobileharness/platform/android/sdktool/binary/platform-tools/adb shell LD_LIBRARY_PATH=/data/fuzz/bot/builds/android-haiku_target_hwasan_libosi_fuzz_buffer_77651789446b3c3a04b9f492ff141f003d437347/revisions/lib:/system/lib64:/system/lib64 HWASAN_OPTIONS=alloc_dealloc_mismatch=0:allocator_may_return_null=1:allow_user_segv_handler=1:check_malloc_usable_size=0:detect_container_overflow=0:detect_leaks=1:detect_odr_violation=0:detect_stack_use_after_return=1:fast_unwind_on_fatal=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:max_uar_stack_size_log=16:print_scariness=1:print_summary=1:print_suppressions=0:redzone=128:strict_memcmp=0:symbolize=0:use_sigaltstack=1 UBSAN_OPTIONS=halt_on_error=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:print_stacktrace=1:print_summary=1:print_suppressions=0:silence_unsigned_overflow=1:use_sigaltstack=1 /data/fuzz/bot/builds/android-haiku_target_hwasan_libosi_fuzz_buffer_77651789446b3c3a04b9f492ff141f003d437347/revisions/libosi_fuzz_buffer -timeout=25 -rss_limit_mb=2560 -artifact_prefix=/data/fuzz/bot/inputs/fuzzer-testcases/ -max_total_time=3000 -print_final_stats=1 /data/fuzz/bot/inputs/fuzzer-testcases-disk/temp-3750393/new /data/fuzz/bot/inputs/data-bundles/android_libosi_fuzz_buffer
Time ran: 0.029541492462158203

/system/bin/sh: /data/fuzz/bot/builds/android-haiku_target_hwasan_libosi_fuzz_buffer_77651789446b3c3a04b9f492ff141f003d437347/revisions/libosi_fuzz_buffer: No such file or directory
```