### PR TITLE
Use Extension Fields from Config to Set Security Flow on Save Issue

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -95,7 +95,7 @@ class Issue(issue_tracker.Issue):
     self._components = _SingleComponentStore(components)
     self._body = None
     self._changed = set()
-    self._issue_access_level = IssueAccessLevel.LIMIT_NONE
+    self._access_limit = {'access_level': IssueAccessLevel.LIMIT_NONE}
 
   def _reset_tracking(self):
     """Resets diff tracking."""
@@ -320,8 +320,8 @@ class Issue(issue_tracker.Issue):
                                 _make_users)
     self._add_update_collection(update_body, added, removed, '_collaborators',
                                 'collaborators', _make_users)
-    self._add_update_single(update_body, added, removed, '_issue_access_level',
-                            'issue_access_level')
+    self._add_update_single(update_body, added, removed, '_access_limit',
+                            'access_limit')
     update_body['addMask'] = ','.join(added)
     update_body['removeMask'] = ','.join(removed)
     if notify:
@@ -404,9 +404,9 @@ class Issue(issue_tracker.Issue):
       collaborators = list(self._collaborators)
       if collaborators:
         self._data['issueState']['collaborators'] = _make_users(collaborators)
-      issue_access_level = self._issue_access_level
-      if issue_access_level:
-        self._data['issueState']['issue_access_level'] = issue_access_level
+      access_limit = self._access_limit
+      if access_limit:
+        self._data['issueState']['access_limit'] = access_limit
       self._data['issueState']['hotlistIds'] = [
           int(label) for label in self.labels
       ]
@@ -611,7 +611,9 @@ class IssueTracker(issue_tracker.IssueTracker):
             'ccs': [],
             'collaborators': [],
             'hotlistIds': [],
-            'issue_access_level': IssueAccessLevel.LIMIT_NONE,
+            'access_limit': {
+                'access_level': IssueAccessLevel.LIMIT_NONE
+            },
         }
     }
     return Issue(data, True, self)

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -112,7 +112,8 @@ class Issue(issue_tracker.Issue):
       # Collaborators may be added to an issue to provide access and visibility
       self._ext_collaborators = policy.security.ext_collaborators or []
       # The issue's access limit may be updated to restrict access
-      self._ext_issue_access_limit = policy.security.ext_issue_access_limit or []
+      self._ext_issue_access_limit = \
+        policy.security.ext_issue_access_limit or []
 
   @property
   def issue_tracker(self):

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -86,6 +86,8 @@ class Issue(issue_tracker.Issue):
     self._ccs = issue_tracker.LabelStore(
         [user['emailAddress'] for user in ccs if 'emailAddress' in user])
     collaborators = data['issueState'].get('collaborators', [])
+    # _ext_collaborators is an extension field that is used in
+    # google_issue_tracker.
     self._ext_collaborators = issue_tracker.LabelStore([
         user['emailAddress'] for user in collaborators if 'emailAddress' in user
     ])
@@ -98,6 +100,8 @@ class Issue(issue_tracker.Issue):
     self._components = _SingleComponentStore(components)
     self._body = None
     self._changed = set()
+    # _ext_issue_access_limit is an extension field that is used in
+    # google_issue_tracker.
     self._ext_issue_access_limit = {'access_level': IssueAccessLevel.LIMIT_NONE}
 
   def _reset_tracking(self):

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -202,11 +202,6 @@ class Issue(issue_tracker.Issue):
     return self._ccs
 
   @property
-  def collaborators(self):
-    """The issue collaborators list."""
-    return self._collaborators
-
-  @property
   def labels(self):
     """The issue labels list."""
     return self._labels
@@ -314,7 +309,7 @@ class Issue(issue_tracker.Issue):
     self._add_update_single(update_body, added, removed, 'title', 'title')
     self._add_update_collection(update_body, added, removed, 'ccs', 'ccs',
                                 _make_users)
