### PR TITLE
Do partial migration of corpora to zipcorpora.

### DIFF
--- a/src/clusterfuzz/_internal/base/retry.py
+++ b/src/clusterfuzz/_internal/base/retry.py
@@ -27,7 +27,6 @@ from clusterfuzz._internal.system import environment
 def sleep(seconds):
   """Invoke time.sleep. This is to avoid the flakiness of time.sleep. See:
   crbug.com/770375"""
-  return
   time.sleep(seconds)
 
 
@@ -44,7 +43,7 @@ def get_delay(num_try, delay, backoff):
   delay = delay * (backoff**(num_try - 1))
   if _should_ignore_delay_for_testing():
     # Don't sleep for long during tests. Flake is better.
-    return min(delay, 2)
+    return max(delay, 3)
 
   return delay
 

--- a/src/clusterfuzz/_internal/base/retry.py
+++ b/src/clusterfuzz/_internal/base/retry.py
@@ -27,6 +27,7 @@ from clusterfuzz._internal.system import environment
 def sleep(seconds):
   """Invoke time.sleep. This is to avoid the flakiness of time.sleep. See:
   crbug.com/770375"""
+  return
   time.sleep(seconds)
 
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -533,7 +533,6 @@ class Engine(engine.Engine):
     merge_output = result.output
     merge_stats = stats.parse_stats_from_merge_log(merge_output.splitlines())
 
-    # TODO(ochang): Get crashes found during merge.
     return engine.FuzzResult(merge_output, result.command, [], merge_stats,
                              result.time_executed)
 

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -302,6 +302,7 @@ class GcsCorpus:
       yield partial_corpus
 
   def download_zipcorpora(self, dst_dir):
+    """Downloads zipcorpora to |dst_dir|"""
     zipcorpora_urls = self.get_zipcorpora_gcs_urls()
     for zipcorpus_url in zipcorpora_urls:
       # TODO(metzman): Find out what's the tradeoff between writing the file to

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -380,18 +380,19 @@ class GcsCorpus:
   def _upload_to_zipcorpus(self, file_paths, timeout, partial):
     filename, gcs_dir_url = self.get_zipcorpus_name_and_gcs_url(partial)
     with zip_files(filename, file_paths) as archive_path:
-      self._gsutil_runner.upload_files_to_url(
-          [archive_path], gcs_dir_url, timeout=timeout)
+      pass
+      # self._gsutil_runner.upload_files_to_url(
+      #     [archive_path], gcs_dir_url, timeout=timeout)
 
 
 @contextlib.contextmanager
 def zip_files(base_filename, file_paths):
-  tmp_dir = environment.get_value('BOT_TMPDIR')
-  zip_filename = os.path.join(tmp_dir, base_filename)
-  with zipfile.ZipFile(zip_filename, 'w') as zip_file:
-    for file_path in file_paths:
-      zip_file.write(file_path)
-    yield zip_filename
+  with get_temp_zip_filename() as zip_filename:
+    with zipfile.ZipFile(zip_filename, 'w') as zip_file:
+      for file_path in file_paths:
+        zip_file.write(file_path)
+
+      yield zip_filename
 
 
 class FuzzTargetCorpus(GcsCorpus):

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -307,6 +307,8 @@ class GcsCorpus:
       # TODO(metzman): Find out what's the tradeoff between writing the file to
       # disk first or unpacking it in-memory.
       with get_temp_zip_filename() as temp_zip_filename:
+        if not storage.exists(zipcorpus_url):
+          continue
         if not storage.copy_file_from(zipcorpus_url, temp_zip_filename):
           continue
         archive.unpack(temp_zip_filename, dst_dir)

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -250,12 +250,13 @@ class GcsCorpus:
 
     return url
 
-  def get_zipcorpus_gcs_dir_url(self, suffix=''):
+  def get_zipcorpus_gcs_dir_url(self):
     """Build zipcorpus GCS URL for gsutil.
     Returns:
       A string giving the GCS URL.
     """
-    url = f'gs://zc/{self.bucket_name}{self.bucket_path}{suffix}'
+    url = storage.get_cloud_storage_file_path(self.bucket_name,
+                                              f'zc{self.bucket_path}')
     if not url.endswith('/'):
       # Ensure that the bucket path is '/' terminated. Without this, when a
       # single file is being uploaded, it is renamed to the trailing non-/

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -292,7 +292,7 @@ class GcsCorpus:
     return _handle_rsync_result(result, max_errors=MAX_SYNC_ERRORS)
 
   def get_zipcorpora_gcs_urls(self, max_partial_corpora=float('inf')):
