### PR TITLE
Revert downgrade Pub/Sub Emulator in `ci` Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
         google-cloud-sdk-app-engine-python-extras \
         google-cloud-sdk-datastore-emulator \
         google-cloud-sdk-gke-gcloud-auth-plugin \
-        google-cloud-sdk-pubsub-emulator=312.0.0-0 \
+        google-cloud-sdk-pubsub-emulator \
         kubectl \
         liblzma-dev \
         openjdk-11-jdk


### PR DESCRIPTION
close #2077 

Due to this bug: https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/224, the version of the Pub/Sub emulator used in the CI Docker image was downgraded to 312.0.0.

Now that this bug has been fixed, and I have noticed that the CI Docker image is being actively maintained again, I would like to propose restoring the Pub/Sub emulator to the latest version.