### PR TITLE
[analyze] Set metadata properly after setting up build

### DIFF
--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -562,9 +562,9 @@ def read_data_from_file(file_path, eval_data=True, default=None):
   if not os.path.exists(file_path):
     return default
 
-  failure_wait_interval = environment.get_value('FAIL_WAIT')
+  failure_wait_interval = environment.get_value('FAIL_WAIT', 0)
   file_content = None
-  retry_limit = environment.get_value('FAIL_RETRIES')
+  retry_limit = environment.get_value('FAIL_RETRIES', 1)
   for _ in range(retry_limit):
     try:
       with open(file_path, 'rb') as file_handle:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -131,9 +131,9 @@ def setup_testcase_and_build(
     return None, error
 
   # Set up build.
-  error_output = setup_build(testcase)
-  if error_output:
-    return None, error_output
+  error = setup_build(testcase)
+  if error:
+    return None, error
 
   # Check if we have an application path. If not, our build failed
   # to setup correctly.
@@ -144,17 +144,17 @@ def setup_testcase_and_build(
         metadata=metadata,
         error=uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP)
 
+  update_testcase_after_build_setup(testcase)
   testcase.absolute_path = testcase_file_path
   return testcase_file_path, None
 
 
-def initialize_testcase_for_main(testcase, job_type):
-  """Initializes a testcase for the crash testing phase."""
-  # Update initial testcase information.
-  testcase.job_type = job_type
-  testcase.queue = tasks.default_queue()
-  testcase.crash_state = ''
-
+def update_testcase_after_build_setup(testcase):
+  """Updates the testcase entity with values from global state that was set
+  during build setup."""
+  # NOTE: This must be done after setting up the build, which also sets
+  # environment variables consumed by set_initial_testcase_metadata. See
+  # https://crbug.com/1453576.
   # Set initial testcase metadata fields (e.g. build url, etc).
   data_handler.set_initial_testcase_metadata(testcase)
 
@@ -168,6 +168,13 @@ def initialize_testcase_for_main(testcase, job_type):
     environment.set_value('APP_ARGS', minimized_arguments)
     testcase.minimized_arguments = minimized_arguments
 
+
+def initialize_testcase_for_main(testcase, job_type):
+  """Initializes a testcase for the crash testing phase."""
+  # Update initial testcase information.
+  testcase.job_type = job_type
+  testcase.queue = tasks.default_queue()
+  testcase.crash_state = ''
   testcase.put()
 
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -788,13 +788,13 @@ def set_initial_testcase_metadata(testcase):
     testcase.set_metadata('build_url', build_url, update_testcase=False)
 
   gn_args_path = environment.get_value('GN_ARGS_PATH', '')
-  sys.stderr.write(f'AAAAA gn_args_path {gn_args_path}')
+  sys.stderr.write(f'AAAAA gn_args_path {gn_args_path}\n')
   # !!! TMP
   if gn_args_path:
-    sys.stderr.write(f'AAAAA doit gn_args')
+    sys.stderr.write('AAAAA doit gn_args\n')
     gn_args = utils.read_data_from_file(
         gn_args_path, eval_data=False, default='is_msan = true').decode('utf-8')
-    sys.stderr.write(f'AAAAA gn_args {gn_args}')
+    sys.stderr.write(f'AAAAA gn_args {gn_args}\n')
 
     # Remove goma_dir from gn args since it is only relevant to the machine that
     # did the build.
@@ -802,9 +802,9 @@ def set_initial_testcase_metadata(testcase):
         line for line in gn_args.splitlines()
         if not GOMA_DIR_LINE_REGEX.match(line)
     ]
-    sys.stderr.write(f'AAAAA filtered_gn_args_lines {filtered_gn_args_lines}')
+    sys.stderr.write(f'AAAAA filtered_gn_args_lines {filtered_gn_args_lines}\n')
     filtered_gn_args = '\n'.join(filtered_gn_args_lines)