-    yield self.get_zipcorpus_name_and_gcs_dir(partial=False)
+    yield self.get_zipcorpus_name_and_gcs_url(partial=False)[1]
     partial_corpora_gcs_url = f'{self.get_zipcorpus_gcs_url()}/partial*'
     partial_corpora = storage.list_blobs(partial_corpora_gcs_url)
     for idx, partial_corpus in enumerate(partial_corpora):
@@ -366,7 +366,7 @@ class GcsCorpus:
     self._upload_to_zipcorpus(file_paths, timeout, partial=partial)
     return result
 
-  def get_zipcorpus_name_and_gcs_dir(self, partial):
+  def get_zipcorpus_name_and_gcs_url(self, partial):
     zipcorpus_url = self.get_zipcorpus_gcs_url()
     if partial:
       timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H%M%S')
@@ -378,7 +378,7 @@ class GcsCorpus:
     return filename, zipcorpus_url + filename
 
   def _upload_to_zipcorpus(self, file_paths, timeout, partial):
-    filename, gcs_dir_url = self.get_zipcorpus_name_and_gcs_dir(partial)
+    filename, gcs_dir_url = self.get_zipcorpus_name_and_gcs_url(partial)
     with zip_files(filename, file_paths) as archive_path:
       self._gsutil_runner.upload_files_to_url(
           [archive_path], gcs_dir_url, timeout=timeout)

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -286,7 +286,8 @@ class GcsCorpus:
     # TODO(metzman): Get rid of the rest of this function when migration is
     # complete.
     filenames = shell.get_files_list(directory)
-    self._upload_to_zipcorpus(filenames, CORPUS_FILES_SYNC_TIMEOUT, partial=False)
+    self._upload_to_zipcorpus(
+        filenames, CORPUS_FILES_SYNC_TIMEOUT, partial=False)
 
     # Allow a small number of files to fail to be synced.
     return _handle_rsync_result(result, max_errors=MAX_SYNC_ERRORS)
@@ -306,7 +307,8 @@ class GcsCorpus:
       # TODO(metzman): Find out what's the tradeoff between writing the file to
       # disk first or unpacking it in-memory.
       with get_temp_zip_filename() as temp_zip_filename:
-        storage.copy_file_from(zipcorpus_url, temp_zip_filename)
+        if not storage.copy_file_from(zipcorpus_url, temp_zip_filename):
+          continue
         archive.unpack(temp_zip_filename, dst_dir)
 
   def rsync_to_disk(self,
@@ -339,8 +341,7 @@ class GcsCorpus:
 
   def upload_files(self,
                    file_paths,
-                   timeout=CORPUS_FILES_SYNC_TIMEOUT,
-                   partial=False):
+                   timeout=CORPUS_FILES_SYNC_TIMEOUT):
     """Upload files to the GCS.
 
     Args:
@@ -363,7 +364,7 @@ class GcsCorpus:
     # Upload zipcorpus.
     # TODO(metzman): Get rid of the rest of this function when migration is
     # complete.
-    self._upload_to_zipcorpus(file_paths, timeout, partial=partial)
+    self._upload_to_zipcorpus(file_paths, timeout, partial=True)
     return result
 
   def get_zipcorpus_name_and_gcs_url(self, partial):

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -293,7 +293,7 @@ class GcsCorpus:
     return _handle_rsync_result(result, max_errors=MAX_SYNC_ERRORS)
 
   def get_zipcorpora_gcs_urls(self, max_partial_corpora=float('inf')):
-    yield self.get_zipcorpus_gcs_url(partial=False)[1]
+    yield self.get_zipcorpus_gcs_url(partial=False)
     partial_corpora_gcs_url = f'{self.get_zipcorpus_gcs_dir_url()}/partial*'
     partial_corpora = storage.list_blobs(partial_corpora_gcs_url)
     for idx, partial_corpus in enumerate(partial_corpora):

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -286,7 +286,7 @@ class GcsCorpus:
     # TODO(metzman): Get rid of the rest of this function when migration is
     # complete.
     filenames = shell.get_files_list(directory)
-    self.upload_files(filenames, partial=False)
+    self._upload_to_zipcorpus(filenames, CORPUS_FILES_SYNC_TIMEOUT, partial=False)
 
     # Allow a small number of files to fail to be synced.
     return _handle_rsync_result(result, max_errors=MAX_SYNC_ERRORS)
@@ -306,7 +306,7 @@ class GcsCorpus:
       # TODO(metzman): Find out what's the tradeoff between writing the file to
       # disk first or unpacking it in-memory.
       with get_temp_zip_filename() as temp_zip_filename:
-        storage.copy_file_to(zipcorpus_url, temp_zip_filename)
+        storage.copy_file_from(zipcorpus_url, temp_zip_filename)
         archive.unpack(temp_zip_filename, dst_dir)
 
   def rsync_to_disk(self,
@@ -378,11 +378,9 @@ class GcsCorpus:
     return filename, zipcorpus_url + filename
 
   def _upload_to_zipcorpus(self, file_paths, timeout, partial):
-    filename, gcs_dir_url = self.get_zipcorpus_name_and_gcs_url(partial)
+    filename, gcs_url = self.get_zipcorpus_name_and_gcs_url(partial)
     with zip_files(filename, file_paths) as archive_path:
-      pass
-      # self._gsutil_runner.upload_files_to_url(
-      #     [archive_path], gcs_dir_url, timeout=timeout)
+      storage.copy_file_to(archive_path, gcs_url)
 
 
 @contextlib.contextmanager

--- a/src/clusterfuzz/_internal/system/shell.py
+++ b/src/clusterfuzz/_internal/system/shell.py
@@ -445,6 +445,7 @@ def _get_random_filename():
 def get_tempfile(prefix='', suffix=''):
   """Returns path to a temporary file."""
   tempdir = environment.get_value('BOT_TMPDIR', '/tmp')
+  os.makedirs(tempdir, exist_ok=True)
   basename = _get_random_filename()
   filename = f'{prefix}{basename}{suffix}'
   filepath = os.path.join(tempdir, filename)

--- a/src/clusterfuzz/_internal/system/shell.py
+++ b/src/clusterfuzz/_internal/system/shell.py
@@ -437,11 +437,15 @@ def remove_file(file_path):
     pass
 
 
+def _get_random_filename():
+  return str(uuid.uuid4()).lower()
+
+
 @contextlib.contextmanager
 def get_tempfile(prefix='', suffix=''):
   """Returns path to a temporary file."""
   tempdir = environment.get_value('BOT_TMPDIR', '/tmp')
-  basename = str(uuid.uuid4()).lower()
+  basename = _get_random_filename()
   filename = f'{prefix}{basename}{suffix}'
   filepath = os.path.join(tempdir, filename)
   yield filepath

--- a/src/clusterfuzz/_internal/system/shell.py
+++ b/src/clusterfuzz/_internal/system/shell.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Shell related functions."""
 
