### PR TITLE
Fix flaky honggfuzz netdriver test

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/honggfuzz/honggfuzz_engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/honggfuzz/honggfuzz_engine_test.py
@@ -208,8 +208,7 @@ class IntegrationTest(unittest.TestCase):
                   crash.stacktrace)
 
     with open(crash.input_path, 'rb') as f:
-      self.assertEqual(b'B', f.read()[:1])
-
+      self.assertIn(b'B', f.read())
     self.assert_has_stats(results)
 
 


### PR DESCRIPTION
The test assumed that inputs are less than 1024 bytes, causing it to frequently break deploys.