### PR TITLE
Detect V8 sandbox violations

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/v8_sandbox_violation.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/v8_sandbox_violation.txt
@@ -1,0 +1,32 @@
+[Environment] ASAN_OPTIONS=alloc_dealloc_mismatch=0:allocator_may_return_null=1:allow_user_segv_handler=1:check_malloc_usable_size=0:detect_leaks=0:detect_odr_violation=0:detect_stack_use_after_return=1:external_symbolizer_path=/mnt/scratch0/clusterfuzz/resources/platform/linux/llvm-symbolizer:fast_unwind_on_fatal=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:handle_sigtrap=1:print_scariness=1:print_summary=1:print_suppressions=0:redzone=128:strict_memcmp=0:symbolize=1:symbolize_inline_frames=false:use_sigaltstack=1
+[Command line] /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_d589982c2e8b1620a2048f2e531c56143969c9ed/revisions/d8 --fuzzing --fuzzing --expose-gc --harmony --omit-quit --disable-in-process-stack-traces --invoke-weak-callbacks --enable-sandbox-crash-filter --enable-sandbox-crash-filter /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/sandbox_escape.js
+
++----------------------------------------Release Build Stacktrace----------------------------------------+
+
+## V8 sandbox violation detected!
+
+AddressSanitizer:DEADLYSIGNAL
+=================================================================
+==2609581==ERROR: AddressSanitizer: SEGV on unknown address 0x414141414141 (pc 0x7f6fcc004bb0 bp 0x7fffc8a41f18 sp 0x7fffc8a41ef8 T0)
+==2609581==The signal is caused by a WRITE memory access.
+SCARINESS: 30 (wild-addr-write)
+    #0 0x7f6fcc004bb0  (<unknown module>)
+    #1 0x5ab9ed87ef89 in Builtins_JSToWasmWrapperAsm (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_d589982c2e8b1620a2048f2e531c56143969c9ed/revisions/d8+0x6555f89) (BuildId: ea3a0db040d70435)
+    #2 0x5ab9ed950319 in Builtins_JSToWasmWrapper (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_d589982c2e8b1620a2048f2e531c56143969c9ed/revisions/d8+0x6627319) (BuildId: ea3a0db040d70435)
+    #3 0x5ab9ed7f1223 in Builtins_InterpreterEntryTrampoline (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_d589982c2e8b1620a2048f2e531c56143969c9ed/revisions/d8+0x64c8223) (BuildId: ea3a0db040d70435)
+    #4 0x5ab9ed7eeddb in Builtins_JSEntryTrampoline (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_d589982c2e8b1620a2048f2e531c56143969c9ed/revisions/d8+0x64c5ddb) (BuildId: ea3a0db040d70435)
+    #5 0x5ab9ed7eeb06 in Builtins_JSEntry (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_d589982c2e8b1620a2048f2e531c56143969c9ed/revisions/d8+0x64c5b06) (BuildId: ea3a0db040d70435)
+    #6 0x5ab9e99c508a in v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) src/execution/execution.cc:427:22
+    #7 0x5ab9e99c5c8e in v8::internal::Execution::CallScript(v8::internal::Isolate*, v8::internal::Handle<v8::internal::JSFunction>, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>) src/execution/execution.cc:539:10
+    #8 0x5ab9e932c4d8 in v8::Script::Run(v8::Local<v8::Context>, v8::Local<v8::Data>) src/api/api.cc:2131:7
+    #9 0x5ab9e932bf4c in v8::Script::Run(v8::Local<v8::Context>) src/api/api.cc:2094:10
+    #10 0x5ab9e924560a in v8::Shell::ExecuteString(v8::Isolate*, v8::Local<v8::String>, v8::Local<v8::String>, v8::Shell::PrintResult, v8::Shell::ReportExceptions, v8::Shell::ProcessMessageQueue) src/d8/d8.cc:961:28
+    #11 0x5ab9e927f2b3 in v8::SourceGroup::Execute(v8::Isolate*) src/d8/d8.cc:4451:10
+    #12 0x5ab9e9287bfe in v8::Shell::RunMainIsolate(v8::Isolate*, bool) src/d8/d8.cc:5264:37
+    #13 0x5ab9e928749a in v8::Shell::RunMain(v8::Isolate*, bool) src/d8/d8.cc:5181:18
+    #14 0x5ab9e928b708 in v8::Shell::Main(int, char**) src/d8/d8.cc:6047:18
+    #15 0x7f6fcc455082 in __libc_start_main /build/glibc-BHL3KM/glibc-2.31/csu/../csu/libc-start.c:308:16
+
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: SEGV (<unknown module>)
+==2609581==ABORTING

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1154,6 +1154,21 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_v8_sandbox_violation(self):
+    """Test a v8 sandbox violation."""
+    data = self._read_test_data('v8_sandbox_violation.txt')
+    expected_type = 'V8 sandbox violation'
+    expected_address = '0x414141414141'
+    expected_state = ('Builtins_JSToWasmWrapperAsm\n'
+                      'Builtins_JSToWasmWrapper\n'
+                      'Builtins_InterpreterEntryTrampoline\n')
+    expected_stacktrace = data
+    expected_security_flag = True
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_generic_segv(self):
     """Test a SEGV caught by a generic signal handler."""
     data = self._read_test_data('generic_segv.txt')

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -297,6 +297,7 @@ V8_CORRECTNESS_FAILURE_REGEX = re.compile(r'#\s*V8 correctness failure')
 V8_CORRECTNESS_METADATA_REGEX = re.compile(
     r'#\s*V8 correctness ((configs|sources|suppression): .*)')
 V8_ERROR_REGEX = re.compile(r'\s*\[[^\]]*\] V8 error: (.+)\.$')
+V8_SANDBOX_VIOLATION_REGEX = re.compile(r'## V8 sandbox violation detected!$')
 WINDOWS_CDB_STACK_FRAME_REGEX = re.compile(
     r'([0-9a-zA-Z`]+) '  # Child EBP or SP; remove ` if needed (1)
     r'([0-9a-zA-Z`]+) '  # RetAddr; remove ` if needed (2)


### PR DESCRIPTION
V8 sandbox violations should never be merged with other crashes. Hence this CL introduces a separate crash type for them, and gives that crash type precedence over other types, so it is not overwritten by subsequent frames / lines.