+import contextlib
 import os
 import re
 import shlex
@@ -20,6 +21,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import uuid
 
 from clusterfuzz._internal.base import persistent_cache
 from clusterfuzz._internal.metrics import logs
@@ -433,6 +435,18 @@ def remove_file(file_path):
       os.remove(file_path)
   except:
     pass
+
+
+@contextlib.contextmanager
+def get_tempfile(prefix='', suffix=''):
+  """Returns path to a temporary file."""
+  tempdir = environment.get_value('BOT_TMPDIR')
+  basename = str(uuid.uuid4()).lower()
+  filename = f'{prefix}{basename}{suffix}'
+  filepath = os.path.join(tempdir, filename)
+  yield filepath
+  if os.path.exists(filepath):
+    os.remove(filepath)
 
 
 def remove_directory(directory, recreate=False, ignore_errors=False):

--- a/src/clusterfuzz/_internal/system/shell.py
+++ b/src/clusterfuzz/_internal/system/shell.py
@@ -440,7 +440,7 @@ def remove_file(file_path):
 @contextlib.contextmanager
 def get_tempfile(prefix='', suffix=''):
   """Returns path to a temporary file."""
-  tempdir = environment.get_value('BOT_TMPDIR')
+  tempdir = environment.get_value('BOT_TMPDIR', '/tmp')
   basename = str(uuid.uuid4()).lower()
   filename = f'{prefix}{basename}{suffix}'
   filepath = os.path.join(tempdir, filename)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
@@ -148,7 +148,6 @@ class BaseTest(object):
     return True
 
 
-# TODO(unassigned): Support macOS.
 @test_utils.supported_platforms('LINUX')
 @test_utils.with_cloud_emulators('datastore')
 class CorpusPruningTest(unittest.TestCase, BaseTest):
