### PR TITLE
Make get_revisions_list uworker safe

### DIFF
--- a/src/clusterfuzz/_internal/base/bisection.py
+++ b/src/clusterfuzz/_internal/base/bisection.py
@@ -93,7 +93,10 @@ def _check_commits(testcase, bisect_type, old_commit, new_commit):
         testcase.job_type, 'RELEASE_BUILD_BUCKET_PATH')
   else:
     bucket_path = build_manager.get_primary_bucket_path()
-  revision_list = build_manager.get_revisions_list(bucket_path)
+  # TODO(https://github.com/google/clusterfuzz/issues/3008): This cannot be done
+  # on a uworker, move it to preprocess.
+  bad_builds = build_manager.get_job_bad_builds()
+  revision_list = build_manager.get_revisions_list(bucket_path, bad_builds)
 
   last_tested_revision = testcase.get_metadata('last_tested_crash_revision')
   known_crash_revision = last_tested_revision or testcase.crash_revision

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -212,6 +212,12 @@ def handle_setup_testcase_error_invalid_fuzzer(
   testcase.put()
 
 
+HANDLED_ERRORS = [
+    uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
+    uworker_msg_pb2.ErrorType.TESTCASE_SETUP_INVALID_FUZZER
+]
+
+
 def setup_testcase(testcase,
                    job_type,
                    fuzzer_override=None,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -94,8 +94,7 @@ def setup_build(testcase: data_types.Testcase,
           testcase=testcase,
           error=uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST)
     return uworker_io.UworkerOutput(
-        testcase=testcase,
-        error=uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP)
+        testcase=testcase, error=uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP)
 
     revision_index = revisions.find_min_revision_index(revision_list, revision)
     if revision_index is None:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -420,10 +420,8 @@ HANDLED_ERRORS = [
     uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH,
     uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP,
     uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST,
-    uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
-    uworker_msg_pb2.ErrorType.TESTCASE_SETUP_INVALID_FUZZER,
     uworker_msg_pb2.ErrorType.UNHANDLED
-]
+] + setup.HANDLED_ERRORS
 
 
 def utask_postprocess(output):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -78,8 +78,8 @@ def handle_analyze_no_revisions_list_error(output):
   handle_build_setup_error(output)
 
 
-def setup_build(
-    testcase: data_types.Testcase, bad_builds) -> Optional[uworker_io.UworkerOutput]:
+def setup_build(testcase: data_types.Testcase,
+                bad_builds) -> Optional[uworker_io.UworkerOutput]:
   """Set up a custom or regular build based on revision. For regular builds,
   if a provided revision is not found, set up a build with the
   closest revision <= provided revision."""
@@ -130,8 +130,7 @@ def prepare_env_for_main(testcase_upload_metadata):
 
 def setup_testcase_and_build(
     testcase, testcase_upload_metadata, job_type, testcase_download_url,
-    bad_builds
-) -> (Optional[str], Optional[uworker_io.UworkerOutput]):
+    bad_builds) -> (Optional[str], Optional[uworker_io.UworkerOutput]):
   """Sets up the |testcase| and builds. Returns the path to the testcase on
   success, None on error."""
   # Set up testcase and get absolute testcase path.
