### PR TITLE
Add libgbm1:i386 to chromium Dockerfile.

### DIFF
--- a/docker/chromium/base/Dockerfile
+++ b/docker/chromium/base/Dockerfile
@@ -31,6 +31,7 @@ RUN dpkg --add-architecture i386 && \
         libdconf-dev \
         libdconf1 \
         libdconf1:i386 \
+        libgbm-dev:i386 \
         libgconf-2-4:i386 \
         libgconf2-dev \
         libgles2-mesa \

--- a/docker/chromium/base/Dockerfile
+++ b/docker/chromium/base/Dockerfile
@@ -31,7 +31,7 @@ RUN dpkg --add-architecture i386 && \
         libdconf-dev \
         libdconf1 \
         libdconf1:i386 \
-        libgbm-dev:i386 \
+        libgbm1:i386 \
         libgconf-2-4:i386 \
         libgconf2-dev \
         libgles2-mesa \


### PR DESCRIPTION
Second attempt at fixing https://crbug.com/1361458. This fixes a typo in the previously-landed-and-reverted PR #3345 by @jonathanmetzman, and aims to install the library runtime instead of the development files. 