### PR TITLE
Fix serialization.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -362,6 +362,8 @@ class UworkerMsg:
     self.save_rich_type(attribute, value)
 
   def save_rich_type(self, attribute, value):
+    """Saves non-primitive types to the _proto. This handles lists, messages and
+    lists of messages."""
     field = getattr(self._proto, attribute)
 
     if isinstance(field, collections.abc.Sequence):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -365,6 +365,7 @@ class UworkerMsg:
     raise NotImplementedError('Child must implement.')
 
   def serialize(self):
+    """Serializes UworkerMsg into proto wire format."""
     for attr in self._set_fields:
       # Do this to make sure _proto fields are up to date.
       value = getattr(self, attr)
@@ -432,7 +433,7 @@ class UworkerOutput(UworkerMsg):
       return
 
     if isinstance(value, UworkerMsg):
-      field.CopyFrom(value._proto)
+      field.CopyFrom(value._proto)  # pylint: disable=protected-access
       return
 
     if not isinstance(value, UworkerEntityWrapper):
@@ -470,20 +471,21 @@ class UworkerInput(UworkerMsg):
     if isinstance(field, collections.abc.Sequence):
       # This the way to tell if it's a repeated field.
       # We can't get the type of the repeated field directly.
+      del field[:]
       value = list(value)
       if len(value) == 0:
         return
       if not isinstance(value[0], ndb.Model):
         field.extend(value)
       else:
+        # TODO(metzman): This is probably unnecessary and very complext to deal
+        # with.
         new_value = [model._entity_to_protobuf(entity) for entity in value]  # pylint: disable=protected-access
         field.extend(new_value)
       return
 
     if isinstance(value, UworkerMsg):
-      if isinstance(value, AnalyzeTaskInput):
-        pass
-      field.CopyFrom(value._proto)
+      field.CopyFrom(value._proto)  # pylint: disable=protected-access
       return
 
     if not isinstance(value, ndb.Model):

--- a/src/clusterfuzz/_internal/protos/uworker_msg.proto
+++ b/src/clusterfuzz/_internal/protos/uworker_msg.proto
@@ -103,7 +103,7 @@ message FuzzTaskOutput {
   optional int64 new_crash_count = 4;
   optional int64 known_crash_count = 5;
   optional int64 testcases_executed = 6;
-  optional Json job_run_crashes = 7;
+  repeated Json job_run_crashes = 7;
   optional string fully_qualified_fuzzer_name = 8;
   optional int32 new_targets_count = 9;
 }