@@ -323,7 +322,8 @@ def utask_main(uworker_input):
 
   testcase_file_path, output = setup_testcase_and_build(
       uworker_input.testcase, uworker_input.testcase_upload_metadata,
-      uworker_input.job_type, uworker_input.testcase_download_url, uworker_input.bad_builds)
+      uworker_input.job_type, uworker_input.testcase_download_url,
+      uworker_input.bad_builds)
   uworker_input.testcase.crash_revision = environment.get_value('APP_REVISION')
 
   if not testcase_file_path:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -93,8 +93,6 @@ def setup_build(testcase: data_types.Testcase,
       return uworker_io.UworkerOutput(
           testcase=testcase,
           error=uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST)
-    return uworker_io.UworkerOutput(
-        testcase=testcase, error=uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP)
 
     revision_index = revisions.find_min_revision_index(revision_list, revision)
     if revision_index is None:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -90,12 +90,12 @@ def setup_build(testcase: data_types.Testcase,
     revision_list = build_manager.get_revisions_list(
         build_bucket_path, bad_builds, testcase=testcase)
     if not revision_list:
-      uworker_io.UworkerOutput(
-          testcase=testcase,
-          error=uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP)
       return uworker_io.UworkerOutput(
           testcase=testcase,
-          error=uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP)
+          error=uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST)
+    return uworker_io.UworkerOutput(
+        testcase=testcase,
+        error=uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP)
 
     revision_index = revisions.find_min_revision_index(revision_list, revision)
     if revision_index is None:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -253,8 +253,12 @@ def find_fixed_range(testcase_id, job_type):
     return
 
   build_bucket_path = build_manager.get_primary_bucket_path()
+  # TODO(https://github.com/google/clusterfuzz/issues/3008): Move this to
+  # preprocess.
+  bad_builds = build_manager.get_job_bad_builds()
+
   revision_list = build_manager.get_revisions_list(
-      build_bucket_path, testcase=testcase)
+      build_bucket_path, bad_builds, testcase=testcase)
   if not revision_list:
     data_handler.close_testcase_with_error(testcase,
                                            'Failed to fetch revision list')

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -243,7 +243,7 @@ def find_regression_range(testcase_id, job_type):
   bad_builds = build_manager.get_job_bad_builds()
 
   revision_list = build_manager.get_revisions_list(
-      build_bucket_path, testcase=testcase)
+      build_bucket_path, bad_builds, testcase=testcase)
   if not revision_list:
     data_handler.close_testcase_with_error(testcase,
                                            'Failed to fetch revision list')

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -237,6 +237,11 @@ def find_regression_range(testcase_id, job_type):
     return
 
   build_bucket_path = build_manager.get_primary_bucket_path()
+
+  # TODO(https://github.com/google/clusterfuzz/issues/3008): Move this to
+  # preprocess.
+  bad_builds = build_manager.get_job_bad_builds()
+
   revision_list = build_manager.get_revisions_list(
       build_bucket_path, testcase=testcase)
   if not revision_list:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -41,7 +41,7 @@ def get_handle_all_errors_mapping():
           analyze_task.handle_noncrash,
       uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
           analyze_task.handle_build_setup_error,
-      uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
+      uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST:
           analyze_task.handle_analyze_no_revisions_list_error,
       uworker_msg_pb2.ErrorType.TESTCASE_SETUP:
           setup.handle_setup_testcase_error,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -41,6 +41,8 @@ def get_handle_all_errors_mapping():
           analyze_task.handle_noncrash,
       uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
           analyze_task.handle_build_setup_error,
+      uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
+          analyze_task.handle_analyze_no_revisions_list_error,
       uworker_msg_pb2.ErrorType.TESTCASE_SETUP:
           setup.handle_setup_testcase_error,
       uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -422,6 +422,16 @@ class UworkerInput(UworkerMsg):
       save_json_field(field, value)
       return
 
+    if isinstance(field, collections.Sequence):
+      # This the way to tell if it's a repeated field.
+      # We can't get the type of the repeated field directly.
+      value = list(value)
+      if len(value) == 0:
+        return
+      assert isinstance(value[0], ndb.Model), value[0]
+      field.extend([model._entity_to_protobuf(entity) for entity in value])  # pylint: disable=protected-access
+      return
+
     if isinstance(value, UworkerMsg):
       field.CopyFrom(value.proto)
       return
@@ -436,20 +446,6 @@ class UworkerInput(UworkerMsg):
 class UpdateFuzzerAndDataBundleInput(UworkerInput):
   """Input for setup.update_fuzzer_and_data_bundle in uworker_main."""
   PROTO_CLS = uworker_msg_pb2.UpdateFuzzerAndDataBundlesInput
