### PR TITLE
Refactor untrusted worker error handling

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -26,8 +26,8 @@ from clusterfuzz._internal.base import task_utils
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager
-from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
+from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.build_management import revisions
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -27,6 +27,7 @@ from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
+from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
 from clusterfuzz._internal.build_management import revisions
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
@@ -200,7 +201,9 @@ def handle_setup_testcase_error(uworker_output: uworker_msg_pb2.Output):
       wait_time=testcase_fail_wait)
 
 
-HANDLED_ERRORS = [uworker_msg_pb2.ErrorType.TESTCASE_SETUP]
+ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.TESTCASE_SETUP: handle_setup_testcase_error,
+})
 
 
 def preprocess_setup_testcase(testcase, fuzzer_override=None, with_deps=True):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -444,19 +444,18 @@ def handle_build_setup_error(output):
       testcase, testcase_upload_metadata, 'Build setup failed')
 
 
-_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH:
+        handle_noncrash,
+    uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
+        handle_build_setup_error,
+    uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST:
+        handle_analyze_no_revisions_list_error,
+    uworker_msg_pb2.ANALYZE_NO_REVISION_INDEX:
+        handle_analyze_no_revision_index,
+}).compose_with(
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
-    uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH:
-            handle_noncrash,
-        uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
-            handle_build_setup_error,
-        uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST:
-            handle_analyze_no_revisions_list_error,
-        uworker_msg_pb2.ANALYZE_NO_REVISION_INDEX:
-            handle_analyze_no_revision_index,
-    }),
 )
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -448,14 +448,14 @@ _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
     uworker_handle_errors.CompositeErrorHandler({
-      uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH:
-          handle_noncrash,
-      uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
-          handle_build_setup_error,
-      uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST:
-          handle_analyze_no_revisions_list_error,
-      uworker_msg_pb2.ANALYZE_NO_REVISION_INDEX:
-          handle_analyze_no_revision_index,
+        uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH:
+            handle_noncrash,
+        uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
+            handle_build_setup_error,
+        uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST:
+            handle_analyze_no_revisions_list_error,
+        uworker_msg_pb2.ANALYZE_NO_REVISION_INDEX:
+            handle_analyze_no_revision_index,
     }),
 )
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -444,13 +444,20 @@ def handle_build_setup_error(output):
       testcase, testcase_upload_metadata, 'Build setup failed')
 
 
-HANDLED_ERRORS = [
-    uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH,
-    uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP,
-    uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST,
-    uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISION_INDEX,
-    uworker_msg_pb2.ErrorType.UNHANDLED,
-] + setup.HANDLED_ERRORS
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
+    setup.ERROR_HANDLER,
+    uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
+    uworker_handle_errors.CompositeErrorHandler({
+      uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH:
+          handle_noncrash,
+      uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
+          handle_build_setup_error,
+      uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST:
+          handle_analyze_no_revisions_list_error,
+      uworker_msg_pb2.ANALYZE_NO_REVISION_INDEX:
+          handle_analyze_no_revision_index,
+    }),
+)
 
 
 def _update_testcase(output):
