### PR TITLE
avoid misinterpreting gcloud CLI's debug logs

### DIFF
--- a/src/local/butler/appengine.py
+++ b/src/local/butler/appengine.py
@@ -130,7 +130,7 @@ def region(project):
   """Get the App Engine region."""
   return_code, location = common.execute(
       'gcloud app describe --project={project} '
-      '--format="value(locationId)"'.format(project=project))
+      '--format="value(locationId)"'.format(project=project), stderr=sys.stderr)
   if return_code:
     raise RuntimeError('Could not get App Engine region')
 


### PR DESCRIPTION
Normally the gcloud CLI emits no debug logs, but they can be enabled in its config for troubleshooting purposes e.g. `gcloud config set core/verbosity info`