-
-  def save_rich_type(self, attribute, value):
-    field = getattr(self.proto, attribute)
-    if isinstance(field, collections.Sequence):
-      # This the way to tell if it's a repeated field.
-      # We can't get the type of the repeated field directly.
-      value = list(value)
-      if len(value) == 0:
-        return
-      assert isinstance(value[0], ndb.Model), value[0]
-      field.extend([model._entity_to_protobuf(entity) for entity in value])  # pylint: disable=protected-access
-      return
-
-    super().save_rich_type(attribute, value)
 
 
 class DeserializedUworkerMsg:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -201,9 +201,8 @@ def handle_build_setup_error(output):
 
 HANDLED_ERRORS = [
     uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP,
-    uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
     uworker_msg_pb2.ErrorType.UNHANDLED
-]
+] + setup.HANDLED_ERRORS
 
 
 def utask_postprocess(output):

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1122,11 +1122,6 @@ def get_revisions_list(bucket_path, bad_builds, testcase=None):
       revision = revisions.convert_revision_to_integer(match.group(1))
       revision_list.append(revision)
 
-  if bad_builds is not None:
-    # Remove revisions for bad builds from the revision list.
-    # TODO(https://github.com/google/clusterfuzz/issues/3008):
-    bad_builds = get_job_bad_builds()
-
   for bad_build in bad_builds:
     # Don't remove testcase revision even if it is in bad build list. This
     # usually happens when a bad bot sometimes marks a particular revision as
@@ -1142,10 +1137,12 @@ def get_revisions_list(bucket_path, bad_builds, testcase=None):
 
 def get_job_bad_builds():
   job_type = environment.get_value('JOB_NAME')
-  bad_builds = ndb_utils.get_all_from_query(
-      data_types.BuildMetadata.query(
-          ndb_utils.is_true(data_types.BuildMetadata.bad_build),
-          data_types.BuildMetadata.job_type == job_type))
+  bad_builds = list(
+      ndb_utils.get_all_from_query(
+          data_types.BuildMetadata.query(
+              ndb_utils.is_true(data_types.BuildMetadata.bad_build),
+              data_types.BuildMetadata.job_type == job_type)))
+  return bad_builds
 
 
 def _base_fuzz_target_name(target_name):

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1104,7 +1104,7 @@ def get_primary_bucket_path():
       'needs to be defined.')
 
 