--- a/src/clusterfuzz/_internal/protos/uworker_msg_pb2.py
+++ b/src/clusterfuzz/_internal/protos/uworker_msg_pb2.py
@@ -35,7 +35,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n.clusterfuzz/_internal/protos/uworker_msg.proto\x1a,google/cloud/datastore_v1/proto/entity.proto\"\x1a\n\x04Json\x12\x12\n\nserialized\x18\x01 \x01(\t\"[\n\x14UworkerEntityWrapper\x12+\n\x06\x65ntity\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.Entity\x12\x16\n\x07\x63hanged\x18\x02 \x01(\x0b\x32\x05.Json\"\xdc\x02\n\nSetupInput\x12\x30\n\x06\x66uzzer\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\x18\n\x0b\x66uzzer_name\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x31\n\x0c\x64\x61ta_bundles\x18\x03 \x03(\x0b\x32\x1b.google.datastore.v1.Entity\x12\"\n\x15\x66uzzer_log_upload_url\x18\x04 \x01(\tH\x02\x88\x01\x01\x12 \n\x13\x66uzzer_download_url\x18\x05 \x01(\tH\x03\x88\x01\x01\x12\"\n\x15testcase_download_url\x18\x06 \x01(\tH\x04\x88\x01\x01\x42\t\n\x07_fuzzerB\x0e\n\x0c_fuzzer_nameB\x18\n\x16_fuzzer_log_upload_urlB\x16\n\x14_fuzzer_download_urlB\x18\n\x16_testcase_download_url\")\n\x10\x41nalyzeTaskInput\x12\x15\n\rbad_revisions\x18\x01 \x03(\x03\"\x14\n\x12SymbolizeTaskInput\"Z\n\rFuzzTaskInput\x12\x37\n\rtargets_count\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x42\x10\n\x0e_targets_count\"M\n\x11MinimizeTaskInput\x12 \n\x13testcase_upload_url\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x16\n\x14_testcase_upload_url\",\n\x13RegressionTaskInput\x12\x15\n\rbad_revisions\x18\x01 \x03(\x03\"[\n\x14ProgressionTaskInput\x12\x1a\n\rcustom_binary\x18\x01 \x01(\x08H\x00\x88\x01\x01\x12\x15\n\rbad_revisions\x18\x02 \x03(\x03\x42\x10\n\x0e_custom_binary\"\x9d\x01\n\x16\x43orpusPruningTaskInput\x12\x35\n\x0b\x66uzz_target\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\"\n\x15last_execution_failed\x18\x02 \x01(\x08H\x01\x88\x01\x01\x42\x0e\n\x0c_fuzz_targetB\x18\n\x16_last_execution_failed\"\xa4\t\n\x05Input\x12\x32\n\x08testcase\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\x42\n\x18testcase_upload_metadata\x18\x02 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x01\x88\x01\x01\x12\x18\n\x0btestcase_id\x18\x03 \x01(\tH\x02\x88\x01\x01\x12\x1f\n\x0buworker_env\x18\x04 \x01(\x0b\x32\x05.JsonH\x03\x88\x01\x01\x12\x15\n\x08job_type\x18\x06 \x01(\tH\x04\x88\x01\x01\x12&\n\x19uworker_output_upload_url\x18\x07 \x01(\tH\x05\x88\x01\x01\x12\x31\n\x07variant\x18\x08 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x06\x88\x01\x01\x12\x1e\n\x11original_job_type\x18\t \x01(\tH\x07\x88\x01\x01\x12\x18\n\x0b\x66uzzer_name\x18\n \x01(\tH\x08\x88\x01\x01\x12%\n\x0bsetup_input\x18\x0b \x01(\x0b\x32\x0b.SetupInputH\t\x88\x01\x01\x12\x32\n\x12\x61nalyze_task_input\x18\x0c \x01(\x0b\x32\x11.AnalyzeTaskInputH\n\x88\x01\x01\x12?\n\x19\x63orpus_pruning_task_input\x18\r \x01(\x0b\x32\x17.CorpusPruningTaskInputH\x0b\x88\x01\x01\x12,\n\x0f\x66uzz_task_input\x18\x0e \x01(\x0b\x32\x0e.FuzzTaskInputH\x0c\x88\x01\x01\x12\x34\n\x13minimize_task_input\x18\x0f \x01(\x0b\x32\x12.MinimizeTaskInputH\r\x88\x01\x01\x12:\n\x16progression_task_input\x18\x10 \x01(\x0b\x32\x15.ProgressionTaskInputH\x0e\x88\x01\x01\x12\x38\n\x15regression_task_input\x18\x11 \x01(\x0b\x32\x14.RegressionTaskInputH\x0f\x88\x01\x01\x12\x36\n\x14symbolize_task_input\x18\x12 \x01(\x0b\x32\x13.SymbolizeTaskInputH\x10\x88\x01\x01\x12\x18\n\x0bmodule_name\x18\x13 \x01(\tH\x11\x88\x01\x01\x42\x0b\n\t_testcaseB\x1b\n\x19_testcase_upload_metadataB\x0e\n\x0c_testcase_idB\x0e\n\x0c_uworker_envB\x0b\n\t_job_typeB\x1c\n\x1a_uworker_output_upload_urlB\n\n\x08_variantB\x14\n\x12_original_job_typeB\x0e\n\x0c_fuzzer_nameB\x0e\n\x0c_setup_inputB\x15\n\x13_analyze_task_inputB\x1c\n\x1a_corpus_pruning_task_inputB\x12\n\x10_fuzz_task_inputB\x16\n\x14_minimize_task_inputB\x19\n\x17_progression_task_inputB\x18\n\x16_regression_task_inputB\x17\n\x15_symbolize_task_inputB\x0e\n\x0c_module_name\"\x15\n\x13SymbolizeTaskOutput\"\x13\n\x11\x41nalyzeTaskOutput\"\xf9\x03\n\x0e\x46uzzTaskOutput\x12\x18\n\x0b\x66uzzer_name\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0e\x63rash_revision\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x1e\n\x11job_run_timestamp\x18\x03 \x01(\x02H\x02\x88\x01\x01\x12\x1c\n\x0fnew_crash_count\x18\x04 \x01(\x03H\x03\x88\x01\x01\x12\x1e\n\x11known_crash_count\x18\x05 \x01(\x03H\x04\x88\x01\x01\x12\x1f\n\x12testcases_executed\x18\x06 \x01(\x03H\x05\x88\x01\x01\x12#\n\x0fjob_run_crashes\x18\x07 \x01(\x0b\x32\x05.JsonH\x06\x88\x01\x01\x12(\n\x1b\x66ully_qualified_fuzzer_name\x18\x08 \x01(\tH\x07\x88\x01\x01\x12\x1e\n\x11new_targets_count\x18\t \x01(\x05H\x08\x88\x01\x01\x42\x0e\n\x0c_fuzzer_nameB\x11\n\x0f_crash_revisionB\x14\n\x12_job_run_timestampB\x12\n\x10_new_crash_countB\x14\n\x12_known_crash_countB\x15\n\x13_testcases_executedB\x12\n\x10_job_run_crashesB\x1e\n\x1c_fully_qualified_fuzzer_nameB\x14\n\x12_new_targets_count\"\xb7\x01\n\x12MinimizeTaskOutput\x12*\n\x16last_crash_result_dict\x18\x01 \x01(\x0b\x32\x05.JsonH\x00\x88\x01\x01\x12\x18\n\x0b\x66laky_stack\x18\x02 \x01(\x08H\x01\x88\x01\x01\x12\x1c\n\x0f\x62uild_fail_wait\x18\x03 \x01(\x03H\x02\x88\x01\x01\x42\x19\n\x17_last_crash_result_dictB\x0e\n\x0c_flaky_stackB\x12\n\x10_build_fail_wait\"\x16\n\x14RegressionTaskOutput\"\xc3\x01\n\tBuildData\x12\x19\n\x0cis_bad_build\x18\x01 \x01(\x08H\x00\x88\x01\x01\x12\'\n\x1ashould_ignore_crash_result\x18\x02 \x01(\x08H\x01\x88\x01\x01\x12%\n\x18\x62uild_run_console_output\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\x0f\n\r_is_bad_buildB\x1d\n\x1b_should_ignore_crash_resultB\x1b\n\x19_build_run_console_output\"\x97\x04\n\x15ProgressionTaskOutput\x12\x19\n\x0cmin_revision\x18\x01 \x01(\x03H\x00\x88\x01\x01\x12\x19\n\x0cmax_revision\x18\x02 \x01(\x03H\x01\x88\x01\x01\x12\x1c\n\x0f\x63rash_on_latest\x18\x03 \x01(\x08H\x02\x88\x01\x01\x12$\n\x17\x63rash_on_latest_message\x18\x04 \x01(\tH\x03\x88\x01\x01\x12\x1b\n\x0e\x63rash_revision\x18\x05 \x01(\x03H\x04\x88\x01\x01\x12)\n\x1clast_tested_crash_stacktrace\x18\x06 \x01(\tH\x05\x88\x01\x01\x12!\n\x14last_progression_min\x18\x07 \x01(\x03H\x06\x88\x01\x01\x12!\n\x14last_progression_max\x18\x08 \x01(\x03H\x07\x88\x01\x01\x12#\n\x16\x63lear_min_max_metadata\x18\t \x01(\x08H\x08\x88\x01\x01\x42\x0f\n\r_min_revisionB\x0f\n\r_max_revisionB\x12\n\x10_crash_on_latestB\x1a\n\x18_crash_on_latest_messageB\x11\n\x0f_crash_revisionB\x1f\n\x1d_last_tested_crash_stacktraceB\x17\n\x15_last_progression_minB\x17\n\x15_last_progression_maxB\x19\n\x17_clear_min_max_metadata\"\xee\x07\n\x06Output\x12,\n\x08testcase\x18\x01 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x00\x88\x01\x01\x12<\n\x18testcase_upload_metadata\x18\x02 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x01\x88\x01\x01\x12+\n\x07variant\x18\x03 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x02\x88\x01\x01\x12#\n\nerror_type\x18\x04 \x01(\x0e\x32\n.ErrorTypeH\x03\x88\x01\x01\x12\"\n\ruworker_input\x18\x05 \x01(\x0b\x32\x06.InputH\x04\x88\x01\x01\x12\x19\n\x0ctest_timeout\x18\x06 \x01(\x02H\x05\x88\x01\x01\x12\x17\n\ncrash_time\x18\x07 \x01(\x02H\x06\x88\x01\x01\x12$\n\x17\x63rash_stacktrace_output\x18\x08 \x01(\tH\x07\x88\x01\x01\x12\x34\n\x13\x61nalyze_task_output\x18\t \x01(\x0b\x32\x12.AnalyzeTaskOutputH\x08\x88\x01\x01\x12.\n\x10\x66uzz_task_output\x18\n \x01(\x0b\x32\x0f.FuzzTaskOutputH\t\x88\x01\x01\x12\x36\n\x14minimize_task_output\x18\x0b \x01(\x0b\x32\x13.MinimizeTaskOutputH\n\x88\x01\x01\x12:\n\x16regression_task_output\x18\x0c \x01(\x0b\x32\x15.RegressionTaskOutputH\x0b\x88\x01\x01\x12<\n\x17progression_task_output\x18\r \x01(\x0b\x32\x16.ProgressionTaskOutputH\x0c\x88\x01\x01\x12\x38\n\x15symbolize_task_output\x18\x0e \x01(\x0b\x32\x14.SymbolizeTaskOutputH\r\x88\x01\x01\x12\x1a\n\rerror_message\x18\x0f \x01(\tH\x0e\x88\x01\x01\x42\x0b\n\t_testcaseB\x1b\n\x19_testcase_upload_metadataB\n\n\x08_variantB\r\n\x0b_error_typeB\x10\n\x0e_uworker_inputB\x0f\n\r_test_timeoutB\r\n\x0b_crash_timeB\x1a\n\x18_crash_stacktrace_outputB\x16\n\x14_analyze_task_outputB\x13\n\x11_fuzz_task_outputB\x17\n\x15_minimize_task_outputB\x19\n\x17_regression_task_outputB\x1a\n\x18_progression_task_outputB\x18\n\x16_symbolize_task_outputB\x10\n\x0e_error_message*\xaa\x04\n\tErrorType\x12\x0c\n\x08NO_ERROR\x10\x00\x12\x17\n\x13\x41NALYZE_BUILD_SETUP\x10\x01\x12\x14\n\x10\x41NALYZE_NO_CRASH\x10\x02\x12\x1d\n\x19\x41NALYZE_NO_REVISIONS_LIST\x10\x03\x12\x1d\n\x19\x41NALYZE_NO_REVISION_INDEX\x10\x04\x12\x12\n\x0eTESTCASE_SETUP\x10\x05\x12\r\n\tUNHANDLED\x10\x06\x12\x17\n\x13VARIANT_BUILD_SETUP\x10\x07\x12\x12\n\x0eMINIMIZE_SETUP\x10\x08\x12\x1c\n\x18\x46UZZ_BUILD_SETUP_FAILURE\x10\t\x12\"\n\x1e\x46UZZ_DATA_BUNDLE_SETUP_FAILURE\x10\n\x12\x12\n\x0e\x46UZZ_NO_FUZZER\x10\x0b\x12#\n\x1fPROGRESSION_REVISION_LIST_ERROR\x10\x0c\x12\x1f\n\x1bPROGRESSION_BUILD_NOT_FOUND\x10\r\x12\x18\n\x14PROGRESSION_NO_CRASH\x10\x0e\x12!\n\x1dPROGRESSION_BAD_STATE_MIN_MAX\x10\x0f\x12\x17\n\x13PROGRESSION_TIMEOUT\x10\x10\x12\x19\n\x15PROGRESSION_BAD_BUILD\x10\x11\x12!\n\x1dPROGRESSION_BUILD_SETUP_ERROR\x10\x12\x12\"\n\x1eREGRESSION_REVISION_LIST_ERROR\x10\x13\x62\x06proto3'
+  serialized_pb=b'\n.clusterfuzz/_internal/protos/uworker_msg.proto\x1a,google/cloud/datastore_v1/proto/entity.proto\"\x1a\n\x04Json\x12\x12\n\nserialized\x18\x01 \x01(\t\"[\n\x14UworkerEntityWrapper\x12+\n\x06\x65ntity\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.Entity\x12\x16\n\x07\x63hanged\x18\x02 \x01(\x0b\x32\x05.Json\"\xdc\x02\n\nSetupInput\x12\x30\n\x06\x66uzzer\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\x18\n\x0b\x66uzzer_name\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x31\n\x0c\x64\x61ta_bundles\x18\x03 \x03(\x0b\x32\x1b.google.datastore.v1.Entity\x12\"\n\x15\x66uzzer_log_upload_url\x18\x04 \x01(\tH\x02\x88\x01\x01\x12 \n\x13\x66uzzer_download_url\x18\x05 \x01(\tH\x03\x88\x01\x01\x12\"\n\x15testcase_download_url\x18\x06 \x01(\tH\x04\x88\x01\x01\x42\t\n\x07_fuzzerB\x0e\n\x0c_fuzzer_nameB\x18\n\x16_fuzzer_log_upload_urlB\x16\n\x14_fuzzer_download_urlB\x18\n\x16_testcase_download_url\")\n\x10\x41nalyzeTaskInput\x12\x15\n\rbad_revisions\x18\x01 \x03(\x03\"\x14\n\x12SymbolizeTaskInput\"Z\n\rFuzzTaskInput\x12\x37\n\rtargets_count\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x42\x10\n\x0e_targets_count\"M\n\x11MinimizeTaskInput\x12 \n\x13testcase_upload_url\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x16\n\x14_testcase_upload_url\",\n\x13RegressionTaskInput\x12\x15\n\rbad_revisions\x18\x01 \x03(\x03\"[\n\x14ProgressionTaskInput\x12\x1a\n\rcustom_binary\x18\x01 \x01(\x08H\x00\x88\x01\x01\x12\x15\n\rbad_revisions\x18\x02 \x03(\x03\x42\x10\n\x0e_custom_binary\"\x9d\x01\n\x16\x43orpusPruningTaskInput\x12\x35\n\x0b\x66uzz_target\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\"\n\x15last_execution_failed\x18\x02 \x01(\x08H\x01\x88\x01\x01\x42\x0e\n\x0c_fuzz_targetB\x18\n\x16_last_execution_failed\"\xa4\t\n\x05Input\x12\x32\n\x08testcase\x18\x01 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x00\x88\x01\x01\x12\x42\n\x18testcase_upload_metadata\x18\x02 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x01\x88\x01\x01\x12\x18\n\x0btestcase_id\x18\x03 \x01(\tH\x02\x88\x01\x01\x12\x1f\n\x0buworker_env\x18\x04 \x01(\x0b\x32\x05.JsonH\x03\x88\x01\x01\x12\x15\n\x08job_type\x18\x06 \x01(\tH\x04\x88\x01\x01\x12&\n\x19uworker_output_upload_url\x18\x07 \x01(\tH\x05\x88\x01\x01\x12\x31\n\x07variant\x18\x08 \x01(\x0b\x32\x1b.google.datastore.v1.EntityH\x06\x88\x01\x01\x12\x1e\n\x11original_job_type\x18\t \x01(\tH\x07\x88\x01\x01\x12\x18\n\x0b\x66uzzer_name\x18\n \x01(\tH\x08\x88\x01\x01\x12%\n\x0bsetup_input\x18\x0b \x01(\x0b\x32\x0b.SetupInputH\t\x88\x01\x01\x12\x32\n\x12\x61nalyze_task_input\x18\x0c \x01(\x0b\x32\x11.AnalyzeTaskInputH\n\x88\x01\x01\x12?\n\x19\x63orpus_pruning_task_input\x18\r \x01(\x0b\x32\x17.CorpusPruningTaskInputH\x0b\x88\x01\x01\x12,\n\x0f\x66uzz_task_input\x18\x0e \x01(\x0b\x32\x0e.FuzzTaskInputH\x0c\x88\x01\x01\x12\x34\n\x13minimize_task_input\x18\x0f \x01(\x0b\x32\x12.MinimizeTaskInputH\r\x88\x01\x01\x12:\n\x16progression_task_input\x18\x10 \x01(\x0b\x32\x15.ProgressionTaskInputH\x0e\x88\x01\x01\x12\x38\n\x15regression_task_input\x18\x11 \x01(\x0b\x32\x14.RegressionTaskInputH\x0f\x88\x01\x01\x12\x36\n\x14symbolize_task_input\x18\x12 \x01(\x0b\x32\x13.SymbolizeTaskInputH\x10\x88\x01\x01\x12\x18\n\x0bmodule_name\x18\x13 \x01(\tH\x11\x88\x01\x01\x42\x0b\n\t_testcaseB\x1b\n\x19_testcase_upload_metadataB\x0e\n\x0c_testcase_idB\x0e\n\x0c_uworker_envB\x0b\n\t_job_typeB\x1c\n\x1a_uworker_output_upload_urlB\n\n\x08_variantB\x14\n\x12_original_job_typeB\x0e\n\x0c_fuzzer_nameB\x0e\n\x0c_setup_inputB\x15\n\x13_analyze_task_inputB\x1c\n\x1a_corpus_pruning_task_inputB\x12\n\x10_fuzz_task_inputB\x16\n\x14_minimize_task_inputB\x19\n\x17_progression_task_inputB\x18\n\x16_regression_task_inputB\x17\n\x15_symbolize_task_inputB\x0e\n\x0c_module_name\"\x15\n\x13SymbolizeTaskOutput\"\x13\n\x11\x41nalyzeTaskOutput\"\xe0\x03\n\x0e\x46uzzTaskOutput\x12\x18\n\x0b\x66uzzer_name\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1b\n\x0e\x63rash_revision\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x1e\n\x11job_run_timestamp\x18\x03 \x01(\x02H\x02\x88\x01\x01\x12\x1c\n\x0fnew_crash_count\x18\x04 \x01(\x03H\x03\x88\x01\x01\x12\x1e\n\x11known_crash_count\x18\x05 \x01(\x03H\x04\x88\x01\x01\x12\x1f\n\x12testcases_executed\x18\x06 \x01(\x03H\x05\x88\x01\x01\x12\x1e\n\x0fjob_run_crashes\x18\x07 \x03(\x0b\x32\x05.Json\x12(\n\x1b\x66ully_qualified_fuzzer_name\x18\x08 \x01(\tH\x06\x88\x01\x01\x12\x1e\n\x11new_targets_count\x18\t \x01(\x05H\x07\x88\x01\x01\x42\x0e\n\x0c_fuzzer_nameB\x11\n\x0f_crash_revisionB\x14\n\x12_job_run_timestampB\x12\n\x10_new_crash_countB\x14\n\x12_known_crash_countB\x15\n\x13_testcases_executedB\x1e\n\x1c_fully_qualified_fuzzer_nameB\x14\n\x12_new_targets_count\"\xb7\x01\n\x12MinimizeTaskOutput\x12*\n\x16last_crash_result_dict\x18\x01 \x01(\x0b\x32\x05.JsonH\x00\x88\x01\x01\x12\x18\n\x0b\x66laky_stack\x18\x02 \x01(\x08H\x01\x88\x01\x01\x12\x1c\n\x0f\x62uild_fail_wait\x18\x03 \x01(\x03H\x02\x88\x01\x01\x42\x19\n\x17_last_crash_result_dictB\x0e\n\x0c_flaky_stackB\x12\n\x10_build_fail_wait\"\x16\n\x14RegressionTaskOutput\"\xc3\x01\n\tBuildData\x12\x19\n\x0cis_bad_build\x18\x01 \x01(\x08H\x00\x88\x01\x01\x12\'\n\x1ashould_ignore_crash_result\x18\x02 \x01(\x08H\x01\x88\x01\x01\x12%\n\x18\x62uild_run_console_output\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\x0f\n\r_is_bad_buildB\x1d\n\x1b_should_ignore_crash_resultB\x1b\n\x19_build_run_console_output\"\x97\x04\n\x15ProgressionTaskOutput\x12\x19\n\x0cmin_revision\x18\x01 \x01(\x03H\x00\x88\x01\x01\x12\x19\n\x0cmax_revision\x18\x02 \x01(\x03H\x01\x88\x01\x01\x12\x1c\n\x0f\x63rash_on_latest\x18\x03 \x01(\x08H\x02\x88\x01\x01\x12$\n\x17\x63rash_on_latest_message\x18\x04 \x01(\tH\x03\x88\x01\x01\x12\x1b\n\x0e\x63rash_revision\x18\x05 \x01(\x03H\x04\x88\x01\x01\x12)\n\x1clast_tested_crash_stacktrace\x18\x06 \x01(\tH\x05\x88\x01\x01\x12!\n\x14last_progression_min\x18\x07 \x01(\x03H\x06\x88\x01\x01\x12!\n\x14last_progression_max\x18\x08 \x01(\x03H\x07\x88\x01\x01\x12#\n\x16\x63lear_min_max_metadata\x18\t \x01(\x08H\x08\x88\x01\x01\x42\x0f\n\r_min_revisionB\x0f\n\r_max_revisionB\x12\n\x10_crash_on_latestB\x1a\n\x18_crash_on_latest_messageB\x11\n\x0f_crash_revisionB\x1f\n\x1d_last_tested_crash_stacktraceB\x17\n\x15_last_progression_minB\x17\n\x15_last_progression_maxB\x19\n\x17_clear_min_max_metadata\"\xee\x07\n\x06Output\x12,\n\x08testcase\x18\x01 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x00\x88\x01\x01\x12<\n\x18testcase_upload_metadata\x18\x02 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x01\x88\x01\x01\x12+\n\x07variant\x18\x03 \x01(\x0b\x32\x15.UworkerEntityWrapperH\x02\x88\x01\x01\x12#\n\nerror_type\x18\x04 \x01(\x0e\x32\n.ErrorTypeH\x03\x88\x01\x01\x12\"\n\ruworker_input\x18\x05 \x01(\x0b\x32\x06.InputH\x04\x88\x01\x01\x12\x19\n\x0ctest_timeout\x18\x06 \x01(\x02H\x05\x88\x01\x01\x12\x17\n\ncrash_time\x18\x07 \x01(\x02H\x06\x88\x01\x01\x12$\n\x17\x63rash_stacktrace_output\x18\x08 \x01(\tH\x07\x88\x01\x01\x12\x34\n\x13\x61nalyze_task_output\x18\t \x01(\x0b\x32\x12.AnalyzeTaskOutputH\x08\x88\x01\x01\x12.\n\x10\x66uzz_task_output\x18\n \x01(\x0b\x32\x0f.FuzzTaskOutputH\t\x88\x01\x01\x12\x36\n\x14minimize_task_output\x18\x0b \x01(\x0b\x32\x13.MinimizeTaskOutputH\n\x88\x01\x01\x12:\n\x16regression_task_output\x18\x0c \x01(\x0b\x32\x15.RegressionTaskOutputH\x0b\x88\x01\x01\x12<\n\x17progression_task_output\x18\r \x01(\x0b\x32\x16.ProgressionTaskOutputH\x0c\x88\x01\x01\x12\x38\n\x15symbolize_task_output\x18\x0e \x01(\x0b\x32\x14.SymbolizeTaskOutputH\r\x88\x01\x01\x12\x1a\n\rerror_message\x18\x0f \x01(\tH\x0e\x88\x01\x01\x42\x0b\n\t_testcaseB\x1b\n\x19_testcase_upload_metadataB\n\n\x08_variantB\r\n\x0b_error_typeB\x10\n\x0e_uworker_inputB\x0f\n\r_test_timeoutB\r\n\x0b_crash_timeB\x1a\n\x18_crash_stacktrace_outputB\x16\n\x14_analyze_task_outputB\x13\n\x11_fuzz_task_outputB\x17\n\x15_minimize_task_outputB\x19\n\x17_regression_task_outputB\x1a\n\x18_progression_task_outputB\x18\n\x16_symbolize_task_outputB\x10\n\x0e_error_message*\xaa\x04\n\tErrorType\x12\x0c\n\x08NO_ERROR\x10\x00\x12\x17\n\x13\x41NALYZE_BUILD_SETUP\x10\x01\x12\x14\n\x10\x41NALYZE_NO_CRASH\x10\x02\x12\x1d\n\x19\x41NALYZE_NO_REVISIONS_LIST\x10\x03\x12\x1d\n\x19\x41NALYZE_NO_REVISION_INDEX\x10\x04\x12\x12\n\x0eTESTCASE_SETUP\x10\x05\x12\r\n\tUNHANDLED\x10\x06\x12\x17\n\x13VARIANT_BUILD_SETUP\x10\x07\x12\x12\n\x0eMINIMIZE_SETUP\x10\x08\x12\x1c\n\x18\x46UZZ_BUILD_SETUP_FAILURE\x10\t\x12\"\n\x1e\x46UZZ_DATA_BUNDLE_SETUP_FAILURE\x10\n\x12\x12\n\x0e\x46UZZ_NO_FUZZER\x10\x0b\x12#\n\x1fPROGRESSION_REVISION_LIST_ERROR\x10\x0c\x12\x1f\n\x1bPROGRESSION_BUILD_NOT_FOUND\x10\r\x12\x18\n\x14PROGRESSION_NO_CRASH\x10\x0e\x12!\n\x1dPROGRESSION_BAD_STATE_MIN_MAX\x10\x0f\x12\x17\n\x13PROGRESSION_TIMEOUT\x10\x10\x12\x19\n\x15PROGRESSION_BAD_BUILD\x10\x11\x12!\n\x1dPROGRESSION_BUILD_SETUP_ERROR\x10\x12\x12\"\n\x1eREGRESSION_REVISION_LIST_ERROR\x10\x13\x62\x06proto3'
   ,
   dependencies=[google_dot_cloud_dot_datastore__v1_dot_proto_dot_entity__pb2.DESCRIPTOR,])
 