@@ -503,7 +510,7 @@ def utask_postprocess(output):
   the db."""
   _update_testcase(output)
   if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
-    uworker_handle_errors.handle(output, HANDLED_ERRORS)
+    _ERROR_HANDLER.handle(output)
     return
   testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
   testcase_upload_metadata = query_testcase_upload_metadata(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -445,14 +445,14 @@ def handle_build_setup_error(output):
 
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
-    uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH:
-        handle_noncrash,
     uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
         handle_build_setup_error,
+    uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH:
+        handle_noncrash,
+    uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISION_INDEX:
+        handle_analyze_no_revision_index,
     uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST:
         handle_analyze_no_revisions_list_error,
-    uworker_msg_pb2.ANALYZE_NO_REVISION_INDEX:
-        handle_analyze_no_revision_index,
 }).compose_with(
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -950,13 +950,13 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
       corpus_pruning_task_input=corpus_pruning_task_input)
 
 
-_HANDLED_ERRORS = [
-    uworker_msg_pb2.ErrorType.CORPUS_PRUNING_FUZZER_SETUP_FAILED,
-]
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.CORPUS_PRUNING_FUZZER_SETUP_FAILED: uworker_handle_errors.noop_handler,
+})
 
 
 def utask_postprocess(output):
   """Trusted: Handles errors and writes anything needed to the db."""
   if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
-    uworker_handle_errors.handle(output, _HANDLED_ERRORS)
+    _ERROR_HANDLER.handle(output)
     return

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -951,7 +951,8 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
 
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
-    uworker_msg_pb2.ErrorType.CORPUS_PRUNING_FUZZER_SETUP_FAILED: uworker_handle_errors.noop_handler,
+    uworker_msg_pb2.ErrorType.CORPUS_PRUNING_FUZZER_SETUP_FAILED:
+        uworker_handle_errors.noop_handler,
 })
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1968,12 +1968,12 @@ def _make_session(uworker_input):
 
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
-    uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER:
-        handle_fuzz_no_fuzzer,
     uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE:
         handle_fuzz_build_setup_failure,
     uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE:
         handle_fuzz_data_bundle_setup_failure,
+    uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER:
+        handle_fuzz_no_fuzzer,
 }).compose_with(uworker_handle_errors.UNHANDLED_ERROR_HANDLER)
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1967,12 +1967,17 @@ def _make_session(uworker_input):
   )
 
 
-HANDLED_ERRORS = [
-    uworker_msg_pb2.ErrorType.UNHANDLED,
-    uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE,
-    uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE,
-    uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER,
-]
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
+    uworker_handle_errors.CompositeErrorHandler({
+      uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER:
+          handle_fuzz_no_fuzzer,
+      uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE:
+          handle_fuzz_build_setup_failure,
+      uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE:
+          handle_fuzz_data_bundle_setup_failure,
+    }),
+    uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
+)
 
 
 def utask_preprocess(fuzzer_name, job_type, uworker_env):
@@ -1998,7 +2003,8 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
 
 def utask_postprocess(output):
   if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
-    uworker_handle_errors.handle(output, HANDLED_ERRORS)
+    _ERROR_HANDLER.handle(output)
     return
+
   session = _make_session(output.uworker_input)
   session.postprocess(output)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1967,17 +1967,14 @@ def _make_session(uworker_input):
   )
 
 
-_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
-    uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER:
-            handle_fuzz_no_fuzzer,
-        uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE:
-            handle_fuzz_build_setup_failure,
-        uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE:
-            handle_fuzz_data_bundle_setup_failure,
-    }),
-    uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
-)
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER:
+        handle_fuzz_no_fuzzer,
+    uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE:
+        handle_fuzz_build_setup_failure,
+    uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE:
+        handle_fuzz_data_bundle_setup_failure,
+}).compose_with(uworker_handle_errors.UNHANDLED_ERROR_HANDLER)
 
 
 def utask_preprocess(fuzzer_name, job_type, uworker_env):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1969,12 +1969,12 @@ def _make_session(uworker_input):
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
     uworker_handle_errors.CompositeErrorHandler({
-      uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER:
-          handle_fuzz_no_fuzzer,
-      uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE:
-          handle_fuzz_build_setup_failure,
-      uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE:
-          handle_fuzz_data_bundle_setup_failure,
+        uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER:
+            handle_fuzz_no_fuzzer,
+        uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE:
+            handle_fuzz_build_setup_failure,
+        uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE:
+            handle_fuzz_data_bundle_setup_failure,
     }),
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
 )

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
@@ -739,23 +739,22 @@ def handle_libfuzzer_minimization_failed(output: uworker_msg_pb2.Output):
       crash_result_dict=output.minimize_task_output.last_crash_result_dict)
 
 
-_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
-    uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.MINIMIZE_SETUP:
-            handle_minimize_setup_error,
-        uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH:
-            handle_minimize_unreproducible_crash,
-        uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY:
-            handle_minimize_crash_too_flaky,
-        uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE:
-            handle_minimize_deadline_exceeded_in_main_file_phase,
-        uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED:
-            handle_minimize_deadline_exceeded,
-        uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE:
-            handle_libfuzzer_minimization_unreproducible,
-        uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED:
-            handle_libfuzzer_minimization_failed,
-    }),
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.MINIMIZE_SETUP:
+        handle_minimize_setup_error,
+    uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH:
+        handle_minimize_unreproducible_crash,
+    uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY:
+        handle_minimize_crash_too_flaky,
+    uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE:
+        handle_minimize_deadline_exceeded_in_main_file_phase,
+    uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED:
+        handle_minimize_deadline_exceeded,
+    uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE:
+        handle_libfuzzer_minimization_unreproducible,
+    uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED:
+        handle_libfuzzer_minimization_failed,
+}).compose_with(
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
 )

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
@@ -740,20 +740,20 @@ def handle_libfuzzer_minimization_failed(output: uworker_msg_pb2.Output):
 
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED:
+        handle_libfuzzer_minimization_failed,
+    uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE:
+        handle_libfuzzer_minimization_unreproducible,
+    uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY:
+        handle_minimize_crash_too_flaky,
+    uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED:
+        handle_minimize_deadline_exceeded,
+    uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE:
+        handle_minimize_deadline_exceeded_in_main_file_phase,
     uworker_msg_pb2.ErrorType.MINIMIZE_SETUP:
         handle_minimize_setup_error,
     uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH:
         handle_minimize_unreproducible_crash,
-    uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY:
-        handle_minimize_crash_too_flaky,
-    uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE:
-        handle_minimize_deadline_exceeded_in_main_file_phase,
-    uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED:
-        handle_minimize_deadline_exceeded,
-    uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE:
-        handle_libfuzzer_minimization_unreproducible,
-    uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED:
-        handle_libfuzzer_minimization_failed,
 }).compose_with(
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
@@ -741,20 +741,20 @@ def handle_libfuzzer_minimization_failed(output: uworker_msg_pb2.Output):
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
     uworker_handle_errors.CompositeErrorHandler({
-      uworker_msg_pb2.ErrorType.MINIMIZE_SETUP:
-          handle_minimize_setup_error,
-      uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH:
-          handle_minimize_unreproducible_crash,
-      uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY:
-          handle_minimize_crash_too_flaky,
-      uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE:
-          handle_minimize_deadline_exceeded_in_main_file_phase,
-      uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED:
-          handle_minimize_deadline_exceeded,
-      uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE:
-          handle_libfuzzer_minimization_unreproducible,
-      uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED:
-          handle_libfuzzer_minimization_failed,
+        uworker_msg_pb2.ErrorType.MINIMIZE_SETUP:
+            handle_minimize_setup_error,
+        uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH:
+            handle_minimize_unreproducible_crash,
+        uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY:
+            handle_minimize_crash_too_flaky,
+        uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE:
+            handle_minimize_deadline_exceeded_in_main_file_phase,
+        uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED:
+            handle_minimize_deadline_exceeded,
+        uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE:
+            handle_libfuzzer_minimization_unreproducible,
+        uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED:
+            handle_libfuzzer_minimization_failed,
     }),
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -599,16 +599,26 @@ def utask_main(uworker_input):
   return find_fixed_range(uworker_input)
 
 
-HANDLED_ERRORS = [
-    uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH,
-    uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR,
-    uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT,
-    uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD,
-    uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR,
-    uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND,
-    uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX,
-    uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
-]
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
+    setup.ERROR_HANDLER,
+    uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
+    uworker_handle_errors.CompositeErrorHandler({
+      uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR:
+          handle_progression_revision_list_error,
+      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND:
+          handle_progression_build_not_found,
+      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX:
+          handle_progression_bad_state_min_max,
+      uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH:
+          handle_progression_no_crash,
+      uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT:
+          handle_progression_timeout,
+      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD:
+          handle_progression_bad_build,
+      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR:
+          handle_progression_build_setup_error,
+    }),
+)
 
 
 def utask_postprocess(output: uworker_msg_pb2.Output):
@@ -624,7 +634,7 @@ def utask_postprocess(output: uworker_msg_pb2.Output):
                            task_output.build_data_list)
 
   if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
-    uworker_handle_errors.handle(output, HANDLED_ERRORS)
+    _ERROR_HANDLER.handle(output)
     return
 
   if task_output and task_output.crash_on_latest:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -599,25 +599,24 @@ def utask_main(uworker_input):
   return find_fixed_range(uworker_input)
 
 
-_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR:
+        handle_progression_revision_list_error,
+    uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND:
+        handle_progression_build_not_found,
+    uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX:
+        handle_progression_bad_state_min_max,
+    uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH:
+        handle_progression_no_crash,
+    uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT:
+        handle_progression_timeout,
+    uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD:
+        handle_progression_bad_build,
+    uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR:
+        handle_progression_build_setup_error,
+}).compose_with(
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
-    uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR:
-            handle_progression_revision_list_error,
-        uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND:
-            handle_progression_build_not_found,
-        uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX:
-            handle_progression_bad_state_min_max,
-        uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH:
-            handle_progression_no_crash,
-        uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT:
-            handle_progression_timeout,
-        uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD:
-            handle_progression_bad_build,
-        uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR:
-            handle_progression_build_setup_error,
-    }),
 )
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -600,20 +600,20 @@ def utask_main(uworker_input):
 
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
-    uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR:
-        handle_progression_revision_list_error,
-    uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND:
-        handle_progression_build_not_found,
-    uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX:
-        handle_progression_bad_state_min_max,
-    uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH:
-        handle_progression_no_crash,
-    uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT:
-        handle_progression_timeout,
     uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD:
         handle_progression_bad_build,
+    uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX:
+        handle_progression_bad_state_min_max,
+    uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND:
+        handle_progression_build_not_found,
     uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR:
         handle_progression_build_setup_error,
+    uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH:
+        handle_progression_no_crash,
+    uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR:
+        handle_progression_revision_list_error,
+    uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT:
+        handle_progression_timeout,
 }).compose_with(
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -603,20 +603,20 @@ _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
     setup.ERROR_HANDLER,
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
     uworker_handle_errors.CompositeErrorHandler({
-      uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR:
-          handle_progression_revision_list_error,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND:
-          handle_progression_build_not_found,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX:
-          handle_progression_bad_state_min_max,
-      uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH:
-          handle_progression_no_crash,
-      uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT:
-          handle_progression_timeout,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD:
-          handle_progression_bad_build,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR:
-          handle_progression_build_setup_error,
+        uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR:
+            handle_progression_revision_list_error,
+        uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND:
+            handle_progression_build_not_found,
+        uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX:
+            handle_progression_bad_state_min_max,
+        uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH:
+            handle_progression_no_crash,
+        uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT:
+            handle_progression_timeout,
+        uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD:
+            handle_progression_bad_build,
+        uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR:
+            handle_progression_build_setup_error,
     }),
 )
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -503,20 +503,20 @@ def handle_low_confidence_in_regression_range(output: uworker_msg_pb2.Output):
 
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
-    uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR:
-        handle_revision_list_error,
+    uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR:
+        handle_regression_bad_build_error,
     uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND:
         handle_build_not_found_error,
     uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR:
         handle_regression_build_setup_error,
-    uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR:
-        handle_regression_bad_build_error,
-    uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH:
-        handle_regression_no_crash,
-    uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR:
-        handle_regression_timeout,
     uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE:
         handle_low_confidence_in_regression_range,
+    uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH:
+        handle_regression_no_crash,
+    uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR:
+        handle_revision_list_error,
+    uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR:
+        handle_regression_timeout,
 }).compose_with(setup.ERROR_HANDLER)
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -505,13 +505,20 @@ def handle_low_confidence_in_regression_range(output: uworker_msg_pb2.Output):
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
     setup.ERROR_HANDLER,
     uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR: handle_revision_list_error,
-        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND: handle_build_not_found_error,
-        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR: handle_regression_build_setup_error,
-        uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR: handle_regression_bad_build_error,
-        uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH: handle_regression_no_crash,
-        uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR: handle_regression_timeout,
-        uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE: handle_low_confidence_in_regression_range,
+        uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR:
+            handle_revision_list_error,
+        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND:
+            handle_build_not_found_error,
+        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR:
+            handle_regression_build_setup_error,
+        uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR:
+            handle_regression_bad_build_error,
+        uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH:
+            handle_regression_no_crash,
+        uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR:
+            handle_regression_timeout,
+        uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE:
+            handle_low_confidence_in_regression_range,
     }))
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -502,24 +502,22 @@ def handle_low_confidence_in_regression_range(output: uworker_msg_pb2.Output):
                                        output.error_message)
 
 
-_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
-    setup.ERROR_HANDLER,
-    uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR:
-            handle_revision_list_error,
-        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND:
-            handle_build_not_found_error,
-        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR:
-            handle_regression_build_setup_error,
-        uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR:
-            handle_regression_bad_build_error,
-        uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH:
-            handle_regression_no_crash,
-        uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR:
-            handle_regression_timeout,
-        uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE:
-            handle_low_confidence_in_regression_range,
-    }))
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR:
+        handle_revision_list_error,
+    uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND:
+        handle_build_not_found_error,
+    uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR:
+        handle_regression_build_setup_error,
+    uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR:
+        handle_regression_bad_build_error,
+    uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH:
+        handle_regression_no_crash,
+    uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR:
+        handle_regression_timeout,
+    uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE:
+        handle_low_confidence_in_regression_range,
+}).compose_with(setup.ERROR_HANDLER)
 
 
 def utask_postprocess(output: uworker_msg_pb2.Output) -> None:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -255,21 +255,6 @@ def validate_regression_range(
   return None
 
 
-def handle_low_confidence_in_regression_range(output: uworker_msg_pb2.Output):
-  testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
-  testcase.regression = 'NA'
-  data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
-                                       output.error_message)
-
-
-def handle_regression_no_crash(output: uworker_msg_pb2.Output):
-  testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
-  data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
-                                       output.error_message)
-
-  task_creation.mark_unreproducible_if_flaky(testcase, 'regression', True)
-
-
 def find_regression_range(uworker_input: uworker_msg_pb2.Input,
                          ) -> uworker_msg_pb2.Output:
   """Attempt to find when the testcase regressed."""
@@ -408,14 +393,6 @@ def find_regression_range(uworker_input: uworker_msg_pb2.Input,
       error_message=error_message)
 
 
-def handle_regression_timeout(output: uworker_msg_pb2.Output):
-  testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
-  data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
-                                       output.error_message)
-  tasks.add_task('regression', output.uworker_input.testcase_id,
-                 output.uworker_input.job_type)
-
-
 def utask_preprocess(testcase_id: str, job_type: str,
                      uworker_env: Dict) -> Optional[uworker_msg_pb2.Input]:
   """Prepares inputs for `utask_main()` to run on an untrusted worker.