-def get_revisions_list(bucket_path, testcase=None):
+def get_revisions_list(bucket_path, bad_builds, testcase=None):
   """Returns a sorted ascending list of revisions from a bucket path, excluding
   bad build revisions and testcase crash revision (if any)."""
   revision_pattern = revisions.revision_pattern_from_build_bucket_path(
@@ -1122,12 +1122,11 @@ def get_revisions_list(bucket_path, testcase=None):
       revision = revisions.convert_revision_to_integer(match.group(1))
       revision_list.append(revision)
 
-  # Remove revisions for bad builds from the revision list.
-  job_type = environment.get_value('JOB_NAME')
-  bad_builds = ndb_utils.get_all_from_query(
-      data_types.BuildMetadata.query(
-          ndb_utils.is_true(data_types.BuildMetadata.bad_build),
-          data_types.BuildMetadata.job_type == job_type))
+  if bad_builds is not None:
+    # Remove revisions for bad builds from the revision list.
+    # TODO(https://github.com/google/clusterfuzz/issues/3008):
+    bad_builds = get_job_bad_builds()
+
   for bad_build in bad_builds:
     # Don't remove testcase revision even if it is in bad build list. This
     # usually happens when a bad bot sometimes marks a particular revision as
@@ -1139,6 +1138,14 @@ def get_revisions_list(bucket_path, testcase=None):
       revision_list.remove(bad_build.revision)
 
   return revision_list
+
+
+def get_job_bad_builds():
+  job_type = environment.get_value('JOB_NAME')
+  bad_builds = ndb_utils.get_all_from_query(
+      data_types.BuildMetadata.query(
+          ndb_utils.is_true(data_types.BuildMetadata.bad_build),
+          data_types.BuildMetadata.job_type == job_type))
 
 
 def _base_fuzz_target_name(target_name):

--- a/src/clusterfuzz/_internal/protos/uworker_msg.proto
+++ b/src/clusterfuzz/_internal/protos/uworker_msg.proto
@@ -48,7 +48,8 @@ message Input {
   optional string original_job_type = 9;
   optional string fuzzer_name = 10;
   optional UpdateFuzzerAndDataBundlesInput update_fuzzer_and_data_bundles_input = 11;
-  optional string module_name = 12;
+  repeated google.datastore.v1.Entity bad_builds = 12;
+  optional string module_name = 13;
 }
 
 message FuzzTaskOutput {
@@ -66,10 +67,11 @@ enum ErrorType {
   NO_ERROR = 0;
   ANALYZE_BUILD_SETUP = 1;
   ANALYZE_NO_CRASH = 2;
-  TESTCASE_SETUP = 3;
-  UNHANDLED = 4;
-  VARIANT_BUILD_SETUP = 5;
-  TESTCASE_SETUP_INVALID_FUZZER = 6;
+  ANALYZE_NO_REVISIONS_LIST = 3;
+  TESTCASE_SETUP = 4;
+  UNHANDLED = 5;
+  VARIANT_BUILD_SETUP = 6;
+  TESTCASE_SETUP_INVALID_FUZZER = 7;
 }
 
 message Output {

--- a/src/clusterfuzz/_internal/protos/uworker_msg_pb2.py
+++ b/src/clusterfuzz/_internal/protos/uworker_msg_pb2.py
@@ -35,7 +35,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n.clusterfuzz/_internal/protos/uworker_msg.proto\x1a,google/cloud/datastore_v1/proto/entity.proto\"\x1a\n\x04Json\x12\x12\n\nserialized\x18\x01 \x01(\t\"[\n\x14UworkerEntityWrapper\x12+\n\x06\x65ntity\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.Entity\x12\x16\n\x07\x63hanged\x18\x02 \x01(\x0b\x32\x05.Json\"\xb3\x02\n\x1fUpdateFuzzerAndDataBundlesInput\x12\x30\n\x06\x66uzzer\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\x18\n\x0b\x66uzzer_name\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x31\n\x0c\x64\x61ta_bundles\x18\x03 \x03(\x0b\x32\x1b.google.datastore.v1.Entity\x12\"\n\x15\x66uzzer_log_upload_url\x18\x04 \x01(\tH\x02\x88\x01\x01\x12 \n\x13\x66uzzer_download_url\x18\x05 \x01(\tH\x03\x88\x01\x01\x42\t\n\x07_fuzzerB\x0e\n\x0c_fuzzer_nameB\x18\n\x16_fuzzer_log_upload_urlB\x16\n\x14_fuzzer_download_url\"\xf3\x05\n\x05Input\x12\x32\n\x08testcase\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\x42\n\x18testcase_upload_metadata\x18\x02 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x01\x88\x01\x01\x12\x18\n\x0btestcase_id\x18\x03 \x01(\tH\x02\x88\x01\x01\x12\x1f\n\x0buworker_env\x18\x04 \x01(\x0b\x32\x05.JsonH\x03\x88\x01\x01\x12\"\n\x15testcase_download_url\x18\x05 \x01(\tH\x04\x88\x01\x01\x12\x15\n\x08job_type\x18\x06 \x01(\tH\x05\x88\x01\x01\x12&\n\x19uworker_output_upload_url\x18\x07 \x01(\tH\x06\x88\x01\x01\x12\x31\n\x07variant\x18\x08 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x07\x88\x01\x01\x12\x1e\n\x11original_job_type\x18\t \x01(\tH\x08\x88\x01\x01\x12\x18\n\x0b\x66uzzer_name\x18\n \x01(\tH\t\x88\x01\x01\x12S\n$update_fuzzer_and_data_bundles_input\x18\x0b \x01(\x0b\x32 .UpdateFuzzerAndDataBundlesInputH\n\x88\x01\x01\x12\x18\n\x0bmodule_name\x18\x0c \x01(\tH\x0b\x88\x01\x01\x42\x0b\n\t_testcaseB\x1b\n\x19_testcase_upload_metadataB\x0e\n\x0c_testcase_idB\x0e\n\x0c_uworker_envB\x18\n\x16_testcase_download_urlB\x0b\n\t_job_typeB\x1c\n\x1a_uworker_output_upload_urlB\n\n\x08_variantB\x14\n\x12_original_job_typeB\x0e\n\x0c_fuzzer_nameB\'\n%_update_fuzzer_and_data_bundles_inputB\x0e\n\x0c_module_name\"\xc3\x03\n\x0e\x46uzzTaskOutput\x12\x18\n\x0b\x66uzzer_name\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0e\x63rash_revision\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x1e\n\x11job_run_timestamp\x18\x03 \x01(\x02H\x02\x88\x01\x01\x12\x1c\n\x0fnew_crash_count\x18\x04 \x01(\x03H\x03\x88\x01\x01\x12\x1e\n\x11known_crash_count\x18\x05 \x01(\x03H\x04\x88\x01\x01\x12\x1f\n\x12testcases_executed\x18\x06 \x01(\x03H\x05\x88\x01\x01\x12#\n\x0fjob_run_crashes\x18\x07 \x01(\x0b\x32\x05.JsonH\x06\x88\x01\x01\x12(\n\x1b\x66ully_qualified_fuzzer_name\x18\x08 \x01(\tH\x07\x88\x01\x01\x42\x0e\n\x0c_fuzzer_nameB\x11\n\x0f_crash_revisionB\x14\n\x12_job_run_timestampB\x12\n\x10_new_crash_countB\x14\n\x12_known_crash_countB\x15\n\x13_testcases_executedB\x12\n\x10_job_run_crashesB\x1e\n\x1c_fully_qualified_fuzzer_name\"\xc0\x04\n\x06Output\x12,\n\x08testcase\x18\x01 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x00\x88\x01\x01\x12<\n\x18testcase_upload_metadata\x18\x02 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x01\x88\x01\x01\x12+\n\x07variant\x18\x03 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x02\x88\x01\x01\x12\x1e\n\x05\x65rror\x18\x04 \x01(\x0e\x32\n.ErrorTypeH\x03\x88\x01\x01\x12\"\n\ruworker_input\x18\x05 \x01(\x0b\x32\x06.InputH\x04\x88\x01\x01\x12\x19\n\x0ctest_timeout\x18\x06 \x01(\x02H\x05\x88\x01\x01\x12\x17\n\ncrash_time\x18\x07 \x01(\x02H\x06\x88\x01\x01\x12$\n\x17\x63rash_stacktrace_output\x18\x08 \x01(\tH\x07\x88\x01\x01\x12.\n\x10\x66uzz_task_output\x18\t \x01(\x0b\x32\x0f.FuzzTaskOutputH\x08\x88\x01\x01\x12\x1a\n\rerror_message\x18\n \x01(\tH\t\x88\x01\x01\x42\x0b\n\t_testcaseB\x1b\n\x19_testcase_upload_metadataB\n\n\x08_variantB\x08\n\x06_errorB\x10\n\x0e_uworker_inputB\x0f\n\r_test_timeoutB\r\n\x0b_crash_timeB\x1a\n\x18_crash_stacktrace_outputB\x13\n\x11_fuzz_task_outputB\x10\n\x0e_error_message*\xa7\x01\n\tErrorType\x12\x0c\n\x08NO_ERROR\x10\x00\x12\x17\n\x13\x41NALYZE_BUILD_SETUP\x10\x01\x12\x14\n\x10\x41NALYZE_NO_CRASH\x10\x02\x12\x12\n\x0eTESTCASE_SETUP\x10\x03\x12\r\n\tUNHANDLED\x10\x04\x12\x17\n\x13VARIANT_BUILD_SETUP\x10\x05\x12!\n\x1dTESTCASE_SETUP_INVALID_FUZZER\x10\x06\x62\x06proto3'
+  serialized_pb=b'\n.clusterfuzz/_internal/protos/uworker_msg.proto\x1a,google/cloud/datastore_v1/proto/entity.proto\"\x1a\n\x04Json\x12\x12\n\nserialized\x18\x01 \x01(\t\"[\n\x14UworkerEntityWrapper\x12+\n\x06\x65ntity\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.Entity\x12\x16\n\x07\x63hanged\x18\x02 \x01(\x0b\x32\x05.Json\"\xb3\x02\n\x1fUpdateFuzzerAndDataBundlesInput\x12\x30\n\x06\x66uzzer\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\x18\n\x0b\x66uzzer_name\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x31\n\x0c\x64\x61ta_bundles\x18\x03 \x03(\x0b\x32\x1b.google.datastore.v1.Entity\x12\"\n\x15\x66uzzer_log_upload_url\x18\x04 \x01(\tH\x02\x88\x01\x01\x12 \n\x13\x66uzzer_download_url\x18\x05 \x01(\tH\x03\x88\x01\x01\x42\t\n\x07_fuzzerB\x0e\n\x0c_fuzzer_nameB\x18\n\x16_fuzzer_log_upload_urlB\x16\n\x14_fuzzer_download_url\"\xa4\x06\n\x05Input\x12\x32\n\x08testcase\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\x42\n\x18testcase_upload_metadata\x18\x02 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x01\x88\x01\x01\x12\x18\n\x0btestcase_id\x18\x03 \x01(\tH\x02\x88\x01\x01\x12\x1f\n\x0buworker_env\x18\x04 \x01(\x0b\x32\x05.JsonH\x03\x88\x01\x01\x12\"\n\x15testcase_download_url\x18\x05 \x01(\tH\x04\x88\x01\x01\x12\x15\n\x08job_type\x18\x06 \x01(\tH\x05\x88\x01\x01\x12&\n\x19uworker_output_upload_url\x18\x07 \x01(\tH\x06\x88\x01\x01\x12\x31\n\x07variant\x18\x08 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x07\x88\x01\x01\x12\x1e\n\x11original_job_type\x18\t \x01(\tH\x08\x88\x01\x01\x12\x18\n\x0b\x66uzzer_name\x18\n \x01(\tH\t\x88\x01\x01\x12S\n$update_fuzzer_and_data_bundles_input\x18\x0b \x01(\x0b\x32 .UpdateFuzzerAndDataBundlesInputH\n\x88\x01\x01\x12/\n\nbad_builds\x18\x0c \x03(\x0b\x32\x1b.google.datastore.v1.Entity\x12\x18\n\x0bmodule_name\x18\r \x01(\tH\x0b\x88\x01\x01\x42\x0b\n\t_testcaseB\x1b\n\x19_testcase_upload_metadataB\x0e\n\x0c_testcase_idB\x0e\n\x0c_uworker_envB\x18\n\x16_testcase_download_urlB\x0b\n\t_job_typeB\x1c\n\x1a_uworker_output_upload_urlB\n\n\x08_variantB\x14\n\x12_original_job_typeB\x0e\n\x0c_fuzzer_nameB\'\n%_update_fuzzer_and_data_bundles_inputB\x0e\n\x0c_module_name\"\xc3\x03\n\x0e\x46uzzTaskOutput\x12\x18\n\x0b\x66uzzer_name\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0e\x63rash_revision\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x1e\n\x11job_run_timestamp\x18\x03 \x01(\x02H\x02\x88\x01\x01\x12\x1c\n\x0fnew_crash_count\x18\x04 \x01(\x03H\x03\x88\x01\x01\x12\x1e\n\x11known_crash_count\x18\x05 \x01(\x03H\x04\x88\x01\x01\x12\x1f\n\x12testcases_executed\x18\x06 \x01(\x03H\x05\x88\x01\x01\x12#\n\x0fjob_run_crashes\x18\x07 \x01(\x0b\x32\x05.JsonH\x06\x88\x01\x01\x12(\n\x1b\x66ully_qualified_fuzzer_name\x18\x08 \x01(\tH\x07\x88\x01\x01\x42\x0e\n\x0c_fuzzer_nameB\x11\n\x0f_crash_revisionB\x14\n\x12_job_run_timestampB\x12\n\x10_new_crash_countB\x14\n\x12_known_crash_countB\x15\n\x13_testcases_executedB\x12\n\x10_job_run_crashesB\x1e\n\x1c_fully_qualified_fuzzer_name\"\xc0\x04\n\x06Output\x12,\n\x08testcase\x18\x01 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x00\x88\x01\x01\x12<\n\x18testcase_upload_metadata\x18\x02 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x01\x88\x01\x01\x12+\n\x07variant\x18\x03 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x02\x88\x01\x01\x12\x1e\n\x05\x65rror\x18\x04 \x01(\x0e\x32\n.ErrorTypeH\x03\x88\x01\x01\x12\"\n\ruworker_input\x18\x05 \x01(\x0b\x32\x06.InputH\x04\x88\x01\x01\x12\x19\n\x0ctest_timeout\x18\x06 \x01(\x02H\x05\x88\x01\x01\x12\x17\n\ncrash_time\x18\x07 \x01(\x02H\x06\x88\x01\x01\x12$\n\x17\x63rash_stacktrace_output\x18\x08 \x01(\tH\x07\x88\x01\x01\x12.\n\x10\x66uzz_task_output\x18\t \x01(\x0b\x32\x0f.FuzzTaskOutputH\x08\x88\x01\x01\x12\x1a\n\rerror_message\x18\n \x01(\tH\t\x88\x01\x01\x42\x0b\n\t_testcaseB\x1b\n\x19_testcase_upload_metadataB\n\n\x08_variantB\x08\n\x06_errorB\x10\n\x0e_uworker_inputB\x0f\n\r_test_timeoutB\r\n\x0b_crash_timeB\x1a\n\x18_crash_stacktrace_outputB\x13\n\x11_fuzz_task_outputB\x10\n\x0e_error_message*\xc6\x01\n\tErrorType\x12\x0c\n\x08NO_ERROR\x10\x00\x12\x17\n\x13\x41NALYZE_BUILD_SETUP\x10\x01\x12\x14\n\x10\x41NALYZE_NO_CRASH\x10\x02\x12\x1d\n\x19\x41NALYZE_NO_REVISIONS_LIST\x10\x03\x12\x12\n\x0eTESTCASE_SETUP\x10\x04\x12\r\n\tUNHANDLED\x10\x05\x12\x17\n\x13VARIANT_BUILD_SETUP\x10\x06\x12!\n\x1dTESTCASE_SETUP_INVALID_FUZZER\x10\x07\x62\x06proto3'
   ,
   dependencies=[google_dot_cloud_dot_datastore__v1_dot_proto_dot_entity__pb2.DESCRIPTOR,])
 
@@ -62,30 +62,35 @@ _ERRORTYPE = _descriptor.EnumDescriptor(
       type=None,
       create_key=_descriptor._internal_create_key),
     _descriptor.EnumValueDescriptor(
-      name='TESTCASE_SETUP', index=3, number=3,
+      name='ANALYZE_NO_REVISIONS_LIST', index=3, number=3,
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
     _descriptor.EnumValueDescriptor(
-      name='UNHANDLED', index=4, number=4,
+      name='TESTCASE_SETUP', index=4, number=4,
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
     _descriptor.EnumValueDescriptor(
-      name='VARIANT_BUILD_SETUP', index=5, number=5,
+      name='UNHANDLED', index=5, number=5,
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
     _descriptor.EnumValueDescriptor(
-      name='TESTCASE_SETUP_INVALID_FUZZER', index=6, number=6,
+      name='VARIANT_BUILD_SETUP', index=6, number=6,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='TESTCASE_SETUP_INVALID_FUZZER', index=7, number=7,
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2319,
-  serialized_end=2486,
+  serialized_start=2368,
+  serialized_end=2566,
 )
 _sym_db.RegisterEnumDescriptor(_ERRORTYPE)
 
@@ -93,10 +98,11 @@ ErrorType = enum_type_wrapper.EnumTypeWrapper(_ERRORTYPE)
 NO_ERROR = 0
 ANALYZE_BUILD_SETUP = 1
 ANALYZE_NO_CRASH = 2
-TESTCASE_SETUP = 3
-UNHANDLED = 4
-VARIANT_BUILD_SETUP = 5
-TESTCASE_SETUP_INVALID_FUZZER = 6
+ANALYZE_NO_REVISIONS_LIST = 3
+TESTCASE_SETUP = 4
+UNHANDLED = 5
+VARIANT_BUILD_SETUP = 6
+TESTCASE_SETUP_INVALID_FUZZER = 7
 
 
 
@@ -337,8 +343,15 @@ _INPUT = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='module_name', full_name='Input.module_name', index=11,
-      number=12, type=9, cpp_type=9, label=1,
+      name='bad_builds', full_name='Input.bad_builds', index=11,
+      number=12, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='module_name', full_name='Input.module_name', index=12,
+      number=13, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -416,7 +429,7 @@ _INPUT = _descriptor.Descriptor(
     fields=[]),
   ],
   serialized_start=528,
-  serialized_end=1283,
+  serialized_end=1332,
 )
 
 
@@ -536,8 +549,8 @@ _FUZZTASKOUTPUT = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1286,
-  serialized_end=1737,
+  serialized_start=1335,
+  serialized_end=1786,
 )
 
 
@@ -681,8 +694,8 @@ _OUTPUT = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1740,
-  serialized_end=2316,
+  serialized_start=1789,
+  serialized_end=2365,
 )
 
 _UWORKERENTITYWRAPPER.fields_by_name['entity'].message_type = google_dot_cloud_dot_datastore__v1_dot_proto_dot_entity__pb2._ENTITY
@@ -706,6 +719,7 @@ _INPUT.fields_by_name['testcase_upload_metadata'].message_type = google_dot_clou
 _INPUT.fields_by_name['uworker_env'].message_type = _JSON
 _INPUT.fields_by_name['variant'].message_type = google_dot_cloud_dot_datastore__v1_dot_proto_dot_entity__pb2._ENTITY
 _INPUT.fields_by_name['update_fuzzer_and_data_bundles_input'].message_type = _UPDATEFUZZERANDDATABUNDLESINPUT
+_INPUT.fields_by_name['bad_builds'].message_type = google_dot_cloud_dot_datastore__v1_dot_proto_dot_entity__pb2._ENTITY
 _INPUT.oneofs_by_name['_testcase'].fields.append(
   _INPUT.fields_by_name['testcase'])
 _INPUT.fields_by_name['testcase'].containing_oneof = _INPUT.oneofs_by_name['_testcase']


### PR DESCRIPTION
Split the unsafe part (get_job_bad_builds) into it's own function that can be called in preprocess.
Call it in preprocess in analyze_task.