### PR TITLE
Clarify that get_testcase_by_id() cannot return None

### DIFF
--- a/src/clusterfuzz/_internal/base/errors.py
+++ b/src/clusterfuzz/_internal/base/errors.py
@@ -50,8 +50,8 @@ class Error(Exception):
 class InvalidTestcaseError(Error):
   """Error thrown when there is an attempt to access an invalid test case."""
 
-  def __init__(self):
-    super().__init__('Invalid test case.')
+  def __init__(self, testcase_id):
+    super().__init__(f'Invalid test case {testcase_id!r}.')
 
 
 class InvalidFuzzerError(Error):

--- a/src/clusterfuzz/_internal/bot/tasks/blame_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/blame_task.py
@@ -273,8 +273,6 @@ def execute_task(testcase_id, _):
   """Attempt to find the CL introducing the bug associated with testcase_id."""
   # Locate the testcase associated with the id.
   testcase = data_handler.get_testcase_by_id(testcase_id)
-  if not testcase:
-    return
 
   # Make sure that predator topic is configured. If not, nothing to do here.
   topic = db_config.get_value('predator_crash_topic')

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -265,12 +265,8 @@ def update_testcase_after_crash(testcase, state, job_type, http_flag):
 
 def utask_preprocess(testcase_id, job_type, uworker_env):
   """Runs preprocessing for analyze task."""
-
-  # Locate the testcase associated with the id.
+  # Get the testcase from the database and mark it as started.
   testcase = data_handler.get_testcase_by_id(testcase_id)
-  if not testcase:
-    return None
-
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   testcase_upload_metadata = data_types.TestcaseUploadMetadata.query(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
@@ -357,8 +357,6 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
   """Preprocess in a trusted bot."""
   # Locate the testcase associated with the id.
   testcase = data_handler.get_testcase_by_id(testcase_id)
-  if not testcase:
-    return None
 
   # Allow setting up a different fuzzer.
   minimize_fuzzer_override = environment.get_value('MINIMIZE_FUZZER_OVERRIDE')

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -60,8 +60,6 @@ def _get_variant_testcase_for_job(testcase, job_type):
 def utask_preprocess(testcase_id, job_type, uworker_env):
   """Run a test case with a different job type to see if they reproduce."""
   testcase = data_handler.get_testcase_by_id(testcase_id)
-  if not testcase:
-    return None
 
   if (environment.is_engine_fuzzer_job(testcase.job_type) !=
       environment.is_engine_fuzzer_job(job_type)):

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -110,13 +110,17 @@ def get_domain():
 
 
 def get_testcase_by_id(testcase_id):
-  """Return the testcase with the given id, or None if it does not exist."""
-  if not testcase_id or not str(testcase_id).isdigit() or int(testcase_id) == 0:
-    raise errors.InvalidTestcaseError
+  """Return the testcase with the given id.
+  Raises InvalidTestcaseError if no such testcase exists.
+  """
+  try:
+    parsed_id = int(testcase_id)
+  except ValueError:
+    raise errors.InvalidTestcaseError(testcase_id)
 
-  testcase = ndb.Key(data_types.Testcase, int(testcase_id)).get()
+  testcase = ndb.Key(data_types.Testcase, parsed_id).get()
   if not testcase:
-    raise errors.InvalidTestcaseError
+    raise errors.InvalidTestcaseError(parsed_id)
 
   return testcase
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -118,6 +118,9 @@ def get_testcase_by_id(testcase_id):
   except ValueError:
     raise errors.InvalidTestcaseError(testcase_id)
 
+  if parsed_id == 0:
+    raise errors.InvalidTestcaseError(0)
+
   testcase = ndb.Key(data_types.Testcase, parsed_id).get()
   if not testcase:
     raise errors.InvalidTestcaseError(parsed_id)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
@@ -157,7 +157,8 @@ class RunCommandTest(unittest.TestCase):
 
   def test_run_command_invalid_testcase(self):
     """Test run_command with an invalid testcase exception."""
-    self.mock.progression_utask_preprocess.side_effect = errors.InvalidTestcaseError(123)
+    self.mock.progression_utask_preprocess.side_effect = errors.InvalidTestcaseError(
+        123)
     commands.run_command('progression', '123', 'job', {})
 
     task_status_entities = list(data_types.TaskStatus.query())

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
@@ -157,7 +157,7 @@ class RunCommandTest(unittest.TestCase):
 
   def test_run_command_invalid_testcase(self):
     """Test run_command with an invalid testcase exception."""
-    self.mock.progression_utask_preprocess.side_effect = errors.InvalidTestcaseError
+    self.mock.progression_utask_preprocess.side_effect = errors.InvalidTestcaseError(123)
     commands.run_command('progression', '123', 'job', {})
 
     task_status_entities = list(data_types.TaskStatus.query())


### PR DESCRIPTION
Instead, it raises an `InvalidTestcaseError` exception.

Along the way, clean up `get_testcase_by_id()` a bit by relying on `int()` exception handling to  catch bad IDs, and augment `InvalidTestcaseError` to capture the invalid ID for (hopefully) better logging.