@@ -453,6 +430,15 @@ def utask_preprocess(testcase_id: str, job_type: str,
   )
 
 
+def utask_main(uworker_input: uworker_msg_pb2.Input,
+              ) -> Optional[uworker_msg_pb2.Output]:
+  """Runs regression task and handles potential errors.
+
+  Runs on an untrusted worker.
+  """
+  return find_regression_range(uworker_input)
+
+
 def handle_revision_list_error(output: uworker_msg_pb2.Output):
   testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
   data_handler.close_testcase_with_error(testcase,
@@ -465,51 +451,6 @@ def handle_build_not_found_error(output: uworker_msg_pb2.Output):
   testcase.regression = 'NA'
   data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                        output.error_message)
-
-
-_HANDLED_ERRORS = [
-    uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR,
-    uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND,
-    uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR,
-    uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR,
-    uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH,
-    uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR,
-    uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE,
-] + setup.HANDLED_ERRORS
-
-
-def utask_postprocess(output: uworker_msg_pb2.Output) -> None:
-  """Handles the output of `utask_main()` run on an untrusted worker.
-
-  Runs on a trusted worker.
-  """
-  if output.HasField('regression_task_output'):
-    task_output = output.regression_task_output
-    _update_build_metadata(output.uworker_input.job_type,
-                           task_output.build_data_list)
-    _save_current_regression_range_indices(task_output,
-                                           output.uworker_input.testcase_id)
-    if task_output.is_testcase_reproducible:
-      # Clear metadata from previous runs had it been marked as potentially
-      # flaky.
-      testcase = data_handler.get_testcase_by_id(
-          output.uworker_input.testcase_id)
-      task_creation.mark_unreproducible_if_flaky(testcase, 'regression', False)
-
-  if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
-    uworker_handle_errors.handle(output, _HANDLED_ERRORS)
-    return
-
-  save_regression_range(output)
-
-
-def utask_main(uworker_input: uworker_msg_pb2.Input,
-              ) -> Optional[uworker_msg_pb2.Output]:
-  """Runs regression task and handles potential errors.
-
-  Runs on an untrusted worker.
-  """
-  return find_regression_range(uworker_input)
 
 
 def handle_regression_build_setup_error(output: uworker_msg_pb2.Output):
