### PR TITLE
Migrate sync_admins cron task to k8s

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/cron/sync_admins.py
+++ b/src/clusterfuzz/_internal/bot/tasks/cron/sync_admins.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ from clusterfuzz._internal.metrics import logs
 
 
 def admins_from_iam_policy(iam_policy):
-  """Get a list of admins from the IAM policy."""
+  """Gets a list of admins from the IAM policy."""
   # Per
   # https://cloud.google.com/appengine/docs/standard/python/users/adminusers, An
   # administrator is a user who has the Viewer, Editor, or Owner primitive role,

--- a/src/clusterfuzz/_internal/bot/tasks/cron/sync_admins.py
+++ b/src/clusterfuzz/_internal/bot/tasks/cron/sync_admins.py
@@ -73,8 +73,7 @@ def update_admins(new_admins):
 
 def main():
   """Admin user syncing cron."""
-  resource_manager = discovery.build('cloudresourcemanager',
-                                                      'v1')
+  resource_manager = discovery.build('cloudresourcemanager', 'v1')
   project_id = utils.get_application_id()
   policy = resource_manager.projects().getIamPolicy(
       resource=project_id, body={}).execute()

--- a/src/clusterfuzz/_internal/bot/tasks/cron/sync_admins.py
+++ b/src/clusterfuzz/_internal/bot/tasks/cron/sync_admins.py
@@ -1,0 +1,84 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cron to sync admin users."""
+
+from googleapiclient import discovery
+
+from clusterfuzz._internal.base import utils
+from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.datastore import ndb_utils
+from clusterfuzz._internal.metrics import logs
+
+
+def admins_from_iam_policy(iam_policy):
+  """Get a list of admins from the IAM policy."""
+  # Per
+  # https://cloud.google.com/appengine/docs/standard/python/users/adminusers, An
+  # administrator is a user who has the Viewer, Editor, or Owner primitive role,
+  # or the App Engine App Admin predefined role
+  roles = [
+      'roles/editor',
+      'roles/owner',
+      'roles/viewer',
+      'roles/appengine.appAdmin',
+  ]
+
+  admins = []
+  for binding in iam_policy['bindings']:
+    if binding['role'] not in roles:
+      continue
+
+    for member in binding['members']:
+      user_type, email = member.split(':', 2)
+      if user_type == 'user':
+        admins.append(email)
+
+  return admins
+
+
+def update_admins(new_admins):
+  """Update list of admins."""
+  existing_admins = ndb_utils.get_all_from_model(data_types.Admin)
+
+  to_remove = []
+  existing_admin_emails = set()
+  for admin in existing_admins:
+    if admin.email not in new_admins:
+      logs.log('Removing admin ' + admin.email)
+      to_remove.append(admin.key)
+
+    existing_admin_emails.add(admin.email)
+
+  ndb_utils.delete_multi(to_remove)
+
+  to_add = []
+  for admin in new_admins:
+    if admin not in existing_admin_emails:
+      to_add.append(data_types.Admin(id=admin, email=admin))
+      logs.log('Adding admin ' + admin)
+
+  ndb_utils.put_multi(to_add)
+
+
+def main():
+  """Admin user syncing cron."""
+  resource_manager = discovery.build('cloudresourcemanager',
+                                                      'v1')
+  project_id = utils.get_application_id()
+  policy = resource_manager.projects().getIamPolicy(
+      resource=project_id, body={}).execute()
+
+  admins = admins_from_iam_policy(policy)
+  update_admins(admins)
+  return True

--- a/src/infra/k8s/sync_admins.yaml
+++ b/src/infra/k8s/sync_admins.yaml
@@ -1,0 +1,38 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync_admins
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: sync_admins
+            image: gcr.io/clusterfuzz-images/base
+            imagePullPolicy: Always
+            env:
+            - name: RUN_CMD
+              value: "python3.7 $ROOT_DIR/src/python/bot/startup/run_cron.py sync_admins"
+            - name: IS_K8S_ENV
+              value: "true"
+            - name: DISABLE_MOUNTS
+              value: "true"
+          restartPolicy: OnFailure
+      backoffLimit: 3

--- a/src/python/bot/startup/run_cron.py
+++ b/src/python/bot/startup/run_cron.py
@@ -27,7 +27,7 @@ from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.datastore import ndb_init
 from clusterfuzz._internal.system import environment
 
-CRON_TASKS = ['backup']
+CRON_TASKS = ['backup', 'sync_admins']
 
 
 def main():


### PR DESCRIPTION
Adding sync_admins to k8s.
Original cron script: https://github.com/google/clusterfuzz/blob/master/src/appengine/handlers/cron/sync_admins.py
1. Copied sync_admins.py to bot/tasks/cron with minor changes (updated handler to main method)
2. Created a new k8s workload yaml file to create job for sync_admins
3. Updated run_cron to add sync_admins task