### PR TITLE
Improve docker images to make CI faster.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -78,7 +78,8 @@ COPY --from=xenial \
 RUN curl -sS https://releases.nixos.org/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2 | tar -C /tmp -xj && \
     cd /tmp/patchelf-*/ && \
     ./configure --prefix=/usr && \
-    make install
+    make install && \
+    rm -rf /tmp/patchelf-*
 
 # Install OpenJDK 15 for Jazzer (Java fuzzer).
 # Copied from gcr.io/oss-fuzz-base/base-runner.
@@ -96,7 +97,7 @@ RUN curl -sS https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz | tar -C /
     cd /tmp/Python-3.7.7 && \
     ./configure --enable-optimizations --enable-loadable-sqlite-extensions && make altinstall && \
     rm -rf /tmp/Python-3.7.7
-RUN pip3.7 install pipenv==2022.8.5
+RUN pip3.7 --no-cache-dir install pipenv==2022.8.5
 
 # Install Node.js
 COPY setup_19.x /data
@@ -145,9 +146,7 @@ COPY setup_common.sh setup_clusterfuzz.sh setup_nfs.sh start_clusterfuzz.sh setu
 RUN cd /data && \
     # Make pip3.7 the default so that pipenv install --system works.
     mv /usr/local/bin/pip3.7 /usr/local/bin/pip && \
-    pipenv install --deploy --system && \
-    # Install tensorflow here as it's not included in the Pipfile due to
-    # strict python version requirements.
-    pip install tensorflow==2.3.0
+    pipenv install --deploy --system
+
 CMD ["bash", "-ex", "/data/start.sh"]
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -55,3 +55,13 @@ RUN chmod a+rx /usr/local/bin/*
 
 # The ClusterFuzz checkout is typically mounted in with a different owner UID.
 RUN git config --global --add safe.directory /workspace
+
+ENV PIPENV_CACHE_DIR /.pipenv-cache
+
+# Make installs faster in CI.
+RUN git clone https://github.com/google/clusterfuzz --depth 1 && \
+    cd clusterfuzz && \
+    export PIPENV_VENV_IN_PROJECT=1 && \
+    pipenv sync --dev --python=python3.7 && \
+    cd - && \
+    rm -rf clusterfuzz


### PR DESCRIPTION
1. Don't waste space so we don't have to spend time pulling.
2. Preinstall python deps.