### PR TITLE
[fuchsia] Handle expected cases of missing fuzzers

### DIFF
--- a/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
+++ b/src/clusterfuzz/_internal/platforms/fuchsia/undercoat.py
@@ -190,7 +190,7 @@ def stop_instance(handle):
 
 
 def list_fuzzers(handle):
-  """Start an instance via undercoat."""
+  """List fuzzers available on an instance, via undercoat."""
   return undercoat_instance_command('list_fuzzers', handle).output.split('\n')
 
 

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -30,6 +30,7 @@ from clusterfuzz._internal.bot.fuzzers import strategy_selection
 from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 from clusterfuzz._internal.bot.fuzzers.libFuzzer import constants
 from clusterfuzz._internal.bot.fuzzers.libFuzzer import engine
+from clusterfuzz._internal.bot.testcase_manager import TargetNotFoundError
 from clusterfuzz._internal.build_management import build_manager
 from clusterfuzz._internal.fuzzing import strategy
 from clusterfuzz._internal.metrics import logs
@@ -992,6 +993,23 @@ class IntegrationTestsFuchsia(BaseIntegrationTest):
     self.assertIn('ERROR: AddressSanitizer: heap-buffer-overflow on address',
                   result.output)
     self.assertIn('Running: data/fuchsia_crash', result.output)
+
+  @unittest.skipIf(
+      not environment.get_value('FUCHSIA_TESTS'),
+      'Temporarily disabling the Fuchsia tests until build size reduced.')
+  def test_nonexistent_fuzzer_raises_error(self):
+    """Tests that attempting reproduction against a non-existent fuzzer raises
+    a meaningful error."""
+    environment.set_value('FUZZ_TARGET', 'example-fuzzers/missing_fuzzer')
+    environment.set_value('JOB_NAME', 'libfuzzer_asan_fuchsia')
+    build_manager.setup_build()
+    testcase_path, _ = setup_testcase_and_corpus('fuchsia_crash',
+                                                 'empty_corpus')
+    engine_impl = engine.Engine()
+
+    with self.assertRaises(TargetNotFoundError):
+      engine_impl.reproduce('example-fuzzers/missing_fuzzer', testcase_path,
+                            ['-timeout=25', '-rss_limit_mb=2560'], 30)
 
   @unittest.skipIf(
       not environment.get_value('FUCHSIA_TESTS'),


### PR DESCRIPTION
In some cases, such as regression tasks, it is expected that a given build may not contain the desired target fuzzer. Instead of failing the task due to an underlying undercoat error, we now explicitly check for this situation and raise the expected error type.

Fix: https://fxbug.dev/100832