### PR TITLE
[consolidation] Securely preserve input for postprocess

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -30,16 +30,20 @@ def tworker_preprocess_no_io(utask_module, task_argument, job_type,
   return uworker_io.serialize_uworker_input(uworker_input)
 
 
-def uworker_main_no_io(utask_module, uworker_input):
+def uworker_main_no_io(utask_module, serialized_uworker_input):
   """Exectues the main part of a utask on the uworker (locally if not using
   remote executor)."""
   logs.log('Starting utask_main: %s.' % utask_module)
-  uworker_input = uworker_io.deserialize_uworker_input(uworker_input)
+  uworker_input = uworker_io.deserialize_uworker_input(serialized_uworker_input)
   # Deal with the environment.
   uworker_env = uworker_input.pop('uworker_env')
   set_uworker_env(uworker_env)
 
   uworker_output = utask_module.utask_main(**uworker_input)
+
+  # Do this to simulate out-of-band tamper-proof storage of the input.
+  uworker_input = uworker_io.deserialize_uworker_input(serialized_uworker_input)
+  uworker_env = uworker_input.pop('uworker_env')
   uworker_output.uworker_env = uworker_env
   uworker_output.uworker_input = uworker_input
   return uworker_io.serialize_uworker_output(uworker_output)
@@ -64,22 +68,16 @@ def tworker_preprocess(utask_module, task_argument, job_type, uworker_env):
     # Bail if preprocessing failed since we can't proceed.
     return None
 
-  # Get URLs for the uworker's output. We need a signed upload URL so it can
-  # write its output. Also get a download URL in case the caller wants to read
-  # the output.
-  uworker_output_upload_url, uworker_output_download_gcs_url = (
-      uworker_io.get_uworker_output_urls())
-
   # Write the uworker's input to GCS and get the URL to download the input in
   # case the caller needs it.
-  uworker_input_download_url = uworker_io.serialize_and_upload_uworker_input(
-      uworker_input, job_type, uworker_output_upload_url)
+  uworker_input_signed_download_url, uworker_output_download_gcs_url = (
+      uworker_io.serialize_and_upload_uworker_input(uworker_input, job_type))
 
-  # Return the uworker_input_download_url for the remote executor to pass to the
-  # batch job and for the local executor to download locally. Return
+  # Return the uworker_input_signed_download_url for the remote executor to pass
+  # to the batch job and for the local executor to download locally. Return
   # uworker_output_download_gcs_url for the local executor to download the
   # output after local execution of the utask_main.
-  return uworker_input_download_url, uworker_output_download_gcs_url
+  return uworker_input_signed_download_url, uworker_output_download_gcs_url
 
 
 def set_uworker_env(uworker_env: dict) -> None:
@@ -101,8 +99,6 @@ def uworker_main(utask_module, input_download_url) -> None:
   set_uworker_env(uworker_env)
 
   uworker_output = utask_module.utask_main(**uworker_input)
-  uworker_output.uworker_env = uworker_env
-  uworker_output.uworker_input = uworker_input
   uworker_io.serialize_and_upload_uworker_output(uworker_output,
                                                  uworker_output_upload_url)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -50,9 +50,7 @@ def uworker_main_no_io(utask_module, serialized_uworker_input):
 
 
 def uworker_postprocess_no_io(utask_module, uworker_output):
-  uworker_output_dict = uworker_io.deserialize_uworker_output(uworker_output)
-
-  uworker_output = uworker_io.uworker_output_from_dict(uworker_output_dict)
+  uworker_output = uworker_io.deserialize_uworker_output(uworker_output)
   utask_module.utask_postprocess(uworker_output)
 
 
@@ -106,7 +104,6 @@ def uworker_main(utask_module, input_download_url) -> None:
 def tworker_postprocess(utask_module, output_download_url) -> None:
   """Executes the postprocess step on the trusted (t)worker."""
   logs.log('Starting utask_postprocess: %s.' % utask_module)
-  uworker_output_dict = uworker_io.download_and_deserialize_uworker_output(
+  uworker_output = uworker_io.download_and_deserialize_uworker_output(
       output_download_url)
-  uworker_output = uworker_io.uworker_output_from_dict(uworker_output_dict)
   utask_module.utask_postprocess(uworker_output)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -17,7 +17,6 @@ import base64
 import datetime
 import json
 import tempfile
-from typing import Optional
 import uuid
 
 from google.cloud import ndb
@@ -28,25 +27,26 @@ from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import logs
 
 
-def generate_new_io_file_name():
+def generate_new_input_file_name():
   """Generates a new I/O file name."""
   return str(uuid.uuid4()).lower()
 
 
-def get_uworker_io_gcs_path():
+def get_uworker_input_gcs_path():
   """Returns a GCS path for uworker I/O."""
   # Inspired by blobs.write_blob.
   io_bucket = storage.uworker_io_bucket()
-  io_file_name = generate_new_io_file_name()
+  io_file_name = generate_new_input_file_name()
   if storage.get(storage.get_cloud_storage_file_path(io_bucket, io_file_name)):
     raise RuntimeError(f'UUID collision found: {io_file_name}.')
   return f'/{io_bucket}/{io_file_name}'
 
 
-def get_uworker_output_urls():
+def get_uworker_output_urls(input_gcs_path):
   """Returns a signed download URL for the uworker to upload the output and a
-  GCS url for the tworker to download the output."""
-  gcs_path = get_uworker_io_gcs_path()
+  GCS url for the tworker to download the output. Make sure we can infer the
+  actual input since the output is not trusted."""
+  gcs_path = input_gcs_path + '.output'
   # Note that the signed upload URL can't be directly downloaded from.
   return storage.get_signed_upload_url(gcs_path), gcs_path
 
@@ -54,20 +54,18 @@ def get_uworker_output_urls():
 def get_uworker_input_urls():
   """Returns a signed download URL for the uworker to download the input and a
   GCS url for the tworker to upload it (this happens first)."""
-  gcs_path = get_uworker_io_gcs_path()
+  gcs_path = get_uworker_input_gcs_path()
   return storage.get_signed_download_url(gcs_path), gcs_path
 
 
-def upload_uworker_input(uworker_input):
+def upload_uworker_input(uworker_input, gcs_path):
   """Uploads input for the untrusted portion of a task."""
-  signed_download_url, gcs_path = get_uworker_input_urls()
 
   with tempfile.NamedTemporaryFile() as uworker_input_file:
     with open(uworker_input_file.name, 'w') as fp:
       fp.write(uworker_input)
     if not storage.copy_file_to(uworker_input_file.name, gcs_path):
       raise RuntimeError('Failed to upload uworker_input.')
-  return signed_download_url
 
 
 def make_ndb_entity_input_obj_serializable(obj):
@@ -125,18 +123,26 @@ def serialize_uworker_input(uworker_input):
   return json.dumps({'serializable': serializable, 'entities': ndb_entities})
 
 
-def serialize_and_upload_uworker_input(uworker_input, job_type,
-                                       uworker_output_upload_url) -> str:
+def serialize_and_upload_uworker_input(uworker_input, job_type) -> str:
   """Serializes input for the untrusted portion of a task."""
   # Add remaining fields to the input.
   assert 'job_type' not in uworker_input
   uworker_input['job_type'] = job_type
+
+  signed_input_download_url, input_gcs_url = get_uworker_input_urls()
+  # Get URLs for the uworker'ps output. We need a signed upload URL so it can
+  # write its output. Also get a download URL in case the caller wants to read
+  # the output.
+  signed_output_upload_url, output_gcs_url = get_uworker_output_urls(
+      input_gcs_url)
+
   assert 'uworker_output_upload_url' not in uworker_input
-  uworker_input['uworker_output_upload_url'] = uworker_output_upload_url
+  uworker_input['uworker_output_upload_url'] = signed_output_upload_url
 
   uworker_input = serialize_uworker_input(uworker_input)
-  uworker_input_download_url = upload_uworker_input(uworker_input)
-  return uworker_input_download_url
+  upload_uworker_input(uworker_input, input_gcs_url)
+
+  return signed_input_download_url, output_gcs_url
 
 
 def download_and_deserialize_uworker_input(uworker_input_download_url):
@@ -184,15 +190,29 @@ def serialize_and_upload_uworker_output(uworker_output, upload_url):
   storage.upload_signed_url(uworker_output, upload_url)
 
 
-def download_and_deserialize_uworker_output(output_url) -> Optional[str]:
-  """Downloads and deserializes uworker output."""
-  with tempfile.NamedTemporaryFile() as uworker_output_local_path:
-    if not storage.copy_file_from(output_url, uworker_output_local_path.name):
-      logs.log_error('Could not download uworker output from %s' % output_url)
+def _download_uworker_io_from_gcs(gcs_url):
+  with tempfile.NamedTemporaryFile() as local_path:
+    if not storage.copy_file_from(gcs_url, local_path.name):
+      logs.log_error('Could not download uworker I/O file from %s' % gcs_url)
       return None
-    with open(uworker_output_local_path.name) as uworker_output_file_handle:
-      uworker_output = uworker_output_file_handle.read()
-  return deserialize_uworker_output(uworker_output)
+    with open(local_path.name) as file_handle:
+      return file_handle.read()
+
+
+def download_and_deserialize_uworker_output(output_url: str):
+  """Downloads and deserializes uworker output."""
+  serialized_uworker_output = _download_uworker_io_from_gcs(output_url)
+  uworker_output = deserialize_uworker_output(serialized_uworker_output)
+
+  # Now download the input, which is stored securely so that the uworker cannot
+  # tamper with it.
+  # Get the portion that does not contain ".output".
+  input_url = output_url.split('.output')[0]
+  serialized_uworker_input = _download_uworker_io_from_gcs(input_url)
+  uworker_input = deserialize_uworker_output(serialized_uworker_input)
+  uworker_output.uworker_env = uworker_input.uworker_env
+  uworker_output.uworker_input = uworker_input
+  return uworker_output
 
 
 def deserialize_uworker_output(uworker_output):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -40,7 +40,7 @@ class TworkerPreprocessTest(unittest.TestCase):
     self.mock.get_uworker_output_urls.return_value = (
         self.OUTPUT_SIGNED_UPLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL)
     self.mock.serialize_and_upload_uworker_input.return_value = (
-        self.INPUT_SIGNED_DOWNLOAD_URL)
+        self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL)
 
   def test_worker_preprocess(self):
     """Tests that tworker_preprocess works as intended."""
@@ -52,7 +52,7 @@ class TworkerPreprocessTest(unittest.TestCase):
     module.utask_preprocess.assert_called_with(self.TASK_ARGUMENT,
                                                self.JOB_TYPE, self.UWORKER_ENV)
     self.mock.serialize_and_upload_uworker_input.assert_called_with(
-        self.INPUT, self.JOB_TYPE, self.OUTPUT_SIGNED_UPLOAD_URL)
+        self.INPUT, self.JOB_TYPE)
     self.assertEqual(
         (self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL), result)
 
@@ -106,7 +106,8 @@ class UworkerMainTest(unittest.TestCase):
 class TworkerPostproceessTest(unittest.TestCase):
   """Tests that tworker_postprocess works as intended."""
   OUTPUT_DOWNLOAD_GCS_URL = '/output-download-gcs'
-  OUTPUT = {'output1': 'something', 'output2': 'something else'}
+  OUTPUT = uworker_io.UworkerOutput(
+      output1='something', output2='something else')
 
   def setUp(self):
     helpers.patch(self, [

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -109,16 +109,16 @@ class TestGetUrls(unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.google_cloud_utils.storage.get',
         'clusterfuzz._internal.google_cloud_utils.storage._sign_url',
-        'clusterfuzz._internal.bot.tasks.utasks.uworker_io.generate_new_io_file_name',
+        'clusterfuzz._internal.bot.tasks.utasks.uworker_io.generate_new_input_file_name',
     ])
 
     self.mock.get.return_value = False
     self.mock._sign_url.return_value = self.FAKE_URL
-    self.mock.generate_new_io_file_name.return_value = self.NEW_IO_FILE_NAME
+    self.mock.generate_new_input_file_name.return_value = self.NEW_IO_FILE_NAME
 
   def test_get_uworker_output_urls(self):
     """Tests that get_uworker_output_urls works."""
-    expected_urls = (self.FAKE_URL, self.EXPECTED_GCS_PATH)
+    expected_urls = (self.FAKE_URL, self.EXPECTED_GCS_PATH + '.output')
     self.assertEqual(uworker_io.get_uworker_output_urls(), expected_urls)
     self.mock._sign_url.assert_called_with(
         self.EXPECTED_GCS_PATH,
@@ -150,11 +150,11 @@ class RoundTripTest(unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.google_cloud_utils.storage.get',
         'clusterfuzz._internal.google_cloud_utils.storage._sign_url',
-        'clusterfuzz._internal.bot.tasks.utasks.uworker_io.generate_new_io_file_name',
+        'clusterfuzz._internal.bot.tasks.utasks.uworker_io.generate_new_input_file_name',
     ])
     self.mock.get.return_value = False
     self.mock._sign_url.return_value = self.FAKE_URL
-    self.mock.generate_new_io_file_name.return_value = self.NEW_IO_FILE_NAME
+    self.mock.generate_new_input_file_name.return_value = self.NEW_IO_FILE_NAME
     crash_type = 'type'
     crash_addr = 'addr'
     crash_state = 'NY :-)'


### PR DESCRIPTION
The postprocess task needs to know about the input for the uworker.
For example, if the uworker is supposed to be analyzing testcase X, the postprocess cannot allow it to modify testcase Y.
To deal with this problem, make sure the postprocess task downloads the actual input and does not rely on it being
untampered with in the uworker output.
