### PR TITLE
Fix fuzzer selection query logic when developing locally

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -19,6 +19,9 @@ from clusterfuzz._internal.google_cloud_utils import batch
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
+# pylint: disable=undefined-variable
+# https://github.com/google/clusterfuzz/pull/3512/#issuecomment-1857737156
+# Linter throwing a false positive for the is_production() call
 
 class BaseTask:
   """Base module for tasks."""
@@ -77,9 +80,6 @@ class UTask(BaseUTask):
 
   def execute(self, task_argument, job_type, uworker_env):
     """Executes a utask locally."""
-    # pylint: disable=undefined-variable
-    # https://github.com/google/clusterfuzz/pull/3512/#issuecomment-1857737156
-    # Linter throwing a false positive for the is_production() call
     if (not environment.is_production() or
         not environment.get_value('REMOTE_UTASK_EXECUTION') or
         environment.platform() != 'LINUX'):

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -23,10 +23,6 @@ from clusterfuzz._internal.system import environment
 class BaseTask:
   """Base module for tasks."""
 
-  @staticmethod
-  def is_execution_remote():
-    return False
-
   def __init__(self, module):
     self.module = module
 
@@ -64,14 +60,6 @@ class BaseUTask(BaseTask):
     utasks.tworker_postprocess_no_io(self.module, uworker_output, uworker_input)
     logs.log('Utask local: done.')
 
-  def preprocess(self, task_argument, job_type, uworker_env):
-    """Executes preprocessing."""
-    raise NotImplementedError('Child class must implement.')
-
-
-def is_remote_utask(command):
-  return COMMAND_TYPES[command].is_execution_remote()
-
 
 class UTaskLocalExecutor(BaseUTask):
   """Represents an untrusted task. Executes it entirely locally and in
@@ -81,19 +69,11 @@ class UTaskLocalExecutor(BaseUTask):
     """Executes a utask locally in-memory."""
     self.execute_locally(task_argument, job_type, uworker_env)
 
-  def preprocess(self, task_argument, job_type, uworker_env):
-    """Executes preprocessing."""
-    raise NotImplementedError('Only needed for utasks.')
-
 
 class UTask(BaseUTask):
   """Represents an untrusted task. Executes preprocess on this machine, main on
   an untrusted machine, and postprocess on another trusted machine if
   opted-in. Otherwise executes locally."""
-
-  @staticmethod
-  def is_execution_remote():
-    return is_remotely_executing_utasks()
 
   def execute(self, task_argument, job_type, uworker_env):
     """Executes a utask locally."""
@@ -103,27 +83,12 @@ class UTask(BaseUTask):
       self.execute_locally(task_argument, job_type, uworker_env)
       return
 
-    download_url = self.preprocess(task_argument, job_type, uworker_env)
-    if download_url is None:
-      return
-
-    batch.create_uworker_main_batch_job(self.module.__name__, job_type,
-                                        download_url)
-
-  def preprocess(self, task_argument, job_type, uworker_env):
     download_url, _ = utasks.tworker_preprocess(self.module, task_argument,
                                                 job_type, uworker_env)
     if not download_url:
       logs.log_error('No download_url returned from preprocess.')
-      return None
+      return
     logs.log('Utask: done with preprocess.')
-    return download_url
-
-
-def is_remotely_executing_utasks():
-  return (environment.is_production() and
-          environment.get_value('REMOTE_UTASK_EXECUTION') and
-          environment.platform() == 'LINUX')
 
 
 class PostprocessTask(BaseTask):
@@ -177,7 +142,7 @@ COMMAND_TYPES = {
     'unpack': TrustedTask,
     'postprocess': PostprocessTask,
     'uworker_main': UworkerMainTask,
-    'variant': UTask,
+    'variant': UTaskLocalExecutor,
 }
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -23,6 +23,10 @@ from clusterfuzz._internal.system import environment
 class BaseTask:
   """Base module for tasks."""
 
+  @staticmethod
+  def is_execution_remote():
+    return False
+
   def __init__(self, module):
     self.module = module
 
@@ -60,6 +64,14 @@ class BaseUTask(BaseTask):
     utasks.tworker_postprocess_no_io(self.module, uworker_output, uworker_input)
     logs.log('Utask local: done.')
 
+  def preprocess(self, task_argument, job_type, uworker_env):
+    """Executes preprocessing."""
+    raise NotImplementedError('Child class must implement.')
+
+
+def is_remote_utask(command):
+  return COMMAND_TYPES[command].is_execution_remote()
+
 
 class UTaskLocalExecutor(BaseUTask):
   """Represents an untrusted task. Executes it entirely locally and in
