### PR TITLE
Fix initialization of postprocess pub/sub messages.

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks.py
+++ b/src/clusterfuzz/_internal/base/tasks.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import datetime
+import json
 import random
 import threading
 import time
@@ -168,12 +169,15 @@ def get_high_end_task():
 def initialize_task(messages):
   """Creates a task from |messages|."""
   message = messages[0]
-  if message.attributes.get('kind', None) != 'storage#object':
+  if message.attributes.get('eventType', None) != 'OBJECT_FINALIZE':
     return PubSubTask(message)
 
   # Handle postprocess task.
-  name = message.attributes.get('name')
-  bucket = message.attributes.get('bucket')
+  # The google cloud API for pub/sub notifications uses the data field unlike
+  # ClusterFuzz which uses attributes more.
+  data = json.loads(message.data)
+  name = data['name']
+  bucket = data['bucket']
   output_url_argument = storage.get_cloud_storage_file_path(bucket, name)
   command = 'postprocess'
   job_type = 'none'
@@ -297,10 +301,12 @@ def get_postprocess_task():
     return None
   pubsub_client = pubsub.PubSubClient()
   application_id = utils.get_application_id()
+  logs.log('Pulling from postprocess queue')
   messages = _get_messages(pubsub_client, application_id, POSTPROCESS_QUEUE)
   if not messages:
     return None
   try:
+    logs.log('Pulled postprocess queue.')
     return initialize_task(messages)
   except KeyError:
     logs.log_error('Received an invalid task, discarding...')

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1146,8 +1146,7 @@ def get_job_bad_revisions():
       ndb_utils.get_all_from_query(
           data_types.BuildMetadata.query(
               ndb_utils.is_true(data_types.BuildMetadata.bad_build),
-              data_types.BuildMetadata.job_type == job_type,
-              projection=[data_types.BuildMetadata.revision])))
+              data_types.BuildMetadata.job_type == job_type)))
   return [build.revision for build in bad_builds]
 
 

--- a/src/clusterfuzz/_internal/tests/core/base/tasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks_test.py
@@ -26,7 +26,6 @@ class InitializeTaskTest(unittest.TestCase):
     self.command = 'symbolize'
     self.argument = 'blah'
     self.job = 'linux_asan_chrome_mp'
-    self.bucket = 'mybucket'
     self.path = 'worker.output'
     self.message = mock.MagicMock()
 
@@ -46,21 +45,36 @@ class InitializeTaskTest(unittest.TestCase):
 
   def test_initialize_untrusted_task(self):
     """Tests that an untrusted task is initialized properly."""
-    self_link = f'https://www.googleapis.com/storage/v1/b/{self.bucket}23/o/{self.path}23'
     self.message.attributes = {
-        'kind': 'storage#object',
-        'bucket': self.bucket,
-        'name': self.path,
-        'selfLink': self_link,
-        'command': self.command,
-        'argument': self.argument,
-        'job': self.job,
+        'eventType':
+            'OBJECT_FINALIZE',
+        'objectGeneration':
+            '1698182630721865',
+        'eventTime':
+            '2023-10-24T21:23:50.761055Z',
+        'payloadFormat':
+            'JSON_API_V1',
+        'bucketId':
+            'uworker-output',
+        'notificationConfig':
+            'projects/_/buckets/uworker-output/notificationConfigs/4',
+        'objectId':
+            'm9'
     }
+    self.message.data = (
+        b'''{\n  "kind": "storage#object",\n  "id": "uworker-output/uworker.output/1698182630721865",\n  '''
+        b'''"selfLink": "https://www.googleapis.com/storage/v1/b/uworker-output/o/uworker.output",\n  '''
+        b'''"name": "worker.output",\n  "bucket": "uworker-output",\n  "generation": "1698182630721865",\n'''
+        b'''"metageneration": "1",\n  "contentType": "application/octet-stream",\n  "timeCreated": "2023-10-24T21:23:50.761Z",\n'''
+        b''' "updated": "2023-10-24T21:23:50.761Z",\n  "storageClass": "STANDARD",\n  '''
+        b'''"timeStorageClassUpdated": "2023-10-24T21:23:50.761Z",\n  "size": "0",\n  "md5Hash": "1B2M2Y8AsgTpgAmY7PhCfg==",\n'''
+        b'''"mediaLink": "https://storage.googleapis.com/download/storage/v1/b/uworker-output/o/uworker.output?generation=1698'''
+        b'''182630721865&alt=media",\n  "contentLanguage": "en",\n  "crc32c": "AAAAAA==",\n  "etag": "CMmS36PPj4IDEAE="\n}\n'''
+    )
     task = tasks.initialize_task([self.message])
     self.assertFalse(isinstance(task, tasks.PubSubTask))
     self.assertEqual(task.command, 'postprocess')
-    # !!! Is this bad for local development.
-    self.assertEqual(task.argument, 'gs://mybucket/worker.output')
+    self.assertEqual(task.argument, 'gs://uworker-output/worker.output')
     self.assertEqual(task.job, 'none')
 
 


### PR DESCRIPTION
The main mistake was assuming pub/sub notifications for GCS use attributes like clusterfuzz does.