@@ -149,8 +149,8 @@ _ERRORTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4802,
-  serialized_end=5356,
+  serialized_start=4777,
+  serialized_end=5331,
 )
 _sym_db.RegisterEnumDescriptor(_ERRORTYPE)
 
@@ -940,8 +940,8 @@ _FUZZTASKOUTPUT = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
       name='job_run_crashes', full_name='FuzzTaskOutput.job_run_crashes', index=6,
-      number=7, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      number=7, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
@@ -1001,23 +1001,18 @@ _FUZZTASKOUTPUT = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_job_run_crashes', full_name='FuzzTaskOutput._job_run_crashes',
+      name='_fully_qualified_fuzzer_name', full_name='FuzzTaskOutput._fully_qualified_fuzzer_name',
       index=6, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_fully_qualified_fuzzer_name', full_name='FuzzTaskOutput._fully_qualified_fuzzer_name',
-      index=7, containing_type=None,
-      create_key=_descriptor._internal_create_key,
-    fields=[]),
-    _descriptor.OneofDescriptor(
       name='_new_targets_count', full_name='FuzzTaskOutput._new_targets_count',
-      index=8, containing_type=None,
+      index=7, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
   serialized_start=2339,
-  serialized_end=2844,
+  serialized_end=2819,
 )
 
 