@@ -536,6 +477,67 @@ def handle_regression_bad_build_error(output: uworker_msg_pb2.Output):
   error_message = 'Unable to recover from bad build'
   data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
                                        error_message)
+
+
+def handle_regression_no_crash(output: uworker_msg_pb2.Output):
+  testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
+  data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
+                                       output.error_message)
+
+  task_creation.mark_unreproducible_if_flaky(testcase, 'regression', True)
+
+
+def handle_regression_timeout(output: uworker_msg_pb2.Output):
+  testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
+  data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
+                                       output.error_message)
+  tasks.add_task('regression', output.uworker_input.testcase_id,
+                 output.uworker_input.job_type)
+
+
+def handle_low_confidence_in_regression_range(output: uworker_msg_pb2.Output):
+  testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
+  testcase.regression = 'NA'
+  data_handler.update_testcase_comment(testcase, data_types.TaskState.ERROR,
+                                       output.error_message)
+
+
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
+    setup.ERROR_HANDLER,
+    uworker_handle_errors.CompositeErrorHandler({
+        uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR: handle_revision_list_error,
+        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND: handle_build_not_found_error,
+        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR: handle_regression_build_setup_error,
+        uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR: handle_regression_bad_build_error,
+        uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH: handle_regression_no_crash,
+        uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR: handle_regression_timeout,
+        uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE: handle_low_confidence_in_regression_range,
+    }))
+
+
+def utask_postprocess(output: uworker_msg_pb2.Output) -> None:
+  """Handles the output of `utask_main()` run on an untrusted worker.
+
+  Runs on a trusted worker.
+  """
+  if output.HasField('regression_task_output'):
+    task_output = output.regression_task_output
+    _update_build_metadata(output.uworker_input.job_type,
+                           task_output.build_data_list)
+    _save_current_regression_range_indices(task_output,
+                                           output.uworker_input.testcase_id)
+    if task_output.is_testcase_reproducible:
+      # Clear metadata from previous runs had it been marked as potentially
+      # flaky.
+      testcase = data_handler.get_testcase_by_id(
+          output.uworker_input.testcase_id)
+      task_creation.mark_unreproducible_if_flaky(testcase, 'regression', False)
+
+  if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
+    _ERROR_HANDLER.handle(output)
+    return
+
+  save_regression_range(output)
 
 
 def _update_build_metadata(job_type: str,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
@@ -290,10 +290,10 @@ def get_symbolized_stacktraces(testcase_file_path, testcase,
 
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
-    setup.ERROR_HANDLER,
-    uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
+    setup.ERROR_HANDLER, uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
     uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR: handle_build_setup_error,
+        uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR:
+            handle_build_setup_error,
     }))
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
@@ -289,12 +289,13 @@ def get_symbolized_stacktraces(testcase_file_path, testcase,
   return symbolized, stacktrace
 
 
-_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
-    setup.ERROR_HANDLER, uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
-    uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR:
-            handle_build_setup_error,
-    }))
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR:
+        handle_build_setup_error,
+}).compose_with(
+    setup.ERROR_HANDLER,
+    uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
+)
 
 
 def utask_postprocess(output):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -54,7 +54,7 @@ class CompositeErrorHandler:
         type.
     """
     for other in args:
-      for error_type, handler in other._handlers.items():
+      for error_type, handler in other._handlers.items():  # pylint: disable=protected-access
         if error_type in self._handlers:
           raise ValueError(f'Duplicate handlers for error type {error_type}')
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -42,26 +42,25 @@ class CompositeErrorHandler:
     self._handlers = handlers
 
   # Must use string types because `CompositeErrorHandler` is not defined yet.
-  @classmethod
-  def compose(cls, *args: 'CompositeErrorHandler') -> 'CompositeErrorHandler':
-    """Composes several composite error handlers into one.
+  def compose_with(self,
+                   *args: 'CompositeErrorHandler') -> 'CompositeErrorHandler':
+    """Adds all handlers from the given composite handlers to this instance.
+    Returns `self` for chaining.
 
-    The given handlers must handle disjoint sets of error types.
+    Eachn handler (including `self`) must handle a disjoint set of error types.
 
     Raises:
-      ValueError: if more than one handler handles the same error type.
+      ValueError: if any two handlers (including `self`) handle the same error
+        type.
     """