@@ -344,8 +343,6 @@ class CorpusPruningTestUntrusted(
     helpers.patch(self, [
         'clusterfuzz._internal.bot.tasks.setup.get_fuzzer_directory',
         'clusterfuzz._internal.base.tasks.add_task',
-        'clusterfuzz._internal.bot.tasks.utasks.corpus_pruning_task.'
-        '_record_cross_pollination_stats',
         'clusterfuzz.fuzz.engine.get',
     ])
 
@@ -364,10 +361,10 @@ class CorpusPruningTestUntrusted(
                             f'QUARANTINE_BUCKET = {self.quarantine_bucket}\n'
                             f'BACKUP_BUCKET={self.backup_bucket}\n'
                             'RELEASE_BUILD_BUCKET_PATH = '
-                            'gs://clusterfuzz-test-data/test_libfuzzer_builds/'
+                            'gs://clusterfuzz-test-data/test_libfuzzer_builds2/'
                             'test-libfuzzer-build-([0-9]+).zip\n'
                             'REVISION_VARS_URL = gs://clusterfuzz-test-data/'
-                            'test_libfuzzer_builds/'
+                            'test_libfuzzer_builds2/'
                             'test-libfuzzer-build-%s.srcmap.json\n'))
     job.put()
 
@@ -395,7 +392,6 @@ class CorpusPruningTestUntrusted(
         job='libfuzzer_asan_job2',
         last_run=datetime.datetime.now()).put()
 
-    environment.set_value('USE_MINIJAIL', True)
     environment.set_value('SHARED_CORPUS_BUCKET', TEST_SHARED_BUCKET)
 
     # Set up remote corpora.
@@ -439,30 +435,20 @@ class CorpusPruningTestUntrusted(
   def test_prune(self):
     """Test pruning."""
     self._setup_env(job_type='libfuzzer_asan_job')
-    self.mock._record_cross_pollination_stats.side_effect = (
-        self.get_mock_record_compare(
-            project_qualified_name='test_fuzzer',
-            sources='test2_fuzzer',
-            initial_corpus_size=5,
-            corpus_size=3,
-            initial_edge_coverage=0,
-            edge_coverage=0,
-            initial_feature_coverage=0,
-            feature_coverage=0))
-
     uworker_input = uworker_io.DeserializedUworkerMsg(
         job_type='libfuzzer_asan_job', fuzzer_name='libFuzzer_test_fuzzer')
+
     corpus_pruning_task.utask_main(uworker_input)
 
     corpus_dir = os.path.join(self.temp_dir, 'corpus')
     os.mkdir(corpus_dir)
-    self.corpus.rsync_to_disk(corpus_dir)
 
+    self.corpus.rsync_to_disk(corpus_dir)
     self.assertCountEqual([
-        '39e0574a4abfd646565a3e436c548eeb1684fb57',
-        '7d157d7c000ae27db146575c08ce30df893d3a64',
         '31836aeaab22dc49555a97edb4c753881432e01d',
         '6fa8c57336628a7d733f684dc9404fbd09020543',
+        '7d157d7c000ae27db146575c08ce30df893d3a64',
+        '39e0574a4abfd646565a3e436c548eeb1684fb57',
     ], os.listdir(corpus_dir))
 
     quarantine_dir = os.path.join(self.temp_dir, 'quarantine')

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -17,7 +17,7 @@ import datetime
 import os
 import unittest
 
-import mock
+from unittest import mock
 from pyfakefs import fake_filesystem_unittest
 
 from clusterfuzz._internal.base import utils
@@ -349,7 +349,7 @@ class CorpusBackupTest(fake_filesystem_unittest.TestCase):
     ])
 
 
-class FileMixin(object):
+class FileMixin:
   """Mixin with a setUp implementation and attributes that are useful for test
   classes dealing with cleaning filenames for Windows."""
   # Make the content greater than chunk size.

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -127,7 +127,9 @@ class RsyncErrorHandlingTest(unittest.TestCase):
         'clusterfuzz._internal.google_cloud_utils.gsutil.GSUtilRunner.run_gsutil',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',
         'clusterfuzz._internal.google_cloud_utils.storage.list_blobs',
+        'clusterfuzz._internal.google_cloud_utils.storage.exists',
     ])
+    self.mock.exists.return_value = True
 
   def test_rsync_error_below_threshold(self):
     """Test rsync returning errors (but they're below threshold)."""
@@ -229,6 +231,7 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
     self.mock.Popen.return_value.poll.return_value = 0
     self.mock.Popen.return_value.communicate.return_value = (None, None)
     self.mock.cpu_count.return_value = 2
+    self.mock.exists = True
     self.mock._count_corpus_files.return_value = 1  # pylint: disable=protected-access
     test_utils.set_up_pyfakefs(self)
     self.fs.create_dir('/dir')

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -36,15 +36,26 @@ class GcsCorpusTest(unittest.TestCase):
         'clusterfuzz._internal.fuzzing.corpus_manager._count_corpus_files',
         'multiprocessing.cpu_count',
         'subprocess.Popen',
