### PR TITLE
Fix access limits integration with issuetracker public API

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -29,11 +29,11 @@ _NUM_RETRIES = 3
 _ISSUE_TRACKER_URL = 'https://issuetracker.googleapis.com/v1/issues'
 
 
-class IssueAccessLevel(enum.Enum):
-  LIMIT_NONE = 0
-  LIMIT_VIEW = 1
-  LIMIT_APPEND = 2
-  LIMIT_VIEW_TRUSTED = 3
+class IssueAccessLevel(str, enum.Enum):
+  LIMIT_NONE = 'LIMIT_NONE'
+  LIMIT_VIEW = 'LIMIT_VIEW'
+  LIMIT_APPEND = 'LIMIT_APPEND'
+  LIMIT_VIEW_TRUSTED = 'LIMIT_VIEW_TRUSTED'
 
 
 class IssueTrackerError(Exception):
@@ -95,7 +95,7 @@ class Issue(issue_tracker.Issue):
     self._components = _SingleComponentStore(components)
     self._body = None
     self._changed = set()
-    self._issue_access_limit = {'access_level': IssueAccessLevel.LIMIT_NONE}
+    self._issue_access_limit = {'accessLevel': IssueAccessLevel.LIMIT_NONE}
 
   def _reset_tracking(self):
     """Resets diff tracking."""
@@ -112,7 +112,7 @@ class Issue(issue_tracker.Issue):
         self._collaborators.add(collaborator)
     self._issue_access_limit = extension_fields.get(
         '_ext_issue_access_limit') or ({
-            'access_level': IssueAccessLevel.LIMIT_NONE
+            'accessLevel': IssueAccessLevel.LIMIT_NONE
         })
 
   @property
@@ -394,7 +394,7 @@ class Issue(issue_tracker.Issue):
         self._data['issueState']['collaborators'] = _make_users(collaborators)
       access_limit = self._issue_access_limit
       if access_limit:
-        self._data['issueState']['access_limit'] = access_limit
+        self._data['issueState']['accessLimit'] = {'accessLevel': access_limit}
       self._data['issueState']['hotlistIds'] = [
           int(label) for label in self.labels
       ]
@@ -605,8 +605,8 @@ class IssueTracker(issue_tracker.IssueTracker):
             'ccs': [],
             'collaborators': [],
             'hotlistIds': [],
-            'access_limit': {
-                'access_level': IssueAccessLevel.LIMIT_NONE
+            'accessLimit': {
+                'accessLevel': IssueAccessLevel.LIMIT_NONE
             },
         }
     }
@@ -704,8 +704,14 @@ def _get_query(keywords, only_open):
 #   issue.title = 'test issue'
 #   issue.assignee = 'rmistry@google.com'
 #   issue.status = 'ASSIGNED'
+#   issue.apply_extension_fields({
+#       '_ext_collaborators': [
+#           'rmistry@google.com',
+#           'skia-npm-audit-mirror@skia-public.iam.gserviceaccount.com'],
+#       '_ext_issue_access_limit': IssueAccessLevel.LIMIT_VIEW_TRUSTED,
+#   })
 #   issue.save(new_comment='testing')
 #
 #   # Test issue query.
-#   queried_issue = it.get_issue(306010501)
+#   queried_issue = it.get_issue(307559515)
 #   print(queried_issue._data)

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -95,7 +95,7 @@ class Issue(issue_tracker.Issue):
     self._components = _SingleComponentStore(components)
     self._body = None
     self._changed = set()
-    self._issue_access_limit = {'accessLevel': IssueAccessLevel.LIMIT_NONE}
+    self._issue_access_limit = IssueAccessLevel.LIMIT_NONE
 
   def _reset_tracking(self):
     """Resets diff tracking."""
@@ -111,9 +111,7 @@ class Issue(issue_tracker.Issue):
       for collaborator in extension_fields['_ext_collaborators']:
         self._collaborators.add(collaborator)
     self._issue_access_limit = extension_fields.get(
-        '_ext_issue_access_limit') or ({
-            'accessLevel': IssueAccessLevel.LIMIT_NONE
-        })
+        '_ext_issue_access_limit') or IssueAccessLevel.LIMIT_NONE
 
   @property
   def issue_tracker(self):

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -244,9 +244,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         'emailAddress': 'reporter@google.com'
                     },
                     'title': 'issue title',
-                    'access_limit': {
-                        'access_level':
-                            issue_tracker.IssueAccessLevel.LIMIT_NONE
+                    'accessLimit': {
+                        'accessLevel': issue_tracker.IssueAccessLevel.LIMIT_NONE
                     },
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
@@ -302,8 +301,10 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         },
                     ],
                     'hotlistIds': [12345, 67890],
-                    'access_limit':
-                        issue_tracker.IssueAccessLevel.LIMIT_VIEW,
+                    'accessLimit': {
+                        'accessLevel':
+                            issue_tracker.IssueAccessLevel.LIMIT_VIEW,
+                    },
                     'reporter': {
                         'emailAddress': 'reporter@google.com'
                     },
@@ -344,8 +345,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 'S2',
             'title':
                 'issue title2',
-            'access_limit': {
-                'access_level': issue_tracker.IssueAccessLevel.LIMIT_NONE
+            'accessLimit': {
+                'accessLevel': issue_tracker.IssueAccessLevel.LIMIT_NONE
             },
             'reporter': {
                 'emailAddress': 'reporter@google.com',


### PR DESCRIPTION
Without these fixes this error shows up when communicating with public API locally:
```
Traceback (most recent call last):
  File "src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py", line 709, in <module>
    issue.save(new_comment='testing')
  File "src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py", line 406, in save
    self.issue_tracker.client.issues().create(
  File "/usr/local/google/home/rmistry/.local/share/virtualenvs/clusterfuzz--XR7raGU/lib/python3.8/site-packages/googleapiclient/discovery.py", line 1123, in method
    headers, params, query, body = model.request(
  File "/usr/local/google/home/rmistry/.local/share/virtualenvs/clusterfuzz--XR7raGU/lib/python3.8/site-packages/googleapiclient/model.py", line 160, in request
    body_value = self.serialize(body_value)
  File "/usr/local/google/home/rmistry/.local/share/virtualenvs/clusterfuzz--XR7raGU/lib/python3.8/site-packages/googleapiclient/model.py", line 273, in serialize
    return json.dumps(body_value)
  File "/usr/local/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type IssueAccessLevel is not JSON serializable

```

Local test steps have been documented in the `google_issue_tracker/issue_tracker.py` file.
An example of a successful issue created with collaborators and issue access limit is: b/307559515