-    handlers = {}
-
-    # Merge all handler dicts, checking that no keys are duplicated.
-    for composite_handler in args:
-      for error_type, handler in composite_handler._handlers.items():
-        if error_type in handlers:
+    for other in args:
+      for error_type, handler in other._handlers.items():
+        if error_type in self._handlers:
           raise ValueError(f'Duplicate handlers for error type {error_type}')
 
-        handlers[error_type] = handler
+        self._handlers[error_type] = handler
 
-    return cls(handlers)
+    return self
 
   def is_handled(self, error_type: uworker_msg_pb2.ErrorType) -> bool:
     """Returns whether the given error type is handled by this instance."""

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -18,11 +18,9 @@ from typing import Dict
 
 from clusterfuzz._internal.protos import uworker_msg_pb2
 
-
 # A handler takes an output object with its `error_type` set, and does whatever
 # it wants with it.
 ErrorHandler = Callable[[uworker_msg_pb2.Output], None]
-
 
 # Must use string type because of protobuf enum shenanigans.
 HandlerDict = Dict["uworker_msg_pb2.ErrorType", ErrorHandler]

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -16,111 +16,12 @@
 from typing import Callable
 from typing import Dict
 
-from clusterfuzz._internal.bot.tasks import setup
-from clusterfuzz._internal.bot.tasks.utasks import analyze_task
-from clusterfuzz._internal.bot.tasks.utasks import fuzz_task
-from clusterfuzz._internal.bot.tasks.utasks import minimize_task
-from clusterfuzz._internal.bot.tasks.utasks import progression_task
-from clusterfuzz._internal.bot.tasks.utasks import regression_task
-from clusterfuzz._internal.bot.tasks.utasks import symbolize_task
-from clusterfuzz._internal.bot.tasks.utasks import uworker_io
-from clusterfuzz._internal.bot.tasks.utasks import variant_task
 from clusterfuzz._internal.protos import uworker_msg_pb2