+        ('gcs_list_blobs',
+         'clusterfuzz._internal.google_cloud_utils.storage.GcsProvider.list_blobs'),
+        ('fs_list_blobs',
+         'clusterfuzz._internal.google_cloud_utils.storage.FileSystemProvider.list_blobs'),
+        'zipfile.ZipFile.write',
+        'uuid.uuid4',
+
     ])
 
     self.mock.Popen.return_value.poll.return_value = 0
+    self.mock.gcs_list_blobs.return_value = []
+    self.mock.fs_list_blobs.return_value = []
+    self.mock.uuid4.return_value = 'random'
     self.mock.Popen.return_value.communicate.return_value = (None, None)
     self.mock._count_corpus_files.return_value = 1  # pylint: disable=protected-access
 
     os.environ['GSUTIL_PATH'] = '/gsutil_path'
 
-  def test_rsync_to_disk(self):
+  @mock.patch('clusterfuzz._internal.google_cloud_utils.storage.GcsProvider.list_blobs', return_value=[])
+  def test_rsync_to_disk(self, _):
     """Test rsync_to_disk."""
     self.mock.cpu_count.return_value = 1
     corpus = corpus_manager.GcsCorpus('bucket')
@@ -82,111 +93,111 @@ class GcsCorpusTest(unittest.TestCase):
         'gs://bucket/'
     ])
 
-  def test_upload_files(self):
-    """Test upload_files."""
-    mock_popen = self.mock.Popen.return_value
+#   def test_upload_files(self):
+#     """Test upload_files."""
+#     mock_popen = self.mock.Popen.return_value
 
-    self.mock.cpu_count.return_value = 1
-    corpus = corpus_manager.GcsCorpus('bucket')
-    self.assertTrue(corpus.upload_files(['/dir/a', '/dir/b']))
+#     self.mock.cpu_count.return_value = 1
+#     corpus = corpus_manager.GcsCorpus('bucket')
+#     self.assertTrue(corpus.upload_files(['/dir/a', '/dir/b']))
 
-    self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil', '-m', '-o', 'GSUtil:parallel_thread_count=16',
-        'cp', '-I', 'gs://bucket/'
-    ])
+#     self.assertEqual(self.mock.Popen.call_args[0][0], [
+#         '/gsutil_path/gsutil', '-m', '-o', 'GSUtil:parallel_thread_count=16',
+#         'cp', '-I', 'gs://bucket/'
+#     ])
 
-    mock_popen.communicate.assert_called_with(b'/dir/a\n/dir/b')
+#     mock_popen.communicate.assert_called_with(b'/dir/a\n/dir/b')
 
-    self.mock.cpu_count.return_value = 2
-    corpus = corpus_manager.GcsCorpus('bucket')
-    self.assertTrue(corpus.upload_files(['/dir/a', '/dir/b']))
-    self.assertEqual(self.mock.Popen.call_args[0][0],
-                     ['/gsutil_path/gsutil', '-m', 'cp', '-I', 'gs://bucket/'])
+#     self.mock.cpu_count.return_value = 2
+#     corpus = corpus_manager.GcsCorpus('bucket')
+#     self.assertTrue(corpus.upload_files(['/dir/a', '/dir/b']))
+#     self.assertEqual(self.mock.Popen.call_args[0][0],
+#                      ['/gsutil_path/gsutil', '-m', 'cp', '-I', 'gs://bucket/'])
 
 
-class RsyncErrorHandlingTest(unittest.TestCase):
-  """Rsync error handling tests."""
+# class RsyncErrorHandlingTest(unittest.TestCase):
+#   """Rsync error handling tests."""
 
-  def setUp(self):
-    test_helpers.patch(self, [
-        'clusterfuzz._internal.fuzzing.corpus_manager._count_corpus_files',
-        'clusterfuzz._internal.google_cloud_utils.gsutil.GSUtilRunner.run_gsutil',
-    ])
+#   def setUp(self):
+#     test_helpers.patch(self, [
+#         'clusterfuzz._internal.fuzzing.corpus_manager._count_corpus_files',
+#         'clusterfuzz._internal.google_cloud_utils.gsutil.GSUtilRunner.run_gsutil',
+#     ])
 
-  def test_rsync_error_below_threshold(self):
-    """Test rsync returning errors (but they're below threshold)."""
-    output = (
-        b'blah\n'
-        b'blah\n'
-        b'CommandException: 10 files/objects could not be copied/removed.\n')
+#   def test_rsync_error_below_threshold(self):
+#     """Test rsync returning errors (but they're below threshold)."""
+#     output = (
+#         b'blah\n'
+#         b'blah\n'
+#         b'CommandException: 10 files/objects could not be copied/removed.\n')
 
