### PR TITLE
Ignore pyenv configuration file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .idea
 /.project
 /.pydevproject
+/.python-version
 /ENV
 /bot/*
 /coverage


### PR DESCRIPTION
This allows using [pyenv](https://github.com/pyenv/pyenv) to manage python versions.