-
-
-def noop(*args, **kwargs):
-  del args
-  del kwargs
-
-
-def handle(output, handled_errors):
-  """Handles the errors bubbled up from the uworker."""
-  if output.error_type not in handled_errors:
-    error = '<None>' if output.error_type is None else output.error_type
-    raise RuntimeError('Can\'t handle ' + error)
-  return get_handle_all_errors_mapping()[output.error_type](output)
-
-
-def get_all_handled_errors():
-  return set(get_handle_all_errors_mapping().keys())
-
-
-def get_handle_all_errors_mapping():
-  """Returns a mapping of all uworker errors to their postprocess handlers."""
-  mapping = {
-      uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH:
-          analyze_task.handle_noncrash,
-      uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP:
-          analyze_task.handle_build_setup_error,
-      uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST:
-          analyze_task.handle_analyze_no_revisions_list_error,
-      uworker_msg_pb2.ANALYZE_NO_REVISION_INDEX:
-          analyze_task.handle_analyze_no_revision_index,
-      uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER:
-          fuzz_task.handle_fuzz_no_fuzzer,
-      uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE:
-          fuzz_task.handle_fuzz_build_setup_failure,
-      uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE:
-          fuzz_task.handle_fuzz_data_bundle_setup_failure,
-      uworker_msg_pb2.ErrorType.MINIMIZE_SETUP:
-          minimize_task.handle_minimize_setup_error,
-      uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH:
-          minimize_task.handle_minimize_unreproducible_crash,
-      uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY:
-          minimize_task.handle_minimize_crash_too_flaky,
-      uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE:
-          minimize_task.handle_minimize_deadline_exceeded_in_main_file_phase,
-      uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED:
-          minimize_task.handle_minimize_deadline_exceeded,
-      uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE:
-          minimize_task.handle_libfuzzer_minimization_unreproducible,
-      uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED:
-          minimize_task.handle_libfuzzer_minimization_failed,
-      uworker_msg_pb2.ErrorType.TESTCASE_SETUP:
-          setup.handle_setup_testcase_error,
-      uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP:
-          variant_task.handle_build_setup_error,
-      uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR:
-          progression_task.handle_progression_revision_list_error,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND:
-          progression_task.handle_progression_build_not_found,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX:
-          progression_task.handle_progression_bad_state_min_max,
-      uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH:
-          progression_task.handle_progression_no_crash,
-      uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT:
-          progression_task.handle_progression_timeout,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD:
-          progression_task.handle_progression_bad_build,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR:
-          progression_task.handle_progression_build_setup_error,
-      uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR:
-          regression_task.handle_revision_list_error,
-      uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND:
-          regression_task.handle_build_not_found_error,
-      uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR:
-          regression_task.handle_regression_build_setup_error,
-      uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR:
-          regression_task.handle_regression_bad_build_error,
-      uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH:
-          regression_task.handle_regression_no_crash,
-      uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR:
-          regression_task.handle_regression_timeout,
-      uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE:
-          regression_task.handle_low_confidence_in_regression_range,
-      uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR:
-          symbolize_task.handle_build_setup_error,
-      uworker_msg_pb2.ErrorType.CORPUS_PRUNING_FUZZER_SETUP_FAILED:
-          noop,
-      uworker_msg_pb2.ErrorType.UNHANDLED:
-          noop,
-  }
-  return mapping
 
 
 # A handler takes an output object with its `error_type` set, and does whatever
 # it wants with it.