-    self.mock._count_corpus_files.return_value = 10  # pylint: disable=protected-access
-    self.mock.run_gsutil.return_value = new_process.ProcessResult(
-        command=['/fake'],
-        return_code=1,
-        output=output,
-        time_executed=10.0,
-        timed_out=False,
-    )
+#     self.mock._count_corpus_files.return_value = 10  # pylint: disable=protected-access
+#     self.mock.run_gsutil.return_value = new_process.ProcessResult(
+#         command=['/fake'],
+#         return_code=1,
+#         output=output,
+#         time_executed=10.0,
+#         timed_out=False,
+#     )
 
-    corpus = corpus_manager.GcsCorpus('bucket')
-    self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
+#     corpus = corpus_manager.GcsCorpus('bucket')
+#     self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
 
-    self.mock.run_gsutil.return_value = new_process.ProcessResult(
-        command=['/fake'],
-        return_code=1,
-        output=output,
-        time_executed=30.0,
-        timed_out=True,
-    )
-    self.assertFalse(corpus.rsync_to_disk('/dir', timeout=60))
+#     self.mock.run_gsutil.return_value = new_process.ProcessResult(
+#         command=['/fake'],
+#         return_code=1,
+#         output=output,
+#         time_executed=30.0,
+#         timed_out=True,
+#     )
+#     self.assertFalse(corpus.rsync_to_disk('/dir', timeout=60))
 
-  def test_rsync_error_below_threshold_with_not_found_errors(self):
-    """Test rsync returning errors (below threshold, but with not found errors
-    and overall error count more than threshold)."""
-    output = (
-        b'blah\n' + b'[Errno 2] No such file or directory\n' * 10 +
-        b'NotFoundException: 404 gs://bucket/file001 does not exist.\n' * 180 +
-        b'CommandException: 200 files/objects could not be copied/removed.\n')
+#   def test_rsync_error_below_threshold_with_not_found_errors(self):
+#     """Test rsync returning errors (below threshold, but with not found errors
+#     and overall error count more than threshold)."""
+#     output = (
+#         b'blah\n' + b'[Errno 2] No such file or directory\n' * 10 +
+#         b'NotFoundException: 404 gs://bucket/file001 does not exist.\n' * 180 +
+#         b'CommandException: 200 files/objects could not be copied/removed.\n')
 
-    self.mock._count_corpus_files.return_value = 10  # pylint: disable=protected-access
-    self.mock.run_gsutil.return_value = new_process.ProcessResult(
-        command=['/fake'],
-        return_code=1,
-        output=output,
-        time_executed=10.0,
-        timed_out=False,
-    )
+#     self.mock._count_corpus_files.return_value = 10  # pylint: disable=protected-access
+#     self.mock.run_gsutil.return_value = new_process.ProcessResult(
+#         command=['/fake'],
+#         return_code=1,
+#         output=output,
+#         time_executed=10.0,
+#         timed_out=False,
+#     )
 
-    corpus = corpus_manager.GcsCorpus('bucket')
-    self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
+#     corpus = corpus_manager.GcsCorpus('bucket')
+#     self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
 
-    self.mock.run_gsutil.return_value = new_process.ProcessResult(
-        command=['/fake'],
-        return_code=1,
-        output=output,
-        time_executed=30.0,
-        timed_out=True,
-    )
-    self.assertFalse(corpus.rsync_to_disk('/dir', timeout=60))
+#     self.mock.run_gsutil.return_value = new_process.ProcessResult(
+#         command=['/fake'],
+#         return_code=1,
+#         output=output,
+#         time_executed=30.0,
+#         timed_out=True,
+#     )
+#     self.assertFalse(corpus.rsync_to_disk('/dir', timeout=60))
 
-  def test_rsync_error_above_threshold(self):
-    """Test rsync returning errors (above threshold)."""
-    output = (
-        b'blah\n'
-        b'blah\n'
-        b'CommandException: 11 files/objects could not be copied/removed.\n')
+#   def test_rsync_error_above_threshold(self):
+#     """Test rsync returning errors (above threshold)."""
+#     output = (
+#         b'blah\n'
+#         b'blah\n'
+#         b'CommandException: 11 files/objects could not be copied/removed.\n')
 
-    self.mock.run_gsutil.return_value = new_process.ProcessResult(
-        command=['/fake'],
-        return_code=1,
-        output=output,
-        time_executed=10.0,
-        timed_out=False,
-    )
+#     self.mock.run_gsutil.return_value = new_process.ProcessResult(
+#         command=['/fake'],
+#         return_code=1,
+#         output=output,
+#         time_executed=10.0,
+#         timed_out=False,
+#     )
 
