### PR TITLE
Delete the fuzzers and jobs filter on the testcase list page.

### DIFF
--- a/src/appengine/handlers/testcase_list.py
+++ b/src/appengine/handlers/testcase_list.py
@@ -184,10 +184,8 @@ class Handler(base_handler.Handler):
     """Get and render the testcase list in HTML."""
     result, params = get_result()
     field_values = {
-        'projects':
-            data_handler.get_all_project_names(),
-        'shouldShowImpact':
-            utils.is_chromium()
+        'projects': data_handler.get_all_project_names(),
+        'shouldShowImpact': utils.is_chromium()
     }
     return self.render('testcase-list.html', {
         'fieldValues': field_values,

--- a/src/appengine/handlers/testcase_list.py
+++ b/src/appengine/handlers/testcase_list.py
@@ -186,11 +186,6 @@ class Handler(base_handler.Handler):
     field_values = {
         'projects':
             data_handler.get_all_project_names(),
-        'fuzzers':
-            data_handler.get_all_fuzzer_names_including_children(
-                include_parents=True),
-        'jobs':
-            data_handler.get_all_job_type_names(),
         'shouldShowImpact':
             utils.is_chromium()
     }

--- a/src/appengine/private/components/testcase-list/search-control-panel.html
+++ b/src/appengine/private/components/testcase-list/search-control-panel.html
@@ -137,56 +137,6 @@
               </paper-listbox>
             </paper-dropdown-menu>
           </template>
-          <paper-dropdown-menu
-              id="fuzzers"
-              class="dropdown-filter"
-              no-animations="true"
-              label="Fuzzer"
-              value="All"
-              noink>
-            <paper-listbox
-                slot="dropdown-content"
-                selected="{{params.fuzzer}}"
-                attr-for-selected="val">
-              <paper-input
-                  label="Search fuzzers"
-                  value="{{fuzzerKey}}"
-                  on-tap="stopEventPropagation"
-                  on-keydown="stopEventPropagation"
-                  on-keyup="stopEventPropagation" no-label-float>
-                <iron-icon icon="icons:search" slot="prefix"></iron-icon>
-                <iron-icon icon="icons:clear" slot="suffix" on-click="clearSearchInput"></iron-icon>
-              </paper-input>
-              <template is="dom-repeat" items="[[fieldValues.fuzzers]]" filter="{{onmatch(fuzzerKey)}}">
-                <paper-item on-click="submit" val="[[sanitise(item)]]">[[item]]</paper-item>
-              </template>
-            </paper-listbox>
-          </paper-dropdown-menu>
-          <paper-dropdown-menu
-              id="jobs"
-              class="dropdown-filter"
-              no-animations="true"
-              label="Job"
-              value="All"
-              noink>
-            <paper-listbox
-                slot="dropdown-content"
-                selected="{{params.job}}"
-                attr-for-selected="val">
-              <paper-input
-                  label="Search jobs"
-                  value="{{jobKey}}"
-                  on-tap="stopEventPropagation"
-                  on-keydown="stopEventPropagation"
-                  on-keyup="stopEventPropagation" no-label-float>
-                <iron-icon icon="icons:search" slot="prefix"></iron-icon>
-                <iron-icon icon="icons:clear" slot="suffix" on-click="clearSearchInput"></iron-icon>
-              </paper-input>
-              <template is="dom-repeat" items="[[fieldValues.jobs]]" filter="{{onmatch(jobKey)}}">
-                <paper-item on-click="submit" val="[[sanitise(item)]]">[[item]]</paper-item>
-              </template>
-            </paper-listbox>
-          </paper-dropdown-menu>
           <template is="dom-if" if="[[fieldValues.shouldShowImpact]]">
             <paper-dropdown-menu
                 id="impactOptions"


### PR DESCRIPTION
They don't scale to our current deployment's sizes, and do not provide much value anyway. The "project" filter still exists.

This provides a consideration speedup to the load speed to almost instantly. 