-    sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}')
+    sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     testcase.set_metadata('gn_args', filtered_gn_args, update_testcase=False)
 
   testcase.platform = environment.platform().lower()

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -786,8 +786,10 @@ def set_initial_testcase_metadata(testcase):
   if build_url:
     testcase.set_metadata('build_url', build_url, update_testcase=False)
 
+  from remote_pdb import RemotePdb; RemotePdb('127.0.0.1', 4444).set_trace()
   gn_args_path = environment.get_value('GN_ARGS_PATH', '')
-  if gn_args_path and os.path.exists(gn_args_path):
+  # !!! TMP
+  if gn_args_path:
     gn_args = utils.read_data_from_file(
         gn_args_path, eval_data=False, default='').decode('utf-8')
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -18,7 +18,6 @@ import datetime
 import os
 import re
 import shlex
-import sys
 import time
 
 from google.cloud import ndb
@@ -787,16 +786,9 @@ def set_initial_testcase_metadata(testcase):
     testcase.set_metadata('build_url', build_url, update_testcase=False)
 
   gn_args_path = environment.get_value('GN_ARGS_PATH', '')
-  sys.stderr.write(f'AAAAA gn_args_path {gn_args_path}\n')
-  sys.stdout.write(f'AAAAA gn_args_path {gn_args_path}\n')
-  # !!! TMP
   if gn_args_path:
-    sys.stderr.write('AAAAA doit gn_args\n')
-    sys.stdout.write('AAAAA doit gn_args\n')
     gn_args = utils.read_data_from_file(
         gn_args_path, eval_data=False, default='is_msan = true').decode('utf-8')
-    sys.stderr.write(f'AAAAA gn_args {gn_args}\n')
-    sys.stdout.write(f'AAAAA gn_args {gn_args}\n')
 
     # Remove goma_dir from gn args since it is only relevant to the machine that
     # did the build.
@@ -804,13 +796,8 @@ def set_initial_testcase_metadata(testcase):
         line for line in gn_args.splitlines()
         if not GOMA_DIR_LINE_REGEX.match(line)
     ]
-    sys.stderr.write(f'AAAAA filtered_gn_args_lines {filtered_gn_args_lines}\n')
-    sys.stdout.write(f'AAAAA filtered_gn_args_lines {filtered_gn_args_lines}\n')
     filtered_gn_args = '\n'.join(filtered_gn_args_lines)
-    sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
-    sys.stdout.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     testcase.set_metadata('gn_args', filtered_gn_args, update_testcase=False)
-    sys.stdout.write(f'AAAAA gn_args {testcase.additional_metadata}\n')
 
   testcase.platform = environment.platform().lower()
   testcase.platform_id = environment.get_platform_id()

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -779,7 +779,6 @@ def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
 
 def set_initial_testcase_metadata(testcase):
   """Set various testcase metadata fields during testcase initialization."""
-  1/0
   build_key = environment.get_value('BUILD_KEY')
   if build_key:
     testcase.set_metadata('build_key', build_key, update_testcase=False)
@@ -790,12 +789,15 @@ def set_initial_testcase_metadata(testcase):
 
   gn_args_path = environment.get_value('GN_ARGS_PATH', '')
   sys.stderr.write(f'AAAAA gn_args_path {gn_args_path}\n')
+  sys.stdout.write(f'AAAAA gn_args_path {gn_args_path}\n')
   # !!! TMP
   if gn_args_path:
     sys.stderr.write('AAAAA doit gn_args\n')
+    sys.stdout.write('AAAAA doit gn_args\n')
     gn_args = utils.read_data_from_file(
         gn_args_path, eval_data=False, default='is_msan = true').decode('utf-8')
     sys.stderr.write(f'AAAAA gn_args {gn_args}\n')
+    sys.stdout.write(f'AAAAA gn_args {gn_args}\n')
 
     # Remove goma_dir from gn args since it is only relevant to the machine that
     # did the build.
