### PR TITLE
Ensure that all entities used as input are wrapped

### DIFF
--- a/src/clusterfuzz/_internal/protos/uworker_msg.proto
+++ b/src/clusterfuzz/_internal/protos/uworker_msg.proto
@@ -25,6 +25,8 @@ message UworkerEntityWrapper {
   Json changed = 2;
 }
 
+// TODO(metzman): Handle None in protobuf. Right now, it's hard to tell if a
+// field was unset or set to None.
 message Input {
   optional google.datastore.v1.Entity testcase = 1;
   optional google.datastore.v1.Entity metadata = 2;

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -179,7 +179,7 @@ class RoundTripTest(unittest.TestCase):
     uworker_input = {
         'testcase': self.testcase,
         'uworker_env': self.env,
-        'testcase_download_url': self.FAKE_URL
+        'testcase_download_url': self.FAKE_URL,
     }
 
     # Create a mocked version of copy_file_to so that when we upload the uworker
@@ -222,6 +222,8 @@ class RoundTripTest(unittest.TestCase):
     self.assertEqual(self.testcase.crash_state, downloaded_testcase.crash_state)
     self.assertEqual(self.testcase.key.serialized(),
                      downloaded_testcase.key.serialized())
+    # Things will break horribly if we pass an unwrapped entity.
+    self.assertIsInstance(downloaded_testcase, uworker_io.UworkerEntityWrapper)
 
     # Now test that the rest of the input was (de)serialized properly.
     del uworker_input['testcase']


### PR DESCRIPTION
Otherwise serialization breaks and we can't track changes.