### PR TITLE
Replace download_as_string with download_as_bytes

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -286,7 +286,7 @@ class GcsProvider(StorageProvider):
     try:
       bucket = client.bucket(bucket_name)
       blob = bucket.blob(path, chunk_size=self._chunk_size())
-      return blob.download_as_string()
+      return blob.download_as_bytes()
     except google.cloud.exceptions.GoogleCloudError as e:
       if e.code == 404:
         return None


### PR DESCRIPTION
Fix issue #3257 by replacing ALLLLLLLLLLLLLLLLLL the download_as_string with download_as_bytes as it's  Deprecated.