### PR TITLE
libfuzzer: rework argument handling to make it more comprehensive

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/constants.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/constants.py
@@ -21,40 +21,43 @@ defined in this function that end with the suffix "_FLAG" should contain
 
 # libFuzzer flags.
 ARTIFACT_PREFIX_FLAG = '-artifact_prefix='
+ARTIFACT_PREFIX_FLAGNAME = 'artifact_prefix'
 
-DATA_FLOW_TRACE_FLAG = '-data_flow_trace='
+DATA_FLOW_TRACE_FLAGNAME = 'data_flow_trace'
 
-DICT_FLAG = '-dict='
+DICT_FLAGNAME = 'dict'
 
-FOCUS_FUNCTION_FLAG = '-focus_function='
+FOCUS_FUNCTION_FLAGNAME = 'focus_function'
 
-FORK_FLAG = '-fork='
+FORK_FLAGNAME = 'fork'
 
-MAX_LEN_FLAG = '-max_len='
+MAX_LEN_FLAGNAME = 'max_len'
 
-MAX_TOTAL_TIME_FLAG = '-max_total_time='
+MAX_TOTAL_TIME_FLAGNAME = 'max_total_time'
 
-RSS_LIMIT_FLAG = '-rss_limit_mb='
+RSS_LIMIT_FLAGNAME = 'rss_limit_mb'
 
-RUNS_FLAG = '-runs='
+RUNS_FLAGNAME = 'runs'
 
-TIMEOUT_FLAG = '-timeout='
+TIMEOUT_FLAGNAME = 'timeout'
 
-EXACT_ARTIFACT_PATH_FLAG = '-exact_artifact_path='
+EXACT_ARTIFACT_PATH_FLAGNAME = 'exact_artifact_path'
 
-CLEANSE_CRASH_ARGUMENT = '-cleanse_crash=1'
+CLEANSE_CRASH_FLAGNAME = 'cleanse_crash'
 
-MERGE_ARGUMENT = '-merge=1'
+MERGE_FLAGNAME = 'merge'
 
-MERGE_CONTROL_FILE_ARGUMENT = '-merge_control_file='
+MERGE_CONTROL_FILE_FLAGNAME = 'merge_control_file'
 
-MINIMIZE_CRASH_ARGUMENT = '-minimize_crash=1'
+MINIMIZE_CRASH_FLAGNAME = 'minimize_crash'
 
-PRINT_FINAL_STATS_ARGUMENT = '-print_final_stats=1'
+PRINT_FINAL_STATS_FLAGNAME = 'print_final_stats'
+
+DETECT_LEAKS_FLAGNAME = 'detect_leaks'
 
 TMP_ARTIFACT_PREFIX_ARGUMENT = '/tmp/'
 
-VALUE_PROFILE_ARGUMENT = '-use_value_profile=1'
+VALUE_PROFILE_FLAGNAME = 'use_value_profile'
 
 # Default value for rss_limit_mb flag to catch OOM.s
 DEFAULT_RSS_LIMIT_MB = 2560

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/stats.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/stats.py
@@ -16,7 +16,7 @@
 import re
 
 from clusterfuzz._internal.bot.fuzzers import dictionary_manager
-from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+from clusterfuzz._internal.bot.fuzzers import options as fuzzer_options
 from clusterfuzz._internal.bot.fuzzers.libFuzzer import constants
 from clusterfuzz._internal.fuzzing import strategy
 from clusterfuzz._internal.metrics import logs
@@ -196,6 +196,7 @@ def parse_performance_features(log_lines, strategies, arguments):
       'timeout_count': 0,
   }
 
