### PR TITLE
Apply ASAN options to targets

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -188,7 +188,7 @@ class Engine(engine.Engine):
       A FuzzResult object.
     """
     runner = _get_runner(target_path)
-    engine_common.process_sanitizer_options_overrides(fuzzer_path)
+    engine_common.process_sanitizer_options_overrides(target_path)
     timeout = max_time + _CLEAN_EXIT_SECS
     fuzz_result = runner.run_and_wait(
         additional_args=options.arguments, timeout=timeout)
@@ -233,7 +233,7 @@ class Engine(engine.Engine):
     Returns:
       A ReproduceResult.
     """
-    engine_common.process_sanitizer_options_overrides(fuzzer_path)
+    engine_common.process_sanitizer_options_overrides(target_path)
     target_binaries = self._get_binary_paths(target_path)
     sanitized_target = str(target_binaries.sanitized)
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -72,14 +72,6 @@ def _get_reproducer_path(log, reproducers_dir):
   return crash_path
 
 
-def _set_sanitizer_options(fuzzer_path):
-  """Sets sanitizer options based on .options file overrides."""
-  engine_common.process_sanitizer_options_overrides(fuzzer_path)
-  sanitizer_options_var = environment.get_current_memory_tool_var()
-  sanitizer_options = environment.get_memory_tool_options(
-      sanitizer_options_var, {})
-  environment.set_memory_tool_options(sanitizer_options_var, sanitizer_options)
-
 
 class Engine(engine.Engine):
   """Centipede engine implementation."""
@@ -197,7 +189,7 @@ class Engine(engine.Engine):
       A FuzzResult object.
     """
     runner = _get_runner(target_path)
-    _set_sanitizer_options(target_path)
+    engine_common.process_sanitizer_options_overrides(fuzzer_path)
     timeout = max_time + _CLEAN_EXIT_SECS
     fuzz_result = runner.run_and_wait(
         additional_args=options.arguments, timeout=timeout)
@@ -242,7 +234,7 @@ class Engine(engine.Engine):
     Returns:
       A ReproduceResult.
     """
-    _set_sanitizer_options(target_path)
+    engine_common.process_sanitizer_options_overrides(fuzzer_path)
     target_binaries = self._get_binary_paths(target_path)
     sanitized_target = str(target_binaries.sanitized)
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -72,7 +72,6 @@ def _get_reproducer_path(log, reproducers_dir):
   return crash_path
 
 
-
 class Engine(engine.Engine):
   """Centipede engine implementation."""
 


### PR DESCRIPTION
[The previous bug](https://clusterfuzz.com/testcase-detail/6589725262151680) regarding `v8_script_parser_fuzzer` was fixed, indicating the correct ASAN options were applied.
However, ASAN options seem not applied on a different target [`html_in_process_fuzzer`](https://clusterfuzz.com/testcases?fuzzer=libFuzzer_html_in_process_fuzzer), even though the options on the report were correct.

This PR addresses this error, and removes some redundant code.