### PR TITLE
Remove ML cronjob

### DIFF
--- a/configs/test/gae/prod3/cron.yaml
+++ b/configs/test/gae/prod3/cron.yaml
@@ -86,11 +86,6 @@ cron:
     timezone: US/Pacific
     target: cron-service
 
-  - description: Train ML model.
-    url: /schedule-ml-train-tasks
-    schedule: every tuesday 09:00
-    target: cron-service
-
   - description: Schedule progression tasks.
     url: /schedule-progression-tasks
     schedule: every day 07:00


### PR DESCRIPTION
Follow up to #2955
It's failing now, because the endpoint was removed.