@@ -804,8 +806,10 @@ def set_initial_testcase_metadata(testcase):
         if not GOMA_DIR_LINE_REGEX.match(line)
     ]
     sys.stderr.write(f'AAAAA filtered_gn_args_lines {filtered_gn_args_lines}\n')
+    sys.stdout.write(f'AAAAA filtered_gn_args_lines {filtered_gn_args_lines}\n')
     filtered_gn_args = '\n'.join(filtered_gn_args_lines)
     sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
+    sys.stdout.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     testcase.set_metadata('gn_args', filtered_gn_args, update_testcase=False)
 
   testcase.platform = environment.platform().lower()

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -791,7 +791,6 @@ def set_initial_testcase_metadata(testcase):
   sys.stderr.write(f'AAAAA gn_args_path {gn_args_path}\n')
   sys.stdout.write(f'AAAAA gn_args_path {gn_args_path}\n')
   # !!! TMP
-  wastaken = False
   if gn_args_path:
     sys.stderr.write('AAAAA doit gn_args\n')
     sys.stdout.write('AAAAA doit gn_args\n')
@@ -812,13 +811,7 @@ def set_initial_testcase_metadata(testcase):
     sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     sys.stdout.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     testcase.set_metadata('gn_args', filtered_gn_args, update_testcase=False)
-    wastaken = True
 
-  # pylint: disable=pointless-statement
-  if wastaken:
-    1 / 0
-  else:
-    2 / 0
   testcase.platform = environment.platform().lower()
   testcase.platform_id = environment.get_platform_id()
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -19,6 +19,7 @@ import os
 import re
 import shlex
 from shlex import quote
+import sys
 import time
 
 from google.cloud import ndb
@@ -787,10 +788,13 @@ def set_initial_testcase_metadata(testcase):
     testcase.set_metadata('build_url', build_url, update_testcase=False)
 
   gn_args_path = environment.get_value('GN_ARGS_PATH', '')
+  sys.stderr.write(f'AAAAA gn_args_path {gn_args_path}')
   # !!! TMP
   if gn_args_path:
+    sys.stderr.write(f'AAAAA doit gn_args {gn_args}')
     gn_args = utils.read_data_from_file(
         gn_args_path, eval_data=False, default='is_msan = true').decode('utf-8')
+    sys.stderr.write(f'AAAAA gn_args {gn_args}')
 
     # Remove goma_dir from gn args since it is only relevant to the machine that
     # did the build.
@@ -798,7 +802,9 @@ def set_initial_testcase_metadata(testcase):
         line for line in gn_args.splitlines()
         if not GOMA_DIR_LINE_REGEX.match(line)
     ]
+    sys.stderr.write(f'AAAAA filtered_gn_arg_lines {filtered_gn_arg_lines}')
     filtered_gn_args = '\n'.join(filtered_gn_args_lines)
+    sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}')
     testcase.set_metadata('gn_args', filtered_gn_args, update_testcase=False)
 
   testcase.platform = environment.platform().lower()

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -790,7 +790,7 @@ def set_initial_testcase_metadata(testcase):
   # !!! TMP
   if gn_args_path:
     gn_args = utils.read_data_from_file(
-        gn_args_path, eval_data=False, default='').decode('utf-8')
+        gn_args_path, eval_data=False, default='is_msan = true').decode('utf-8')
 
     # Remove goma_dir from gn args since it is only relevant to the machine that
     # did the build.

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -18,7 +18,6 @@ import datetime
 import os
 import re
 import shlex
-from shlex import quote
 import sys
 import time
 
@@ -346,7 +345,7 @@ def _get_memory_tool_options(testcase):
 
     options_string = environment.join_memory_tool_options(options_value)
     result.append('{options_name}="{options_string}"'.format(
-        options_name=options_name, options_string=quote(options_string)))
+        options_name=options_name, options_string=shlex.quote(options_string)))
 
   return result
 
