### PR TITLE
[unittest] Have centipede_engine_test setup and teardown properly.

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
@@ -53,7 +53,7 @@ def get_test_paths():
 
 
 TEST_PATH = pathlib.Path(__file__).parent
-MAX_TIME = 25
+MAX_TIME = 5
 
 # Centipede's runtime args for testing.
 _SERVER_COUNT = 1
@@ -61,7 +61,7 @@ _RSS_LIMIT = 4096
 _ADDRESS_SPACE_LIMIT = 4096
 _TIMEOUT_PER_INPUT = 25
 _RSS_LIMIT_TEST = 2
-_TIMEOUT_PER_INPUT_TEST = 5  # For testing timeout only.
+_TIMEOUT_PER_INPUT_TEST = 2  # For testing timeout only.
 _DEFAULT_ARGUMENTS = [
     '--exit_on_crash=1',
     f'--fork_server={_SERVER_COUNT}',
@@ -99,16 +99,16 @@ class IntegrationTest(unittest.TestCase):
   """Integration tests."""
 
   def run(self, *args, **kwargs):
-    test_helpers.patch_environ(self)
     with get_test_paths() as test_paths:
       self.test_paths = test_paths
-      os.environ['BUILD_DIR'] = str(self.test_paths.data)
       super().run(*args, **kwargs)
 
   def setUp(self):
     self.maxDiff = None  # pylint: disable=invalid-name
     test_helpers.patch(self, ['os.getpid'])
     self.mock.getpid.return_value = 1337
+    test_helpers.patch_environ(self)
+    os.environ['BUILD_DIR'] = str(self.test_paths.data)
 
   def compare_arguments(self, expected, actual):
     """Compares expected arguments."""


### PR DESCRIPTION
When running unit tests, if the centipede_engine_test is skipped (e.g. when running locally), the call to `run` will still happen, but the calls to setUp will not.

This caused a problem with spurious failures in other unit tests, because `run` patched in new environment variables, and when subsequent tests made assertions about them (e.g. calls to `_assert_env_vars` in build_manager_test.py), it caused those tests to fail.

Arguably tests shouldn't assume that sort of thing, but Centipede should probably tear down properly as well. Moving this functionality into setUp will enforce this.

Additionally, tests using assertIsNone to check environment variables ought to check using assertIsFale instead. Due to a quirk of how os.environ is implemented, it's impossible to change an environment variable back to None once it's been set, only to the empty string. I updated build_manager_test.py to handle this appropriately.