### PR TITLE
Fix sanitizers overrides

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -604,22 +604,22 @@ def process_sanitizer_options_overrides(fuzzer_path):
   hwasan_options = environment.get_memory_tool_options('HWASAN_OPTIONS', {})
 
   asan_overrides = fuzzer_options.get_asan_options()
-  if asan_options and asan_overrides:
+  if asan_overrides:
     asan_options.update(asan_overrides)
     environment.set_memory_tool_options('ASAN_OPTIONS', asan_options)
 
   msan_overrides = fuzzer_options.get_msan_options()
-  if msan_options and msan_overrides:
+  if msan_overrides:
     msan_options.update(msan_overrides)
     environment.set_memory_tool_options('MSAN_OPTIONS', msan_options)
 
   ubsan_overrides = fuzzer_options.get_ubsan_options()
-  if ubsan_options and ubsan_overrides:
+  if ubsan_overrides:
     ubsan_options.update(ubsan_overrides)
     environment.set_memory_tool_options('UBSAN_OPTIONS', ubsan_options)
 
   hwasan_overrides = fuzzer_options.get_hwasan_options()
-  if hwasan_options and hwasan_overrides:
+  if hwasan_overrides:
     hwasan_options.update(hwasan_overrides)
     environment.set_memory_tool_options('HWASAN_OPTIONS', hwasan_options)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/builtin_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/builtin_test.py
@@ -148,7 +148,7 @@ class EngineFuzzerTest(BaseEngineFuzzerTest):
 
     self.assertEqual('fake_option1=1:fake_option2=1',
                      environment.get_value('ASAN_OPTIONS'))
-    self.assertEqual(None, environment.get_value('MSAN_OPTIONS'))
+    self.assertEqual('fake_options3=1', environment.get_value('MSAN_OPTIONS'))
 
 
 class GetFuzzerPath(unittest.TestCase):


### PR DESCRIPTION
As for now, if no environment variables are set, we won't use the sanitizers override to update those. This fix allows changing sanitizers overrides even though the environment variable is not initially set.