@@ -355,10 +354,10 @@ def _get_bazel_test_args(arguments, sanitizer_options):
   """Return arguments to pass to a bazel test."""
   result = []
   for sanitizer_option in sanitizer_options:
-    result.append('--test_env=%s' % sanitizer_option)
+    result.append(f'--test_env={sanitizer_option}')
 
   for argument in shlex.split(arguments):
-    result.append('--test_arg=%s' % quote(argument))
+    result.append(f'--test_arg={shlex.quote(argument)}')
 
   return ' '.join(result)
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -779,6 +779,7 @@ def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
 
 def set_initial_testcase_metadata(testcase):
   """Set various testcase metadata fields during testcase initialization."""
+  1/0
   build_key = environment.get_value('BUILD_KEY')
   if build_key:
     testcase.set_metadata('build_key', build_key, update_testcase=False)

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -786,7 +786,6 @@ def set_initial_testcase_metadata(testcase):
   if build_url:
     testcase.set_metadata('build_url', build_url, update_testcase=False)
 
-  from remote_pdb import RemotePdb; RemotePdb('127.0.0.1', 4444).set_trace()
   gn_args_path = environment.get_value('GN_ARGS_PATH', '')
   # !!! TMP
   if gn_args_path:

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -791,7 +791,7 @@ def set_initial_testcase_metadata(testcase):
   sys.stderr.write(f'AAAAA gn_args_path {gn_args_path}')
   # !!! TMP
   if gn_args_path:
-    sys.stderr.write(f'AAAAA doit gn_args {gn_args}')
+    sys.stderr.write(f'AAAAA doit gn_args')
     gn_args = utils.read_data_from_file(
         gn_args_path, eval_data=False, default='is_msan = true').decode('utf-8')
     sys.stderr.write(f'AAAAA gn_args {gn_args}')

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -811,6 +811,7 @@ def set_initial_testcase_metadata(testcase):
     sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     sys.stdout.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     testcase.set_metadata('gn_args', filtered_gn_args, update_testcase=False)
+    sys.stdout.write(f'AAAAA gn_args {testcase.additional_metadata}\n')
 
   testcase.platform = environment.platform().lower()
   testcase.platform_id = environment.get_platform_id()

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -791,6 +791,7 @@ def set_initial_testcase_metadata(testcase):
   sys.stderr.write(f'AAAAA gn_args_path {gn_args_path}\n')
   sys.stdout.write(f'AAAAA gn_args_path {gn_args_path}\n')
   # !!! TMP
+  wastaken = False
   if gn_args_path:
     sys.stderr.write('AAAAA doit gn_args\n')
     sys.stdout.write('AAAAA doit gn_args\n')
@@ -811,7 +812,13 @@ def set_initial_testcase_metadata(testcase):
     sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     sys.stdout.write(f'AAAAA filtered_gn_args {filtered_gn_args}\n')
     testcase.set_metadata('gn_args', filtered_gn_args, update_testcase=False)
+    wastaken = True
 
+  # pylint: disable=pointless-statement
+  if wastaken:
+    1 / 0
+  else:
+    2 / 0
   testcase.platform = environment.platform().lower()
   testcase.platform_id = environment.get_platform_id()
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -802,7 +802,7 @@ def set_initial_testcase_metadata(testcase):
         line for line in gn_args.splitlines()
         if not GOMA_DIR_LINE_REGEX.match(line)
     ]
-    sys.stderr.write(f'AAAAA filtered_gn_arg_lines {filtered_gn_arg_lines}')
+    sys.stderr.write(f'AAAAA filtered_gn_args_lines {filtered_gn_args_lines}')
     filtered_gn_args = '\n'.join(filtered_gn_args_lines)
     sys.stderr.write(f'AAAAA filtered_gn_args {filtered_gn_args}')
     testcase.set_metadata('gn_args', filtered_gn_args, update_testcase=False)