+  arguments = fuzzer_options.FuzzerArguments.from_list(arguments)
   # Extract strategy selection method.
   # TODO(ochang): Move to more general place?
   stats['strategy_selection_method'] = environment.get_value(
@@ -219,13 +220,12 @@ def parse_performance_features(log_lines, strategies, arguments):
     stats['startup_crash_count'] = 0
 
   # Extract '-max_len' value from arguments, if possible.
-  stats['max_len'] = int(
-      fuzzer_utils.extract_argument(
-          arguments, constants.MAX_LEN_FLAG, remove=False) or stats['max_len'])
+  max_len = arguments.get(
+      constants.MAX_LEN_FLAGNAME, default=None, constructor=int)
+  stats['max_len'] = max_len if max_len is not None else int(stats['max_len'])
 
   # Extract sizes of manual dictionary used for fuzzing.
-  dictionary_path = fuzzer_utils.extract_argument(
-      arguments, constants.DICT_FLAG, remove=False)
+  dictionary_path = arguments.get(constants.DICT_FLAGNAME, constructor=str)
   stats['manual_dict_size'] = dictionary_manager.get_stats_for_dictionary_file(
       dictionary_path)
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -26,6 +26,7 @@ import sys
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.fuzzers import engine_common
+from clusterfuzz._internal.bot.fuzzers import options as fuzzer_options
 from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 from clusterfuzz._internal.bot.fuzzers.libFuzzer import constants
 from clusterfuzz._internal.bot.fuzzers.libFuzzer.peach import pits
@@ -148,32 +149,27 @@ class LibFuzzerCommon:
     Returns:
       A process.ProcessResult.
     """
-    additional_args = copy.copy(additional_args)
-    if additional_args is None:
-      additional_args = []
+    arguments = fuzzer_options.FuzzerArguments.from_list(additional_args)
+    assert arguments is not None
 
     max_total_time = fuzz_timeout
-    if any(arg.startswith(constants.FORK_FLAG) for arg in additional_args):
+    if constants.FORK_FLAGNAME in arguments:
       max_total_time -= self.LIBFUZZER_FORK_MODE_CLEAN_EXIT_TIME
     assert max_total_time > 0
 
     # Old libFuzzer jobs specify -artifact_prefix through additional_args
     if artifact_prefix:
-      additional_args.append(
-          '%s%s' % (constants.ARTIFACT_PREFIX_FLAG,
-                    self._normalize_artifact_prefix(artifact_prefix)))
+      arguments[constants.ARTIFACT_PREFIX_FLAGNAME] = str(
+          self._normalize_artifact_prefix(artifact_prefix))
 
-    additional_args.extend([
-        '%s%d' % (constants.MAX_TOTAL_TIME_FLAG, max_total_time),
-        constants.PRINT_FINAL_STATS_ARGUMENT,
-        # FIXME: temporarily disabled due to a lack of crash information in
-        # output.
-        # '-close_fd_mask=3',
-    ])
+    arguments[constants.MAX_TOTAL_TIME_FLAGNAME] = int(max_total_time)
+    arguments[constants.PRINT_FINAL_STATS_FLAGNAME] = 1
+    # FIXME: temporarily disabled due to a lack of crash information in
+    # output.
+    # arguments['close_fd_mask'] = 3
 
-    additional_args.extend(corpus_directories)
     return self.run_and_wait(
-        additional_args=additional_args,
+        additional_args=arguments.list() + corpus_directories,
         timeout=self.get_total_timeout(fuzz_timeout),
         terminate_before_kill=True,
         terminate_wait_time=self.SIGTERM_WAIT_TIME,
@@ -204,27 +200,23 @@ class LibFuzzerCommon:
     Returns:
       A process.ProcessResult.
     """
-    additional_args = copy.copy(additional_args)
-    if additional_args is None:
-      additional_args = []
+    arguments = fuzzer_options.FuzzerArguments.from_list(additional_args)
+    assert arguments is not None
 
-    additional_args.append(constants.MERGE_ARGUMENT)
+    arguments[constants.MERGE_FLAGNAME] = 1
     if artifact_prefix:
-      additional_args.append(
-          '%s%s' % (constants.ARTIFACT_PREFIX_FLAG,
-                    self._normalize_artifact_prefix(artifact_prefix)))
+      arguments[constants.ARTIFACT_PREFIX_FLAGNAME] = str(
+          self._normalize_artifact_prefix(artifact_prefix))
 
     if merge_control_file:
-      additional_args.append(constants.MERGE_CONTROL_FILE_ARGUMENT +
-                             merge_control_file)
+      arguments[constants.MERGE_CONTROL_FILE_FLAGNAME] = merge_control_file
 
     extra_env = {}
     if tmp_dir:
       extra_env['TMPDIR'] = tmp_dir
 
-    additional_args.extend(corpus_directories)
     return self.run_and_wait(
-        additional_args=additional_args,
+        additional_args=arguments.list() + corpus_directories,
         timeout=merge_timeout,
         max_stdout_len=MAX_OUTPUT_LEN,
         extra_env=extra_env)
@@ -270,27 +262,20 @@ class LibFuzzerCommon:
       additional_args: A sequence of additional arguments to be passed to the
           executable.
     """
-    additional_args = copy.copy(additional_args)
-    if additional_args is None:
-      additional_args = []
+    arguments = fuzzer_options.FuzzerArguments.from_list(additional_args)
+    assert arguments is not None
 
     max_total_time = self.get_minimize_total_time(timeout)
-    max_total_time_argument = '%s%d' % (constants.MAX_TOTAL_TIME_FLAG,
-                                        max_total_time)
-
-    additional_args.extend([
-        constants.MINIMIZE_CRASH_ARGUMENT,
-        max_total_time_argument,
-        constants.EXACT_ARTIFACT_PATH_FLAG + output_path,
-    ])
+    arguments[constants.MAX_TOTAL_TIME_FLAGNAME] = int(max_total_time)
+    arguments[constants.EXACT_ARTIFACT_PATH_FLAGNAME] = str(output_path)
+    arguments[constants.MINIMIZE_CRASH_FLAGNAME] = 1
 
     if artifact_prefix:
-      additional_args.append(constants.ARTIFACT_PREFIX_FLAG +
-                             self._normalize_artifact_prefix(artifact_prefix))
-    additional_args.append(testcase_path)
+      arguments[constants.ARTIFACT_PREFIX_FLAGNAME] = str(
+          self._normalize_artifact_prefix(artifact_prefix))
 
     return self.run_and_wait(
-        additional_args=additional_args,
+        additional_args=arguments.list() + [testcase_path],
         timeout=timeout,
         max_stdout_len=MAX_OUTPUT_LEN)
 
@@ -310,22 +295,18 @@ class LibFuzzerCommon:
       additional_args: A sequence of additional arguments to be passed to the
           executable.
     """
-    additional_args = copy.copy(additional_args)
-    if additional_args is None:
-      additional_args = []
+    arguments = fuzzer_options.FuzzerArguments.from_list(additional_args)
+    assert arguments is not None
 
-    additional_args.extend([
-        constants.CLEANSE_CRASH_ARGUMENT,
-        constants.EXACT_ARTIFACT_PATH_FLAG + output_path,
-    ])
+    arguments[constants.CLEANSE_CRASH_FLAGNAME] = 1
+    arguments[constants.EXACT_ARTIFACT_PATH_FLAGNAME] = str(output_path)
 
     if artifact_prefix:
-      additional_args.append(constants.ARTIFACT_PREFIX_FLAG +
-                             self._normalize_artifact_prefix(artifact_prefix))
-    additional_args.append(testcase_path)
+      arguments[constants.ARTIFACT_PREFIX_FLAGNAME] = str(
+          self._normalize_artifact_prefix(artifact_prefix))
 
     return self.run_and_wait(
-        additional_args=additional_args,
+        additional_args=arguments.list() + [testcase_path],
         timeout=timeout,
         max_stdout_len=MAX_OUTPUT_LEN)
 
@@ -456,22 +437,19 @@ class FuchsiaUndercoatLibFuzzerRunner(new_process.UnicodeProcessRunner,
            additional_args=None,
            extra_env=None):
     """LibFuzzerCommon.fuzz override."""
-    additional_args = copy.copy(additional_args)
-    if additional_args is None:
-      additional_args = []
+    arguments = fuzzer_options.FuzzerArguments.from_list(additional_args)
+    assert arguments is not None
 
     undercoat.prepare_fuzzer(self.handle, self.executable_path)
     self._push_corpora_from_host_to_target(corpus_directories)
 
     max_total_time = fuzz_timeout
-    if any(arg.startswith(constants.FORK_FLAG) for arg in additional_args):
+    if constants.FORK_FLAGNAME in arguments:
       max_total_time -= self.LIBFUZZER_FORK_MODE_CLEAN_EXIT_TIME
     assert max_total_time > 0
 
-    additional_args.extend([
-        constants.MAX_TOTAL_TIME_FLAG + str(max_total_time),
-        constants.PRINT_FINAL_STATS_ARGUMENT,
-    ])
+    arguments[constants.MAX_TOTAL_TIME_FLAGNAME] = int(max_total_time)
+    arguments[constants.PRINT_FINAL_STATS_FLAGNAME] = 1
 
     # Run the fuzzer.
     # TODO(eep): Clarify comment from previous implementation: "actually we want
@@ -481,7 +459,7 @@ class FuchsiaUndercoatLibFuzzerRunner(new_process.UnicodeProcessRunner,
         self.executable_path,
         artifact_prefix,
         self._corpus_directories_libfuzzer(corpus_directories) +
-        additional_args,
+        arguments.list(),
         timeout=self.get_total_timeout(fuzz_timeout))
 
     self._pull_new_corpus_from_target_to_host(corpus_directories)
@@ -499,11 +477,10 @@ class FuchsiaUndercoatLibFuzzerRunner(new_process.UnicodeProcessRunner,
     undercoat.prepare_fuzzer(self.handle, self.executable_path)
     self._push_corpora_from_host_to_target(corpus_directories)
 
-    additional_args = copy.copy(additional_args)
-    if additional_args is None:
-      additional_args = []
-    max_total_time_flag = constants.MAX_TOTAL_TIME_FLAG + str(merge_timeout)
-    additional_args.append(max_total_time_flag)
+    arguments = fuzzer_options.FuzzerArguments.from_list(additional_args)
+    assert arguments is not None
+
+    arguments[constants.MAX_TOTAL_TIME_FLAGNAME] = int(merge_timeout)
 
     target_merge_control_file = 'data/.mergefile'
 
@@ -512,15 +489,15 @@ class FuchsiaUndercoatLibFuzzerRunner(new_process.UnicodeProcessRunner,
                          target_merge_control_file)
 
     # Run merge.
-    additional_args += [
-        '-merge=1', '-merge_control_file=' + target_merge_control_file
-    ]
+    arguments['merge'] = 1
+    arguments['merge_control_file'] = target_merge_control_file
+
     result = undercoat.run_fuzzer(
         self.handle,
         self.executable_path,
         None,
         self._corpus_directories_libfuzzer(corpus_directories) +
-        additional_args,
+        arguments.list(),
         timeout=self.get_total_timeout(merge_timeout))
 
     self._pull_new_corpus_from_target_to_host(corpus_directories)
@@ -566,19 +543,17 @@ class FuchsiaUndercoatLibFuzzerRunner(new_process.UnicodeProcessRunner,
                      artifact_prefix=None,
                      additional_args=None):
 
-    additional_args = copy.copy(additional_args)
-    if additional_args is None:
-      additional_args = []
-    additional_args.append(constants.MINIMIZE_CRASH_ARGUMENT)
-    max_total_time = self.get_minimize_total_time(timeout)
-    max_total_time_arg = constants.MAX_TOTAL_TIME_FLAG + str(max_total_time)
-    additional_args.append(max_total_time_arg)
+    arguments = fuzzer_options.FuzzerArguments.from_list(additional_args)
+    assert arguments is not None
+
+    arguments[constants.MINIMIZE_CRASH_FLAGNAME] = 1
+    arguments[constants.MAX_TOTAL_TIME_FLAGNAME] = int(
+        self.get_minimize_total_time(timeout))
 
     target_artifact_prefix = 'data/'
     target_minimized_file = 'final-minimized-crash'
     min_file_fullpath = target_artifact_prefix + target_minimized_file
-    exact_artifact_arg = constants.EXACT_ARTIFACT_PATH_FLAG + min_file_fullpath
-    additional_args.append(exact_artifact_arg)
+    arguments[constants.EXACT_ARTIFACT_PATH_FLAGNAME] = str(min_file_fullpath)
 
     # We need to push the testcase to the device and pass in the name.
     testcase_path_name = os.path.basename(os.path.normpath(testcase_path))
@@ -590,7 +565,7 @@ class FuchsiaUndercoatLibFuzzerRunner(new_process.UnicodeProcessRunner,
     result = undercoat.run_fuzzer(
         self.handle,
         self.executable_path,
-        output_dir, ['data/' + testcase_path_name] + additional_args,
+        output_dir, ['data/' + testcase_path_name] + arguments.list(),
         timeout=self.get_total_timeout(timeout))
 
     # The minimized artifact is automatically fetched if minimization succeeded,
@@ -999,22 +974,23 @@ class AndroidLibFuzzerRunner(new_process.UnicodeProcessRunner, LibFuzzerCommon):
       artifact_prefix = self._get_device_path(artifact_prefix)
 
     # Extract local dict path from arguments list and subsitute with device one.
-    additional_args = copy.copy(additional_args)
-    if additional_args is None:
-      additional_args = []
-    dict_path = fuzzer_utils.extract_argument(additional_args,
-                                              constants.DICT_FLAG)
+    arguments = fuzzer_options.FuzzerArguments.from_list(additional_args)
+    assert arguments is not None
+
+    dict_path = arguments.get(
+        constants.DICT_FLAGNAME, default=None, constructor=str)
+
     if dict_path:
       device_dict_path = self._get_device_path(dict_path)
       android.adb.copy_local_file_to_remote(dict_path, device_dict_path)
-      additional_args.append(constants.DICT_FLAG + device_dict_path)
+      arguments[constants.DICT_FLAGNAME] = device_dict_path
 
     result = LibFuzzerCommon.fuzz(
         self,
         corpus_directories,
         fuzz_timeout,
         artifact_prefix=artifact_prefix,
-        additional_args=additional_args,
+        additional_args=arguments.list(),
         extra_env=extra_env)
 
     result.output = self._add_logcat_output_if_needed(result.output)
@@ -1217,42 +1193,50 @@ def copy_from_corpus(dest_corpus_path, src_corpus_path, num_testcases):
     shutil.copy(os.path.join(to_copy), os.path.join(dest_corpus_path, str(i)))
 
 
-def remove_fuzzing_arguments(arguments, is_merge=False):
+def strip_fuzzing_arguments(arguments, is_merge=False):
   """Remove arguments used during fuzzing."""
+  args = fuzzer_options.FuzzerArguments.from_list(arguments)
   for argument in [
       # Remove as it overrides `-merge` argument.
-      constants.FORK_FLAG,  # It overrides `-merge` argument.
+      constants.FORK_FLAGNAME,  # It overrides `-merge` argument.
 
       # Remove as it may shrink the testcase.
-      constants.MAX_LEN_FLAG,  # This may shrink the testcases.
+      constants.MAX_LEN_FLAGNAME,  # This may shrink the testcases.
 
       # Remove any existing runs argument as we will create our own for
       # reproduction.
-      constants.RUNS_FLAG,  # Make sure we don't have any '-runs' argument.
+      constants.RUNS_FLAGNAME,  # Make sure we don't have any '-runs' argument.
 
       # Remove the following flags/arguments that are only used for fuzzing.
-      constants.DATA_FLOW_TRACE_FLAG,
-      constants.DICT_FLAG,
-      constants.FOCUS_FUNCTION_FLAG,
+      constants.DATA_FLOW_TRACE_FLAGNAME,
+      constants.DICT_FLAGNAME,
+      constants.FOCUS_FUNCTION_FLAGNAME,
   ]:
-    fuzzer_utils.extract_argument(arguments, argument)
+    if argument in args:
+      del args[argument]
 
   # Value profile is needed during corpus merge, so do not remove if set.
   if not is_merge:
-    fuzzer_utils.extract_argument(arguments, constants.VALUE_PROFILE_ARGUMENT)
+    if constants.VALUE_PROFILE_FLAGNAME in args:
+      del args[constants.VALUE_PROFILE_FLAGNAME]
+
+  return args.list()
 
 
 def fix_timeout_argument_for_reproduction(arguments):
   """Changes timeout argument for reproduction. This is slightly less than the
   |TEST_TIMEOUT| value for the job."""
-  fuzzer_utils.extract_argument(arguments, constants.TIMEOUT_FLAG)
+  args = fuzzer_options.FuzzerArguments.from_list(arguments)
+  if constants.TIMEOUT_FLAGNAME in args:
+    del args[constants.TIMEOUT_FLAGNAME]
 
   # Leave 5 sec buffer for report processing.
   adjusted_test_timeout = max(
       1,
       environment.get_value('TEST_TIMEOUT', constants.DEFAULT_TIMEOUT_LIMIT) -
       constants.REPORT_PROCESSING_TIME)
-  arguments.append('%s%d' % (constants.TIMEOUT_FLAG, adjusted_test_timeout))
+  args[constants.TIMEOUT_FLAGNAME] = adjusted_test_timeout
+  return args.list()
 
 
 def parse_log_stats(log_lines):
@@ -1396,7 +1380,7 @@ def pick_strategies(strategy_pool,
   """Pick strategies."""
   build_directory = environment.get_value('BUILD_DIR')
   fuzzing_strategies = []
-  arguments = []
+  arguments = fuzzer_options.FuzzerArguments({})
   additional_corpus_dirs = []
 
   # Select a generator to attempt to use for existing testcase mutations.
@@ -1415,9 +1399,8 @@ def pick_strategies(strategy_pool,
         dataflow_build_dir, os.path.relpath(fuzzer_path, build_directory))
     dataflow_trace_dir = dataflow_binary_path + DATAFLOW_TRACE_DIR_SUFFIX
     if os.path.exists(dataflow_trace_dir):
-      arguments.append(
-          '%s%s' % (constants.DATA_FLOW_TRACE_FLAG, dataflow_trace_dir))
-      arguments.append('%s%s' % (constants.FOCUS_FUNCTION_FLAG, 'auto'))
+      arguments[constants.DATA_FLOW_TRACE_FLAGNAME] = str(dataflow_trace_dir)
+      arguments[constants.FOCUS_FUNCTION_FLAGNAME] = 'auto'
       fuzzing_strategies.append(strategy.DATAFLOW_TRACING_STRATEGY.name)
     else:
       logs.log_warn(
@@ -1438,15 +1421,13 @@ def pick_strategies(strategy_pool,
     additional_corpus_dirs.append(new_testcase_mutations_directory)
 
   if strategy_pool.do_strategy(strategy.RANDOM_MAX_LENGTH_STRATEGY):
-    max_len_argument = fuzzer_utils.extract_argument(
-        existing_arguments, constants.MAX_LEN_FLAG, remove=False)
-    if not max_len_argument:
+    if constants.MAX_LEN_FLAGNAME not in existing_arguments:
       max_length = random.SystemRandom().randint(1, MAX_VALUE_FOR_MAX_LENGTH)
-      arguments.append('%s%d' % (constants.MAX_LEN_FLAG, max_length))
+      arguments[constants.MAX_LEN_FLAGNAME] = max_length
       fuzzing_strategies.append(strategy.RANDOM_MAX_LENGTH_STRATEGY.name)
 
   if strategy_pool.do_strategy(strategy.VALUE_PROFILE_STRATEGY):
-    arguments.append(constants.VALUE_PROFILE_ARGUMENT)
+    arguments[constants.VALUE_PROFILE_FLAGNAME] = 1
     fuzzing_strategies.append(strategy.VALUE_PROFILE_STRATEGY.name)
 
   # FIXME: Disable for now to avoid severe battery drainage. Stabilize and
@@ -1460,14 +1441,13 @@ def pick_strategies(strategy_pool,
   # Do not use fork mode for DFT-based fuzzing. This is needed in order to
   # collect readable and actionable logs from fuzz targets running with DFT.
   # If fork_server is already set by the user, let's keep it that way.
-  fork_server = fuzzer_utils.extract_argument(
-      existing_arguments, constants.FORK_FLAG, remove=False)
+  fork_server = existing_arguments.get(constants.FORK_FLAGNAME, constructor=int)
   if (not is_fuchsia and not is_android and not is_ephemeral and
       not use_dataflow_tracing and not fork_server and
       strategy_pool.do_strategy(strategy.FORK_STRATEGY)):
     max_fuzz_threads = environment.get_value('MAX_FUZZ_THREADS', 1)
     num_fuzz_processes = max(1, utils.cpu_count() // max_fuzz_threads)
-    arguments.append('%s%d' % (constants.FORK_FLAG, num_fuzz_processes))
+    arguments[constants.FORK_FLAGNAME] = num_fuzz_processes
     fuzzing_strategies.append(
         '%s_%d' % (strategy.FORK_STRATEGY.name, num_fuzz_processes))
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/options.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/options.py
@@ -36,10 +36,10 @@ class FuzzerOptionsError(Exception):
 class FuzzerArguments:
   """Fuzzer flags."""
 
-  PARSING_REGEX = re.compile(r'^[-]{1,2}([a-zA-Z_]+)(=|\ )(.*)$')
+  PARSING_REGEX = re.compile(r'^[-]{1,2}([a-zA-Z0-9_]+)(=|\ )(.*)$')
 
-  def __init__(self, flags):
-    self.flags = flags
+  def __init__(self, flags=None):
+    self.flags = flags if flags is not None else {}
 
   def __contains__(self, key):
     return key in self.flags
@@ -75,9 +75,15 @@ class FuzzerArguments:
     """Return arguments as a list."""
     return [f'-{key}={value}' for key, value in self.flags.items()]
 
+  def extend(self, flags):
+    """Extends the existing flags with the provided ones. In case of both
+    containing the same key, `flag[key]` is the value that will be used."""
+    for key, value in flags.flags.items():
+      self.flags[key] = value
+
   @staticmethod
   def from_list(arguments):
-    res = FuzzerArguments({})
+    res = FuzzerArguments()
     for arg in arguments:
       match = FuzzerArguments.PARSING_REGEX.match(arg)
       if not match:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -325,7 +325,8 @@ class Runner:
     rss_limit = RSS_LIMIT
     max_len = engine_common.CORPUS_INPUT_SIZE_LIMIT
     detect_leaks = 1
-    arguments = [TIMEOUT_FLAG]
+    arguments = options.FuzzerArguments()
+    arguments[constants.TIMEOUT_FLAGNAME] = SINGLE_UNIT_TIMEOUT
 
     if self.fuzzer_options:
       # Default values from above can be customized for a given fuzz target.
@@ -348,12 +349,12 @@ class Runner:
       if custom_detect_leaks is not None:
         detect_leaks = custom_detect_leaks
 
-    arguments.append(RSS_LIMIT_MB_FLAG % rss_limit)
-    arguments.append(MAX_LEN_FLAG % max_len)
-    arguments.append(DETECT_LEAKS_FLAG % detect_leaks)
-    arguments.append(constants.VALUE_PROFILE_ARGUMENT)
+    arguments[constants.RSS_LIMIT_FLAGNAME] = rss_limit
+    arguments[constants.MAX_LEN_FLAGNAME] = max_len
+    arguments[constants.DETECT_LEAKS_FLAGNAME] = detect_leaks
+    arguments[constants.VALUE_PROFILE_FLAGNAME] = 1
 
-    return arguments
+    return arguments.list()
 
   def process_sanitizer_options(self):
     """Process sanitizer options overrides."""


### PR DESCRIPTION
The current way of handling arguments makes it hard to understand what's really going on, and the way we're merging or extending existing arguments. Using a dictionary like object, it makes it much easier to understand what we're trying to do.