@@ -1077,8 +1072,8 @@ _MINIMIZETASKOUTPUT = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=2847,
-  serialized_end=3030,
+  serialized_start=2822,
+  serialized_end=3005,
 )
 
 
@@ -1102,8 +1097,8 @@ _REGRESSIONTASKOUTPUT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3032,
-  serialized_end=3054,
+  serialized_start=3007,
+  serialized_end=3029,
 )
 
 
@@ -1163,8 +1158,8 @@ _BUILDDATA = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3057,
-  serialized_end=3252,
+  serialized_start=3032,
+  serialized_end=3227,
 )
 
 
@@ -1296,8 +1291,8 @@ _PROGRESSIONTASKOUTPUT = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3255,
-  serialized_end=3790,
+  serialized_start=3230,
+  serialized_end=3765,
 )
 
 
@@ -1501,8 +1496,8 @@ _OUTPUT = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=3793,
-  serialized_end=4799,
+  serialized_start=3768,
+  serialized_end=4774,
 )
 
 _UWORKERENTITYWRAPPER.fields_by_name['entity'].message_type = google_dot_cloud_dot_datastore__v1_dot_proto_dot_entity__pb2._ENTITY
@@ -1626,9 +1621,6 @@ _FUZZTASKOUTPUT.fields_by_name['known_crash_count'].containing_oneof = _FUZZTASK
 _FUZZTASKOUTPUT.oneofs_by_name['_testcases_executed'].fields.append(
   _FUZZTASKOUTPUT.fields_by_name['testcases_executed'])
 _FUZZTASKOUTPUT.fields_by_name['testcases_executed'].containing_oneof = _FUZZTASKOUTPUT.oneofs_by_name['_testcases_executed']