-    self._add_update_collection(update_body, added, removed, 'collaborators',
+    self._add_update_collection(update_body, added, removed, '_collaborators',
                                 'collaborators', _make_users)
     update_body['addMask'] = ','.join(added)
     update_body['removeMask'] = ','.join(removed)
@@ -522,17 +517,6 @@ class Action(issue_tracker.Action):
   def ccs(self):
     """The issue CC change list."""
     removed, added = self._get_field_update_changes('ccs')
-    change_list = issue_tracker.ChangeList()
-    if added:
-      change_list.added.extend(added)
-    if removed:
-      change_list.removed.extend(removed)
-    return change_list
-
-  @property
-  def collaborators(self):
-    """The issue collaborators change list."""
-    removed, added = self._get_field_update_changes('collaborators')
     change_list = issue_tracker.ChangeList()
     if added:
       change_list.added.extend(added)

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -86,9 +86,7 @@ class Issue(issue_tracker.Issue):
     self._ccs = issue_tracker.LabelStore(
         [user['emailAddress'] for user in ccs if 'emailAddress' in user])
     collaborators = data['issueState'].get('collaborators', [])
-    # _ext_collaborators is an extension field that is used in
-    # google_issue_tracker.
-    self._ext_collaborators = issue_tracker.LabelStore([
+    self._collaborators = issue_tracker.LabelStore([
         user['emailAddress'] for user in collaborators if 'emailAddress' in user
     ])
     labels = [
@@ -100,29 +98,23 @@ class Issue(issue_tracker.Issue):
     self._components = _SingleComponentStore(components)
     self._body = None
     self._changed = set()
-    # _ext_issue_access_limit is an extension field that is used in
-    # google_issue_tracker.
-    self._ext_issue_access_limit = {'access_level': IssueAccessLevel.LIMIT_NONE}
+    self._issue_access_limit = {'access_level': IssueAccessLevel.LIMIT_NONE}
 
   def _reset_tracking(self):
     """Resets diff tracking."""
     self._changed.clear()
     self._ccs.reset_tracking()
-    self._ext_collaborators.reset_tracking()
+    self._collaborators.reset_tracking()
     self._labels.reset_tracking()
     self._components.reset_tracking()
 
-  def set_extension_fields(self, policy):
-    """Sets extension fields which are defined for a single tracker."""
-    if not policy['security']:
-      return
-
-    # Collaborators may be added to an issue to provide access and visibility
-    for collaborator in policy['security']['_ext_collaborators']:
-      self._ext_collaborators.add(collaborator)
-    # The issue's access limit may be updated to restrict access
-    self._ext_issue_access_limit = (
-        policy['security']['_ext_issue_access_limit'] or {
+  def apply_extension_fields(self, extension_fields):
+    """Applies _ext_ prefixed extension fields."""
+    if extension_fields.get('_ext_collaborators'):
+      for collaborator in extension_fields['_ext_collaborators']:
+        self._collaborators.add(collaborator)
+    self._issue_access_limit = extension_fields.get(
+        '_ext_issue_access_limit') or ({
             'access_level': IssueAccessLevel.LIMIT_NONE
         })
 
@@ -339,11 +331,10 @@ class Issue(issue_tracker.Issue):
     self._add_update_single(update_body, added, removed, 'title', 'title')
     self._add_update_collection(update_body, added, removed, 'ccs', 'ccs',
                                 _make_users)
-    self._add_update_collection(update_body, added, removed,
-                                '_ext_collaborators', 'collaborators',
-                                _make_users)
-    self._add_update_single(update_body, added, removed,
-                            '_ext_issue_access_limit', 'access_limit')
+    self._add_update_collection(update_body, added, removed, '_collaborators',
+                                'collaborators', _make_users)
+    self._add_update_single(update_body, added, removed, '_issue_access_limit',
+                            'access_limit')
     update_body['addMask'] = ','.join(added)
     update_body['removeMask'] = ','.join(removed)
     if notify:
@@ -401,10 +392,10 @@ class Issue(issue_tracker.Issue):
       ccs = list(self._ccs)
       if ccs:
         self._data['issueState']['ccs'] = _make_users(ccs)
-      collaborators = list(self._ext_collaborators)
+      collaborators = list(self._collaborators)
       if collaborators:
         self._data['issueState']['collaborators'] = _make_users(collaborators)
-      access_limit = self._ext_issue_access_limit
+      access_limit = self._issue_access_limit
       if access_limit:
         self._data['issueState']['access_limit'] = access_limit
       self._data['issueState']['hotlistIds'] = [

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -27,9 +27,6 @@ from clusterfuzz._internal.metrics import logs
 
 _NUM_RETRIES = 3
 _ISSUE_TRACKER_URL = 'https://issuetracker.googleapis.com/v1/issues'
-# TODO(micahbales, rmistry): Update below with the actual security group that
-# will be used as a trusted collaborator.
-CHROME_SECURITY_EMAIL = 'chromium-security-members@google.com'
 
 
 class IssueAccessLevel(enum.Enum):

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -27,7 +27,9 @@ from clusterfuzz._internal.metrics import logs
 
 _NUM_RETRIES = 3
 _ISSUE_TRACKER_URL = 'https://issuetracker.googleapis.com/v1/issues'
-CHROME_SECURITY_EMAIL = 'security@chromium.org'
+# TODO(micahbales, rmistry): Update below with the actual security group that
+# will be used as a trusted collaborator.
+CHROME_SECURITY_EMAIL = 'chromium-security-members@google.com'
 
 
 class IssueAccessLevel(enum.Enum):
@@ -107,15 +109,18 @@ class Issue(issue_tracker.Issue):
     self._components.reset_tracking()
 
   def set_extension_fields(self, policy):
-    # Extension fields are ones defined by the config for a single tracker
-    if policy['security']:
-      # Collaborators may be added to an issue to provide access and visibility
-      for collaborator in policy['security']['_ext_collaborators']:
-        self._ext_collaborators.add(collaborator)
-      # The issue's access limit may be updated to restrict access
-      self._ext_issue_access_limit = \
-        policy['security']['_ext_issue_access_limit'] or \
-        {'access_level': IssueAccessLevel.LIMIT_NONE}
+    """Sets extension fields which are defined for a single tracker."""
+    if not policy['security']:
+      return
+
+    # Collaborators may be added to an issue to provide access and visibility
+    for collaborator in policy['security']['_ext_collaborators']:
+      self._ext_collaborators.add(collaborator)
+    # The issue's access limit may be updated to restrict access
+    self._ext_issue_access_limit = (
+        policy['security']['_ext_issue_access_limit'] or {
+            'access_level': IssueAccessLevel.LIMIT_NONE
+        })
 
   @property
   def issue_tracker(self):

--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -356,6 +356,11 @@ def file_issue(testcase,
 
       update_issue_impact_labels(testcase, issue)
 
+      # Set extension fields for Chromium on Google Issue Tracker
+      if hasattr(issue_tracker,
+                 'type') and issue_tracker.type == 'google-issue-tracker':
+        issue.set_extension_fields(policy)
+
     # Check for MiraclePtr in stacktrace.
     miracle_label = check_miracleptr_status(testcase)
     if miracle_label:

--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -356,11 +356,6 @@ def file_issue(testcase,
 
       update_issue_impact_labels(testcase, issue)
 
-      # Set extension fields for Chromium on Google Issue Tracker
-      if hasattr(issue_tracker,
-                 'type') and issue_tracker.type == 'google-issue-tracker':
-        issue.set_extension_fields(policy)
-
     # Check for MiraclePtr in stacktrace.
     miracle_label = check_miracleptr_status(testcase)
     if miracle_label:
@@ -460,6 +455,9 @@ def file_issue(testcase,
 
   for cc in ccs:
     issue.ccs.add(cc)
+
+  # Apply extension fields.
+  issue.apply_extension_fields(policy.extension_fields)
 
   # Add additional labels and components from testcase metadata.
   metadata_labels = _get_from_metadata(testcase, 'issue_labels')

--- a/src/clusterfuzz/_internal/issue_management/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_tracker.py
@@ -202,6 +202,11 @@ class Issue:
     """Save the issue."""
     raise NotImplementedError
 
+  # pylint: disable=unused-argument
+  def apply_extension_fields(self, extension_fields):
+    """Applies _ext_ prefixed extension fields to the issue."""
+    return
+
 
 class ChangeList:
   """Records a change in a list."""

--- a/src/clusterfuzz/_internal/issue_management/issue_tracker_policy.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_tracker_policy.py
@@ -42,7 +42,7 @@ class NewIssuePolicy:
     self.labels = []
     self.issue_body_footer = ''
 
-    # Contains ext_ prefixed extension fields. Eg: ext_collaborators.
+    # Contains _ext_ prefixed extension fields. Eg: _ext_collaborators.
     self.extension_fields = {}
 
 

--- a/src/clusterfuzz/_internal/issue_management/issue_tracker_policy.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_tracker_policy.py
@@ -15,6 +15,8 @@
 from collections import namedtuple
 
 from clusterfuzz._internal.config import local_config
+from clusterfuzz._internal.issue_management.google_issue_tracker import \
+    issue_tracker as google_issue_tracker
 
 Status = namedtuple('Status',
                     ['assigned', 'duplicate', 'wontfix', 'fixed', 'verified'])
@@ -41,6 +43,10 @@ class NewIssuePolicy:
     self.ccs = []
     self.labels = []
     self.issue_body_footer = ''
+    self.ext_collaborators = []
+    self.ext_issue_access_limit = {
+        'access_limit': google_issue_tracker.IssueAccessLevel.LIMIT_NONE
+    }
 
 
 def _to_str_list(values):
@@ -164,6 +170,17 @@ class IssueTrackerPolicy:
       non_crash_labels = issue_type.get('non_crash_labels')
       if non_crash_labels:
         policy.labels.extend(_to_str_list(non_crash_labels))
+
+    ## extension fields are fields that are only used in a single tracker
+    # ext_collaborators is used in google_issue_tracker
+    ext_collaborators = issue_type.get('ext_collaborators')
+    if ext_collaborators:
+      policy.ext_collaborators.extend(_to_str_list(ext_collaborators))
+
+    # ext_issue_access_limit is used in google_issue_tracker
+    ext_issue_access_limit = issue_type.get('ext_issue_access_limit')
+    if ext_issue_access_limit:
+      policy.ext_issue_access_limit = ext_issue_access_limit
 
   def get_existing_issue_properties(self):
     """Get the properties to apply to a new issue."""

--- a/src/clusterfuzz/_internal/issue_management/issue_tracker_policy.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_tracker_policy.py
@@ -43,7 +43,11 @@ class NewIssuePolicy:
     self.ccs = []
     self.labels = []
     self.issue_body_footer = ''
+
+    # Extension fields are fields that are only used in a single tracker.
+    # ext_collaborators is used in google_issue_tracker.
     self.ext_collaborators = []
+    # ext_issue_access_limit is used in google_issue_tracker.
     self.ext_issue_access_limit = {
         'access_limit': google_issue_tracker.IssueAccessLevel.LIMIT_NONE
     }
@@ -171,13 +175,12 @@ class IssueTrackerPolicy:
       if non_crash_labels:
         policy.labels.extend(_to_str_list(non_crash_labels))
 
-    ## extension fields are fields that are only used in a single tracker
-    # ext_collaborators is used in google_issue_tracker
+    # ext_collaborators is used in google_issue_tracker.
     ext_collaborators = issue_type.get('ext_collaborators')
     if ext_collaborators:
       policy.ext_collaborators.extend(_to_str_list(ext_collaborators))
 
-    # ext_issue_access_limit is used in google_issue_tracker
+    # ext_issue_access_limit is used in google_issue_tracker.
     ext_issue_access_limit = issue_type.get('ext_issue_access_limit')
     if ext_issue_access_limit:
       policy.ext_issue_access_limit = ext_issue_access_limit

--- a/src/clusterfuzz/_internal/issue_management/issue_tracker_policy.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_tracker_policy.py
@@ -28,6 +28,8 @@ EXPECTED_STATUSES = [
     'new',
 ]
 
+EXTENSION_PREFIX = '_ext_'
+
 
 class ConfigurationError(Exception):
   """Base configuration error class."""
@@ -174,7 +176,7 @@ class IssueTrackerPolicy:
 
     # Find all _ext_ keys and add to extension_fields
     for k, v in self._data.items():
-      if k.startswith('_ext_'):
+      if k.startswith(EXTENSION_PREFIX):
         policy.extension_fields[k] = v
 
   def get_existing_issue_properties(self):

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -71,7 +71,7 @@ CHROMIUM_POLICY = issue_tracker_policy.IssueTrackerPolicy({
     },
     'security': {
         'labels': ['Type-Bug-Security'],
-        '_ext_collaborators': [google_issue_tracker.CHROME_SECURITY_EMAIL],
+        '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
         '_ext_issue_access_limit': {
             'access_limit': google_issue_tracker.IssueAccessLevel.LIMIT_VIEW
         }
@@ -117,7 +117,7 @@ CHROMIUM_POLICY_FALLBACK = issue_tracker_policy.IssueTrackerPolicy({
     },
     'security': {
         'labels': ['Type-Bug-Security'],
-        '_ext_collaborators': [google_issue_tracker.CHROME_SECURITY_EMAIL],
+        '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
         '_ext_issue_access_limit': {
             'access_limit': google_issue_tracker.IssueAccessLevel.LIMIT_VIEW
         }

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -27,6 +27,8 @@ from clusterfuzz._internal.google_cloud_utils import pubsub
 from clusterfuzz._internal.issue_management import issue_filer
 from clusterfuzz._internal.issue_management import issue_tracker_policy
 from clusterfuzz._internal.issue_management import monorail
+from clusterfuzz._internal.issue_management.google_issue_tracker import \
+    issue_tracker as google_issue_tracker
 from clusterfuzz._internal.issue_management.issue_tracker import LabelStore
 from clusterfuzz._internal.issue_management.monorail.issue import \
     Issue as MonorailIssue
@@ -68,7 +70,11 @@ CHROMIUM_POLICY = issue_tracker_policy.IssueTrackerPolicy({
         'restrict_view': 'Restrict-View-SecurityTeam'
     },
     'security': {
-        'labels': ['Type-Bug-Security']
+        'labels': ['Type-Bug-Security'],
+        'ext_collaborators': [google_issue_tracker.CHROME_SECURITY_EMAIL],
+        'ext_issue_access_limit': {
+            'access_limit': google_issue_tracker.IssueAccessLevel.LIMIT_VIEW
+        }
     },
     'existing': {
         'labels': ['Stability-%SANITIZER%']
@@ -110,7 +116,11 @@ CHROMIUM_POLICY_FALLBACK = issue_tracker_policy.IssueTrackerPolicy({
         'restrict_view': 'Restrict-View-SecurityTeam'
     },
     'security': {
-        'labels': ['Type-Bug-Security']
+        'labels': ['Type-Bug-Security'],
+        'ext_collaborators': [google_issue_tracker.CHROME_SECURITY_EMAIL],
+        'ext_issue_access_limit': {
+            'access_limit': google_issue_tracker.IssueAccessLevel.LIMIT_VIEW
+        }
     },
     'existing': {
         'labels': ['Stability-%SANITIZER%']

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -71,8 +71,8 @@ CHROMIUM_POLICY = issue_tracker_policy.IssueTrackerPolicy({
     },
     'security': {
         'labels': ['Type-Bug-Security'],
-        'ext_collaborators': [google_issue_tracker.CHROME_SECURITY_EMAIL],
-        'ext_issue_access_limit': {
+        '_ext_collaborators': [google_issue_tracker.CHROME_SECURITY_EMAIL],
+        '_ext_issue_access_limit': {
             'access_limit': google_issue_tracker.IssueAccessLevel.LIMIT_VIEW
         }
     },
@@ -117,8 +117,8 @@ CHROMIUM_POLICY_FALLBACK = issue_tracker_policy.IssueTrackerPolicy({
     },
     'security': {
         'labels': ['Type-Bug-Security'],
-        'ext_collaborators': [google_issue_tracker.CHROME_SECURITY_EMAIL],
-        'ext_issue_access_limit': {
+        '_ext_collaborators': [google_issue_tracker.CHROME_SECURITY_EMAIL],
+        '_ext_issue_access_limit': {
             'access_limit': google_issue_tracker.IssueAccessLevel.LIMIT_VIEW
         }
     },

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -232,15 +232,15 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'comment': 'issue body'
                 },
                 'issueState': {
-                    'status':
-                        'ASSIGNED',
+                    'status': 'ASSIGNED',
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title':
-                        'issue title',
-                    'issue_access_level':
-                        issue_tracker.IssueAccessLevel.LIMIT_NONE,
+                    'title': 'issue title',
+                    'access_limit': {
+                        'access_level':
+                            issue_tracker.IssueAccessLevel.LIMIT_NONE
+                    },
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
@@ -248,11 +248,9 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId':
-                        9001,
+                    'componentId': 9001,
                     'hotlistIds': [12345],
-                    'type':
-                        'BUG',
+                    'type': 'BUG',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -278,8 +276,9 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'S2',
             'title':
                 'issue title2',
-            'issue_access_level':
-                issue_tracker.IssueAccessLevel.LIMIT_NONE,
+            'access_limit': {
+                'access_level': issue_tracker.IssueAccessLevel.LIMIT_NONE
+            },
             'reporter': {
                 'emailAddress': 'reporter@google.com',
                 'userGaiaStatus': 'ACTIVE',

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -232,11 +232,15 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'comment': 'issue body'
                 },
                 'issueState': {
-                    'status': 'ASSIGNED',
+                    'status':
+                        'ASSIGNED',
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title': 'issue title',
+                    'title':
+                        'issue title',
+                    'issue_access_level':
+                        issue_tracker.IssueAccessLevel.LIMIT_NONE,
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
@@ -244,9 +248,11 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId': 9001,
+                    'componentId':
+                        9001,
                     'hotlistIds': [12345],
-                    'type': 'BUG',
+                    'type':
+                        'BUG',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -272,6 +278,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'S2',
             'title':
                 'issue title2',
+            'issue_access_level':
+                issue_tracker.IssueAccessLevel.LIMIT_NONE,
             'reporter': {
                 'emailAddress': 'reporter@google.com',
                 'userGaiaStatus': 'ACTIVE',

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -22,11 +22,9 @@ from clusterfuzz._internal.issue_management.google_issue_tracker import \
     issue_tracker
 from clusterfuzz._internal.issue_management.google_issue_tracker import client
 
-SECURITY_POLICY = {
-    'security': {
-        '_ext_collaborators': ['security@chromium.org'],
-        '_ext_issue_access_limit': issue_tracker.IssueAccessLevel.LIMIT_VIEW
-    }
+EXTENSION_FIELDS = {
+    '_ext_collaborators': ['security@chromium.org'],
+    '_ext_issue_access_limit': issue_tracker.IssueAccessLevel.LIMIT_VIEW,
 }
 TEST_CONFIG = {
     'default_component_id': 1337,
@@ -272,7 +270,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue = self.issue_tracker.new_issue()
 
     # Mimic issue_filer's action in setting up the issue
-    issue.set_extension_fields(SECURITY_POLICY)
+    issue.apply_extension_fields(EXTENSION_FIELDS)
 
     issue.labels.add('Type-Bug-Security')
     issue.reporter = 'reporter@google.com'

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -23,6 +23,7 @@ from clusterfuzz._internal.issue_management.google_issue_tracker import client
 
 TEST_CONFIG = {
     'default_component_id': 1337,
+    'type': 'google-issue-tracker',
 }
 
 BASIC_ISSUE = {

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -111,7 +111,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     self.assertCountEqual([], issue.labels)
     self.assertCountEqual(['29002'], issue.components)
     self.assertCountEqual([], issue.ccs)
-    self.assertCountEqual([], issue.collaborators)
     self.assertEqual('test body', issue.body)
 
   def test_closed(self):
@@ -214,44 +213,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         issue.ccs,
     )
 
-  def test_get_collaborators(self):
-    """Test getting collaborators."""
-    self.client.issues().get().execute.return_value = {
-        'issueId': '68823253',
-        'issueState': {
-            'componentId':
-                '29002',
-            'type':
-                'BUG',
-            'status':
-                'NEW',
-            'priority':
-                'P2',
-            'severity':
-                'S2',
-            'title':
-                'test',
-            'collaborators': [
-                {
-                    'emailAddress': 'collaborator1@google.com',
-                    'userGaiaStatus': 'ACTIVE'
-                },
-                {
-                    'emailAddress': 'collaborator2@google.com',
-                    'userGaiaStatus': 'ACTIVE'
-                },
-            ],
-        },
-    }
-    issue = self.issue_tracker.get_issue(68823253)
-    self.assertCountEqual(
-        [
-            'collaborator1@google.com',
-            'collaborator2@google.com',
-        ],
-        issue.collaborators,
-    )
-
   def test_new_issue(self):
     """Test basic new issue creation."""
     issue = self.issue_tracker.new_issue()
@@ -259,7 +220,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
-    issue.collaborators.add('collaborator@google.com')
     issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
@@ -272,27 +232,21 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'comment': 'issue body'
                 },
                 'issueState': {
-                    'status':
-                        'ASSIGNED',
+                    'status': 'ASSIGNED',
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title':
-                        'issue title',
+                    'title': 'issue title',
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
-                    'collaborators': [{
-                        'emailAddress': 'collaborator@google.com'
-                    }],
+                    'collaborators': [],
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId':
-                        9001,
+                    'componentId': 9001,
                     'hotlistIds': [12345],
-                    'type':
-                        'BUG',
+                    'type': 'BUG',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -332,9 +286,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'emailAddress': 'cc@google.com',
                 'userGaiaStatus': 'ACTIVE'
             },],
-            'collaborators': [{
-                'emailAddress': 'collaborator@google.com'
-            }],
             'hotlistIds': ['12345',],
         },
         'createdTime': '2019-06-25T01:29:30.021Z',
@@ -352,7 +303,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
-    issue.collaborators.add('collaborator@google.com')
     issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
@@ -363,25 +313,20 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call(
             body={
                 'add': {
-                    'status':
-                        'ASSIGNED',
+                    'status': 'ASSIGNED',
                     'assignee': {
                         'emailAddress': 'assignee2@google.com'
                     },
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
-                    'collaborators': [{
-                        'emailAddress': 'collaborator@google.com'
-                    }],
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title':
-                        'issue title2',
+                    'title': 'issue title2',
                 },
                 'removeMask': '',
-                'addMask': 'status,assignee,reporter,title,ccs,collaborators',
+                'addMask': 'status,assignee,reporter,title,ccs',
                 'remove': {},
                 'significanceOverride': 'MAJOR',
             },

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -111,6 +111,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     self.assertCountEqual([], issue.labels)
     self.assertCountEqual(['29002'], issue.components)
     self.assertCountEqual([], issue.ccs)
+    self.assertCountEqual([], issue.collaborators)
     self.assertEqual('test body', issue.body)
 
   def test_closed(self):
@@ -213,6 +214,44 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         issue.ccs,
     )
 
+  def test_get_collaborators(self):
+    """Test getting collaborators."""
+    self.client.issues().get().execute.return_value = {
+        'issueId': '68823253',
+        'issueState': {
+            'componentId':
+                '29002',
+            'type':
+                'BUG',
+            'status':
+                'NEW',
+            'priority':
+                'P2',
+            'severity':
+                'S2',
+            'title':
+                'test',
+            'collaborators': [
+                {
+                    'emailAddress': 'collaborator1@google.com',
+                    'userGaiaStatus': 'ACTIVE'
+                },
+                {
+                    'emailAddress': 'collaborator2@google.com',
+                    'userGaiaStatus': 'ACTIVE'
+                },
+            ],
+        },
+    }
+    issue = self.issue_tracker.get_issue(68823253)
+    self.assertCountEqual(
+        [
+            'collaborator1@google.com',
+            'collaborator2@google.com',
+        ],
+        issue.collaborators,
+    )
+
   def test_new_issue(self):
     """Test basic new issue creation."""
     issue = self.issue_tracker.new_issue()
@@ -220,6 +259,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
+    issue.collaborators.add('collaborator@google.com')
     issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
@@ -232,20 +272,27 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'comment': 'issue body'
                 },
                 'issueState': {
-                    'status': 'ASSIGNED',
+                    'status':
+                        'ASSIGNED',
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title': 'issue title',
+                    'title':
+                        'issue title',
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
+                    }],
+                    'collaborators': [{
+                        'emailAddress': 'collaborator@google.com'
                     }],
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId': 9001,
+                    'componentId':
+                        9001,
                     'hotlistIds': [12345],
-                    'type': 'BUG',
+                    'type':
+                        'BUG',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -285,6 +332,9 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'emailAddress': 'cc@google.com',
                 'userGaiaStatus': 'ACTIVE'
             },],
+            'collaborators': [{
+                'emailAddress': 'collaborator@google.com'
+            }],
             'hotlistIds': ['12345',],
         },
         'createdTime': '2019-06-25T01:29:30.021Z',
@@ -302,6 +352,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
+    issue.collaborators.add('collaborator@google.com')
     issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
@@ -312,20 +363,25 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call(
             body={
                 'add': {
-                    'status': 'ASSIGNED',
+                    'status':
+                        'ASSIGNED',
                     'assignee': {
                         'emailAddress': 'assignee2@google.com'
                     },
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
+                    'collaborators': [{
+                        'emailAddress': 'collaborator@google.com'
+                    }],
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
-                    'title': 'issue title2',
+                    'title':
+                        'issue title2',
                 },
                 'removeMask': '',
-                'addMask': 'status,assignee,reporter,title,ccs',
+                'addMask': 'status,assignee,reporter,title,ccs,collaborators',
                 'remove': {},
                 'significanceOverride': 'MAJOR',
             },

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -23,7 +23,7 @@ from clusterfuzz._internal.issue_management.google_issue_tracker import \
 from clusterfuzz._internal.issue_management.google_issue_tracker import client
 
 EXTENSION_FIELDS = {
-    '_ext_collaborators': ['security@chromium.org'],
+    '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
     '_ext_issue_access_limit': issue_tracker.IssueAccessLevel.LIMIT_VIEW,
 }
 TEST_CONFIG = {
@@ -293,9 +293,14 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
-                    'collaborators': [{
-                        'emailAddress': 'security@chromium.org'
-                    }],
+                    'collaborators': [
+                        {
+                            'emailAddress': 'superman@krypton.com'
+                        },
+                        {
+                            'emailAddress': 'batman@gotham.com'
+                        },
+                    ],
                     'hotlistIds': [12345, 67890],
                     'access_limit':
                         issue_tracker.IssueAccessLevel.LIMIT_VIEW,


### PR DESCRIPTION
In a previous iteration, we used an existing 'label' value to trigger the Chrome Security workflow for security issues. In our new approach, we are looking to two 'extension fields' to be set under 'security' on the config for google-issue-tracker: ext_collaborators and ext_issue_access_limit.

In a subsequent PR, we will add logic for the security workflow, depending on these extension fields from the config.

This PR builds on work done in https://github.com/google/clusterfuzz/pull/3432 and https://github.com/google/clusterfuzz/pull/3437.