### PR TITLE
Added Fuzzer-crash-state crash_category

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -419,7 +419,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_state = 'boom_internal\nanother_boom\nboom\n'
     expected_stacktrace = data
     expected_security_flag = True
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -508,7 +508,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_state = 'boom_internal\nanother_boom\nboom\n'
     expected_stacktrace = data
     expected_security_flag = True
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -808,7 +808,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
                       'regexp-builtins.cc\n')
     expected_stacktrace = data
     expected_security_flag = True
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -899,7 +899,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -918,7 +918,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -1410,7 +1410,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_address = '0x631000001001'
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -1424,7 +1424,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_address = '0x631000001001'
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -1438,7 +1438,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_address = '0x000000000000'
     expected_stacktrace = data
     expected_security_flag = True
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -1547,7 +1547,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_address = ''
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag, expected_categories)
@@ -1560,7 +1560,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_address = ''
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag, expected_categories)
@@ -2527,7 +2527,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_state = 'pdfium_fuzzer\n'
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -2541,7 +2541,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_state = ''
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -2558,7 +2558,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_state = 'freetype2_fuzzer\n'
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -2582,7 +2582,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     expected_state = 'freetype2_fuzzer\n'
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -3162,7 +3162,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
     expected_stacktrace = data
     expected_security_flag = False
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
@@ -3661,7 +3661,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
                       'android::FuzzEventHub::getEvents\n')
     expected_stacktrace = data
     expected_security_flag = True
-    expected_categories = {'Fuzzer-exit'}
+    expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
 
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -114,6 +114,8 @@ FATAL_ERROR_DCHECK_FAILURE = re.compile(r'#\s+(Debug check failed: )(.*)')
 FATAL_ERROR_REGEX = re.compile(r'#\s*Fatal error in (.*)')
 FATAL_ERROR_LINE_REGEX = re.compile(r'#\s*Fatal error in (.*), line [0-9]+')
 FATAL_ERROR_UNREACHABLE = re.compile(r'# un(reachable|implemented) code')
+FUZZER_DIR_REGEX = re.compile(r'^\s*#\d 0x.*(?:fuzzer|fuzz/|/fuzz)',
+                              re.IGNORECASE)
 FUZZER_EXIT_REGEX = re.compile(r'^\s*(?:#0|#1) 0x.*(?:fuzzer|fuzz/|/fuzz)',
                                re.IGNORECASE)
 GENERIC_SEGV_HANDLER_REGEX = re.compile(


### PR DESCRIPTION
The inclusion of frames arising from fuzzing directories in crash_state has been a good heuristic in Android for 'No Security Impact' bugs caused by poor fuzzer implementation or fuzzer error. Examples:
  
  https://clusterfuzz.corp.google.com/testcase?key=6233947671429120
  https://clusterfuzz.corp.google.com/testcase-detail/5752617099984896
  https://clusterfuzz.corp.google.com/testcase-detail/5147091159875584

This change adds a label to CF-filed issues, the label indicating that a majority of the frames used for crash_state had arisen from a fuzzer directory.

This change is an alternative design to using STACK_FRAME_IGNORE_REGEXES to remove fuzzing stack frames from crash_state consideration altogether. Because crash_state is used as a deduplication key, changing crash_state construction would regenerate past testcases when the same fuzzer crashes are seen again, and allow an unknown number of previously-triaged bugs to bypass deduping and be refiled. @jonathanmetzman noticed that this regeneration could be potentially avoided with a script triggering progression tasks, although efforts would be needed to avoid a race condition between progression and fuzzing each generating new crash_states.