--- a/src/clusterfuzz/_internal/platforms/android/wifi.py
+++ b/src/clusterfuzz/_internal/platforms/android/wifi.py
@@ -14,7 +14,7 @@
 """Wifi related functions."""
 
 import os
-from shlex import quote
+import shlex
 import time
 
 from clusterfuzz._internal.config import db_config
@@ -93,8 +93,8 @@ def configure(force_enable=False):
 
   output = adb.run_shell_command(
       connect_wifi_command.format(
-          ssid=quote(wifi_ssid),
-          password=quote(wifi_password),
+          ssid=shlex.quote(wifi_ssid),
+          password=shlex.quote(wifi_password),
           call_path=WIFI_UTIL_CALL_PATH))
   if 'result=true' not in output:
     logs.log_warn('Failed to connect to wifi.', output=output)

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -15,7 +15,7 @@
 # pylint: disable=unused-argument
 
 import os
-from shlex import quote
+import shlex
 import shutil
 import tempfile
 import unittest
@@ -1070,7 +1070,7 @@ class IntegrationTestsAndroid(BaseIntegrationTest, android_helpers.AndroidTest):
 
     self.crash_dir = TEMP_DIR
     self.adb_path = android.adb.get_adb_path()
-    hwasan_options = quote(environment.get_value('HWASAN_OPTIONS'))
+    hwasan_options = shlex.quote(environment.get_value('HWASAN_OPTIONS'))
     self.hwasan_options = f'HWASAN_OPTIONS="{hwasan_options}"'
 
   def device_path(self, local_path):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
@@ -22,8 +22,8 @@ import tempfile
 import threading
 import time
 import unittest
-
 from unittest import mock
+
 import parameterized
 from pyfakefs import fake_filesystem_unittest
 
@@ -837,14 +837,12 @@ class ProcessCrashesTest(fake_filesystem_unittest.TestCase):
 
     testcases = list(data_types.Testcase.query())
     self.assertEqual(5, len(testcases))
-    self.assertSetEqual(
-        {r2_stacktrace, 'r4', 'u1', 'u2', 'u4'},
-        {t.crash_stacktrace for t in testcases})
+    self.assertSetEqual({r2_stacktrace, 'r4', 'u1', 'u2', 'u4'},
+                        {t.crash_stacktrace for t in testcases})
 
     self.assertSetEqual(
-        {
-            '{"fuzzing_strategies": ["value_profile"]}', None, None, None, None
-        }, {t.additional_metadata for t in testcases})
+        {'{"fuzzing_strategies": ["value_profile"]}', None, None, None, None},
+        {t.additional_metadata for t in testcases})
 
     # r2 is a reproducible crash, so r3 doesn't
     # invoke archive_testcase_in_blobstore. Therefore, the

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
@@ -840,9 +840,8 @@ class ProcessCrashesTest(fake_filesystem_unittest.TestCase):
     self.assertSetEqual({r2_stacktrace, 'r4', 'u1', 'u2', 'u4'},
                         {t.crash_stacktrace for t in testcases})
 
-    self.assertSetEqual(
-        {'{"fuzzing_strategies": ["value_profile"]}', None},
-        {t.additional_metadata for t in testcases})
+    self.assertSetEqual({'{"fuzzing_strategies": ["value_profile"]}', None},
+                        {t.additional_metadata for t in testcases})
 
     # r2 is a reproducible crash, so r3 doesn't
     # invoke archive_testcase_in_blobstore. Therefore, the

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
@@ -23,7 +23,7 @@ import threading
 import time
 import unittest
 
-import mock
+from unittest import mock
 import parameterized
 from pyfakefs import fake_filesystem_unittest
 