-ErrorHandler = Callable[[uworker_io.UworkerOutput], None]
+ErrorHandler = Callable[[uworker_msg_pb2.Output], None]
 
 
 # Must use string type because of protobuf enum shenanigans.
@@ -172,7 +73,7 @@ class CompositeErrorHandler(object):
     """Returns whether the given error type is handled by this instance."""
     return error_type in self._handlers
 
-  def handle(self, output: uworker_io.UworkerOutput):
+  def handle(self, output: uworker_msg_pb2.Output):
     """Handles the given `output`, delegating to underlying handlers.
 
     Raises:
@@ -185,7 +86,12 @@ class CompositeErrorHandler(object):
     handler(output)
 
 
+def noop_handler(*args, **kwargs):
+  del args
+  del kwargs
+
+
 # A composite error handler for `UNHANDLED` errors, that ignores such errors.
 UNHANDLED_ERROR_HANDLER = CompositeErrorHandler({
-    uworker_msg_pb2.ErrorType.UNHANDLED: noop,
+    uworker_msg_pb2.ErrorType.UNHANDLED: noop_handler,
 })

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_handle_errors.py
@@ -23,10 +23,10 @@ from clusterfuzz._internal.protos import uworker_msg_pb2
 ErrorHandler = Callable[[uworker_msg_pb2.Output], None]
 
 # Must use string type because of protobuf enum shenanigans.
-HandlerDict = Dict["uworker_msg_pb2.ErrorType", ErrorHandler]
+HandlerDict = Dict['uworker_msg_pb2.ErrorType', ErrorHandler]
 
 
-class CompositeErrorHandler(object):
+class CompositeErrorHandler:
   """A handler for several different types of uworker errors."""
 
   def __init__(self, handlers: HandlerDict):
@@ -41,9 +41,9 @@ class CompositeErrorHandler(object):
     """
     self._handlers = handlers
 
-  # Mut use string types because `CompositeErrorHandler` is not defined yet.
+  # Must use string types because `CompositeErrorHandler` is not defined yet.
   @classmethod
-  def compose(cls, *args: "CompositeErrorHandler") -> "CompositeErrorHandler":
+  def compose(cls, *args: 'CompositeErrorHandler') -> 'CompositeErrorHandler':
     """Composes several composite error handlers into one.
 
     The given handlers must handle disjoint sets of error types.
@@ -55,17 +55,13 @@ class CompositeErrorHandler(object):
 
     # Merge all handler dicts, checking that no keys are duplicated.
     for composite_handler in args:
-      for error_type, handler in composite_handler.handlers().items():
+      for error_type, handler in composite_handler._handlers.items():
         if error_type in handlers:
-          raise ValueError(f"Duplicate handlers for error type {error_type}")
+          raise ValueError(f'Duplicate handlers for error type {error_type}')
 
         handlers[error_type] = handler
 
     return cls(handlers)
-
-  def handlers(self) -> HandlerDict:
-    """Returns a shallow copy of this handler's underlying dictionary."""
-    return self._handlers.copy()
 
   def is_handled(self, error_type: uworker_msg_pb2.ErrorType) -> bool:
     """Returns whether the given error type is handled by this instance."""
