### PR TITLE
[consolidation] Handle errors in a structured way.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/impact_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/impact_task.py
@@ -18,6 +18,7 @@ from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.tasks import setup
+from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
 from clusterfuzz._internal.build_management import build_manager
 from clusterfuzz._internal.build_management import revisions
 from clusterfuzz._internal.chrome import build_info
@@ -405,10 +406,9 @@ def execute_task(testcase_id, job_type):
     return
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path, retry_task = setup.setup_testcase(
-      testcase, job_type)
-  if retry_task:
-    setup.retry_task(testcase_id, job_type)
+  _, testcase_file_path, error = setup.setup_testcase(testcase, job_type)
+  if error:
+    uworker_handle_errors.handle(error)
     return
 
   # Setup extended stable, stable, beta builds

--- a/src/clusterfuzz/_internal/bot/tasks/impact_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/impact_task.py
@@ -405,8 +405,10 @@ def execute_task(testcase_id, job_type):
     return
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
-  if not file_list:
+  file_list, testcase_file_path, retry_task = setup.setup_testcase(
+      testcase, job_type)
+  if retry_task:
+    setup.retry_task(testcase_id, job_type)
     return
 
   # Setup extended stable, stable, beta builds

--- a/src/clusterfuzz/_internal/bot/tasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/minimize_task.py
@@ -35,6 +35,7 @@ from clusterfuzz._internal.bot.minimizer import js_minimizer
 from clusterfuzz._internal.bot.minimizer import minimizer
 from clusterfuzz._internal.bot.tasks import setup
 from clusterfuzz._internal.bot.tasks import task_creation
+from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
 from clusterfuzz._internal.bot.tokenizer.antlr_tokenizer import AntlrTokenizer
 from clusterfuzz._internal.bot.tokenizer.grammars.JavaScriptLexer import \
     JavaScriptLexer
@@ -366,10 +367,10 @@ def execute_task(testcase_id, job_type):
   # Setup testcase and its dependencies. Also, allow setting up a different
   # fuzzer.
   minimize_fuzzer_override = environment.get_value('MINIMIZE_FUZZER_OVERRIDE')