@@ -838,13 +838,13 @@ class ProcessCrashesTest(fake_filesystem_unittest.TestCase):
     testcases = list(data_types.Testcase.query())
     self.assertEqual(5, len(testcases))
     self.assertSetEqual(
-        set([r2_stacktrace, 'r4', 'u1', 'u2', 'u4']),
-        set(t.crash_stacktrace for t in testcases))
+        {r2_stacktrace, 'r4', 'u1', 'u2', 'u4'},
+        {t.crash_stacktrace for t in testcases})
 
     self.assertSetEqual(
-        set([
+        {
             '{"fuzzing_strategies": ["value_profile"]}', None, None, None, None
-        ]), set(t.additional_metadata for t in testcases))
+        }, {t.additional_metadata for t in testcases})
 
     # r2 is a reproducible crash, so r3 doesn't
     # invoke archive_testcase_in_blobstore. Therefore, the
@@ -1133,7 +1133,7 @@ class WriteCrashToBigQueryTest(unittest.TestCase):
     self.assertEqual(3, failure_count)
 
 
-class ConvertGroupsToCrashesTest(object):
+class ConvertGroupsToCrashesTest(unittest.TestCase):
   """Test convert_groups_to_crashes."""
 
   def test_convert(self):
@@ -1331,9 +1331,9 @@ class DoBlackboxFuzzingTest(fake_filesystem_unittest.TestCase):
     self.assertEqual({'fuzzer_binary_name': 'fantasy_fuzz'}, fuzzer_metadata)
     self.assertEqual(expected_testcase_file_paths, testcase_file_paths)
     self.assertEqual(
-        dict((t, {
+        {t: {
             'gestures': []
-        }) for t in expected_testcase_file_paths), testcases_metadata)
+        } for t in expected_testcase_file_paths}, testcases_metadata)
 
     self.assertEqual(3, len(self.mock.is_crash.call_args_list))
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/fuzz_task_test.py
@@ -841,7 +841,7 @@ class ProcessCrashesTest(fake_filesystem_unittest.TestCase):
                         {t.crash_stacktrace for t in testcases})
 
     self.assertSetEqual(
-        {'{"fuzzing_strategies": ["value_profile"]}', None, None, None, None},
+        {'{"fuzzing_strategies": ["value_profile"]}', None},
         {t.additional_metadata for t in testcases})
 
     # r2 is a reproducible crash, so r3 doesn't

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for analyze task."""
 
-# import json
+import json
 import os
 import tempfile
 import unittest
@@ -119,7 +119,7 @@ class AddDefaultIssueMetadataTest(unittest.TestCase):
                      testcase.get_metadata('issue_labels'))
     self.assertEqual(0, self.mock.log.call_count)
 
-
+@test_utils.with_cloud_emulators('datastore')
 class SetupTestcaseAndBuildTest(unittest.TestCase):
   """Tests for setup_testcase_and_build."""
 
@@ -155,9 +155,9 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
       gn_args_path.seek(0)
       result = analyze_task.setup_testcase_and_build(testcase, None, 'job',
                                                      'https://fake-url')
-      # metadata = json.loads(testcase.additional_metadata)
-      # self.assertEqual(metadata['gn_args'], self.gn_args)
+      metadata = json.loads(testcase.additional_metadata)
+      self.assertEqual(metadata['gn_args'], self.gn_args)
     self.assertEqual(result, (self.testcase_path, None))
     self.assertEqual(testcase.absolute_path, self.testcase_path)
-    # self.assertEqual(metadata['build_url'], self.build_url)
+    self.assertEqual(metadata['build_url'], self.build_url)
     self.assertEqual(testcase.platform, 'linux')

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -133,9 +133,9 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
     self.build_url = 'https://build.zip'
     self.mock.setup_testcase.return_value = (None, self.testcase_path, None)
     self.gn_args = ('is_asan = true\n'
-                  'goma_dir = /home/user/goma\n'
-                  'use_goma = true\n'
-                  'v8_enable_verify_heap = true')
+                    'goma_dir = /home/user/goma\n'
+                    'use_goma = true\n'
+                    'v8_enable_verify_heap = true')
 
     def setup_build(*args, **kwargs):  # pylint: disable=useless-return
       del args

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -132,7 +132,10 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
     self.testcase_path = '/fake-testcase-path'
     self.build_url = 'https://build.zip'
     self.mock.setup_testcase.return_value = (None, self.testcase_path, None)
-    self.gn_args = 'is_asan = true'
+    self.gn_args = ('is_asan = true\n'
+                  'goma_dir = /home/user/goma\n'
+                  'use_goma = true\n'
+                  'v8_enable_verify_heap = true')
 
     def setup_build(*args, **kwargs):  # pylint: disable=useless-return
       del args

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for analyze task."""
 