-_FUZZTASKOUTPUT.oneofs_by_name['_job_run_crashes'].fields.append(
-  _FUZZTASKOUTPUT.fields_by_name['job_run_crashes'])
-_FUZZTASKOUTPUT.fields_by_name['job_run_crashes'].containing_oneof = _FUZZTASKOUTPUT.oneofs_by_name['_job_run_crashes']
 _FUZZTASKOUTPUT.oneofs_by_name['_fully_qualified_fuzzer_name'].fields.append(
   _FUZZTASKOUTPUT.fields_by_name['fully_qualified_fuzzer_name'])
 _FUZZTASKOUTPUT.fields_by_name['fully_qualified_fuzzer_name'].containing_oneof = _FUZZTASKOUTPUT.oneofs_by_name['_fully_qualified_fuzzer_name']

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -371,11 +371,13 @@ class RoundTripTest(unittest.TestCase):
     bundle2.put()
     data_bundles = [bundle1, bundle2]
     setup_input = uworker_io.SetupInput(data_bundles=data_bundles)
+    new_name = 'newname'
+    setup_input.data_bundles[0].name = new_name
     uworker_input = uworker_io.UworkerInput(setup_input=setup_input)
     serialized = uworker_io.serialize_uworker_input(uworker_input)
     deserialized = uworker_io.deserialize_uworker_input(serialized)
     setup_input = deserialized.setup_input
