### PR TITLE
[consolidation] Ensure uworker_input is always included in uworker_output

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -203,8 +203,9 @@ def setup_testcase(testcase,
   uworker_error_input = {'testcase_id': testcase_id, 'job_type': job_type}
   uworker_error_output = uworker_io.UworkerOutput(
       uworker_input=uworker_error_input,
-      error=uworker_msg_pb2.ErrorType.UNHANDLED)
-  error_result = (None, None, uworker_error_output)
+      error=uworker_msg_pb2.ErrorType.TESTCASE_SETUP)
+
+  testcase_setup_error_result = (None, None, uworker_error_output)
 
   # Clear testcase directories.
   shell.clear_testcase_directories()
@@ -232,13 +233,14 @@ def setup_testcase(testcase,
       error_message = 'Fuzzer %s no longer exists' % fuzzer_name
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
-      return error_result
+      return testcase_setup_error_result
 
     if not update_successful:
       error_message = f'Unable to setup fuzzer {fuzzer_name}'
       data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                            error_message)
-      return error_result
+      return None, None, uworker_io.UworkerOutput(
+          error=uworker_msg_pb2.ErrorType.TESTCASE_SETUP)
 
   # Extract the testcase and any of its resources to the input directory.
   file_list, testcase_file_path = unpack_testcase(testcase,
@@ -247,7 +249,7 @@ def setup_testcase(testcase,
     error_message = 'Unable to setup testcase %s' % testcase_file_path
     data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                          error_message)
-    return error_result
+    return testcase_setup_error_result
 
   # For Android/Fuchsia, we need to sync our local testcases directory with the
   # one on the device.


### PR DESCRIPTION
Right now, callers to setup_testcase are all using its error handler which assumes the uworker module adds
uworker_input to the output.
Temporarily include this for callers that are not migrated to utasks.