-  file_list, testcase_file_path, retry_task = setup.setup_testcase(
+  file_list, testcase_file_path, error = setup.setup_testcase(
       testcase, job_type, fuzzer_override=minimize_fuzzer_override)
-  if retry_task:
-    setup.retry_task(testcase_id, job_type)
+  if error:
+    uworker_handle_errors.handle(error)
     return
 
   # Initialize variables.

--- a/src/clusterfuzz/_internal/bot/tasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/minimize_task.py
@@ -366,9 +366,10 @@ def execute_task(testcase_id, job_type):
   # Setup testcase and its dependencies. Also, allow setting up a different
   # fuzzer.
   minimize_fuzzer_override = environment.get_value('MINIMIZE_FUZZER_OVERRIDE')
-  file_list, testcase_file_path = setup.setup_testcase(
+  file_list, testcase_file_path, retry_task = setup.setup_testcase(
       testcase, job_type, fuzzer_override=minimize_fuzzer_override)
-  if not file_list:
+  if retry_task:
+    setup.retry_task(testcase_id, job_type)
     return
 
   # Initialize variables.

--- a/src/clusterfuzz/_internal/bot/tasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/progression_task.py
@@ -250,7 +250,7 @@ def find_fixed_range(testcase_id, job_type):
   revision_list = build_manager.get_revisions_list(
       build_bucket_path, testcase=testcase)
   if not revision_list:
-    data_handler.close_testcase_with_error(testcase_id,
+    data_handler.close_testcase_with_error(testcase,
                                            'Failed to fetch revision list')
     return
 

--- a/src/clusterfuzz/_internal/bot/tasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/progression_task.py
@@ -24,6 +24,7 @@ from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.fuzzers import engine_common
 from clusterfuzz._internal.bot.tasks import setup
 from clusterfuzz._internal.bot.tasks import task_creation
+from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
 from clusterfuzz._internal.build_management import build_manager
 from clusterfuzz._internal.build_management import revisions
 from clusterfuzz._internal.chrome import crash_uploader
@@ -232,10 +233,9 @@ def find_fixed_range(testcase_id, job_type):
     return
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path, retry_task = setup.setup_testcase(
-      testcase, job_type)
-  if retry_task:
-    setup.retry_task(testcase_id, job_type)
+  _, testcase_file_path, error = setup.setup_testcase(testcase, job_type)
+  if error:
+    uworker_handle_errors.handle(error)
     return
 
   # Set a flag to indicate we are running progression task. This shows pending

--- a/src/clusterfuzz/_internal/bot/tasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/progression_task.py
@@ -232,8 +232,10 @@ def find_fixed_range(testcase_id, job_type):
     return
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
-  if not file_list:
+  file_list, testcase_file_path, retry_task = setup.setup_testcase(
+      testcase, job_type)
+  if retry_task:
+    setup.retry_task(testcase_id, job_type)
     return
 
   # Set a flag to indicate we are running progression task. This shows pending

--- a/src/clusterfuzz/_internal/bot/tasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/regression_task.py
@@ -22,6 +22,7 @@ from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.tasks import setup
 from clusterfuzz._internal.bot.tasks import task_creation
+from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
 from clusterfuzz._internal.build_management import build_manager
 from clusterfuzz._internal.build_management import revisions
 from clusterfuzz._internal.datastore import data_handler
@@ -226,10 +227,9 @@ def find_regression_range(testcase_id, job_type):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path, retry_task = setup.setup_testcase(
-      testcase, job_type)
-  if retry_task:
-    setup.retry_task(testcase_id, job_type)
+  _, testcase_file_path, error = setup.setup_testcase(testcase, job_type)
+  if error:
+    uworker_handle_errors.handle(error)
     return
 
   build_bucket_path = build_manager.get_primary_bucket_path()

--- a/src/clusterfuzz/_internal/bot/tasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/regression_task.py
@@ -238,7 +238,7 @@ def find_regression_range(testcase_id, job_type):
   revision_list = build_manager.get_revisions_list(
       build_bucket_path, testcase=testcase)
   if not revision_list:
-    data_handler.close_testcase_with_error(testcase_id,
+    data_handler.close_testcase_with_error(testcase,
                                            'Failed to fetch revision list')
     return
 

--- a/src/clusterfuzz/_internal/bot/tasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/regression_task.py
@@ -226,12 +226,10 @@ def find_regression_range(testcase_id, job_type):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
-  if not file_list:
-    testcase = data_handler.get_testcase_by_id(testcase_id)
-    data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
-                                         'Failed to setup testcase')
-    tasks.add_task('regression', testcase_id, job_type)
+  file_list, testcase_file_path, retry_task = setup.setup_testcase(
+      testcase, job_type)
+  if retry_task:
+    setup.retry_task(testcase_id, job_type)
     return
 
   build_bucket_path = build_manager.get_primary_bucket_path()

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -24,6 +24,7 @@ from clusterfuzz._internal.base import errors
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager
+from clusterfuzz._internal.bot.tasks.utasks import uworker_errors
 from clusterfuzz._internal.build_management import revisions
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
@@ -173,11 +174,13 @@ def prepare_environment_for_testcase(testcase, job_type, task_name):
     environment.set_value('APP_ARGS', app_args)
 
 
-def retry_task(testcase_id, job_type):
+def handle_testcase_setup_error(error):
   task_name = environment.get_value('TASK_NAME')
   testcase_fail_wait = environment.get_value('FAIL_WAIT')
   tasks.add_task(
-      task_name, output.testcase_id, output.job_type,
+      task_name,
+      error.testcase_id,
+      error.job_type,
       wait_time=testcase_fail_wait)
 
 
@@ -204,6 +207,7 @@ def setup_testcase(testcase,
     try:
       update_successful = update_fuzzer_and_data_bundles(fuzzer_name)
     except errors.InvalidFuzzerError:
+      # Don't need to use an error handler here.
       # Close testcase and don't recreate tasks if this fuzzer is invalid.
       testcase.open = False
       testcase.fixed = 'NA'
@@ -214,13 +218,16 @@ def setup_testcase(testcase,
       error_message = 'Fuzzer %s no longer exists' % fuzzer_name
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
-      return None, None
+      return None, None, None
 
     if not update_successful:
       error_message = 'Unable to setup fuzzer %s' % fuzzer_name
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
-      return None, None, True
+      return None, None, uworker_errors.Error(
+          uworker_errors.Type.TESTCASE_SETUP,
+          job_type=job_type,
+          testcase_id=testcase_id)
 
   # Extract the testcase and any of its resources to the input directory.
   file_list, testcase_file_path = unpack_testcase(testcase,
@@ -229,7 +236,10 @@ def setup_testcase(testcase,
     error_message = 'Unable to setup testcase %s' % testcase_file_path
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                          error_message)
-    return None, None, True
+    return None, None, uworker_errors.Error(
+        uworker_errors.Type.TESTCASE_SETUP,
+        job_type=job_type,
+        testcase_id=testcase_id)
 
   # For Android/Fuchsia, we need to sync our local testcases directory with the
   # one on the device.
@@ -247,9 +257,10 @@ def setup_testcase(testcase,
     # Get local blacklist without this testcase's entry.
     leak_blacklist.copy_global_to_local_blacklist(excluded_testcase=testcase)
 
+  task_name = environment.get_value('TASK_NAME')
   prepare_environment_for_testcase(testcase, job_type, task_name)
 
-  return file_list, testcase_file_path
+  return file_list, testcase_file_path, None
 
 
 def _get_testcase_file_and_path(testcase):
@@ -569,6 +580,8 @@ def update_fuzzer_and_data_bundles(fuzzer_name):
   _clear_old_data_bundles_if_needed()
 
   # Setup data bundles associated with this fuzzer.
+  # TODO(https://github.com/google/clusterfuzz/issues/3008): Move this to a
+  # seperate function.
   data_bundles = ndb_utils.get_all_from_query(
       data_types.DataBundle.query(
           data_types.DataBundle.name == fuzzer.data_bundle_name))

--- a/src/clusterfuzz/_internal/bot/tasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/symbolize_task.py
@@ -48,8 +48,10 @@ def execute_task(testcase_id, job_type):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
-  if not file_list:
+  file_list, testcase_file_path, retry_task = setup.setup_testcase(
+      testcase, job_type)
+  if retry_task:
+    setup.retry_task(testcase_id, job_type)
     return
 
   # Initialize variables.

--- a/src/clusterfuzz/_internal/bot/tasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/symbolize_task.py
@@ -21,6 +21,7 @@ from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.tasks import setup
 from clusterfuzz._internal.bot.tasks import task_creation
+from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
 from clusterfuzz._internal.build_management import build_manager
 from clusterfuzz._internal.crash_analysis import crash_analyzer
 from clusterfuzz._internal.crash_analysis.crash_result import CrashResult
@@ -48,10 +49,9 @@ def execute_task(testcase_id, job_type):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path, retry_task = setup.setup_testcase(
-      testcase, job_type)
-  if retry_task:
-    setup.retry_task(testcase_id, job_type)
+  _, testcase_file_path, error = setup.setup_testcase(testcase, job_type)
+  if error:
+    uworker_handle_errors.handle(error)
     return
 
   # Initialize variables.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -46,8 +46,8 @@ def uworker_main_no_io(utask_module, uworker_input):
 
 
 def uworker_postprocess_no_io(utask_module, uworker_output):
-  uworker_output_dict = uworker_io.deserialize_uworker_output(
-      utask_module, uworker_output)
+  uworker_output_dict = uworker_io.deserialize_uworker_output(uworker_output)
+
   uworker_output = uworker_io.uworker_output_from_dict(uworker_output_dict)
   utask_module.utask_postprocess(uworker_output)
 
@@ -111,6 +111,6 @@ def tworker_postprocess(utask_module, output_download_url) -> None:
   """Executes the postprocess step on the trusted (t)worker."""
   logs.log('Starting utask_postprocess: %s.' % utask_module)
   uworker_output_dict = uworker_io.download_and_deserialize_uworker_output(
-      utask_module, output_download_url)
+      output_download_url)
   uworker_output = uworker_io.uworker_output_from_dict(uworker_output_dict)
   utask_module.utask_postprocess(uworker_output)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -24,6 +24,8 @@ from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.fuzzers import engine_common
 from clusterfuzz._internal.bot.tasks import setup
 from clusterfuzz._internal.bot.tasks import task_creation
+from clusterfuzz._internal.bot.tasks.utasks import uworker_errors
+from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.build_management import build_manager
 from clusterfuzz._internal.build_management import revisions
@@ -112,11 +114,14 @@ def setup_testcase_and_build(
   """Sets up the |testcase| and builds. Returns the path to the testcase on
   success, None on error."""
   # Set up testcase and get absolute testcase path.
-  file_list, testcase_file_path, retry_task = setup.setup_testcase(
-      testcase, job_type, testcase_download_url=testcase_download_url)
-  if not retry_task:
+  _, testcase_file_path, error = setup.setup_testcase(
+      testcase,
+      job_type,
+      testcase_download_url=testcase_download_url,
+      metadata=metadata)
+  if error:
     return None, uworker_io.UworkerOutput(
-        testcase=testcase, metadata=metadata, error=ErrorType.TESTCASE_SETUP)
+        testcase=testcase, metadata=metadata, error=error)
 
   # Set up build.
   setup_build(testcase)
@@ -126,7 +131,9 @@ def setup_testcase_and_build(
   if not build_manager.check_app_path():
     # Let postprocess handle BUILD_SETUP and restart tasks if needed.
     return None, uworker_io.UworkerOutput(
-        testcase=testcase, metadata=metadata, error=ErrorType.BUILD_SETUP)
+        testcase=testcase,
+        metadata=metadata,
+        error=uworker_errors.Error(uworker_errors.Type.BUILD_SETUP))
 
   testcase.absolute_path = testcase_file_path
   return testcase_file_path, None
@@ -199,31 +206,32 @@ def test_for_crash_with_retries(testcase, testcase_file_path, test_timeout):
   return result, http_flag
 
 
-def handle_noncrash(testcase, metadata, testcase_id, job_type, test_timeout):
+def handle_noncrash(output):
   """Handles a non-crashing testcase. Either deletes the testcase or schedules
   another, final analysis."""
   # Could not reproduce the crash.
   log_message = (
-      f'Testcase didn\'t crash in {test_timeout} seconds (with retries)')
-  data_handler.update_testcase_comment(testcase, data_types.TaskState.FINISHED,
-                                       log_message)
+      f'Testcase didn\'t crash in {output.test_timeout} seconds (with retries)')
+  data_handler.update_testcase_comment(
+      output.testcase, data_types.TaskState.FINISHED, log_message)
 
   # For an unreproducible testcase, retry once on another bot to confirm
   # our results and in case this bot is in a bad state which we didn't catch
   # through our usual means.
-  if data_handler.is_first_retry_for_task(testcase):
-    testcase.status = 'Unreproducible, retrying'
-    testcase.put()
+  if data_handler.is_first_retry_for_task(output.testcase):
+    output.testcase.status = 'Unreproducible, retrying'
+    output.testcase.put()
 
-    tasks.add_task('analyze', testcase_id, job_type)
+    tasks.add_task('analyze', output.uworker_input['testcase_id'],
+                   output.uworker_input['job_type'])
     return
 
-  data_handler.close_invalid_uploaded_testcase(testcase, metadata,
+  data_handler.close_invalid_uploaded_testcase(output.testcase, output.metadata,
                                                'Unreproducible')
 
   # A non-reproducing testcase might still impact production branches.
   # Add the impact task to get that information.
-  task_creation.create_impact_task_if_needed(testcase)
+  task_creation.create_impact_task_if_needed(output.testcase)
 
 
 def update_testcase_after_crash(testcase, state, job_type, http_flag):
@@ -327,7 +335,7 @@ def utask_main(testcase, testcase_id, testcase_download_url, job_type,
     return uworker_io.UworkerOutput(
         testcase,
         metadata=metadata,
-        error=ErrorType.NO_CRASH,
+        error=uworker_errors.Error(uworker_errors.Type.NO_CRASH),
         test_timeout=test_timeout,
         job_type=job_type)
   # Update testcase crash parameters.
@@ -335,8 +343,8 @@ def utask_main(testcase, testcase_id, testcase_download_url, job_type,
 
   # See if we have to ignore this crash.
   if crash_analyzer.ignore_stacktrace(state.crash_stacktrace):
-    return uworker_io.UworkerOutput(
-        testcase=testcase, metadata=metadata, error=ErrorType.IGNORE_STACK)
+    data_handler.close_invalid_uploaded_testcase(output.testcase,
+                                                 output.metadata, 'Irrelavant')
 
   test_for_reproducibility(testcase, testcase_file_path, state, test_timeout)
   return uworker_io.UworkerOutput(
@@ -354,30 +362,16 @@ def test_for_reproducibility(testcase, testcase_file_path, state, test_timeout):
   testcase.one_time_crasher_flag = one_time_crasher_flag
 
 
-def utask_handle_errors(output):
-  """Handles errors that happened in utask_main."""
-  if output.error == ErrorType.BUILD_SETUP:
-    data_handler.update_testcase_comment(
-        output.testcase, data_types.TaskState.ERROR, 'Build setup failed')
+def handle_build_setup_error(output):
+  data_handler.update_testcase_comment(
+      output.testcase, data_types.TaskState.ERROR, 'Build setup failed')
 
-    if data_handler.is_first_retry_for_task(output.testcase):
-      setup.retry_task(
-          output.uworker_input['testcase_id'],
-          output.uworker_input['job_type'])
-    else:
-      data_handler.close_invalid_uploaded_testcase(
-          output.testcase, output.metadata, 'Build setup failed')
-  elif output.error == ErrorType.NO_CRASH:
-    handle_noncrash(output.testcase, output.metadata,
-                    output.uworker_input['testcase_id'],
-                    output.uworker_input['job_type'], output.test_timeout)
-  elif output.error == ErrorType.TESTCASE_SETUP:
-    # Unclear if this state is ever actually reached.
-    setup.retry_task(
-        output.uworker_input['testcase_id'], output.uworker_input['job_type'])
-  elif output.error == ErrorType.IGNORE_STACK:
-    data_handler.close_invalid_uploaded_testcase(output.testcase,
-                                                 output.metadata, 'Irrelavant')
+  if data_handler.is_first_retry_for_task(output.testcase):
+    setup.retry_task(output.uworker_input['testcase_id'],
+                     output.uworker_input['job_type'])
+  else:
+    data_handler.close_invalid_uploaded_testcase(
+        output.testcase, output.metadata, 'Build setup failed)')
 
 
 def utask_postprocess(output):
@@ -387,7 +381,7 @@ def utask_postprocess(output):
   testcase = output.testcase
   metadata = output.metadata
   if output.error:
-    utask_handle_errors(output)
+    uworker_handle_errors(output)
     return
 
   log_message = (f'Testcase crashed in {output.test_timeout} seconds '
@@ -447,4 +441,3 @@ class ErrorType(enum.Enum):
   BUILD_SETUP = 1
   NO_CRASH = 2
   TESTCASE_SETUP = 3
-  IGNORE_STACK = 4

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_errors.py
@@ -14,6 +14,7 @@
 """Module for enumerating errors in utasks."""
 import enum
 
+
 class Type(enum.Enum):
   """Errors during utask_main."""
   ANALYZE_BUILD_SETUP = 1
@@ -21,7 +22,9 @@ class Type(enum.Enum):
   TESTCASE_SETUP = 3
   NO_FUZZER = 4
 
+
 class Error:
+
   def __init__(self, error_type, **kwargs):
     self.error_type = error_type
     assert error_type not in kwargs

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_errors.py
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for enumerating errors in utasks."""
+import enum
+
+class Type(enum.Enum):
+  """Errors during utask_main."""
+  ANALYZE_BUILD_SETUP = 1
+  ANALYZE_NO_CRASH = 2
+  TESTCASE_SETUP = 3
+  NO_FUZZER = 4
+
+class Error:
+  def __init__(self, error_type, **kwargs):
+    self.error_type = error_type
+    assert error_type not in kwargs
+    for key, value in kwargs.items():
+      setattr(self, key, value)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for handling errors in utasks."""
+from clusterfuzz._internal.bot.tasks.utasks import uworker_errors
+from clusterfuzz._internal.bot.tasks.utasks import analyze_task
+from clusterfuzz._internal.bot.tasks import setup
+
+
+def noop(*args, **kwargs):
+  pass
+
+def handle(error_or_output):
+  # TODO(metzman): Once every task supports utasks we can stop handling errors
+  # objects directly and only handle utask output objects.
+  if isinstance(error_or_output, uworker_errors.Error):
+    error_type = error_or_output.type
+  else:
+    error_type = error_or_output.error.type
+  return MAPPING[error_output.type](error_or_output)
+
+
+MAPPING = {
+  uworker_errors.Type.ANALYZE_NO_CRASH: analyze_task.handle_noncrash,
+  uworker_errors.Type.ANALYZE_BUILD_SETUP:
+      analyze_task.handle_build_setup_error,
+  uworker_errors.Type.TESTCASE_SETUP: setup.handle_testcase_setup_error,
+  uworker_errors.Type.NO_FUZZER: noop,
+}

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module for handling errors in utasks."""
-from clusterfuzz._internal.bot.tasks.utasks import uworker_errors
-from clusterfuzz._internal.bot.tasks.utasks import analyze_task
 from clusterfuzz._internal.bot.tasks import setup
+from clusterfuzz._internal.bot.tasks.utasks import analyze_task
+from clusterfuzz._internal.bot.tasks.utasks import uworker_errors
 
 
 def noop(*args, **kwargs):
-  pass
+  del args
+  del kwargs
+
 
 def handle(error_or_output):
   # TODO(metzman): Once every task supports utasks we can stop handling errors
@@ -27,13 +29,16 @@ def handle(error_or_output):
     error_type = error_or_output.type
   else:
     error_type = error_or_output.error.type
-  return MAPPING[error_output.type](error_or_output)
+  return MAPPING[error_type](error_or_output)
 
 
 MAPPING = {
-  uworker_errors.Type.ANALYZE_NO_CRASH: analyze_task.handle_noncrash,
-  uworker_errors.Type.ANALYZE_BUILD_SETUP:
-      analyze_task.handle_build_setup_error,
-  uworker_errors.Type.TESTCASE_SETUP: setup.handle_testcase_setup_error,
-  uworker_errors.Type.NO_FUZZER: noop,
+    uworker_errors.Type.ANALYZE_NO_CRASH:
+        analyze_task.handle_noncrash,
+    uworker_errors.Type.ANALYZE_BUILD_SETUP:
+        analyze_task.handle_build_setup_error,
+    uworker_errors.Type.TESTCASE_SETUP:
+        setup.handle_testcase_setup_error,
+    uworker_errors.Type.NO_FUZZER:
+        noop,
 }

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -251,6 +251,13 @@ class UworkerEntityWrapper:
     # Make the attribute change.
     setattr(self._entity, attribute, value)
 
+  def put(self, *args, **kwargs):
+    """Block put method since wrapped objects can't be written by the
+    uworker."""
+    del args
+    del kwargs
+    logs.log(f'Not putting {self._entity}.')
+
 
 class UworkerOutput:
   """Convenience class for results from uworker_main. This is useful for

--- a/src/clusterfuzz/_internal/bot/tasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/variant_task.py
@@ -17,6 +17,7 @@ from clusterfuzz._internal.base import errors
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.tasks import setup
+from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
 from clusterfuzz._internal.build_management import build_manager
 from clusterfuzz._internal.crash_analysis.crash_comparer import CrashComparer
 from clusterfuzz._internal.datastore import data_handler
@@ -72,9 +73,9 @@ def execute_task(testcase_id, job_type):
   testcase = _get_variant_testcase_for_job(testcase, job_type)
 
   # Setup testcase and its dependencies.
-  file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
-  if retry_task:
-    setup.retry_task(testcase_id, job_type)
+  _, testcase_file_path, error = setup.setup_testcase(testcase, job_type)
+  if error:
+    uworker_handle_errors.handle(error)
     return
 
   # Set up a custom or regular build. We explicitly omit the crash revision

--- a/src/clusterfuzz/_internal/bot/tasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/variant_task.py
@@ -73,7 +73,8 @@ def execute_task(testcase_id, job_type):
 
   # Setup testcase and its dependencies.
   file_list, testcase_file_path = setup.setup_testcase(testcase, job_type)
-  if not file_list:
+  if retry_task:
+    setup.retry_task(testcase_id, job_type)
     return
 
   # Set up a custom or regular build. We explicitly omit the crash revision

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1673,9 +1673,8 @@ def get_coverage_information(fuzzer_name, date, create_if_needed=False):
   return coverage_info
 
 
-def close_testcase_with_error(testcase_id, error_message):
+def close_testcase_with_error(testcase, error_message):
   """Close testcase (fixed=NA) with an error message."""
-  testcase = get_testcase_by_id(testcase_id)
   update_testcase_comment(testcase, data_types.TaskState.ERROR, error_message)
   testcase.fixed = 'NA'
   testcase.open = False

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/impact_task_test.py
@@ -50,7 +50,7 @@ class ExecuteTaskTest(unittest.TestCase):
     self.mock.is_custom_binary.return_value = False
     self.mock.has_production_builds.return_value = True
     self.mock.get_impacts_from_url.return_value = impacts
-    self.mock.setup_testcase.return_value = (['a'], 'path')
+    self.mock.setup_testcase.return_value = (['a'], 'path', None)
     self.mock.get_impacts_on_prod_builds.return_value = impacts
 
     self.testcase = data_types.Testcase()
@@ -145,8 +145,10 @@ class ExecuteTaskTest(unittest.TestCase):
   def test_bail_out_setup_testcase(self):
     """Test bailing out when setting up testcase fails."""
     self.mock.has_production_builds.return_value = True
-    self.mock.setup_testcase.return_value = ([], 'path')
-    impact_task.execute_task(self.testcase.key.id(), 'job')
+    self.mock.setup_testcase.return_value = ([], 'path', True)
+    with mock.patch(
+        'clusterfuzz._internal.bot.tasks.utasks.uworker_handle_errors.handle'):
+      impact_task.execute_task(self.testcase.key.id(), 'job')
     self.expect_unchanged()
 
   def test_build_failed_exception(self):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -118,10 +118,10 @@ class TworkerPostproceessTest(unittest.TestCase):
   def test_tworker_postprocess(self):
     """Tests that tworker_postprocess works as intended."""
     module = mock.MagicMock()
-    module.utask_postrocess.return_value = None
+    module.utask_postprocess.return_value = None
     utasks.tworker_postprocess(module, self.OUTPUT_DOWNLOAD_GCS_URL)
     self.mock.download_and_deserialize_uworker_output.assert_called_with(
-        module, self.OUTPUT_DOWNLOAD_GCS_URL)
+        self.OUTPUT_DOWNLOAD_GCS_URL)
     args = module.utask_postprocess.call_args[0][0]
     self.assertEqual(args.output1, 'something')
     self.assertEqual(args.output2, 'something else')

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -21,7 +21,6 @@ from unittest import mock
 
 from google.cloud import ndb
 
-from clusterfuzz._internal.bot.tasks.utasks import analyze_task
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.tests.test_libs import helpers

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -270,7 +270,7 @@ class RoundTripTest(unittest.TestCase):
 
       with mock.patch(copy_file_from_name, copy_file_from) as _:
         downloaded_output = uworker_io.download_and_deserialize_uworker_output(
-            analyze_task, self.FAKE_URL)
+            self.FAKE_URL)
 
     # Test that the entity (de)serialization and change tracking working.
     downloaded_testcase = downloaded_output.pop('testcase')


### PR DESCRIPTION
Previously, error handling in tasks (such as, retrying a task or closing a testcase), could be done immediately when the error was detected in code. With the rearchitecture, this is no longer possible.
To replace this create a structured method of handling errors, then handle those errors using the new method.
So far only setup_testcase is partially migrated.