-# import json
+import json
 import os
 import tempfile
 import unittest

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -150,6 +150,7 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
     """Tests that the correct fields are set after setting up the build.
     Especially testcase.metadata."""
     testcase = data_types.Testcase()
+    testcase.put()
     with tempfile.NamedTemporaryFile() as gn_args_path:
       os.environ['GN_ARGS_PATH'] = gn_args_path.name
       gn_args_path.write(bytes(self.gn_args, 'utf-8'))

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -119,6 +119,7 @@ class AddDefaultIssueMetadataTest(unittest.TestCase):
                      testcase.get_metadata('issue_labels'))
     self.assertEqual(0, self.mock.log.call_count)
 
+
 @test_utils.with_cloud_emulators('datastore')
 class SetupTestcaseAndBuildTest(unittest.TestCase):
   """Tests for setup_testcase_and_build."""

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -157,7 +157,7 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
       gn_args_path.seek(0)
       result = analyze_task.setup_testcase_and_build(testcase, None, 'job',
                                                      'https://fake-url')
-      self.assertTrue(False)
+      self.assertTrue(False)  # pylint: disable=redundant-unittest-assert
       # metadata = json.loads(testcase.additional_metadata)
       # self.assertEqual(metadata['gn_args'], self.gn_args)
     self.assertEqual(result, (self.testcase_path, None))

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for analyze task."""
 
-import json
+# import json
 import os
 import tempfile
 import unittest
@@ -155,9 +155,9 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
       gn_args_path.seek(0)
       result = analyze_task.setup_testcase_and_build(testcase, None, 'job',
                                                      'https://fake-url')
-      metadata = json.loads(testcase.additional_metadata)
-      self.assertEqual(metadata['gn_args'], self.gn_args)
+      # metadata = json.loads(testcase.additional_metadata)
+      # self.assertEqual(metadata['gn_args'], self.gn_args)
     self.assertEqual(result, (self.testcase_path, None))
     self.assertEqual(testcase.absolute_path, self.testcase_path)
-    self.assertEqual(metadata['build_url'], self.build_url)
+    # self.assertEqual(metadata['build_url'], self.build_url)
     self.assertEqual(testcase.platform, 'linux')

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -146,6 +146,7 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
 
     self.mock.setup_build.side_effect = setup_build
 
+  @unittest.skip('Metadata isn\'t set properly in tests.')
   def test_field_setting(self):
     """Tests that the correct fields are set after setting up the build.
     Especially testcase.metadata."""

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -157,6 +157,7 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
       gn_args_path.seek(0)
       result = analyze_task.setup_testcase_and_build(testcase, None, 'job',
                                                      'https://fake-url')
+      self.assertTrue(False)
       # metadata = json.loads(testcase.additional_metadata)
       # self.assertEqual(metadata['gn_args'], self.gn_args)
     self.assertEqual(result, (self.testcase_path, None))

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -14,8 +14,8 @@
 """Tests for analyze task."""
 
 import os
-import unittest
 import tempfile
+import unittest
 
 from clusterfuzz._internal.bot.tasks.utasks import analyze_task
 from clusterfuzz._internal.datastore import data_types

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -158,9 +158,9 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
       result = analyze_task.setup_testcase_and_build(testcase, None, 'job',
                                                      'https://fake-url')
       self.assertTrue(False)  # pylint: disable=redundant-unittest-assert
-      # metadata = json.loads(testcase.additional_metadata)
-      # self.assertEqual(metadata['gn_args'], self.gn_args)
+      metadata = json.loads(testcase.additional_metadata)
+      self.assertEqual(metadata['gn_args'], self.gn_args)
     self.assertEqual(result, (self.testcase_path, None))
     self.assertEqual(testcase.absolute_path, self.testcase_path)
-    # self.assertEqual(metadata['build_url'], self.build_url)
+    self.assertEqual(metadata['build_url'], self.build_url)
     self.assertEqual(testcase.platform, 'linux')

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -157,7 +157,6 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
       gn_args_path.seek(0)
       result = analyze_task.setup_testcase_and_build(testcase, None, 'job',
                                                      'https://fake-url')
-      self.assertTrue(False)  # pylint: disable=redundant-unittest-assert
       metadata = json.loads(testcase.additional_metadata)
       self.assertEqual(metadata['gn_args'], self.gn_args)
     self.assertEqual(result, (self.testcase_path, None))

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for analyze task."""
 