-    self.assertEqual(setup_input.data_bundles[0].name, bundle1.name)
+    self.assertEqual(setup_input.data_bundles[0].name, new_name)
     self.assertEqual(setup_input.data_bundles[1].name, bundle2.name)
 
   def test_minimization_output_serialization(self):
@@ -485,3 +487,17 @@ class ComplexFieldsTest(unittest.TestCase):
     wire_format = uworker_io.serialize_uworker_input(uworker_input)
     deserialized = uworker_io.deserialize_uworker_input(wire_format)
     self.assertEqual(deserialized.analyze_task_input.bad_revisions, expected)
+
+  def test_set_to_none(self):
+    """Tests that updating a field to None works."""
+    analyze_task_input = uworker_io.AnalyzeTaskInput(bad_revisions=[0])
+    uworker_input = uworker_io.UworkerInput(
+        analyze_task_input=analyze_task_input)
+    expected = None
+    with self.assertRaises(TypeError):
+      analyze_task_input.bad_revisions = None
+
+    uworker_input.analyze_task_input = None
+    wire_format = uworker_io.serialize_uworker_input(uworker_input)
+    deserialized = uworker_io.deserialize_uworker_input(wire_format)
+    self.assertEqual(deserialized.analyze_task_input, expected)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -169,7 +169,7 @@ class UworkerOutputTest(unittest.TestCase):
     error_value = 1
     self.output.error_type = error_value
     self.assertEqual(self.output.error_type, error_value)