@@ -69,11 +81,19 @@ class UTaskLocalExecutor(BaseUTask):
     """Executes a utask locally in-memory."""
     self.execute_locally(task_argument, job_type, uworker_env)
 
+  def preprocess(self, task_argument, job_type, uworker_env):
+    """Executes preprocessing."""
+    raise NotImplementedError('Only needed for utasks.')
+
 
 class UTask(BaseUTask):
   """Represents an untrusted task. Executes preprocess on this machine, main on
   an untrusted machine, and postprocess on another trusted machine if
   opted-in. Otherwise executes locally."""
+
+  @staticmethod
+  def is_execution_remote():
+    return is_remotely_executing_utasks()
 
   def execute(self, task_argument, job_type, uworker_env):
     """Executes a utask locally."""
@@ -83,16 +103,27 @@ class UTask(BaseUTask):
       self.execute_locally(task_argument, job_type, uworker_env)
       return
 
+    download_url = self.preprocess(task_argument, job_type, uworker_env)
+    if download_url is None:
+      return
+
+    batch.create_uworker_main_batch_job(self.module.__name__, job_type,
+                                        download_url)
+
+  def preprocess(self, task_argument, job_type, uworker_env):
     download_url, _ = utasks.tworker_preprocess(self.module, task_argument,
                                                 job_type, uworker_env)
     if not download_url:
       logs.log_error('No download_url returned from preprocess.')
-      return
-
+      return None
     logs.log('Utask: done with preprocess.')
-    batch.create_uworker_main_batch_job(self.module.__name__, job_type,
-                                        download_url)
-    logs.log('Utask: done creating main.')
+    return download_url
+
+
+def is_remotely_executing_utasks():
+  return (environment.is_production() and
+          environment.get_value('REMOTE_UTASK_EXECUTION') and
+          environment.platform() == 'LINUX')
 
 
 class PostprocessTask(BaseTask):
@@ -146,7 +177,7 @@ COMMAND_TYPES = {
     'unpack': TrustedTask,
     'postprocess': PostprocessTask,
     'uworker_main': UworkerMainTask,
-    'variant': UTaskLocalExecutor,
+    'variant': UTask,
 }
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -77,6 +77,9 @@ class UTask(BaseUTask):
 
   def execute(self, task_argument, job_type, uworker_env):
     """Executes a utask locally."""
