### PR TITLE
Remove return value from setup_testcase

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/analyze_task.py
@@ -108,7 +108,7 @@ def setup_testcase_and_build(testcase, metadata, job_type, testcase_id):
   """Sets up the |testcase| and builds. Returns the path to the testcase on
   success, None on error."""
   # Set up testcase and get absolute testcase path.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
+  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return None
 

--- a/src/clusterfuzz/_internal/bot/tasks/impact_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/impact_task.py
@@ -405,7 +405,7 @@ def execute_task(testcase_id, job_type):
     return
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
+  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return
 

--- a/src/clusterfuzz/_internal/bot/tasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/minimize_task.py
@@ -366,7 +366,7 @@ def execute_task(testcase_id, job_type):
   # Setup testcase and its dependencies. Also, allow setting up a different
   # fuzzer.
   minimize_fuzzer_override = environment.get_value('MINIMIZE_FUZZER_OVERRIDE')
-  file_list, input_directory, testcase_file_path = setup.setup_testcase(
+  file_list, testcase_file_path = setup.setup_testcase(
       testcase, job_type, fuzzer_override=minimize_fuzzer_override)
   if not file_list:
     return
@@ -422,6 +422,7 @@ def execute_task(testcase_id, job_type):
     required_arguments = '%s %s' % (required_arguments,
                                     additional_required_arguments)
 
+  input_directory = environment.get_value('FUZZ_INPUTS')
   test_runner = TestRunner(testcase, testcase_file_path, file_list,
                            input_directory, app_arguments, required_arguments,
                            max_threads, deadline)

--- a/src/clusterfuzz/_internal/bot/tasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/progression_task.py
@@ -232,7 +232,7 @@ def find_fixed_range(testcase_id, job_type):
     return
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
+  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return
 

--- a/src/clusterfuzz/_internal/bot/tasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/regression_task.py
@@ -268,7 +268,7 @@ def find_regression_range(testcase_id, job_type):
       testcase, testcase_file_path, job_type, max_revision, should_log=False)
   if not crashes_in_max_revision:
     testcase = data_handler.get_testcase_by_id(testcase_id)
-    error_message = ('Known crash revision %d did not crash' % max_revision)
+    error_message = f'Known crash revision {max_revision} did not crash'
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                          error_message)
     task_creation.mark_unreproducible_if_flaky(testcase, True)

--- a/src/clusterfuzz/_internal/bot/tasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/regression_task.py
@@ -226,7 +226,7 @@ def find_regression_range(testcase_id, job_type):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
+  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     testcase = data_handler.get_testcase_by_id(testcase_id)
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -214,24 +214,24 @@ def setup_testcase(testcase,
       error_message = 'Fuzzer %s no longer exists' % fuzzer_name
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
-      return None, None, None
+      return None, None
 
     if not update_successful:
       error_message = 'Unable to setup fuzzer %s' % fuzzer_name
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
       handle_setup_testcase_error(testcase, task_name, testcase_id, job_type)
-      return None, None, None
+      return None, None
 
   # Extract the testcase and any of its resources to the input directory.
-  file_list, input_directory, testcase_file_path = unpack_testcase(
+  file_list, testcase_file_path = unpack_testcase(
       testcase, testcase_download_url)
   if not file_list:
     error_message = 'Unable to setup testcase %s' % testcase_file_path
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                          error_message)
     handle_setup_testcase_error(testcase, task_name, testcase_id, job_type)
-    return None, None, None
+    return None, None
 
   # For Android/Fuchsia, we need to sync our local testcases directory with the
   # one on the device.
@@ -251,7 +251,7 @@ def setup_testcase(testcase,
 
   prepare_environment_for_testcase(testcase, job_type, task_name)
 
-  return file_list, input_directory, testcase_file_path
+  return file_list, testcase_file_path
 
 
 def _get_testcase_file_and_path(testcase):
@@ -335,7 +335,7 @@ def unpack_testcase(testcase, testcase_download_url=None):
     temp_filename = testcase_file_path
 
   if not download_testcase(key, testcase_download_url, temp_filename):
-    return None, input_directory, testcase_file_path
+    return None, testcase_file_path
 
   file_list = []
   if archived:
@@ -354,11 +354,11 @@ def unpack_testcase(testcase, testcase_download_url=None):
           'Expected file to run %s is not in archive. Base directory is %s and '
           'files in archive are [%s].' % (testcase_file_path, input_directory,
                                           ','.join(file_list)))
-      return None, input_directory, testcase_file_path
+      return None, testcase_file_path
   else:
     file_list.append(testcase_file_path)
 
-  return file_list, input_directory, testcase_file_path
+  return file_list, testcase_file_path
 
 
 def _get_data_bundle_update_lock_name(data_bundle_name):

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -51,7 +51,8 @@ def _set_timeout_value_from_user_upload(testcase_id, metadata):
   """Get the timeout associated with this testcase."""
   if metadata is None:
     metadata = data_types.TestcaseUploadMetadata.query(
-        data_types.TestcaseUploadMetadata.testcase_id == int(testcase_id)).get()
+        data_types.TestcaseUploadMetadata.testcase_id == int(
+            testcase_id)).get()
   if metadata and metadata.timeout:
     environment.set_value('TEST_TIMEOUT', metadata.timeout)
 
