### PR TITLE
Find more fuzzers.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -58,7 +58,7 @@ def is_fuzz_target_local(file_path, file_handle=None):
     # Ignore non-existent files for cases when we don't have a file handle.
     return False
 
-  if filename.endswith('_fuzzer') or filename.endswidth('_fuzztest')::
+  if filename.endswith('_fuzzer') or filename.endswidth('_fuzztest'):
     return True
 
   # TODO(aarya): Remove this optimization if it does not show up significant

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -58,7 +58,7 @@ def is_fuzz_target_local(file_path, file_handle=None):
     # Ignore non-existent files for cases when we don't have a file handle.
     return False
 
-  if filename.endswith('_fuzzer'):
+  if filename.endswith('_fuzzer') or filename.endswidth('_fuzztest')::
     return True
 
   # TODO(aarya): Remove this optimization if it does not show up significant

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -58,7 +58,7 @@ def is_fuzz_target_local(file_path, file_handle=None):
     # Ignore non-existent files for cases when we don't have a file handle.
     return False
 
-  if filename.endswith('_fuzzer') or filename.endswidth('_fuzztest'):
+  if filename.endswith('_fuzzer') or filename.endswith('_fuzztest'):
     return True
 
   # TODO(aarya): Remove this optimization if it does not show up significant

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -79,8 +79,7 @@ def is_fuzz_target_local(file_path, file_handle=None):
   for pattern in FUZZ_TARGET_SEARCH_BYTES:
     # TODO(metzman): Bound this call so we don't read forever if something went
     # wrong.
-    result = utils.search_bytes_in_file(pattern,
-                                        local_file_handle)
+    result = utils.search_bytes_in_file(pattern, local_file_handle)
     if result:
       break
 


### PR DESCRIPTION
Some fuzzers, in particular those built using fuzztest, obey the libfuzzer external interface but do not have LLVMFuzzerTestOneInput, instead having LLVMFuzzerRunDriver. Search for that string as well when identifying whether an executable is a fuzzer.

(I'm unable to run `butler.py` to format or test this due to python version issues).