### PR TITLE
Allow preprocess to return None

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -28,10 +28,11 @@ def tworker_preprocess_no_io(utask_module, task_argument, job_type,
   set_uworker_env(uworker_env)
   uworker_input = utask_module.utask_preprocess(task_argument, job_type,
                                                 uworker_env)
+  if not uworker_input:
+    logs.log_error('No uworker_input returned from preprocess')
+    return None
   assert not uworker_input.module_name
   uworker_input.module_name = utask_module.__name__
-  if not uworker_input:
-    return None
   return uworker_io.serialize_uworker_input(uworker_input)
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -353,7 +353,10 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
     return None
 
   if testcase.fixed:
-    logs.log_error(f'Fixed range is already set as {testcase.fixed}, skip.')
+    error_message = f'Fixed range is already set as {testcase.fixed}, skip.'
+    logs.log_error(error_message)
+    data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
+                                         error_message)
     return None
 
   # TODO(alhijazi): Make sure this is always properly cleared on failure.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -353,10 +353,7 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
     return None
 
   if testcase.fixed:
-    error_message = f'Fixed range is already set as {testcase.fixed}, skip.'
-    logs.log_error(error_message)
-    data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
-                                         error_message)
+    logs.log_error(f'Fixed range is already set as {testcase.fixed}, skip.')
     return None
 
   # TODO(alhijazi): Make sure this is always properly cleared on failure.

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -58,6 +58,16 @@ class TworkerPreprocessTest(unittest.TestCase):
     self.assertEqual(
         (self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL), result)
 
+  def test_return_none(self):
+    module = mock.MagicMock()
+    module.utask_preprocess.return_value = None
+    self.assertIsNone(
+        utasks.tworker_preprocess(module, self.TASK_ARGUMENT, self.JOB_TYPE,
+                                  self.UWORKER_ENV))
+    self.assertIsNone(
+        utasks.tworker_preprocess_no_io(module, self.TASK_ARGUMENT,
+                                        self.JOB_TYPE, self.UWORKER_ENV))
+
 
 class SetUworkerEnvTest(unittest.TestCase):
   """Tests that set_uworker_env works as intended."""


### PR DESCRIPTION
Skip main when this happens.
This behavior was originally intended and is needed to preserved functionality in progression_task.