+    # pylint: disable=undefined-variable
+    # https://github.com/google/clusterfuzz/pull/3512/#issuecomment-1857737156
+    # Linter throwing a false positive for the is_production() call
     if (not environment.is_production() or
         not environment.get_value('REMOTE_UTASK_EXECUTION') or
         environment.platform() != 'LINUX'):

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -78,8 +78,9 @@ class UTask(BaseUTask):
   def execute(self, task_argument, job_type, uworker_env):
     """Executes a utask locally."""
     if (not environment.is_production() or
-        not environment.get_value('REMOTE_UTASK_EXECUTION')):
-      super().execute(task_argument, job_type, uworker_env)
+        not environment.get_value('REMOTE_UTASK_EXECUTION') or
+        environment.platform() != 'LINUX'):
+      self.execute_locally(task_argument, job_type, uworker_env)
       return
 
     download_url, _ = utasks.tworker_preprocess(self.module, task_argument,

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -88,7 +88,11 @@ class UTask(BaseUTask):
     if not download_url:
       logs.log_error('No download_url returned from preprocess.')
       return
+
     logs.log('Utask: done with preprocess.')
+    batch.create_uworker_main_batch_job(self.module.__name__, job_type,
+                                        download_url)
+    logs.log('Utask: done creating main.')
 
 
 class PostprocessTask(BaseTask):

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -41,21 +41,6 @@ class TrustedTask(BaseTask):
     self.module.execute_task(task_argument, job_type)
 
 
-class UTask(BaseTask):
-  """Represents an untrusted task. Executes the preprocess part on this machine
-  and causes the other parts to be executed on on other machines."""
-
-  def execute(self, task_argument, job_type, uworker_env):
-    """Executes a utask locally."""
-    preprocess_result = utasks.tworker_preprocess(self.module, task_argument,
-                                                  job_type, uworker_env)
-
-    if preprocess_result is None:
-      return
-
-    # TODO(metzman): Execute main on other machines.
-
-
 class BaseUTask(BaseTask):
   """Base class representing an untrusted task. Children must decide to execute
   locally or remotely."""

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -23,6 +23,7 @@ from clusterfuzz._internal.system import environment
 # https://github.com/google/clusterfuzz/pull/3512/#issuecomment-1857737156
 # Linter throwing a false positive for the is_production() call
 
+
 class BaseTask:
   """Base module for tasks."""
 

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -127,7 +127,7 @@ def get_fuzz_task_payload(platform=None):
       mappings.extend(entity.fuzzer_jobs)
   else:
     query = data_types.FuzzerJob.query()
-    mappings = list(ndb_utils.get_all_from_query(query))[:1]  
+    mappings = list(ndb_utils.get_all_from_query(query))[:1]
 
   if not mappings:
     return None, None

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -118,11 +118,10 @@ def get_fuzz_task_payload(platform=None):
   if base_platform != platform:
     platforms.append(base_platform)
 
-  if environment.is_local_development():
-    query = data_types.FuzzerJob.query()
-    query = query.filter(data_types.FuzzerJob.platform.IN(platforms))
-    mappings = list(ndb_utils.get_all_from_query(query))[:1]
-  else:
+  query = data_types.FuzzerJob.query()
+  mappings = list(ndb_utils.get_all_from_query(query))[:1]
+
+  if environment.is_production():
     query = data_types.FuzzerJobs.query()
     query = query.filter(data_types.FuzzerJobs.platform.IN(platforms))
 

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -118,11 +118,12 @@ def get_fuzz_task_payload(platform=None):
   if base_platform != platform:
     platforms.append(base_platform)
 
-  query = data_types.FuzzerJobs.query()
   if environment.is_local_development():
-    query = query.filter(data_types.FuzzerJobs.platform.IN(platforms))
+    query = data_types.FuzzerJob.query()
+    query = query.filter(data_types.FuzzerJob.platform.IN(platforms))
     mappings = list(ndb_utils.get_all_from_query(query))[:1]
   else:
+    query = data_types.FuzzerJobs.query()
     query = query.filter(data_types.FuzzerJobs.platform.IN(platforms))
 
     mappings = []

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -118,9 +118,6 @@ def get_fuzz_task_payload(platform=None):
   if base_platform != platform:
     platforms.append(base_platform)
 
-  query = data_types.FuzzerJob.query()
-  mappings = list(ndb_utils.get_all_from_query(query))[:1]
-
   if environment.is_production():
     query = data_types.FuzzerJobs.query()
     query = query.filter(data_types.FuzzerJobs.platform.IN(platforms))
@@ -128,6 +125,9 @@ def get_fuzz_task_payload(platform=None):
     mappings = []
     for entity in query:
       mappings.extend(entity.fuzzer_jobs)
+  else:
+    query = data_types.FuzzerJob.query()
+    mappings = list(ndb_utils.get_all_from_query(query))[:1]  
 
   if not mappings:
     return None, None

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -126,6 +126,8 @@ def get_fuzz_task_payload(platform=None):
     for entity in query:
       mappings.extend(entity.fuzzer_jobs)
   else:
+    # 'FuzzerJobs' may not exist locally because they are created by
+    # the 'batch_fuzzer_jobs' cron job
     query = data_types.FuzzerJob.query()
     mappings = list(ndb_utils.get_all_from_query(query))[:1]
 

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -129,6 +129,7 @@ def get_fuzz_task_payload(platform=None):
     # 'FuzzerJobs' may not exist locally because they are created by
     # the 'batch_fuzzer_jobs' cron job
     query = data_types.FuzzerJob.query()
+    query = query.filter(data_types.FuzzerJob.platform.IN(platforms))
     mappings = list(ndb_utils.get_all_from_query(query))[:1]
 
   if not mappings:

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1073,10 +1073,8 @@ def is_local_development():
 def is_production():
   """Returns True if there are no environmental indicators
   of local development."""
-  return not (is_local_development() or
-              get_value('UNTRUSTED_RUNNER_TESTS') or
-              get_value('LOCAL_DEVELOPMENT') or
-              get_value('UTASK_TESTS'))
+  return not (is_local_development() or get_value('UNTRUSTED_RUNNER_TESTS') or
+              get_value('LOCAL_DEVELOPMENT') or get_value('UTASK_TESTS'))
 
 
 def local_noop(func):

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1071,9 +1071,12 @@ def is_local_development():
 
 
 def is_production():
-  """Return True if running in production environment (e.g. not running
-  a bot locally, excludes tests)."""
-  return not is_local_development()
+  """Returns True if there are no environmental indicators
+  of local development."""
+  return not (is_local_development() or
+              get_value('UNTRUSTED_RUNNER_TESTS') or
+              get_value('LOCAL_DEVELOPMENT') or
+              get_value('UTASK_TESTS'))
 
 
 def local_noop(func):

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1070,6 +1070,12 @@ def is_local_development():
   return bool(get_value('LOCAL_DEVELOPMENT') and not get_value('PY_UNITTESTS'))
 
 
+def is_production():
+  """Return True if running in production environment (e.g. not running
+  a bot locally, excludes tests)."""
+  return not is_local_development()
+
+
 def local_noop(func):
   """Wrap a function into no-op and return None if running in local
   development environment."""

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1072,7 +1072,7 @@ def is_local_development():
 
 def is_production():
   """Returns True if there are no environmental indicators
-  of local development."""
+  of local development ocurring."""
   return not (is_local_development() or get_value('UNTRUSTED_RUNNER_TESTS') or
               get_value('LOCAL_DEVELOPMENT') or get_value('UTASK_TESTS'))
 

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/fuzzer_selection_test.py
@@ -239,7 +239,7 @@ class GetFuzzTaskPayloadTest(unittest.TestCase):
     self.assertEqual(
         (None, None), fuzzer_selection.get_fuzz_task_payload(platform='linux'))
 
-  @parameterized.parameterized.expand([('False',), ('True',)])
+  @parameterized.parameterized.expand([('True',), ('False',)])
   def test_platform_restriction(self, local_development):
     """Ensure that we can find a task with a valid platform."""
     os.environ['LOCAL_DEVELOPMENT'] = local_development

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/fuzzer_selection_test.py
@@ -239,7 +239,7 @@ class GetFuzzTaskPayloadTest(unittest.TestCase):
     self.assertEqual(
         (None, None), fuzzer_selection.get_fuzz_task_payload(platform='linux'))
 
-  @parameterized.parameterized.expand([('True',), ('False',)])
+  @parameterized.parameterized.expand([('False',), ('True',)])
   def test_platform_restriction(self, local_development):
     """Ensure that we can find a task with a valid platform."""
     os.environ['LOCAL_DEVELOPMENT'] = local_development


### PR DESCRIPTION
No matter how I modify the query logic, the `FuzzerJobs` data type will not return query results when running locally.