### PR TITLE
Increase fuzzer process priority for Centipede fuzzers

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -212,8 +212,11 @@ class Engine(engine.Engine):
     runner = _get_runner(target_path)
     _set_sanitizer_options(target_path)
     timeout = max_time + _CLEAN_EXIT_SECS
+    popen_args = {}
+    if environment.platform() == 'LINUX':
+      popen_args['preexec_fn'] = fuzzer_utils.set_process_high_priority
     fuzz_result = runner.run_and_wait(
-        additional_args=options.arguments, timeout=timeout)
+        additional_args=options.arguments, timeout=timeout, **popen_args)
     fuzz_result.output = Engine.trim_logs(fuzz_result.output)
 
     reproducer_path = _get_reproducer_path(fuzz_result.output, reproducers_dir)

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -18,6 +18,8 @@ import re
 import stat
 import tempfile
 
+import psutil
+
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
@@ -178,3 +180,7 @@ def get_file_from_untrusted_worker(worker_file_path):
 def cleanup():
   """Clean up temporary metadata."""
   shell.remove_directory(get_temp_dir())
+
+
+def set_process_high_priority():
+  psutil.Process().nice(psutil.HIGH_PRIORITY_CLASS)


### PR DESCRIPTION
As for now, we are seeing slowness and timeouts in our chrome browser based fuzzers. Since those fuzzers are running in the same process for Centipede, we can give that a shot and see whether that improves fuzzers stability.

Note that even though we are running Centipede first, nice priorities are inherited on linux, so our fuzzers should also have this priority.