### PR TITLE
[analyze] Ensure that the correct object is passed to error handler. 

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -179,11 +179,10 @@ def handle_setup_testcase_error(uworker_output: uworker_io.UworkerOutput):
   """Handles for setup_testcase that is called by uworker_postprocess."""
   task_name = environment.get_value('TASK_NAME')
   testcase_fail_wait = environment.get_value('FAIL_WAIT')
-  error = uworker_output
   tasks.add_task(
       task_name,
-      error.testcase_id,
-      error.job_type,
+      uworker_output.testcase_id,
+      uworker_output.job_type,
       wait_time=testcase_fail_wait)
 
 
@@ -223,14 +222,14 @@ def setup_testcase(testcase,
       error_message = 'Fuzzer %s no longer exists' % fuzzer_name
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
-      return None, None, uworker_errors.Error(uworker_errors.Type.NO_FUZZER)
+      return None, None, uworker_io.Output(error=uworker_errors.Type.NO_FUZZER)
 
     if not update_successful:
       error_message = 'Unable to setup fuzzer %s' % fuzzer_name
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
-      return None, None, uworker_errors.Error(
-          uworker_errors.Type.TESTCASE_SETUP,
+      return None, None, uworker_io.Output(
+          error=uworker_errors.Type.TESTCASE_SETUP,
           job_type=job_type,
           testcase_id=testcase_id)
 
@@ -241,8 +240,8 @@ def setup_testcase(testcase,
     error_message = 'Unable to setup testcase %s' % testcase_file_path
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                          error_message)
-    return None, None, uworker_errors.Error(
-        uworker_errors.Type.TESTCASE_SETUP,
+    return None, None, uworker_io.Output(
+        error=uworker_errors.Type.TESTCASE_SETUP,
         job_type=job_type,
         testcase_id=testcase_id)
 
@@ -329,6 +328,7 @@ def _is_testcase_minimized(testcase):
 
 def download_testcase(key, testcase_download_url, dst):
   if testcase_download_url:
+    logs.log(f'Downloading testcase from: {testcase_download_url}')
     return storage.download_signed_url(testcase_download_url, dst)
   return blobs.read_blob_to_disk(key, dst)
 

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -349,6 +349,7 @@ def unpack_testcase(testcase, testcase_download_url=None):
     temp_filename = testcase_file_path
 
   if not download_testcase(key, testcase_download_url, temp_filename):
+    logs.log(f'Couldn\'t download testcase {key} {testcase_download_url}.')
     return None, testcase_file_path
 
   file_list = []

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -119,8 +119,7 @@ def setup_testcase_and_build(
       testcase_download_url=testcase_download_url,
       metadata=metadata)
   if error:
-    return None, uworker_io.UworkerOutput(
-        testcase=testcase, metadata=metadata, error=error)
+    return None, error
 
   # Set up build.
   setup_build(testcase)
@@ -132,7 +131,7 @@ def setup_testcase_and_build(
     return None, uworker_io.UworkerOutput(
         testcase=testcase,
         metadata=metadata,
-        error=uworker_errors.Error(uworker_errors.Type.ANALYZE_BUILD_SETUP))
+        error=uworker_errors.Type.ANALYZE_BUILD_SETUP)
 
   testcase.absolute_path = testcase_file_path
   return testcase_file_path, None
@@ -334,7 +333,7 @@ def utask_main(testcase, testcase_id, testcase_download_url, job_type,
     return uworker_io.UworkerOutput(
         testcase,
         metadata=metadata,
-        error=uworker_errors.Error(uworker_errors.Type.ANALYZE_NO_CRASH),
+        error=uworker_errors.Type.ANALYZE_NO_CRASH,
         test_timeout=test_timeout,
         job_type=job_type)
   # Update testcase crash parameters.
@@ -344,7 +343,7 @@ def utask_main(testcase, testcase_id, testcase_download_url, job_type,
   if crash_analyzer.ignore_stacktrace(state.crash_stacktrace):
     data_handler.close_invalid_uploaded_testcase(output.testcase,
                                                  output.metadata, 'Irrelevant')
-    error = uworker_errors.Error(uworker_errors.Type.UNHANDLED)
+    error = uworker_io.Output(uworker_errors.Type.UNHANDLED)
     return uworker_io.UworkerOutput(
         testcase=testcase, metadata=metadata, error=error)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -343,9 +343,10 @@ def utask_main(testcase, testcase_id, testcase_download_url, job_type,
   if crash_analyzer.ignore_stacktrace(state.crash_stacktrace):
     data_handler.close_invalid_uploaded_testcase(output.testcase,
                                                  output.metadata, 'Irrelevant')
-    error = uworker_io.Output(uworker_errors.Type.UNHANDLED)
     return uworker_io.UworkerOutput(
-        testcase=testcase, metadata=metadata, error=error)
+        testcase=testcase,
+        metadata=metadata,
+        error=uworker_errors.Type.UNHANDLED)
 
   test_for_reproducibility(testcase, testcase_file_path, state, test_timeout)
   return uworker_io.UworkerOutput(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_errors.py
@@ -22,18 +22,3 @@ class Type(enum.Enum):
   TESTCASE_SETUP = 3
   NO_FUZZER = 4
   UNHANDLED = 5
-
-
-class Error:
-  """Class representing error messages from the untrusted worker. This should
-  contain the type of the error |error_type| as well as any other data to handle
-  the error."""
-
-  def __init__(self, error_type, **kwargs):
-    self.error_type = error_type
-    for key, value in kwargs.items():
-      setattr(self, key, value)
-
-  def to_dict(self):
-    # Make a copy so calls to pop don't modify the object.
-    return self.__dict__.copy()

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -15,7 +15,6 @@
 from clusterfuzz._internal.bot.tasks import setup
 from clusterfuzz._internal.bot.tasks.utasks import analyze_task
 from clusterfuzz._internal.bot.tasks.utasks import uworker_errors
-from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 
 
 def noop(*args, **kwargs):
@@ -23,19 +22,9 @@ def noop(*args, **kwargs):
   del kwargs
 
 
-def handle(error_or_output):
+def handle(output):
   """Handles the errors bubbled up from the uworker."""
-  # TODO(metzman): Once every task supports utasks we can stop handling errors
-  # objects directly and only handle utask output objects.
-  if isinstance(error_or_output, uworker_errors.Error):
-    error = error_or_output
-    error_type = error.error_type
-    output = uworker_io.UworkerOutput(error=error)
-  else:
-    error_type = error_or_output.error.error_type
-    output = error_or_output
-
-  return MAPPING[error_type](output)
+  return MAPPING[output.error](output)
 
 
 MAPPING = {

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -22,7 +22,6 @@ import uuid
 
 from google.cloud import ndb
 
-from clusterfuzz._internal.bot.tasks.utasks import uworker_errors
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import logs
@@ -164,7 +163,7 @@ def serialize_uworker_output(uworker_output_obj):
   if error is not None:
     error = error.to_dict()
     # Change from enum type to the int so we can serialize.
-    error['error_type'] = error['error_type'].value
+    error['error'] = error['error'].value
 
   for name, value in uworker_output.items():
     if not isinstance(value, UworkerEntityWrapper):
@@ -202,12 +201,6 @@ def deserialize_uworker_output(uworker_output):
   entities here."""
   uworker_output = json.loads(uworker_output)
   deserialized_output = uworker_output['serializable']
-  error = uworker_output.pop('error')
-  if error is not None:
-    error_type = uworker_errors.Type(error.pop('error_type'))
-    deserialized_output['error'] = uworker_errors.Error(error_type, **error)
-  else:
-    deserialized_output['error'] = None
   for name, entity_dict in uworker_output['entities'].items():
     key = entity_dict['key']
     ndb_key = ndb.Key(serialized=base64.b64decode(key))

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -42,7 +42,7 @@ class TworkerPreprocessTest(unittest.TestCase):
     self.mock.serialize_and_upload_uworker_input.return_value = (
         self.INPUT_SIGNED_DOWNLOAD_URL)
 
-  def test_worker_preprocess(self):
+  def test_tworker_preprocess(self):
     """Tests that tworker_preprocess works as intended."""
     module = mock.MagicMock()
     module.utask_preprocess.return_value = self.INPUT

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -235,11 +235,9 @@ class RoundTripTest(unittest.TestCase):
 
     # Prepare an output that tests db entity change tracking and
     # (de)serialization.
-    error_field = 'error-field-value'
-    output_error = uworker_errors.Error(
-        uworker_errors.Type.ANALYZE_BUILD_SETUP, error_field=error_field)
     field_value = 'field-value'
-    output = uworker_io.UworkerOutput(error=output_error)
+    output = uworker_io.UworkerOutput(
+        error=uworker_errors.Type.ANALYZE_BUILD_SETUP)
     output.field = field_value
     output.testcase = testcase
     output.uworker_input = {}
@@ -283,10 +281,8 @@ class RoundTripTest(unittest.TestCase):
     # Test that the rest of the output was (de)serialized correctly.
     self.assertEqual(downloaded_testcase.key.serialized(),
                      self.testcase.key.serialized())
-    downloaded_error = downloaded_output.pop('error')
-    self.assertEqual(downloaded_error.error_type, output.error.error_type)
-    self.assertIsInstance(downloaded_error.error_type, uworker_errors.Type)
-    self.assertEqual(downloaded_error.error_field, output.error.error_field)
+    self.assertEqual(downloaded_testcase.error,
+                     uworker_errors.Type.ANALYZE_BUILD_SETUP)
     self.assertDictEqual(downloaded_output, {
         'field': field_value,
         'uworker_input': {}

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -281,8 +281,8 @@ class RoundTripTest(unittest.TestCase):
     # Test that the rest of the output was (de)serialized correctly.
     self.assertEqual(downloaded_testcase.key.serialized(),
                      self.testcase.key.serialized())
-    self.assertEqual(downloaded_testcase.error,
-                     uworker_errors.Type.ANALYZE_BUILD_SETUP)
+    error = downloaded_output.pop('error')
+    self.assertEqual(error, uworker_errors.Type.ANALYZE_BUILD_SETUP)
     self.assertDictEqual(downloaded_output, {
         'field': field_value,
         'uworker_input': {}


### PR DESCRIPTION
Previously the error object was wrapped, leading to the handler
trying to access fields that exist on the error object but not
on the output object.