### PR TITLE
Print actual error on unittest import failure

### DIFF
--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -156,9 +156,13 @@ def run_tests_parallel(args, test_directory, top_level_dir):
         unittest.TextTestRunner(verbosity=1).run(subsuite)
         raise RuntimeError('A failure occurred while importing the module.')
 
-      for test_class in subsuite._tests:  # pylint: disable=protected-access
-        test_classes.append((test_class.__module__,
-                             test_class.__class__.__name__))
+      try:
+        for test_class in subsuite._tests:  # pylint: disable=protected-access
+          test_classes.append((test_class.__module__,
+                               test_class.__class__.__name__))
+      except AttributeError:
+        subsuite.debug()
+
   test_classes = sorted(test_classes)
 
   test_modules = []


### PR DESCRIPTION
Instead of getting meaningless errors like this:
```
Traceback (most recent call last):                                                                                                           
  File "src/local/butler/py_unittest.py", line 160, in run_tests_parallel
    for test_class in subsuite._tests:  # pylint: disable=protected-access                                                                                                                                                                                                                
  File "/usr/local/lib/python3.7/unittest/loader.py", line 32, in __getattr__
    return super(_FailedTest, self).__getattr__(name)          
AttributeError: 'super' object has no attribute '__getattr__'
```