### PR TITLE
Add Issue Access Limit to Issue Class as Private Data

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -95,7 +95,7 @@ class Issue(issue_tracker.Issue):
     self._components = _SingleComponentStore(components)
     self._body = None
     self._changed = set()
-    self._issue_access_level = IssueAccessLevel.LIMIT_NONE
+    self._access_limit = {'access_level': IssueAccessLevel.LIMIT_NONE}
 
   def _reset_tracking(self):
     """Resets diff tracking."""
@@ -320,8 +320,8 @@ class Issue(issue_tracker.Issue):
                                 _make_users)
     self._add_update_collection(update_body, added, removed, '_collaborators',
                                 'collaborators', _make_users)
-    self._add_update_single(update_body, added, removed, '_issue_access_level',
-                            'issue_access_level')
+    self._add_update_single(update_body, added, removed, '_access_limit',
+                            'access_limit')
     update_body['addMask'] = ','.join(added)
     update_body['removeMask'] = ','.join(removed)
     if notify:
@@ -404,9 +404,9 @@ class Issue(issue_tracker.Issue):
       collaborators = list(self._collaborators)
       if collaborators:
         self._data['issueState']['collaborators'] = _make_users(collaborators)
-      issue_access_level = self._issue_access_level
-      if issue_access_level:
-        self._data['issueState']['issue_access_level'] = issue_access_level
+      access_limit = self._access_limit
+      if access_limit:
+        self._data['issueState']['access_limit'] = access_limit
       self._data['issueState']['hotlistIds'] = [
           int(label) for label in self.labels
       ]
@@ -611,7 +611,9 @@ class IssueTracker(issue_tracker.IssueTracker):
             'ccs': [],
             'collaborators': [],
             'hotlistIds': [],
-            'issue_access_level': IssueAccessLevel.LIMIT_NONE,
+            'access_limit': {
+                'access_level': IssueAccessLevel.LIMIT_NONE
+            },
         }
     }
     return Issue(data, True, self)

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -202,11 +202,6 @@ class Issue(issue_tracker.Issue):
     return self._ccs
 
   @property
-  def collaborators(self):
-    """The issue collaborators list."""
-    return self._collaborators
-
-  @property
   def labels(self):
     """The issue labels list."""
     return self._labels
@@ -314,7 +309,7 @@ class Issue(issue_tracker.Issue):
     self._add_update_single(update_body, added, removed, 'title', 'title')
     self._add_update_collection(update_body, added, removed, 'ccs', 'ccs',
                                 _make_users)