-import json
+# import json
 import os
 import tempfile
 import unittest
@@ -157,9 +157,9 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
       gn_args_path.seek(0)
       result = analyze_task.setup_testcase_and_build(testcase, None, 'job',
                                                      'https://fake-url')
-      metadata = json.loads(testcase.additional_metadata)
-      self.assertEqual(metadata['gn_args'], self.gn_args)
+      # metadata = json.loads(testcase.additional_metadata)
+      # self.assertEqual(metadata['gn_args'], self.gn_args)
     self.assertEqual(result, (self.testcase_path, None))
     self.assertEqual(testcase.absolute_path, self.testcase_path)
-    self.assertEqual(metadata['build_url'], self.build_url)
+    # self.assertEqual(metadata['build_url'], self.build_url)
     self.assertEqual(testcase.platform, 'linux')

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/analyze_task_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for analyze task."""
 
+import json
 import os
 import tempfile
 import unittest
@@ -133,7 +134,6 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
     self.build_url = 'https://build.zip'
     self.mock.setup_testcase.return_value = (None, self.testcase_path, None)
     self.gn_args = ('is_asan = true\n'
-                    'goma_dir = /home/user/goma\n'
                     'use_goma = true\n'
                     'v8_enable_verify_heap = true')
 
@@ -155,8 +155,9 @@ class SetupTestcaseAndBuildTest(unittest.TestCase):
       gn_args_path.seek(0)
       result = analyze_task.setup_testcase_and_build(testcase, None, 'job',
                                                      'https://fake-url')
-      self.assertEqual(testcase.get_metadata('gn_args'), self.gn_args)
+      metadata = json.loads(testcase.additional_metadata)
+      self.assertEqual(metadata['gn_args'], self.gn_args)
     self.assertEqual(result, (self.testcase_path, None))
     self.assertEqual(testcase.absolute_path, self.testcase_path)
-    self.assertEqual(testcase.get_metadata('build_url'), self.build_url)
+    self.assertEqual(metadata['build_url'], self.build_url)
     self.assertEqual(testcase.platform, 'linux')

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -19,7 +19,7 @@ from distutils import dir_util
 import io
 import os
 import platform
-from shlex import quote
+import shlex
 import shutil
 import stat
 import subprocess
@@ -64,7 +64,7 @@ class Gsutil:
 
 def _run_and_handle_exception(arguments, exception_class):
   """Run a command and handle its error output."""
-  print('Running:', ' '.join(quote(arg) for arg in arguments))
+  print('Running:', ' '.join(shlex.quote(arg) for arg in arguments))
   try:
     return subprocess.check_output(arguments)
   except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Also add test for this behavior.
Fixes crbug.com/1450594
Also fix testcase in fuzz_task.py that accidentally inherited from object instead of unittest.TestCase