### PR TITLE
Fix serialization into proto

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -181,8 +181,8 @@ def handle_setup_testcase_error(uworker_output: uworker_io.UworkerOutput):
   testcase_fail_wait = environment.get_value('FAIL_WAIT')
   tasks.add_task(
       task_name,
-      uworker_output.testcase_id,
-      uworker_output.job_type,
+      uworker_output.uworker_input['testcase_id'],
+      uworker_output.uworker_input['job_type'],
       wait_time=testcase_fail_wait)
 
 
@@ -230,9 +230,7 @@ def setup_testcase(testcase,
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
       return None, None, uworker_io.UworkerOutput(
-          error=uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
-          job_type=job_type,
-          testcase_id=testcase_id)
+          error=uworker_msg_pb2.ErrorType.TESTCASE_SETUP)
 
   # Extract the testcase and any of its resources to the input directory.
   file_list, testcase_file_path = unpack_testcase(testcase,
@@ -242,9 +240,7 @@ def setup_testcase(testcase,
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                          error_message)
     return None, None, uworker_io.UworkerOutput(
-        error=uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
-        job_type=job_type,
-        testcase_id=testcase_id)
+        error=uworker_msg_pb2.ErrorType.TESTCASE_SETUP)
 
   # For Android/Fuchsia, we need to sync our local testcases directory with the
   # one on the device.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -338,7 +338,7 @@ def utask_main(testcase, testcase_id, testcase_download_url, job_type,
 
   if not crashed:
     return uworker_io.UworkerOutput(
-        testcase,
+        testcase=testcase,
         metadata=metadata,
         error=uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH,
         test_timeout=test_timeout,
@@ -348,8 +348,10 @@ def utask_main(testcase, testcase_id, testcase_download_url, job_type,
 
   # See if we have to ignore this crash.
   if crash_analyzer.ignore_stacktrace(state.crash_stacktrace):
-    data_handler.close_invalid_uploaded_testcase(output.testcase,
-                                                 output.metadata, 'Irrelevant')  # pylint: disable=no-member
+    data_handler.close_invalid_uploaded_testcase(
+        output.testcase,  # pylint: disable=no-member
+        output.metadata,  # pylint: disable=no-member
+        'Irrelevant')
     return uworker_io.UworkerOutput(
         testcase=testcase,
         metadata=metadata,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -147,10 +147,10 @@ def serialize_uworker_output(uworker_output_obj):
   proto_output = uworker_msg_pb2.Output()
   for name, value in uworker_output.items():
     if not isinstance(value, UworkerEntityWrapper):
-      if proto_output.fields_by_name[name].message_type is not None:
-        logs.log_error(
-            f'field: {name} {value} is '
-            f'{proto_output.fields_by_name[name].message_type}')
+      field_descriptor = proto_output.DESCRIPTOR.fields_by_name[name]
+      if field_descriptor.message_type is not None:
+        logs.log_error(f'field: {name} {value} is '
+                       f'{field_descriptor.message_type}')
       setattr(proto_output, name, value)
       continue
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -147,6 +147,10 @@ def serialize_uworker_output(uworker_output_obj):
   proto_output = uworker_msg_pb2.Output()
   for name, value in uworker_output.items():
     if not isinstance(value, UworkerEntityWrapper):
+      if proto_output.fields_by_name[name].message_type is not None:
+        logs.log_error(
+            f'field: {name} {value} is '
+            f'{proto_output.fields_by_name[name].message_type}')
       setattr(proto_output, name, value)
       continue
 
@@ -271,9 +275,9 @@ class UworkerOutput:
   """Convenience class for results from uworker_main. This is useful for
   ensuring we are returning values for fields expected by utask_postprocess."""
 
-  def __init__(self, testcase=None, error=None, **kwargs):
-    self.testcase = testcase
-    self.error = error
+  def __init__(self, **kwargs):
+    # Don't have any default fields, or it will cause us to send None back to
+    # the tworker.
     for key, value in kwargs.items():
       setattr(self, key, value)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -305,11 +305,10 @@ class RoundTripTest(unittest.TestCase):
 
   def test_output_error_serialization(self):
     """Tests that errors can be returned by the tasks."""
-    job_type = 'libfuzzer_chrome_asan'
-    testcase_id = '1'
+    test_timeout = 1337
     output = uworker_io.UworkerOutput(
         error=uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
-        job_type=job_type,
-        testcase_id=testcase_id)
+        test_timeout=test_timeout)
     serialized = uworker_io.serialize_uworker_output(output)
     processed_output = uworker_io.deserialize_uworker_output(serialized)
+    self.assertEqual(processed_output.test_timeout, test_timeout)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -302,3 +302,14 @@ class RoundTripTest(unittest.TestCase):
                 'PATH': '/blah'
             }
         })
+
+  def test_output_error_serialization(self):
+    """Tests that errors can be returned by the tasks."""
+    job_type = 'libfuzzer_chrome_asan'
+    testcase_id = '1'
+    output = uworker_io.UworkerOutput(
+        error=uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
+        job_type=job_type,
+        testcase_id=testcase_id)
+    serialized = uworker_io.serialize_uworker_output(output)
+    processed_output = uworker_io.deserialize_uworker_output(serialized)


### PR DESCRIPTION
Don't have any default fields on UworkerOutput, it can trick deserialization into thinking we want to set None on the proto.