### PR TITLE
[rearchitecture] Handle unset fields in protos.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -88,7 +88,7 @@ def get_proto_fields(proto):
   a little different than the behavior of protobuf which sets the value to a
   Falsey version of the same type e.g. string fields are empty strings, int
   fields are 0."""
-  for descriptor in uworker_input_proto.DESCRIPTOR.fields:
+  for descriptor in proto.DESCRIPTOR.fields:
     field_name = descriptor.name
     try:
       has_field = proto.HasField(field_name)
@@ -102,6 +102,7 @@ def get_proto_fields(proto):
       field_value = None
     yield field_name, field_value
 
+
 def deserialize_uworker_input(serialized_uworker_input):
   """Deserializes input for the untrusted part of a task."""
   uworker_input_proto = uworker_msg_pb2.Input()
@@ -114,9 +115,9 @@ def deserialize_uworker_input(serialized_uworker_input):
     if isinstance(field_value, entity_pb2.Entity):
       field_value = UworkerEntityWrapper(
           model._entity_from_protobuf(field_value))  # pylint: disable=protected-access
-      setattr(uworker_input, field_name, entity_wrapper)
     elif isinstance(field_value, uworker_msg_pb2.Json):
       field_value = json.loads(field_value.serialized)
+
     setattr(uworker_input, field_name, field_value)
   return uworker_input
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -246,14 +246,11 @@ class RoundTripTest(unittest.TestCase):
     # Things will break horribly if we pass an unwrapped entity.
     self.assertIsInstance(downloaded_testcase, uworker_io.UworkerEntityWrapper)
 
-    # Now test that the rest of the input was (de)serialized properly.
-    input_dict = uworker_input.__dict__
-    del input_dict['testcase']  # Can't compare object to wrapped object.
-    del input_dict['proto']  # This is just the holder.
-    downloaded_dict = downloaded_input.__dict__
-    del downloaded_dict['testcase']
-    del downloaded_dict['error']  # This is just set by default.
-    self.assertEqual(input_dict, downloaded_dict)
+    self.assertDictEqual(uworker_input.uworker_env, downloaded_input.uworker_env)
+    self.assertEqual(uworker_input.uworker_output_upload_url,
+                     downloaded_input.uworker_output_upload_url)
+    self.assertEqual(uworker_input.testcase_download_url,
+                     downloaded_input.testcase_download_url)
 
   def test_upload_and_download_output(self):
     """Tests that uploading and downloading uworker output works. This means

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -246,7 +246,8 @@ class RoundTripTest(unittest.TestCase):
     # Things will break horribly if we pass an unwrapped entity.
     self.assertIsInstance(downloaded_testcase, uworker_io.UworkerEntityWrapper)
 
-    self.assertDictEqual(uworker_input.uworker_env, downloaded_input.uworker_env)
+    self.assertDictEqual(uworker_input.uworker_env,
+                         downloaded_input.uworker_env)
     self.assertEqual(uworker_input.uworker_output_upload_url,
                      downloaded_input.uworker_output_upload_url)
     self.assertEqual(uworker_input.testcase_download_url,


### PR DESCRIPTION
Ensure that in our deserialized rich-type representation of uworker messages: DeserializedUworkerMsg, that we never throw an attribute error when accessing the proto would not.