### PR TITLE
Modernize code (remove deprecated, backward compatibility)

### DIFF
--- a/src/clusterfuzz/_internal/bot/untrusted_runner/tasks_impl.py
+++ b/src/clusterfuzz/_internal/bot/untrusted_runner/tasks_impl.py
@@ -14,7 +14,7 @@
 """Tasks RPC implementations."""
 
 from google.protobuf import wrappers_pb2
-from google.protobuf.any_pb2 import Any
+from google.protobuf.any_pb2 import Any  # pylint: disable=no-name-in-module
 
 from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.tasks import corpus_pruning_task

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -14,9 +14,9 @@
 """Build manager."""
 
 from collections import namedtuple
-from distutils import spawn
 import os
 import re
+import shutil
 import subprocess
 import time
 
@@ -1473,7 +1473,7 @@ def _set_rpaths_chrpath(binary_path, rpaths):
 
 def _set_rpaths_patchelf(binary_path, rpaths):
   """Set rpaths using patchelf."""
-  patchelf = spawn.find_executable('patchelf')
+  patchelf = shutil.which('patchelf')
   if not patchelf:
     raise BuildManagerException('Failed to find patchelf')
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -18,12 +18,8 @@ import datetime
 import os
 import re
 import shlex
+from shlex import quote
 import time
-
-try:
-  from shlex import quote
-except ImportError:
-  from pipes import quote
 
 from google.cloud import ndb
 

--- a/src/clusterfuzz/_internal/platforms/android/wifi.py
+++ b/src/clusterfuzz/_internal/platforms/android/wifi.py
@@ -14,12 +14,8 @@
 """Wifi related functions."""
 
 import os
+from shlex import quote
 import time
-
-try:
-  from shlex import quote
-except ImportError:
-  from pipes import quote
 
 from clusterfuzz._internal.config import db_config
 from clusterfuzz._internal.metrics import logs

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -15,6 +15,7 @@
 # pylint: disable=unused-argument
 
 import os
+from shlex import quote
 import shutil
 import tempfile
 import unittest
@@ -41,11 +42,6 @@ from clusterfuzz._internal.system import shell
 from clusterfuzz._internal.tests.test_libs import android_helpers
 from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
-
-try:
-  from shlex import quote
-except ImportError:
-  from pipes import quote
 
 TEST_PATH = os.path.abspath(os.path.dirname(__file__))
 TEST_DIR = os.path.join(TEST_PATH, 'libfuzzer_test_data')

--- a/src/local/butler/appengine.py
+++ b/src/local/butler/appengine.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """App Engine helpers."""
 
-from distutils import spawn
 import os
 import shutil
 import sys
@@ -75,7 +74,7 @@ def find_sdk_path():
   if common.get_platform() == 'windows':
     _, gcloud_path = common.execute('where gcloud.cmd', print_output=False)
   else:
-    gcloud_path = spawn.find_executable('gcloud')
+    gcloud_path = shutil.which('gcloud')
 
   if not gcloud_path:
     print('Please install the Google Cloud SDK and set up PATH to point to it.')

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -41,7 +41,7 @@ class GsutilError(Exception):
   """Gsutil error."""
 
 
-class Gcloud(object):
+class Gcloud:
   """Project specific gcloud."""
 
   def __init__(self, project_id):
@@ -53,7 +53,7 @@ class Gcloud(object):
     return _run_and_handle_exception(arguments, GcloudError)
 
 
-class Gsutil(object):
+class Gsutil:
   """gsutil runner."""
 
   def run(self, *args):
