### PR TITLE
Improve uworker_io serialization.

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -217,7 +217,8 @@ class RoundTripTest(unittest.TestCase):
         testcase=self.testcase,
         uworker_env=self.env,
         setup_input=uworker_io.SetupInput(testcase_download_url=self.FAKE_URL),
-    )
+        analyze_task_input=uworker_io.AnalyzeTaskInput(
+            bad_revisions=[1234, 9999]))
 
     # Create a mocked version of write_data so that when we upload the uworker
     # input, it goes to a known file we can read from.
@@ -270,6 +271,8 @@ class RoundTripTest(unittest.TestCase):
                      downloaded_input.uworker_output_upload_url)
     self.assertEqual(uworker_input.setup_input.testcase_download_url,
                      downloaded_input.setup_input.testcase_download_url)
+    self.assertEqual(uworker_input.analyze_task_input.bad_revisions,
+                     downloaded_input.analyze_task_input.bad_revisions)
 
   def test_upload_and_download_output(self):
     """Tests that uploading and downloading uworker output works. This means


### PR DESCRIPTION
All subfields of UworkerOutput now extend it and use the same save_rich_type method.