### PR TITLE
Deduplicate V8 CSA crashes.

### DIFF
--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -541,6 +541,7 @@ STACK_FRAME_IGNORE_REGEXES = [
     r'.*logging::LogMessage',
     r'.*stdext::exception::what',
     r'.*v8::base::OS::Abort',
+    r'.*Runtime_AbortCSADcheck',
 
     # File paths.
     r'.* base/callback',


### PR DESCRIPTION
Currently, ClusterFuzz treats all CSA crashes as duplicates because it takes account of these stack frames. Ignore the CSA error handling stack frames so that earlier stack frames are treated as the relevant frames from a deduplication perspective.

https://crbug.com/1473885