@@ -146,7 +146,7 @@ def execute(command,
 
   print_string = f'Running: {command}'
   if cwd:
-    print_string += f' (cwd=\'{cwd}\')'
+    print_string += f' (cwd="{cwd}")'
   _print(print_string)
 
   proc = execute_async(command, extra_environments, cwd=cwd, stderr=stderr)
@@ -295,7 +295,7 @@ def _install_platform_pip(requirements_path, target_path, platform_name):
       print(f'Did not find package for platform: {pip_platform}')
       continue
 
-    execute(f'unzip -o -d {target_path} \'{temp_dir}/*.whl\'')
+    execute(f'unzip -o -d {target_path} "{temp_dir}/*.whl"')
     shutil.rmtree(temp_dir, ignore_errors=True)
     break
 

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -429,4 +429,7 @@ def copy_if_newer(src, dst):
 def update_dir(src_dir, dst_dir):
   """Recursively copy from src_dir to dst_dir, replacing files but only if
   they're newer or don't exist."""
-  dir_util.copy_tree(src_dir, dst_dir, copy_function=copy_if_newer)  # pylint: disable=unexpected-keyword-arg
+  # TODO(metzman): Replace this with
+  # shutil.copytree(src_dir, dst_dir, copy_function=copy_if_newer)
+  # After we migrate to python3.9.
+  dir_util.copy_tree(src_dir, dst_dir, update=True)

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -14,14 +14,12 @@
 """common.py contains common methods and variables that are used by multiple
    commands."""
 
-# TODO(ochang): Fix these.
-# pylint: disable=consider-using-f-string
-
 import datetime
 from distutils import dir_util
 import io
 import os
 import platform
+from shlex import quote
 import shutil
 import stat
 import subprocess
@@ -31,11 +29,6 @@ import urllib.request
 import zipfile
 
 from local.butler import constants
-
-try:
-  from shlex import quote
-except ImportError:
-  from pipes import quote
 
 INVALID_FILENAMES = ['src/third_party/setuptools/script (dev).tmpl']
 

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -23,6 +23,7 @@ import io
 import os
 import platform
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -114,7 +115,7 @@ def process_proc_output(proc, print_output=True):
 
   lines = []
   for line in iter(proc.stdout.readline, b''):
-    _print('| %s' % line.rstrip().decode('utf-8'))
+    _print(f'| {line.rstrip().decode("utf-8")}')
     lines.append(line)
 
   return b''.join(lines)
@@ -150,9 +151,9 @@ def execute(command,
     if print_output:
       print(s)
 
-  print_string = 'Running: %s' % command
+  print_string = f'Running: {command}'
   if cwd:
-    print_string += " (cwd='%s')" % cwd
+    print_string += f' (cwd=\'{cwd}\')'
   _print(print_string)
 
   proc = execute_async(command, extra_environments, cwd=cwd, stderr=stderr)
@@ -160,7 +161,7 @@ def execute(command,
 
   proc.wait()
   if proc.returncode != 0:
-    _print('| Return code is non-zero (%d).' % proc.returncode)
+    _print(f'| Return code is non-zero ({proc.returncode}).')
     if exit_on_error:
       _print('| Exit.')
       sys.exit(proc.returncode)
@@ -176,7 +177,7 @@ def kill_process(name):
         'wmic process where (commandline like "%%%s%%") delete' % name,
         exit_on_error=False)
   elif plt in ['linux', 'macos']:
-    execute('pkill -KILL -f "%s"' % name, exit_on_error=False)
+    execute(f'pkill -KILL -f "{name}"', exit_on_error=False)
 
 
 def is_git_dirty():
@@ -224,7 +225,7 @@ def _install_chromedriver():
 
   chromedriver_archive.extract(chromedriver_binary, output_directory)
   os.chmod(chromedriver_path, 0o750)
-  print('Installed chromedriver at: %s' % chromedriver_path)
+  print(f'Installed chromedriver at: {chromedriver_path}')
 
 
 def _pip():
@@ -254,7 +255,7 @@ def _pipfile_to_requirements(pipfile_dir, requirements_path, dev=False):
         stderr=subprocess.DEVNULL)
 
   if return_code != 0:
-    raise Exception('Failed to generate requirements from Pipfile.')
+    raise RuntimeError('Failed to generate requirements from Pipfile.')
 
   with open(requirements_path, 'wb') as f:
     f.write(output)
@@ -277,7 +278,7 @@ def _install_platform_pip(requirements_path, target_path, platform_name):
   """Install platform specific pip packages."""
   pip_platform = constants.PLATFORMS.get(platform_name)
   if not pip_platform:
-    raise Exception('Unknown platform: %s.' % platform_name)
+    raise OSError(f'Unknown platform: {platform_name}.')
 
   # Some platforms can specify multiple pip platforms (e.g. macOS has multiple
   # SDK versions).
@@ -292,26 +293,22 @@ def _install_platform_pip(requirements_path, target_path, platform_name):
   for pip_platform in pip_platforms:
     temp_dir = tempfile.mkdtemp()
     return_code, _ = execute(
-        '{pip} download --no-deps --only-binary=:all: --platform={platform} '
-        '--abi={abi} -r {requirements_path} -d {output_dir}'.format(
-            pip=_pip(),
-            platform=pip_platform,
-            abi=pip_abi,
-            requirements_path=requirements_path,
-            output_dir=temp_dir),
+        f'{_pip()} download --no-deps --only-binary=:all: '
+        f'--platform={pip_platform} --abi={pip_abi} -r {requirements_path} -d '
+        f'{temp_dir}',
         exit_on_error=False)
 
     if return_code != 0:
-      print('Did not find package for platform: ' + pip_platform)
+      print(f'Did not find package for platform: {pip_platform}')
       continue
 
-    execute('unzip -o -d %s \'%s/*.whl\'' % (target_path, temp_dir))
+    execute(f'unzip -o -d {target_path} \'{temp_dir}/*.whl\'')
     shutil.rmtree(temp_dir, ignore_errors=True)
     break
 
   if return_code != 0:
-    raise Exception('Failed to find package in supported platforms: %s' +
-                    str(pip_platforms))
+    raise RuntimeError(
+        f'Failed to find package in supported platforms: {pip_platforms}')
 
 
 def _remove_invalid_files():
@@ -361,16 +358,13 @@ def symlink(src, target):
   remove_symlink(target)
 
   if get_platform() == 'windows':
-    execute(r'cmd /c mklink /j %s %s' % (target, src))
+    execute(rf'cmd /c mklink /j {target} {src}')
   else:
     os.symlink(src, target)
 
-  assert os.path.exists(target), (
-      'Failed to create {target} symlink for {src}.'.format(
-          target=target, src=src))
+  assert os.path.exists(target), f'Failed to create {target} symlink for {src}.'
 
-  print('Created symlink: source: {src}, target {target}.'.format(
-      src=src, target=target))
+  print(f'Created symlink: source: {src}, target {target}.')
 
 
 def copy_dir(src, target):
@@ -395,8 +389,7 @@ def test_bucket(env_var):
   """Get the integration test bucket."""
   bucket = os.getenv(env_var)
   if not bucket:
-    raise RuntimeError(
-        'You need to specify {var} for integration testing'.format(var=env_var))
+    raise RuntimeError(f'You need to specify {env_var} for integration testing')
 
   return bucket
 
@@ -418,10 +411,29 @@ def get_platform():
   if platform.system() == 'Windows':
     return 'windows'
 
-  raise Exception('Unknown platform: %s.' % platform.system())
+  raise OSError(f'Unknown platform: {platform.system()}.')
+
+
+def get_modified_time(filename):
+  return os.stat(filename)[stat.ST_MTIME]
+
+
+def is_newer(src, dst):
+  if not os.path.exists(dst):
+    return True
+
+  src_time = get_modified_time(src)
+  dst_time = get_modified_time(dst)
+  return src_time > dst_time
+
+
+def copy_if_newer(src, dst):
+  if is_newer(src, dst):
+    return shutil.copy2(src, dst)
+  return False
 
 
 def update_dir(src_dir, dst_dir):
   """Recursively copy from src_dir to dst_dir, replacing files but only if
   they're newer or don't exist."""
-  dir_util.copy_tree(src_dir, dst_dir, update=True)
+  dir_util.copy_tree(src_dir, dst_dir, copy_function=copy_if_newer)  # pylint: disable=unexpected-keyword-arg


### PR DESCRIPTION
Replace disutils.spawn.find_executable with shutil.which.
distutils is deprecated.
Also stop using `pipes.quote`, we no longer need to support <python3.3.
Use f-strings where possible.