@@ -172,12 +173,9 @@ def prepare_environment_for_testcase(testcase, job_type, task_name):
     environment.set_value('APP_ARGS', app_args)
 
 
-
-def handle_setup_testcase_error(error, testcase, task_name, testcase_id, job_type):
-  del error
+def handle_setup_testcase_error(task_name, testcase_id, job_type):
   testcase_fail_wait = environment.get_value('FAIL_WAIT')
-  tasks.add_task(
-        task_name, testcase_id, job_type, wait_time=testcase_fail_wait)
+  tasks.add_task(task_name, testcase_id, job_type, wait_time=testcase_fail_wait)
 
 
 def setup_testcase(testcase,
@@ -220,17 +218,17 @@ def setup_testcase(testcase,
       error_message = 'Unable to setup fuzzer %s' % fuzzer_name
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
-      handle_setup_testcase_error(testcase, task_name, testcase_id, job_type)
+      handle_setup_testcase_error(task_name, testcase_id, job_type)
       return None, None
 
   # Extract the testcase and any of its resources to the input directory.
-  file_list, testcase_file_path = unpack_testcase(
-      testcase, testcase_download_url)
+  file_list, testcase_file_path = unpack_testcase(testcase,
+                                                  testcase_download_url)
   if not file_list:
     error_message = 'Unable to setup testcase %s' % testcase_file_path
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                          error_message)
-    handle_setup_testcase_error(testcase, task_name, testcase_id, job_type)
+    handle_setup_testcase_error(task_name, testcase_id, job_type)
     return None, None
 
   # For Android/Fuchsia, we need to sync our local testcases directory with the

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -47,7 +47,7 @@ _SYNC_FILENAME = '.sync'
 _TESTCASE_ARCHIVE_EXTENSION = '.zip'
 
 
- def _set_timeout_value_from_user_upload(testcase_id, metadata):
+def _set_timeout_value_from_user_upload(testcase_id, metadata):
   """Get the timeout associated with this testcase."""
   if metadata is None:
     metadata = data_types.TestcaseUploadMetadata.query(

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -47,10 +47,11 @@ _SYNC_FILENAME = '.sync'
 _TESTCASE_ARCHIVE_EXTENSION = '.zip'
 
 
- def _set_timeout_value_from_user_upload(testcase_id):
+ def _set_timeout_value_from_user_upload(testcase_id, metadata):
   """Get the timeout associated with this testcase."""
-  metadata = data_types.TestcaseUploadMetadata.query(
-      data_types.TestcaseUploadMetadata.testcase_id == int(testcase_id)).get()
+  if metadata is None:
+    metadata = data_types.TestcaseUploadMetadata.query(
+        data_types.TestcaseUploadMetadata.testcase_id == int(testcase_id)).get()
   if metadata and metadata.timeout:
     environment.set_value('TEST_TIMEOUT', metadata.timeout)
 
@@ -182,7 +183,8 @@ def handle_setup_testcase_error(error, testcase, task_name, testcase_id, job_typ
 def setup_testcase(testcase,
                    job_type,
                    fuzzer_override=None,
-                   testcase_download_url=None):
+                   testcase_download_url=None,
+                   metadata=None):
   """Sets up the testcase and needed dependencies like fuzzer,
   data bundle, etc."""
   fuzzer_name = fuzzer_override or testcase.fuzzer_name
@@ -195,7 +197,7 @@ def setup_testcase(testcase,
   # Adjust the test timeout value if this is coming from an user uploaded
   # testcase.
   if testcase.uploader_email:
-    _set_timeout_value_from_user_upload(testcase_id)
+    _set_timeout_value_from_user_upload(testcase_id, metadata)
 
   # Update the fuzzer if necessary in order to get the updated data bundle.
   if fuzzer_name:

--- a/src/clusterfuzz/_internal/bot/tasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/symbolize_task.py
@@ -48,7 +48,7 @@ def execute_task(testcase_id, job_type):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
+  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return
 

--- a/src/clusterfuzz/_internal/bot/tasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/variant_task.py
@@ -72,7 +72,7 @@ def execute_task(testcase_id, job_type):
   testcase = _get_variant_testcase_for_job(testcase, job_type)
 
   # Setup testcase and its dependencies.
-  file_list, _, testcase_file_path = setup.setup_testcase(testcase, job_type)
+  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
   if not file_list:
     return
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
@@ -145,7 +145,7 @@ class ExecuteTaskTest(unittest.TestCase):
   def test_bail_out_setup_testcase(self):
     """Test bailing out when setting up testcase fails."""
     self.mock.has_production_builds.return_value = True
-    self.mock.setup_testcase.return_value = ([], None, 'path')
+    self.mock.setup_testcase.return_value = ([], 'path')
     impact_task.execute_task(self.testcase.key.id(), 'job')
     self.expect_unchanged()
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
@@ -50,7 +50,7 @@ class ExecuteTaskTest(unittest.TestCase):
     self.mock.is_custom_binary.return_value = False
     self.mock.has_production_builds.return_value = True
     self.mock.get_impacts_from_url.return_value = impacts
-    self.mock.setup_testcase.return_value = (['a'], None, 'path')
+    self.mock.setup_testcase.return_value = (['a'], 'path')
     self.mock.get_impacts_on_prod_builds.return_value = impacts
 
     self.testcase = data_types.Testcase()

--- a/src/clusterfuzz/_internal/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/untrusted_runner/untrusted_runner_integration_test.py
@@ -426,13 +426,11 @@ class UntrustedRunnerIntegrationTest(
 
     testcase.put()
 
-    file_list, input_directory, testcase_file_path = (
-        setup.setup_testcase(testcase, job_type))
+    file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
 
     self.assertCountEqual(file_list, [
         testcase.absolute_path,
     ])
-    self.assertEqual(input_directory, fuzz_inputs)
     self.assertEqual(testcase_file_path, testcase.absolute_path)
 
     worker_fuzz_inputs = file_host.rebase_to_worker_root(fuzz_inputs)

--- a/src/python/other-bots/chromium-tests-syncer/run.py
+++ b/src/python/other-bots/chromium-tests-syncer/run.py
@@ -82,7 +82,7 @@ def unpack_crash_testcases(crash_testcases_directory):
 
     # Un-pack testcase.
     try:
-      _, input_directory, _ = setup.unpack_testcase(testcase)
+      setup.unpack_testcase(testcase)
     except Exception:
       logs.log_error('Failed to unpack testcase %d.' % testcase.key.id())
       continue
@@ -90,6 +90,7 @@ def unpack_crash_testcases(crash_testcases_directory):
     # Move this to our crash testcases directory.
     crash_testcase_directory = os.path.join(crash_testcases_directory,
                                             str(testcase_id))
+    input_directory = environment.get_value('FUZZ_INPUTS')
     shell.move(input_directory, crash_testcase_directory)
 
     # Re-create input directory for unpacking testcase in next iteration.

--- a/src/python/other-bots/chromium-tests-syncer/run.py
+++ b/src/python/other-bots/chromium-tests-syncer/run.py
@@ -39,6 +39,8 @@ from clusterfuzz._internal.system import shell
 MAX_TESTCASE_DIRECTORY_SIZE = 10 * 1024 * 1024  # in bytes.
 STORED_TESTCASES_LIST = []
 
+# pylint: disable=broad-exception-raised
+
 
 def unpack_crash_testcases(crash_testcases_directory):
   """Unpacks the old crash testcases in the provided directory."""


### PR DESCRIPTION
It's unneeded by 90% of callers and can be obtained through alternative
means.