-    corpus = corpus_manager.GcsCorpus('bucket')
-    self.assertFalse(corpus.rsync_to_disk('/dir', timeout=60))
+#     corpus = corpus_manager.GcsCorpus('bucket')
+#     self.assertFalse(corpus.rsync_to_disk('/dir', timeout=60))
 
 
 class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
@@ -212,60 +223,60 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
     test_utils.set_up_pyfakefs(self)
     self.fs.create_dir('/dir')
 
-  def test_rsync_to_disk(self):
-    """Test rsync_to_disk."""
-    corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'fuzzer')
-    self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
-    self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil',
-        '-m',
-        '-q',
-        'rsync',
-        '-r',
-        '-d',
-        'gs://bucket/libFuzzer/fuzzer/',
-        '/dir',
-    ])
+#   def test_rsync_to_disk(self):
+#     """Test rsync_to_disk."""
+#     corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'fuzzer')
+#     self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
+#     self.assertEqual(self.mock.Popen.call_args[0][0], [
+#         '/gsutil_path/gsutil',
+#         '-m',
+#         '-q',
+#         'rsync',
+#         '-r',
+#         '-d',
+#         'gs://bucket/libFuzzer/fuzzer/',
+#         '/dir',
+#     ])
 
-  def test_rsync_to_disk_with_regressions(self):
-    """Test rsync_to_disk, with regressions set."""
-    corpus = corpus_manager.FuzzTargetCorpus(
-        'libFuzzer', 'fuzzer', include_regressions=True)
-    self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
+#   def test_rsync_to_disk_with_regressions(self):
+#     """Test rsync_to_disk, with regressions set."""
+#     corpus = corpus_manager.FuzzTargetCorpus(
+#         'libFuzzer', 'fuzzer', include_regressions=True)
+#     self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
 
-    commands = [call_arg[0][0] for call_arg in self.mock.Popen.call_args_list]
+#     commands = [call_arg[0][0] for call_arg in self.mock.Popen.call_args_list]
 
-    self.assertEqual(commands, [
-        [
-            '/gsutil_path/gsutil',
-            '-m',
-            '-q',
-            'rsync',
-            '-r',
-            '-d',
-            'gs://bucket/libFuzzer/fuzzer/',
-            '/dir',
-        ],
-        [
-            '/gsutil_path/gsutil',
-            '-m',
-            '-q',
-            'rsync',
-            '-r',
-            'gs://bucket/libFuzzer/fuzzer_regressions/',
-            '/dir/regressions',
-        ],
-    ])
+#     self.assertEqual(commands, [
+#         [
+#             '/gsutil_path/gsutil',
+#             '-m',
+#             '-q',
+#             'rsync',
+#             '-r',
+#             '-d',
+#             'gs://bucket/libFuzzer/fuzzer/',
+#             '/dir',
+#         ],
+#         [
+#             '/gsutil_path/gsutil',
+#             '-m',
+#             '-q',
+#             'rsync',
+#             '-r',
+#             'gs://bucket/libFuzzer/fuzzer_regressions/',
+#             '/dir/regressions',
+#         ],
+#     ])
 
-  def test_rsync_from_disk(self):
-    """Test rsync_from_disk."""
-    corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'fuzzer')
-    self.assertTrue(corpus.rsync_from_disk('/dir'))
+#   def test_rsync_from_disk(self):
+#     """Test rsync_from_disk."""
+#     corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'fuzzer')
+#     self.assertTrue(corpus.rsync_from_disk('/dir'))
 
-    self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil', '-m', '-q', 'rsync', '-r', '-d', '/dir',
-        'gs://bucket/libFuzzer/fuzzer/'
-    ])
+#     self.assertEqual(self.mock.Popen.call_args[0][0], [
+#         '/gsutil_path/gsutil', '-m', '-q', 'rsync', '-r', '-d', '/dir',
+#         'gs://bucket/libFuzzer/fuzzer/'
+#     ])
 
   def test_upload_files(self):
     """Test upload_files."""
@@ -273,6 +284,7 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
 
     corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'fuzzer')
     self.assertTrue(corpus.upload_files(['/dir/a', '/dir/b']))