-    self._add_update_collection(update_body, added, removed, 'collaborators',
+    self._add_update_collection(update_body, added, removed, '_collaborators',
                                 'collaborators', _make_users)
     update_body['addMask'] = ','.join(added)
     update_body['removeMask'] = ','.join(removed)
@@ -522,17 +517,6 @@ class Action(issue_tracker.Action):
   def ccs(self):
     """The issue CC change list."""
     removed, added = self._get_field_update_changes('ccs')
-    change_list = issue_tracker.ChangeList()
-    if added:
-      change_list.added.extend(added)
-    if removed:
-      change_list.removed.extend(removed)
-    return change_list
-
-  @property
-  def collaborators(self):
-    """The issue collaborators change list."""
-    removed, added = self._get_field_update_changes('collaborators')
     change_list = issue_tracker.ChangeList()
     if added:
       change_list.added.extend(added)

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -232,15 +232,15 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'comment': 'issue body'
                 },
                 'issueState': {
-                    'status':
-                        'ASSIGNED',
+                    'status': 'ASSIGNED',
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title':
-                        'issue title',
-                    'issue_access_level':
-                        issue_tracker.IssueAccessLevel.LIMIT_NONE,
+                    'title': 'issue title',
+                    'access_limit': {
+                        'access_level':
+                            issue_tracker.IssueAccessLevel.LIMIT_NONE
+                    },
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
@@ -248,11 +248,9 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId':
-                        9001,
+                    'componentId': 9001,
                     'hotlistIds': [12345],
-                    'type':
-                        'BUG',
+                    'type': 'BUG',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -278,8 +276,9 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'S2',
             'title':
                 'issue title2',
-            'issue_access_level':
-                issue_tracker.IssueAccessLevel.LIMIT_NONE,
+            'access_limit': {
+                'access_level': issue_tracker.IssueAccessLevel.LIMIT_NONE
+            },
             'reporter': {
                 'emailAddress': 'reporter@google.com',
                 'userGaiaStatus': 'ACTIVE',

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -232,11 +232,15 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'comment': 'issue body'
                 },
                 'issueState': {
-                    'status': 'ASSIGNED',
+                    'status':
+                        'ASSIGNED',
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title': 'issue title',
+                    'title':
+                        'issue title',
+                    'issue_access_level':
+                        issue_tracker.IssueAccessLevel.LIMIT_NONE,
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
@@ -244,9 +248,11 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId': 9001,
+                    'componentId':
+                        9001,
                     'hotlistIds': [12345],
-                    'type': 'BUG',
+                    'type':
+                        'BUG',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -272,6 +278,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'S2',
             'title':
                 'issue title2',
+            'issue_access_level':
+                issue_tracker.IssueAccessLevel.LIMIT_NONE,
             'reporter': {
                 'emailAddress': 'reporter@google.com',
                 'userGaiaStatus': 'ACTIVE',

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -111,7 +111,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     self.assertCountEqual([], issue.labels)
     self.assertCountEqual(['29002'], issue.components)
     self.assertCountEqual([], issue.ccs)
-    self.assertCountEqual([], issue.collaborators)
     self.assertEqual('test body', issue.body)
 
   def test_closed(self):
@@ -214,44 +213,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         issue.ccs,
     )
 
-  def test_get_collaborators(self):
-    """Test getting collaborators."""
-    self.client.issues().get().execute.return_value = {
-        'issueId': '68823253',
-        'issueState': {
-            'componentId':
-                '29002',
-            'type':
-                'BUG',
-            'status':
-                'NEW',
-            'priority':
-                'P2',
-            'severity':
-                'S2',
-            'title':
-                'test',
-            'collaborators': [
-                {
-                    'emailAddress': 'collaborator1@google.com',
-                    'userGaiaStatus': 'ACTIVE'
-                },
-                {
-                    'emailAddress': 'collaborator2@google.com',
-                    'userGaiaStatus': 'ACTIVE'
-                },
-            ],
-        },
-    }
-    issue = self.issue_tracker.get_issue(68823253)
-    self.assertCountEqual(
-        [
-            'collaborator1@google.com',
-            'collaborator2@google.com',
-        ],
-        issue.collaborators,
-    )
-
   def test_new_issue(self):
     """Test basic new issue creation."""
     issue = self.issue_tracker.new_issue()
@@ -259,7 +220,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
-    issue.collaborators.add('collaborator@google.com')
     issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
@@ -272,27 +232,21 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'comment': 'issue body'
                 },
                 'issueState': {
-                    'status':
-                        'ASSIGNED',
+                    'status': 'ASSIGNED',
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title':
-                        'issue title',
+                    'title': 'issue title',
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
-                    'collaborators': [{
-                        'emailAddress': 'collaborator@google.com'
-                    }],
+                    'collaborators': [],
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId':
-                        9001,
+                    'componentId': 9001,
                     'hotlistIds': [12345],
-                    'type':
-                        'BUG',
+                    'type': 'BUG',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -332,9 +286,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'emailAddress': 'cc@google.com',
                 'userGaiaStatus': 'ACTIVE'
             },],
-            'collaborators': [{
-                'emailAddress': 'collaborator@google.com'
-            }],
             'hotlistIds': ['12345',],
         },
         'createdTime': '2019-06-25T01:29:30.021Z',
@@ -352,7 +303,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
-    issue.collaborators.add('collaborator@google.com')
     issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