-    self.assertEqual(self.output.proto.error_type, error_value)
+    self.assertEqual(self.output._proto.error_type, error_value)  # pylint: disable=protected-member
 
 
 @test_utils.with_cloud_emulators('datastore')
@@ -217,7 +217,10 @@ class RoundTripTest(unittest.TestCase):
         testcase=self.testcase,
         uworker_env=self.env,
         setup_input=uworker_io.SetupInput(testcase_download_url=self.FAKE_URL),
+        analyze_task_input=uworker_io.AnalyzeTaskInput(),
     )
+    uworker_input.analyze_task_input.bad_revisions.extend([8922])
+    self.assertEqual([8922], uworker_input.analyze_task_input.bad_revisions)
 
     # Create a mocked version of write_data so that when we upload the uworker
     # input, it goes to a known file we can read from.
@@ -270,6 +273,7 @@ class RoundTripTest(unittest.TestCase):
                      downloaded_input.uworker_output_upload_url)
     self.assertEqual(uworker_input.setup_input.testcase_download_url,
                      downloaded_input.setup_input.testcase_download_url)
+    self.assertEqual([8922], downloaded_input.analyze_task_input.bad_revisions)
 
   def test_upload_and_download_output(self):
     """Tests that uploading and downloading uworker output works. This means

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -443,3 +443,45 @@ class RoundTripTest(unittest.TestCase):
     self.assertEqual(deserialized.fuzz_task_output.job_run_crashes, crashes)
     self.assertEqual(deserialized.fuzz_task_output.crash_revision,
                      crash_revision)
+
+
+class ComplexFieldsTest(unittest.TestCase):
+  """Tests handling of complex UworkerMsg fields (e.g. lists and
+  submessages)."""
+
+  def test_list_initialize(self):
+    """Tests that initialization with a list works."""
+    analyze_task_input = uworker_io.AnalyzeTaskInput(bad_revisions=[0])
+    uworker_input = uworker_io.UworkerInput(
+        analyze_task_input=analyze_task_input)
+    wire_format = uworker_io.serialize_uworker_input(uworker_input)
+    deserialized = uworker_io.deserialize_uworker_input(wire_format)
+    self.assertEqual(deserialized.analyze_task_input.bad_revisions, [0])
+
+  def test_list_update(self):
+    """Tests that updating a list works."""
+    analyze_task_input = uworker_io.AnalyzeTaskInput(bad_revisions=[0])
+    analyze_task_input.bad_revisions = [1]
+    uworker_input = uworker_io.UworkerInput(
+        analyze_task_input=analyze_task_input)
+    wire_format = uworker_io.serialize_uworker_input(uworker_input)
+    deserialized = uworker_io.deserialize_uworker_input(wire_format)
+    self.assertEqual(deserialized.analyze_task_input.bad_revisions, [1])
+
+  def test_submessage_references(self):
+    """Tests that updating a submessage works both when directly reading from
+    uworker_input and from reading from it once it has been serialized and
+    deserialized."""
+    analyze_task_input = uworker_io.AnalyzeTaskInput(bad_revisions=[0])
+    uworker_input = uworker_io.UworkerInput(
+        analyze_task_input=analyze_task_input)
+    uworker_input.analyze_task_input.bad_revisions.append(-1)
+    uworker_input.analyze_task_input.bad_revisions = [1]
+    uworker_input.analyze_task_input.bad_revisions.extend([2])
+    uworker_input.analyze_task_input.bad_revisions.append(3)
+    analyze_task_input.bad_revisions.append(4)
+    expected = [1, 2, 3, 4]
+    self.assertEqual(analyze_task_input.bad_revisions, expected)
+    wire_format = uworker_io.serialize_uworker_input(uworker_input)
+    deserialized = uworker_io.deserialize_uworker_input(wire_format)
+    self.assertEqual(deserialized.analyze_task_input.bad_revisions, expected)


### PR DESCRIPTION
1. Don't use UworkerMsg's underlying proto as the source of truth before
serializing. To type check, we copy any messages immediately to the proto.
This can lead to errors as the UworkerMsg can still be used and assigned
to, leaving proto's representation of the UworkerMsg stale. To deal with
this: Re-set all values on proto fields before serializing (and do the same
to any submessages so that we properly handle (great) grandchildren).
2. Handle initializing with list values.
3. Handle reassigning list values properly by clearing any existing items and then extending.