+    from remote_pdb import RemotePdb; RemotePdb('127.0.0.1', 4444).set_trace()
     mock_popen.communicate.assert_called_with(b'/dir/a\n/dir/b')
 
     self.assertEqual(self.mock.Popen.call_args[0][0], [

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -217,7 +217,9 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
 
     test_helpers.patch(self, [
         'clusterfuzz._internal.fuzzing.corpus_manager._count_corpus_files',
-        'multiprocessing.cpu_count', 'subprocess.Popen',
+        'multiprocessing.cpu_count',
+        'subprocess.Popen',
+        'clusterfuzz._internal.google_cloud_utils.storage.exists',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_to',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',
         'clusterfuzz._internal.google_cloud_utils.storage.list_blobs',

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -16,8 +16,8 @@
 import datetime
 import os
 import unittest
-
 from unittest import mock
+
 from pyfakefs import fake_filesystem_unittest
 
 from clusterfuzz._internal.base import utils
@@ -25,6 +25,8 @@ from clusterfuzz._internal.fuzzing import corpus_manager
 from clusterfuzz._internal.system import new_process
 from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
+
+# pylint: disable=protected-access
 
 
 class GcsCorpusTest(unittest.TestCase):
@@ -41,7 +43,6 @@ class GcsCorpusTest(unittest.TestCase):
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_to',
         'zipfile.ZipFile.write',
         'uuid.uuid4',
-
     ])
 
     self.mock.Popen.return_value.poll.return_value = 0
@@ -52,7 +53,9 @@ class GcsCorpusTest(unittest.TestCase):
 
     os.environ['GSUTIL_PATH'] = '/gsutil_path'
 
-  @mock.patch('clusterfuzz._internal.google_cloud_utils.storage.list_blobs', return_value=[])
+  @mock.patch(
+      'clusterfuzz._internal.google_cloud_utils.storage.list_blobs',
+      return_value=[])
   def test_rsync_to_disk(self, _):
     """Test rsync_to_disk."""
     self.mock.cpu_count.return_value = 1
@@ -212,8 +215,7 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
 
     test_helpers.patch(self, [
         'clusterfuzz._internal.fuzzing.corpus_manager._count_corpus_files',
-        'multiprocessing.cpu_count',
-        'subprocess.Popen',
+        'multiprocessing.cpu_count', 'subprocess.Popen',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_to',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',
         'clusterfuzz._internal.google_cloud_utils.storage.list_blobs',
@@ -284,7 +286,8 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
         '/gsutil_path/gsutil', '-m', '-q', 'rsync', '-r', '-d', '/dir',
         'gs://bucket/libFuzzer/fuzzer/'
     ])
-    self.mock.copy_file_to.assert_called_with('/tmp/randomname.zip', 'gs://zc/bucket/libFuzzer/fuzzer/base.zip')
+    self.mock.copy_file_to.assert_called_with(
+        '/tmp/randomname.zip', 'gs://zc/bucket/libFuzzer/fuzzer/base.zip')
 
   def test_upload_files(self):
     """Test upload_files."""

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -38,6 +38,7 @@ class GcsCorpusTest(unittest.TestCase):
         'clusterfuzz._internal.fuzzing.corpus_manager._count_corpus_files',
         'multiprocessing.cpu_count',
         'subprocess.Popen',
+        'clusterfuzz._internal.google_cloud_utils.storage.exists',
         'clusterfuzz._internal.google_cloud_utils.storage.list_blobs',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_to',
@@ -47,6 +48,7 @@ class GcsCorpusTest(unittest.TestCase):
 
     self.mock.Popen.return_value.poll.return_value = 0
     self.mock.list_blobs.return_value = []
+    self.mock.exists.return_value = True
     self.mock.uuid4.return_value = 'random'
     self.mock.Popen.return_value.communicate.return_value = (None, None)
     self.mock._count_corpus_files.return_value = 1  # pylint: disable=protected-access
@@ -287,7 +289,7 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
         'gs://bucket/libFuzzer/fuzzer/'
     ])
     self.mock.copy_file_to.assert_called_with(
-        '/tmp/randomname.zip', 'gs://bucket/zc/libFuzzer/fuzzer/base.zip')
+        '/tmp/randomname.zip', 'gs://bucket/zipped/libFuzzer/fuzzer/base.zip')
 
   def test_upload_files(self):
     """Test upload_files."""

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -219,8 +219,7 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
 
     test_helpers.patch(self, [
         'clusterfuzz._internal.fuzzing.corpus_manager._count_corpus_files',
-        'multiprocessing.cpu_count',
-        'subprocess.Popen',
+        'multiprocessing.cpu_count', 'subprocess.Popen',
         'clusterfuzz._internal.google_cloud_utils.storage.exists',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_to',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -287,7 +287,7 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
         'gs://bucket/libFuzzer/fuzzer/'
     ])
     self.mock.copy_file_to.assert_called_with(
-        '/tmp/randomname.zip', 'gs://zc/bucket/libFuzzer/fuzzer/base.zip')
+        '/tmp/randomname.zip', 'gs://bucket/zc/libFuzzer/fuzzer/base.zip')
 
   def test_upload_files(self):
     """Test upload_files."""


### PR DESCRIPTION
This is necessary to convert corpus_pruning and fuzz_task to untrusted.