### PR TITLE
Integrate with issuetracker public API + Some cleanup

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -352,8 +352,6 @@ class Issue(issue_tracker.Issue):
     if self._is_new:
       priority = _extract_label(self.labels, 'Pri-')
       issue_type = _extract_label(self.labels, 'Type-') or 'BUG'
-      issue_type = 'BUG'
-      priority = None
       self._data['issueState']['type'] = issue_type
       if priority:
         self._data['issueState']['priority'] = priority

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -347,33 +347,13 @@ class Issue(issue_tracker.Issue):
                                       issueId=str(self.id)))
     return result
 
-  def _override_priority_and_type(self):
-    """Determines whether if we should override the priority and type."""
-    if '1680101' in self.labels:
-      # Unreproducible hotlist.
-      return False
-    if '5075787' in self.labels:
-      # Targets marked explicitly as non-security relevant.
-      return False
-    # 347144: Language Platforms>Software Analysis>SunDew>Target Generation -
-    # FUDGE>Target Crashes
-    # 1056691: Security>ISE>TPS>Autofuzz>ClusterFuzz>Unreproducible
-    if self._components.get_single() in ('347144', '1056691'):
-      return False
-    if '//security/laser/sundew/targetgen' in self.title:
-      # Noisy targets.
-      return False
-    return True
-
   def save(self, new_comment=None, notify=True):
     """Saves the issue."""
     if self._is_new:
       priority = _extract_label(self.labels, 'Pri-')
       issue_type = _extract_label(self.labels, 'Type-') or 'BUG'
-      if not self._override_priority_and_type():
-        # Reset to default.
-        issue_type = 'BUG'
-        priority = None
+      issue_type = 'BUG'
+      priority = None
       self._data['issueState']['type'] = issue_type
       if priority:
         self._data['issueState']['priority'] = priority
@@ -544,10 +524,10 @@ class Action(issue_tracker.Action):
 class IssueTracker(issue_tracker.IssueTracker):
   """Google issue tracker implementation."""
 
-  def __init__(self, project, http_client, config):
+  def __init__(self, project, http_client, component_id):
     self._project = project
     self._client = http_client
-    self._default_component_id = config['default_component_id']
+    self._component_id = component_id
 
   @property
   def client(self):
@@ -583,7 +563,7 @@ class IssueTracker(issue_tracker.IssueTracker):
     """Creates an unsaved new issue."""
     data = {
         'issueState': {
-            'componentId': self._default_component_id,
+            'componentId': self._component_id,
             'ccs': [],
             'hotlistIds': [],
         }
@@ -665,6 +645,30 @@ def _get_query(keywords, only_open):
   return query
 
 
-def get(project, config, issue_tracker_client=None):
+def get(project, component_id, issue_tracker_client=None):
   """Gets an IssueTracker for the project."""
-  return IssueTracker(project, issue_tracker_client, config)
+  return IssueTracker(project, issue_tracker_client, component_id)
+
+
+# Uncomment for local testing. Will need access to a service account for these
+# steps to work. List of steps taken (for posterity)-
+# 1. gcloud iam service-accounts keys create --iam-account=${service_account} \
+#    --key-file-type=json /tmp/sa-key
+# 2. pipenv shell
+# 3. GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa-key PYTHONPATH=$PYTHONPATH:src/ \
+#    python src/clusterfuzz/_internal/issue_management/google_issue_tracker/\
+#    issue_tracker.py
+
+# if __name__ == '__main__':
+#   it = get('chromium', 1434846, None)
+#
+#   # Test issue creation.
+#   issue = it.new_issue()
+#   issue.title = 'test issue'
+#   issue.assignee = 'rmistry@google.com'
+#   issue.status = 'ASSIGNED'
+#   issue.save(new_comment='testing')
+#
+#   # Test issue query.
+#   queried_issue = it.get_issue(306010501)
+#   print(queried_issue._data)

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -522,10 +522,10 @@ class Action(issue_tracker.Action):
 class IssueTracker(issue_tracker.IssueTracker):
   """Google issue tracker implementation."""
 
-  def __init__(self, project, http_client, component_id):
+  def __init__(self, project, http_client, config):
     self._project = project
     self._client = http_client
-    self._component_id = component_id
+    self._default_component_id = config['default_component_id']
 
   @property
   def client(self):
@@ -561,7 +561,7 @@ class IssueTracker(issue_tracker.IssueTracker):
     """Creates an unsaved new issue."""
     data = {
         'issueState': {
-            'componentId': self._component_id,
+            'componentId': self._default_component_id,
             'ccs': [],
             'hotlistIds': [],
         }
@@ -643,9 +643,9 @@ def _get_query(keywords, only_open):
   return query
 
 
-def get(project, component_id, issue_tracker_client=None):
+def get(project, config, issue_tracker_client=None):
   """Gets an IssueTracker for the project."""
-  return IssueTracker(project, issue_tracker_client, component_id)
+  return IssueTracker(project, issue_tracker_client, config)
 
 
 # Uncomment for local testing. Will need access to a service account for these
@@ -658,7 +658,7 @@ def get(project, component_id, issue_tracker_client=None):
 #    issue_tracker.py
 
 # if __name__ == '__main__':
-#   it = get('chromium', 1434846, None)
+#   it = get('chromium', {'default_component_id': 1434846}, None)
 #
 #   # Test issue creation.
 #   issue = it.new_issue()


### PR DESCRIPTION
This PR contains the changes necessary to get ClusterFuzz working with the issuetracker public API- It fixes the discovery URL and completes the `client.build_http()` method.

The integration with public API was verified locally by using a GCP service account and tested against a test component. Example created issue: b/306010501
The steps taken to setup the local environment have been documented in the `issue_tracker.py` file.

Cleanup has also been done-
* The `_override_priority_and_type` method has been removed. It was not used.
* The `config`dict  has been replaced by `component_id`. That was the only field accessed from the `config` dict.