@@ -79,7 +75,7 @@ class CompositeErrorHandler(object):
     """
     handler = self._handlers.get(output.error_type)
     if handler is None:
-      raise RuntimeError(f"Cannot handle error type {output.error_type}")
+      raise RuntimeError(f'Cannot handle error type {output.error_type}')
 
     handler(output)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -201,10 +201,9 @@ def handle_build_setup_error(output):
       f'Build setup failed with job: {output.uworker_input.testcase_id}')
 
 
-_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
-    uworker_handle_errors.CompositeErrorHandler({
-        uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP: handle_build_setup_error,
-    }),
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
+    uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP: handle_build_setup_error,
+}).compose_with(
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
     setup.ERROR_HANDLER,
 )

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -203,7 +203,7 @@ def handle_build_setup_error(output):
 
 _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
     uworker_handle_errors.CompositeErrorHandler({
-      uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP: handle_build_setup_error,
+        uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP: handle_build_setup_error,
     }),
     uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
     setup.ERROR_HANDLER,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -201,16 +201,19 @@ def handle_build_setup_error(output):
       f'Build setup failed with job: {output.uworker_input.testcase_id}')
 
 
-HANDLED_ERRORS = [
-    uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP,
-    uworker_msg_pb2.ErrorType.UNHANDLED
-] + setup.HANDLED_ERRORS
+_ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler.compose(
+    uworker_handle_errors.CompositeErrorHandler({
+      uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP: handle_build_setup_error,
+    }),
+    uworker_handle_errors.UNHANDLED_ERROR_HANDLER,
+    setup.ERROR_HANDLER,
+)
 
 
 def utask_postprocess(output):
   """Handle the output from utask_main."""
   if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
-    uworker_handle_errors.handle(output, HANDLED_ERRORS)
+    _ERROR_HANDLER.handle(output)
     return
 
   testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/progression_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/progression_task_test.py
@@ -197,7 +197,7 @@ class UTaskPostprocessTest(unittest.TestCase):
   def setUp(self):
     helpers.patch_environ(self)
     helpers.patch(self, [
-        'clusterfuzz._internal.bot.tasks.utasks.uworker_handle_errors.handle',
+        'clusterfuzz._internal.bot.tasks.utasks.progression_task._ERROR_HANDLER.handle',
         'clusterfuzz._internal.bot.tasks.utasks.progression_task.crash_on_latest',
         'clusterfuzz._internal.datastore.data_handler.is_first_attempt_for_task',
         'clusterfuzz._internal.base.bisection.request_bisection'

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/symbolize_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/symbolize_task_test.py
@@ -66,9 +66,9 @@ class UTaskPostprocessTest(unittest.TestCase):
   def setUp(self):
     helpers.patch_environ(self)
     helpers.patch(self, [
-        'clusterfuzz._internal.bot.tasks.utasks.uworker_handle_errors.handle',
         'clusterfuzz._internal.datastore.data_handler.handle_duplicate_entry',
-        'clusterfuzz._internal.bot.tasks.task_creation.create_blame_task_if_needed'
+        'clusterfuzz._internal.bot.tasks.task_creation.create_blame_task_if_needed',
+        'clusterfuzz._internal.bot.tasks.utasks.symbolize_task._ERROR_HANDLER.handle',
     ])
 
   def test_error_handling_called_on_error(self):


### PR DESCRIPTION
This breaks an implicit dependency cycle between tasks and error handling code:

- tasks defined error handlers
- which were stored in a global map in `uworker_handle_errors`
- referenced by `uworker_handle_errors.handle()`
- which was called by tasks to handle errors

Because not all tasks could handle all errors, a subset of error types to handle was passed to `uworker_handle_errors.handle()` along with the error itself. This implicitly depended on those errors being mapped to the right handlers in `uworker_handle_errors`.

Instead, this new approach has tasks build their own maps of handlers (called `CompositeErrorHandler` here) out of building blocks provided by `uworker_handle_errors` and other dependencies of theirs (currently, only `setup`). Dependencies like `setup` can provide their own error handlers for composition by consumers.

Hopefully this makes sense :)

A benefit of this approach is that since the error -> handler mapping is defined per task module, error types can be reused across tasks. For example, both progression task and regression task fail when the build manager fails to find any good revisions to use. #3469 introduces a new `REGRESSION_REVISION_LIST_ERROR` error that mirrors `PROGRESSION_REVISION_LIST_ERROR`, just because the keys need to be distinct in `uworker_handle_error`'s global map. Were this refactor merged, we could define a generic `EMPTY_REVISION_LIST` error type that both progression task and regression task could use and map to their respective error handlers.