@@ -363,25 +313,20 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call(
             body={
                 'add': {
-                    'status':
-                        'ASSIGNED',
+                    'status': 'ASSIGNED',
                     'assignee': {
                         'emailAddress': 'assignee2@google.com'
                     },
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
-                    'collaborators': [{
-                        'emailAddress': 'collaborator@google.com'
-                    }],
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title':
-                        'issue title2',
+                    'title': 'issue title2',
                 },
                 'removeMask': '',
-                'addMask': 'status,assignee,reporter,title,ccs,collaborators',
+                'addMask': 'status,assignee,reporter,title,ccs',
                 'remove': {},
                 'significanceOverride': 'MAJOR',
             },

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -111,6 +111,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     self.assertCountEqual([], issue.labels)
     self.assertCountEqual(['29002'], issue.components)
     self.assertCountEqual([], issue.ccs)
+    self.assertCountEqual([], issue.collaborators)
     self.assertEqual('test body', issue.body)
 
   def test_closed(self):
@@ -213,6 +214,44 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         issue.ccs,
     )
 
+  def test_get_collaborators(self):
+    """Test getting collaborators."""
+    self.client.issues().get().execute.return_value = {
+        'issueId': '68823253',
+        'issueState': {
+            'componentId':
+                '29002',
+            'type':
+                'BUG',
+            'status':
+                'NEW',
+            'priority':
+                'P2',
+            'severity':
+                'S2',
+            'title':
+                'test',
+            'collaborators': [
+                {
+                    'emailAddress': 'collaborator1@google.com',
+                    'userGaiaStatus': 'ACTIVE'
+                },
+                {
+                    'emailAddress': 'collaborator2@google.com',
+                    'userGaiaStatus': 'ACTIVE'
+                },
+            ],
+        },
+    }
+    issue = self.issue_tracker.get_issue(68823253)
+    self.assertCountEqual(
+        [
+            'collaborator1@google.com',
+            'collaborator2@google.com',
+        ],
+        issue.collaborators,
+    )
+
   def test_new_issue(self):
     """Test basic new issue creation."""
     issue = self.issue_tracker.new_issue()
@@ -220,6 +259,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
+    issue.collaborators.add('collaborator@google.com')
     issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
@@ -232,20 +272,27 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'comment': 'issue body'
                 },
                 'issueState': {
-                    'status': 'ASSIGNED',
+                    'status':
+                        'ASSIGNED',
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title': 'issue title',
+                    'title':
+                        'issue title',
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
+                    }],
+                    'collaborators': [{
+                        'emailAddress': 'collaborator@google.com'
                     }],
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId': 9001,
+                    'componentId':
+                        9001,
                     'hotlistIds': [12345],
-                    'type': 'BUG',
+                    'type':
+                        'BUG',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -285,6 +332,9 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'emailAddress': 'cc@google.com',
                 'userGaiaStatus': 'ACTIVE'
             },],
+            'collaborators': [{
+                'emailAddress': 'collaborator@google.com'
+            }],
             'hotlistIds': ['12345',],
         },
         'createdTime': '2019-06-25T01:29:30.021Z',
@@ -302,6 +352,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
+    issue.collaborators.add('collaborator@google.com')
     issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
@@ -312,20 +363,25 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call(
             body={
                 'add': {
-                    'status': 'ASSIGNED',
+                    'status':
+                        'ASSIGNED',
                     'assignee': {
                         'emailAddress': 'assignee2@google.com'
                     },
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
+                    'collaborators': [{
+                        'emailAddress': 'collaborator@google.com'
+                    }],
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title': 'issue title2',
+                    'title':
+                        'issue title2',
                 },
                 'removeMask': '',
-                'addMask': 'status,assignee,reporter,title,ccs',
+                'addMask': 'status,assignee,reporter,title,ccs,collaborators',
                 'remove': {},
                 'significanceOverride': 'MAJOR',
             },


### PR DESCRIPTION
We will use this data in the subsequent PRs to allow saving and updating an issue's access level