### PR TITLE
Retrieve APP_REVISION for custom_binaries after setup_build is called.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -214,9 +214,9 @@ def _log_output(revision, crash_result):
 
 def _check_fixed_for_custom_binary(testcase, testcase_file_path):
   """Simplified fixed check for test cases using custom binaries."""
-  revision = environment.get_value('APP_REVISION')
-
   build_manager.setup_build()
+  # 'APP_REVISION' is set during setup_build().
+  revision = environment.get_value('APP_REVISION')
   if not build_manager.check_app_path():
     return uworker_io.UworkerOutput(
         testcase=testcase,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -217,6 +217,10 @@ def _check_fixed_for_custom_binary(testcase, testcase_file_path):
   build_manager.setup_build()
   # 'APP_REVISION' is set during setup_build().
   revision = environment.get_value('APP_REVISION')
+  if revision is None:
+    logs.log_error('APP_REVISION is not set, setting revision to 0')
+    revision = 0
+
   if not build_manager.check_app_path():
     return uworker_io.UworkerOutput(
         testcase=testcase,

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -1035,6 +1035,8 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
     """Test setting up a custom binary."""
     os.environ['JOB_NAME'] = 'job_custom'
     self.mock.time.return_value = 1000.0
+    # APP_REVISION env variable is set during setup_custom_binary.
+    self.assertIsNone(os.environ.get('APP_REVISION'))
     build = build_manager.setup_custom_binary()
     self.assertIsInstance(build, build_manager.CustomBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)


### PR DESCRIPTION
@jonathanmetzman  Could you please take a look?
This is related to: 
https://pantheon.corp.google.com/errors/detail/CLm6ree1lZ_79QE;filter=%5B%22progression%22%5D?e=-13802955&mods=logs_tg_prod&project=google.com:clusterfuzz