### PR TITLE
archive: rework archive classes to make it extendable

### DIFF
--- a/src/appengine/handlers/fuzzers.py
+++ b/src/appengine/handlers/fuzzers.py
@@ -97,8 +97,8 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
       executable_path = 'run'  # Check for default.
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
-    archive_reader = archive.open(upload_info.filename, reader)
-    return archive_reader.get_first_file_matching(executable_path)
+    with archive.open(upload_info.filename, reader) as archive_reader:
+      return archive_reader.get_first_file_matching(executable_path)
 
   def _get_launcher_script(self, upload_info):
     """Get launcher script path."""

--- a/src/appengine/handlers/fuzzers.py
+++ b/src/appengine/handlers/fuzzers.py
@@ -98,7 +98,6 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
     archive_reader = archive.get_archive_reader(upload_info.filename, reader)
-    assert archive_reader
     return archive_reader.get_first_file_matching(executable_path)
 
   def _get_launcher_script(self, upload_info):
@@ -115,7 +114,6 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
     archive_reader = archive.get_archive_reader(upload_info.filename, reader)
-    assert archive_reader
     launcher_script = archive_reader.get_first_file_matching(launcher_script)
     if not launcher_script:
       raise helpers.EarlyExitError(

--- a/src/appengine/handlers/fuzzers.py
+++ b/src/appengine/handlers/fuzzers.py
@@ -97,8 +97,9 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
       executable_path = 'run'  # Check for default.
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
-    return archive.get_first_file_matching(executable_path, reader,
-                                           upload_info.filename)
+    archive_reader = archive.get_archive_reader(upload_info.filename, reader)
+    assert archive_reader
+    return archive_reader.get_first_file_matching(executable_path)
 
   def _get_launcher_script(self, upload_info):
     """Get launcher script path."""
@@ -113,8 +114,9 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
       return launcher_script
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
-    launcher_script = archive.get_first_file_matching(launcher_script, reader,
-                                                      upload_info.filename)
+    archive_reader = archive.get_archive_reader(upload_info.filename, reader)
+    assert archive_reader
+    launcher_script = archive_reader.get_first_file_matching(launcher_script)
     if not launcher_script:
       raise helpers.EarlyExitError(
           'Specified launcher script was not found in archive!', 400)

--- a/src/appengine/handlers/fuzzers.py
+++ b/src/appengine/handlers/fuzzers.py
@@ -97,7 +97,7 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
       executable_path = 'run'  # Check for default.
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
-    archive_reader = archive.get_archive_reader(upload_info.filename, reader)
+    archive_reader = archive.open(upload_info.filename, reader)
     return archive_reader.get_first_file_matching(executable_path)
 
   def _get_launcher_script(self, upload_info):
@@ -113,7 +113,7 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
       return launcher_script
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
-    archive_reader = archive.get_archive_reader(upload_info.filename, reader)
+    archive_reader = archive.open(upload_info.filename, reader)
     launcher_script = archive_reader.get_first_file_matching(launcher_script)
     if not launcher_script:
       raise helpers.EarlyExitError(

--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -136,10 +136,10 @@ def guess_input_file(uploaded_file, filename):
   """Guess the main test case file from an archive."""
   for file_pattern in RUN_FILE_PATTERNS:
     blob_reader = _read_to_bytesio(uploaded_file.gcs_path)
-    reader = archive.open(filename, blob_reader)
-    file_path_input = reader.get_first_file_matching(file_pattern)
-    if file_path_input:
-      return file_path_input
+    with archive.open(filename, blob_reader) as reader:
+      file_path_input = reader.get_first_file_matching(file_pattern)
+      if file_path_input:
+        return file_path_input
 
   return None
 

--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -136,7 +136,7 @@ def guess_input_file(uploaded_file, filename):
   """Guess the main test case file from an archive."""
   for file_pattern in RUN_FILE_PATTERNS:
     blob_reader = _read_to_bytesio(uploaded_file.gcs_path)
-    reader = archive.get_archive_reader(filename, blob_reader)
+    reader = archive.open(filename, blob_reader)
     file_path_input = reader.get_first_file_matching(file_pattern)
     if file_path_input:
       return file_path_input

--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -137,8 +137,6 @@ def guess_input_file(uploaded_file, filename):
   for file_pattern in RUN_FILE_PATTERNS:
     blob_reader = _read_to_bytesio(uploaded_file.gcs_path)
     reader = archive.get_archive_reader(filename, blob_reader)
-    if not reader:
-      return None
     file_path_input = reader.get_first_file_matching(file_pattern)
     if file_path_input:
       return file_path_input

--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -136,8 +136,10 @@ def guess_input_file(uploaded_file, filename):
   """Guess the main test case file from an archive."""
   for file_pattern in RUN_FILE_PATTERNS:
     blob_reader = _read_to_bytesio(uploaded_file.gcs_path)
-    file_path_input = archive.get_first_file_matching(file_pattern, blob_reader,
-                                                      filename)
+    reader = archive.get_archive_reader(filename, blob_reader)
+    if not reader:
+      return None
+    file_path_input = reader.get_first_file_matching(file_pattern)
     if file_path_input:
       return file_path_input
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -649,23 +649,25 @@ def unpack_seed_corpus_if_needed(fuzz_target_path,
   try:
     reader = archive.open(seed_corpus_archive_path)
   except:
-    logs.log_error(f"Failed reading archive: {seed_corpus_archive_path}")
+    logs.log_error(f'Failed reading archive: {seed_corpus_archive_path}')
     return
 
   idx = 0
-  for file in reader.list_members():
-    if file.is_dir:
-      continue
+  with reader:
+    for file in reader.list_members():
+      if file.is_dir:
+        continue
 
-    if file.size_bytes > max_bytes:
-      continue
+      if file.size_bytes > max_bytes:
+        continue
 
-    output_filename = '%016d' % idx
-    output_file_path = os.path.join(corpus_directory, output_filename)
-    with open(output_file_path, 'wb') as file_handle:
-      shutil.copyfileobj(reader.open(file.name), file_handle)
+      output_filename = '%016d' % idx
+      output_file_path = os.path.join(corpus_directory, output_filename)
+      with open(output_file_path, 'wb') as file_handle:
+        with reader.open(file.name) as file:
+          shutil.copyfileobj(file, file_handle)
 
-    idx += 1
+      idx += 1
 
   logs.log('Unarchiving %d files from seed corpus %s.' %
            (idx, seed_corpus_archive_path))

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -646,8 +646,9 @@ def unpack_seed_corpus_if_needed(fuzz_target_path,
   if force_unpack:
     logs.log('Forced unpack: %s.' % seed_corpus_archive_path)
 
-  reader = archive.get_archive_reader(seed_corpus_archive_path)
-  if not reader:
+  try:
+    reader = archive.get_archive_reader(seed_corpus_archive_path)
+  except:
     logs.log_error(f"Failed reading archive: {seed_corpus_archive_path}")
     return
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -653,17 +653,17 @@ def unpack_seed_corpus_if_needed(fuzz_target_path,
     return
 
   idx = 0
-  for file in reader.list_files():
+  for file in reader.list_members():
     if file.is_dir:
       continue
 
-    if file.file_size_bytes > max_bytes:
+    if file.size_bytes > max_bytes:
       continue
 
     output_filename = '%016d' % idx
     output_file_path = os.path.join(corpus_directory, output_filename)
     with open(output_file_path, 'wb') as file_handle:
-      shutil.copyfileobj(reader.open(file.filename), file_handle)
+      shutil.copyfileobj(reader.open(file.name), file_handle)
 
     idx += 1
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -647,7 +647,7 @@ def unpack_seed_corpus_if_needed(fuzz_target_path,
     logs.log('Forced unpack: %s.' % seed_corpus_archive_path)
 
   try:
-    reader = archive.get_archive_reader(seed_corpus_archive_path)
+    reader = archive.open(seed_corpus_archive_path)
   except:
     logs.log_error(f"Failed reading archive: {seed_corpus_archive_path}")
     return

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -653,10 +653,10 @@ def unpack_seed_corpus_if_needed(fuzz_target_path,
 
   idx = 0
   for file in reader.list_files():
-    if file.is_dir():
+    if file.is_dir:
       continue
 
-    if file.file_size > max_bytes:
+    if file.file_size_bytes > max_bytes:
       continue
 
     output_filename = '%016d' % idx

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -1327,7 +1327,7 @@ def use_peach_mutator(extra_env, grammar):
   unzipped = os.path.join(peach_dir, 'mutator')
   source = os.path.join(peach_dir, 'peach_mutator.zip')
 
-  reader = archive.get_archive_reader(source)
+  reader = archive.open(source)
   archive.unpack(reader, unzipped, trusted=True)
 
   # Set LD_PRELOAD.

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -1327,8 +1327,8 @@ def use_peach_mutator(extra_env, grammar):
   unzipped = os.path.join(peach_dir, 'mutator')
   source = os.path.join(peach_dir, 'peach_mutator.zip')
 
-  reader = archive.open(source)
-  archive.unpack(reader, unzipped, trusted=True)
+  with archive.open(source) as reader:
+    archive.unpack(reader, unzipped, trusted=True)
 
   # Set LD_PRELOAD.
   peach_path = os.path.join(unzipped, 'peach_mutator', 'src', 'peach.so')

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -1327,7 +1327,9 @@ def use_peach_mutator(extra_env, grammar):
   unzipped = os.path.join(peach_dir, 'mutator')
   source = os.path.join(peach_dir, 'peach_mutator.zip')
 
-  archive.unpack(source, unzipped, trusted=True)
+  reader = archive.get_archive_reader(source)
+  assert reader
+  archive.unpack(reader, unzipped, trusted=True)
 
   # Set LD_PRELOAD.
   peach_path = os.path.join(unzipped, 'peach_mutator', 'src', 'peach.so')

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -1328,7 +1328,6 @@ def use_peach_mutator(extra_env, grammar):
   source = os.path.join(peach_dir, 'peach_mutator.zip')
 
   reader = archive.get_archive_reader(source)
-  assert reader
   archive.unpack(reader, unzipped, trusted=True)
 
   # Set LD_PRELOAD.

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -383,7 +383,7 @@ def unpack_testcase(testcase, testcase_download_url):
 
   file_list = []
   if archived:
-    reader = archive.get_archive_reader(temp_filename)
+    reader = archive.open(temp_filename)
 
     archive.unpack(reader, input_directory)
 
@@ -599,7 +599,7 @@ def _update_fuzzer(update_input: uworker_msg_pb2.SetupInput,
     return False
 
   try:
-    archive.unpack(archive.get_archive_reader(archive_path), fuzzer_directory)
+    archive.unpack(archive.open(archive_path), fuzzer_directory)
   except Exception:
     error_message = (f'Failed to unpack fuzzer archive {fuzzer.filename} '
                      '(bad archive or unsupported format).')

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -383,10 +383,10 @@ def unpack_testcase(testcase, testcase_download_url):
 
   file_list = []
   if archived:
-    archive.unpack(temp_filename, input_directory)
-
     reader = archive.get_archive_reader(temp_filename)
     assert reader
+
+    archive.unpack(reader, input_directory)
 
     file_list = [f.filename for f in reader.list_files()]
     reader.close()
@@ -599,9 +599,15 @@ def _update_fuzzer(update_input: uworker_msg_pb2.SetupInput,
     logs.log_error('Failed to copy fuzzer archive.')
     return False
 
-  try:
-    archive.unpack(archive_path, fuzzer_directory)
-  except Exception:
+  reader = archive.get_archive_reader(archive_path)
+  error_occurred = reader is None
+  if reader:
+    try:
+      archive.unpack(reader, fuzzer_directory)
+    except Exception:
+      error_occurred = True
+
+  if error_occurred:
     error_message = (f'Failed to unpack fuzzer archive {fuzzer.filename} '
                      '(bad archive or unsupported format).')
     logs.log_error(error_message)

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -383,12 +383,9 @@ def unpack_testcase(testcase, testcase_download_url):
 
   file_list = []
   if archived:
-    reader = archive.open(temp_filename)
-
-    archive.unpack(reader, input_directory)
-
-    file_list = [f.name for f in reader.list_members()]
-    reader.close()
+    with archive.open(temp_filename) as reader:
+      archive.unpack(reader, input_directory)
+      file_list = [f.name for f in reader.list_members()]
 
     shell.remove_file(temp_filename)
 
@@ -599,7 +596,8 @@ def _update_fuzzer(update_input: uworker_msg_pb2.SetupInput,
     return False
 
   try:
-    archive.unpack(archive.open(archive_path), fuzzer_directory)
+    with archive.open(archive_path) as reader:
+      archive.unpack(reader, fuzzer_directory)
   except Exception:
     error_message = (f'Failed to unpack fuzzer archive {fuzzer.filename} '
                      '(bad archive or unsupported format).')

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -387,7 +387,7 @@ def unpack_testcase(testcase, testcase_download_url):
 
     archive.unpack(reader, input_directory)
 
-    file_list = [f.filename for f in reader.list_files()]
+    file_list = [f.name for f in reader.list_members()]
     reader.close()
 
     shell.remove_file(temp_filename)

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -384,7 +384,13 @@ def unpack_testcase(testcase, testcase_download_url):
   file_list = []
   if archived:
     archive.unpack(temp_filename, input_directory)
-    file_list = archive.get_file_list(temp_filename)
+
+    reader = archive.get_archive_reader(temp_filename)
+    assert reader
+
+    file_list = [f.filename for f in reader.list_files()]
+    reader.close()
+
     shell.remove_file(temp_filename)
 
     file_exists = False

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -384,7 +384,6 @@ def unpack_testcase(testcase, testcase_download_url):
   file_list = []
   if archived:
     reader = archive.get_archive_reader(temp_filename)
-    assert reader
 
     archive.unpack(reader, input_directory)
 
@@ -599,15 +598,9 @@ def _update_fuzzer(update_input: uworker_msg_pb2.SetupInput,
     logs.log_error('Failed to copy fuzzer archive.')
     return False
 
-  reader = archive.get_archive_reader(archive_path)
-  error_occurred = reader is None
-  if reader:
-    try:
-      archive.unpack(reader, fuzzer_directory)
-    except Exception:
-      error_occurred = True
-
-  if error_occurred:
+  try:
+    archive.unpack(archive.get_archive_reader(archive_path), fuzzer_directory)
+  except Exception:
     error_message = (f'Failed to unpack fuzzer archive {fuzzer.filename} '
                      '(bad archive or unsupported format).')
     logs.log_error(error_message)

--- a/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
@@ -65,7 +65,7 @@ def execute_task(metadata_id, job_type):
     return
 
   try:
-    reader = archive.get_archive_reader(archive_path)
+    reader = archive.open(archive_path)
     archive.unpack(reader, testcases_directory)
   except:
     logs.log_error('Could not unpack archive for bundle %d.' % metadata_id)

--- a/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
@@ -79,7 +79,7 @@ def execute_task(metadata_id, job_type):
 
   archive_state = data_types.ArchiveStatus.NONE
   bundled = True
-  file_list = [f.filename for f in reader.list_files()]
+  file_list = [f.name for f in reader.list_members()]
 
   for file_path in file_list:
     absolute_file_path = os.path.join(testcases_directory, file_path)

--- a/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
@@ -64,9 +64,13 @@ def execute_task(metadata_id, job_type):
     tasks.add_task('unpack', metadata_id, job_type)
     return
 
+  reader = archive.get_archive_reader(archive_path)
+  error_occured = reader is None
   try:
-    archive.unpack(archive_path, testcases_directory)
+    archive.unpack(reader, testcases_directory)
   except:
+    error_occured = True
+  if error_occured:
     logs.log_error('Could not unpack archive for bundle %d.' % metadata_id)
     tasks.add_task('unpack', metadata_id, job_type)
     return
@@ -78,8 +82,6 @@ def execute_task(metadata_id, job_type):
 
   archive_state = data_types.ArchiveStatus.NONE
   bundled = True
-  reader = archive.get_archive_reader(archive_path)
-  assert reader
   file_list = [f.filename for f in reader.list_files()]
 
   for file_path in file_list:

--- a/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
@@ -65,8 +65,8 @@ def execute_task(metadata_id, job_type):
     return
 
   try:
-    reader = archive.open(archive_path)
-    archive.unpack(reader, testcases_directory)
+    with archive.open(archive_path) as reader:
+      archive.unpack(reader, testcases_directory)
   except:
     logs.log_error('Could not unpack archive for bundle %d.' % metadata_id)
     tasks.add_task('unpack', metadata_id, job_type)
@@ -79,10 +79,9 @@ def execute_task(metadata_id, job_type):
 
   archive_state = data_types.ArchiveStatus.NONE
   bundled = True
-  file_list = [f.name for f in reader.list_members()]
 
-  for file_path in file_list:
-    absolute_file_path = os.path.join(testcases_directory, file_path)
+  for f in reader.list_members():
+    absolute_file_path = os.path.join(testcases_directory, f.name)
     filename = os.path.basename(absolute_file_path)
 
     # Only files are actual testcases. Skip directories.

--- a/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
@@ -78,7 +78,9 @@ def execute_task(metadata_id, job_type):
 
   archive_state = data_types.ArchiveStatus.NONE
   bundled = True
-  file_list = archive.get_file_list(archive_path)
+  reader = archive.get_archive_reader(archive_path)
+  assert reader
+  file_list = [f.filename for f in reader.list_files()]
 
   for file_path in file_list:
     absolute_file_path = os.path.join(testcases_directory, file_path)

--- a/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
@@ -64,13 +64,10 @@ def execute_task(metadata_id, job_type):
     tasks.add_task('unpack', metadata_id, job_type)
     return
 
-  reader = archive.get_archive_reader(archive_path)
-  error_occured = reader is None
   try:
+    reader = archive.get_archive_reader(archive_path)
     archive.unpack(reader, testcases_directory)
   except:
-    error_occured = True
-  if error_occured:
     logs.log_error('Could not unpack archive for bundle %d.' % metadata_id)
     tasks.add_task('unpack', metadata_id, job_type)
     return

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -256,8 +256,7 @@ def update_source_code():
       os.chmod(extracted_path, mode)
     except:
       error_occurred = True
-      logs.log_error(
-          'Failed to extract file %s from source archive.' % file.name)
+      logs.log_error(f'Failed to extract file {file.name} from source archive.')
 
   reader.close()
 
@@ -311,9 +310,8 @@ def update_tests_if_needed():
     try:
       shell.remove_directory(data_directory, recreate=True)
       storage.copy_file_from(tests_url, temp_archive)
-      reader = archive.open(temp_archive)
-      archive.unpack(reader, data_directory, trusted=True)
-      reader.close()
+      with archive.open(temp_archive) as reader:
+        archive.unpack(reader, data_directory, trusted=True)
       shell.remove_file(temp_archive)
       error_occured = False
       break

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -206,10 +206,12 @@ def update_source_code():
     logs.log_error('Could not retrieve source code archive from url.')
     return
 
-  reader = archive.get_archive_reader(temp_archive)
-  if not reader:
+  try:
+    reader = archive.get_archive_reader(temp_archive)
+  except:
     logs.log_error('Bad zip file.')
     return
+
   file_list = reader.list_files()
 
   src_directory = os.path.join(root_directory, 'src')
@@ -312,13 +314,10 @@ def update_tests_if_needed():
       shell.remove_directory(data_directory, recreate=True)
       storage.copy_file_from(tests_url, temp_archive)
       reader = archive.get_archive_reader(temp_archive)
-      if not reader:
-        error_occured = True
-      else:
-        archive.unpack(reader, data_directory, trusted=True)
-        reader.close()
-        shell.remove_file(temp_archive)
-        error_occured = False
+      archive.unpack(reader, data_directory, trusted=True)
+      reader.close()
+      shell.remove_file(temp_archive)
+      error_occured = False
       break
     except:
       logs.log_error(

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -207,7 +207,7 @@ def update_source_code():
     return
 
   try:
-    reader = archive.get_archive_reader(temp_archive)
+    reader = archive.open(temp_archive)
   except:
     logs.log_error('Bad zip file.')
     return
@@ -313,7 +313,7 @@ def update_tests_if_needed():
     try:
       shell.remove_directory(data_directory, recreate=True)
       storage.copy_file_from(tests_url, temp_archive)
-      reader = archive.get_archive_reader(temp_archive)
+      reader = archive.open(temp_archive)
       archive.unpack(reader, data_directory, trusted=True)
       reader.close()
       shell.remove_file(temp_archive)

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -311,9 +311,14 @@ def update_tests_if_needed():
     try:
       shell.remove_directory(data_directory, recreate=True)
       storage.copy_file_from(tests_url, temp_archive)
-      archive.unpack(temp_archive, data_directory, trusted=True)
-      shell.remove_file(temp_archive)
-      error_occured = False
+      reader = archive.get_archive_reader(temp_archive)
+      if not reader:
+        error_occured = True
+      else:
+        archive.unpack(reader, data_directory, trusted=True)
+        reader.close()
+        shell.remove_file(temp_archive)
+        error_occured = False
       break
     except:
       logs.log_error(

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -208,23 +208,21 @@ def update_source_code():
 
   try:
     reader = archive.open(temp_archive)
-  except:
-    logs.log_error('Bad zip file.')
+  except Exception as e:
+    logs.log_error('Bad zip file: %s.' % repr(e))
     return
-
-  file_list = reader.list_files()
 
   src_directory = os.path.join(root_directory, 'src')
   error_occurred = False
   normalized_file_set = set()
-  for file in file_list:
-    filename = os.path.basename(file.filename)
+  for file in reader.list_members():
+    filename = os.path.basename(file.name)
 
     # This file cannot be updated on the fly since it is running as server.
     if filename == 'adb':
       continue
 
-    absolute_filepath = os.path.join(cf_source_root_parent_dir, file.filename)
+    absolute_filepath = os.path.join(cf_source_root_parent_dir, file.name)
     if os.path.altsep:
       absolute_filepath = absolute_filepath.replace(os.path.altsep, os.path.sep)
 
@@ -252,14 +250,14 @@ def update_source_code():
                      'version.' % absolute_filepath)
 
     try:
-      extracted_path = reader.extract(file.filename, cf_source_root_parent_dir)
+      extracted_path = reader.extract(file.name, cf_source_root_parent_dir)
       mode = file.mode
       mode |= 0o440
       os.chmod(extracted_path, mode)
     except:
       error_occurred = True
       logs.log_error(
-          'Failed to extract file %s from source archive.' % file.filename)
+          'Failed to extract file %s from source archive.' % file.name)
 
   reader.close()
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -288,8 +288,9 @@ class Context:
       corpus_backup_output_directory = os.path.join(self.shared_corpus_path,
                                                     project_qualified_name)
       shell.create_directory(corpus_backup_output_directory)
-      result = archive.unpack(corpus_backup_local_path,
-                              corpus_backup_output_directory)
+      reader = archive.get_archive_reader(corpus_backup_local_path)
+      assert reader
+      result = archive.unpack(reader, corpus_backup_output_directory)
       shell.remove_file(corpus_backup_local_path)
 
       if result:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -288,7 +288,7 @@ class Context:
       corpus_backup_output_directory = os.path.join(self.shared_corpus_path,
                                                     project_qualified_name)
       shell.create_directory(corpus_backup_output_directory)
-      reader = archive.get_archive_reader(corpus_backup_local_path)
+      reader = archive.open(corpus_backup_local_path)
       result = archive.unpack(reader, corpus_backup_output_directory)
       shell.remove_file(corpus_backup_local_path)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -289,7 +289,6 @@ class Context:
                                                     project_qualified_name)
       shell.create_directory(corpus_backup_output_directory)
       reader = archive.get_archive_reader(corpus_backup_local_path)
-      assert reader
       result = archive.unpack(reader, corpus_backup_output_directory)
       shell.remove_file(corpus_backup_local_path)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -288,8 +288,8 @@ class Context:
       corpus_backup_output_directory = os.path.join(self.shared_corpus_path,
                                                     project_qualified_name)
       shell.create_directory(corpus_backup_output_directory)
-      reader = archive.open(corpus_backup_local_path)
-      result = archive.unpack(reader, corpus_backup_output_directory)
+      with archive.open(corpus_backup_local_path) as reader:
+        result = archive.unpack(reader, corpus_backup_output_directory)
       shell.remove_file(corpus_backup_local_path)
 
       if result:

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1097,7 +1097,7 @@ def setup_user_profile_directory_if_needed(user_profile_directory):
     # Unpack the fuzzPriv extension.
     extension_archive = os.path.join(environment.get_resources_directory(),
                                      'firefox', 'fuzzPriv-extension.zip')
-    reader = archive.get_archive_reader(extension_archive)
+    reader = archive.open(extension_archive)
     assert reader
     archive.unpack(reader, extensions_directory)
 

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1098,7 +1098,6 @@ def setup_user_profile_directory_if_needed(user_profile_directory):
     extension_archive = os.path.join(environment.get_resources_directory(),
                                      'firefox', 'fuzzPriv-extension.zip')
     reader = archive.open(extension_archive)
-    assert reader
     archive.unpack(reader, extensions_directory)
 
     # Add this extension in the extensions configuration file.

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1097,7 +1097,9 @@ def setup_user_profile_directory_if_needed(user_profile_directory):
     # Unpack the fuzzPriv extension.
     extension_archive = os.path.join(environment.get_resources_directory(),
                                      'firefox', 'fuzzPriv-extension.zip')
-    archive.unpack(extension_archive, extensions_directory)
+    reader = archive.get_archive_reader(extension_archive)
+    assert reader
+    archive.unpack(reader, extensions_directory)
 
     # Add this extension in the extensions configuration file.
     extension_config_file_path = os.path.join(user_profile_directory,

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1097,8 +1097,8 @@ def setup_user_profile_directory_if_needed(user_profile_directory):
     # Unpack the fuzzPriv extension.
     extension_archive = os.path.join(environment.get_resources_directory(),
                                      'firefox', 'fuzzPriv-extension.zip')
-    reader = archive.open(extension_archive)
-    archive.unpack(reader, extensions_directory)
+    with archive.open(extension_archive) as reader:
+      archive.unpack(reader, extensions_directory)
 
     # Add this extension in the extensions configuration file.
     extension_config_file_path = os.path.join(user_profile_directory,

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -543,7 +543,7 @@ class Build(BaseBuild):
     try:
       reader = archive.open(build_local_archive)
     except:
-      logs.log_error('Unable to open build archive %s.' % build_local_archive)
+      logs.log_error(f'Unable to open build archive {build_local_archive}.')
       return False
 
     if not unpack_everything:
@@ -582,6 +582,7 @@ class Build(BaseBuild):
       logs.log_error('Unable to unpack build archive %s.' % build_local_archive)
       return False
 
+    reader.close()
     if unpack_everything:
       # Set a random fuzz target now that the build has been unpacked, if we
       # didn't set one earlier. For an auxiliary build, fuzz target is already
@@ -845,8 +846,8 @@ class CuttlefishKernelBuild(RegularBuild):
     # Extract syzkaller binary.
     syzkaller_path = os.path.join(self.build_dir, 'syzkaller')
     shell.remove_directory(syzkaller_path)
-    reader = archive.open(archive_dst_path)
-    archive.unpack(reader, syzkaller_path)
+    with archive.open(archive_dst_path) as reader:
+      archive.unpack(reader, syzkaller_path)
     shell.remove_file(archive_dst_path)
 
     environment.set_value('VMLINUX_PATH', self.build_dir)
@@ -990,6 +991,7 @@ class CustomBuild(Build):
       # Remove the archive.
       shell.remove_file(build_local_archive)
 
+    reader.close()
     self._pick_fuzz_target(
         self._get_fuzz_targets_from_dir(self.build_dir), self.target_weights)
     return True

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -157,8 +157,7 @@ def _make_space_for_build(archive_reader,
   """Make space for extracting the build archive by deleting the least recently
   used builds."""
   extracted_size = 0
-  if archive_reader:
-    extracted_size = archive_reader.extracted_size(file_match_callback)
+  extracted_size = archive_reader.extracted_size(file_match_callback)
 
   return _make_space(extracted_size, current_build_dir=current_build_dir)
 
@@ -612,7 +611,7 @@ class Build(BaseBuild):
     # Import here as this path is not available in App Engine context.
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
-    for archive_file in reader.list_files():
+    for archive_file in reader.list_members():
       if fuzzer_utils.is_fuzz_target_local(
           archive_file.filename, reader.try_open(archive_file.filename)):
         fuzz_target = _normalize_target_name(archive_file.filename)

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -156,7 +156,6 @@ def _make_space_for_build(archive_reader,
                           file_match_callback=None):
   """Make space for extracting the build archive by deleting the least recently
   used builds."""
-  extracted_size = 0
   extracted_size = archive_reader.extracted_size(file_match_callback)
 
   return _make_space(extracted_size, current_build_dir=current_build_dir)
@@ -612,9 +611,9 @@ class Build(BaseBuild):
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
     for archive_file in reader.list_members():
-      if fuzzer_utils.is_fuzz_target_local(
-          archive_file.filename, reader.try_open(archive_file.filename)):
-        fuzz_target = _normalize_target_name(archive_file.filename)
+      if fuzzer_utils.is_fuzz_target_local(archive_file.name,
+                                           reader.try_open(archive_file.name)):
+        fuzz_target = _normalize_target_name(archive_file.name)
         yield fuzz_target
 
   def _get_fuzz_targets_from_dir(self, build_dir):

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -606,10 +606,14 @@ class Build(BaseBuild):
     # Import here as this path is not available in App Engine context.
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
-    for archive_file in archive.iterator(archive_path):
-      if fuzzer_utils.is_fuzz_target_local(archive_file.name,
-                                           archive_file.handle):
-        fuzz_target = _normalize_target_name(archive_file.name)
+    reader = archive.get_archive_reader(archive_path)
+    if not reader:
+      return
+
+    for archive_file in reader.list_files():
+      if fuzzer_utils.is_fuzz_target_local(
+          archive_file.filename, reader.try_open(archive_file.filename)):
+        fuzz_target = _normalize_target_name(archive_file.filename)
         yield fuzz_target
 
   def _get_fuzz_targets_from_dir(self, build_dir):

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -543,7 +543,7 @@ class Build(BaseBuild):
         'UNPACK_ALL_FUZZ_TARGETS_AND_FILES')
 
     try:
-      reader = archive.get_archive_reader(build_local_archive)
+      reader = archive.open(build_local_archive)
     except:
       logs.log_error('Unable to open build archive %s.' % build_local_archive)
       return False
@@ -847,7 +847,7 @@ class CuttlefishKernelBuild(RegularBuild):
     # Extract syzkaller binary.
     syzkaller_path = os.path.join(self.build_dir, 'syzkaller')
     shell.remove_directory(syzkaller_path)
-    reader = archive.get_archive_reader(archive_dst_path)
+    reader = archive.open(archive_dst_path)
     archive.unpack(reader, syzkaller_path)
     shell.remove_file(archive_dst_path)
 
@@ -967,7 +967,7 @@ class CustomBuild(Build):
       return False
 
     try:
-      reader = archive.get_archive_reader(build_local_archive)
+      reader = archive.open(build_local_archive)
     except:
       logs.log_error('Unable to open build archive %s.' % build_local_archive)
       return False

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -335,7 +335,6 @@ class GcsCorpus:
         if not storage.copy_file_from(zipcorpus_url, temp_zip_filename):
           continue
         reader = archive.get_archive_reader(temp_zip_filename)
-        assert reader
         archive.unpack(reader, dst_dir)
 
   def rsync_to_disk(self,

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -334,7 +334,9 @@ class GcsCorpus:
           continue
         if not storage.copy_file_from(zipcorpus_url, temp_zip_filename):
           continue
-        archive.unpack(temp_zip_filename, dst_dir)
+        reader = archive.get_archive_reader(temp_zip_filename)
+        assert reader
+        archive.unpack(reader, dst_dir)
 
   def rsync_to_disk(self,
                     directory,

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -334,7 +334,7 @@ class GcsCorpus:
           continue
         if not storage.copy_file_from(zipcorpus_url, temp_zip_filename):
           continue
-        reader = archive.get_archive_reader(temp_zip_filename)
+        reader = archive.open(temp_zip_filename)
         archive.unpack(reader, dst_dir)
 
   def rsync_to_disk(self,

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -334,8 +334,8 @@ class GcsCorpus:
           continue
         if not storage.copy_file_from(zipcorpus_url, temp_zip_filename):
           continue
-        reader = archive.open(temp_zip_filename)
-        archive.unpack(reader, dst_dir)
+        with archive.open(temp_zip_filename) as reader:
+          archive.unpack(reader, dst_dir)
 
   def rsync_to_disk(self,
                     directory,

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -86,8 +86,8 @@ def download_latest_build(build_info, image_regexes, image_directory):
 
     for file_path in image_file_paths:
       if file_path.endswith('.zip') or file_path.endswith('.tar.gz'):
-        reader = archive.open(file_path)
-        archive.unpack(reader, image_directory)
+        with archive.open(file_path) as reader:
+          archive.unpack(reader, image_directory)
 
 
 def flash_to_latest_build_if_needed():

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -86,7 +86,9 @@ def download_latest_build(build_info, image_regexes, image_directory):
 
     for file_path in image_file_paths:
       if file_path.endswith('.zip') or file_path.endswith('.tar.gz'):
-        archive.unpack(file_path, image_directory)
+        reader = archive.get_archive_reader(file_path)
+        assert reader
+        archive.unpack(reader, image_directory)
 
 
 def flash_to_latest_build_if_needed():

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -86,7 +86,7 @@ def download_latest_build(build_info, image_regexes, image_directory):
 
     for file_path in image_file_paths:
       if file_path.endswith('.zip') or file_path.endswith('.tar.gz'):
-        reader = archive.get_archive_reader(file_path)
+        reader = archive.open(file_path)
         archive.unpack(reader, image_directory)
 
 

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -87,7 +87,6 @@ def download_latest_build(build_info, image_regexes, image_directory):
     for file_path in image_file_paths:
       if file_path.endswith('.zip') or file_path.endswith('.tar.gz'):
         reader = archive.get_archive_reader(file_path)
-        assert reader
         archive.unpack(reader, image_directory)
 
 

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -169,7 +169,9 @@ def download_system_symbols_if_needed(symbols_directory):
         'Unable to locate symbols archive %s.' % symbols_archive_path)
     return
 
-  archive.unpack(symbols_archive_path, symbols_directory, trusted=True)
+  reader = archive.get_archive_reader(symbols_archive_path)
+  assert reader
+  archive.unpack(reader, symbols_directory, trusted=True)
   shell.remove_file(symbols_archive_path)
 
   utils.write_data_to_file(build_params, build_params_check_path)

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -170,7 +170,6 @@ def download_system_symbols_if_needed(symbols_directory):
     return
 
   reader = archive.get_archive_reader(symbols_archive_path)
-  assert reader
   archive.unpack(reader, symbols_directory, trusted=True)
   shell.remove_file(symbols_archive_path)
 

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -169,7 +169,7 @@ def download_system_symbols_if_needed(symbols_directory):
         'Unable to locate symbols archive %s.' % symbols_archive_path)
     return
 
-  reader = archive.get_archive_reader(symbols_archive_path)
+  reader = archive.open(symbols_archive_path)
   archive.unpack(reader, symbols_directory, trusted=True)
   shell.remove_file(symbols_archive_path)
 

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -169,8 +169,8 @@ def download_system_symbols_if_needed(symbols_directory):
         'Unable to locate symbols archive %s.' % symbols_archive_path)
     return
 
-  reader = archive.open(symbols_archive_path)
-  archive.unpack(reader, symbols_directory, trusted=True)
+  with archive.open(symbols_archive_path) as reader:
+    archive.unpack(reader, symbols_directory, trusted=True)
   shell.remove_file(symbols_archive_path)
 
   utils.write_data_to_file(build_params, build_params_check_path)

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -88,12 +88,12 @@ class ArchiveReader(abc.ABC):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def extract(self, member, path=None, trusted=False) -> str:
+  def extract(self, member, path, trusted=False) -> str:
     """Extracts `member` out of the archive to the provided path.
 
     Args:
         member (str): the member name
-        path (str, optional): the path at which the member should be extracted.
+        path (str): the path where the member should be extracted.
         Defaults to None.
         trusted (bool, optional): whether the archive is trusted. Defaults to
         False.
@@ -122,11 +122,11 @@ class ArchiveReader(abc.ABC):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def extractall(self, path=None, members=None, trusted=False) -> None:
+  def extractall(self, path, members=None, trusted=False) -> None:
     """Extract the whole archive content or the members listed in `members`.
 
     Args:
-        path (str, optional): the path where the members should be extracted.
+        path (str): the path where the members should be extracted.
         Defaults to None.
         members ([str], optional): the member names. Defaults to None.
         trusted (bool, optional): whether the archive is trusted or not.
@@ -211,7 +211,7 @@ class TarArchiveReader(ArchiveReader):
   def close(self) -> None:
     self.archive.close()
 
-  def extract(self, member, path=None, trusted=False):
+  def extract(self, member, path, trusted=False):
     # If the output directory is a symlink, get its actual path since we will be
     # doing directory traversal checks later when unpacking the archive.
     output_directory = os.path.realpath(path)
@@ -224,7 +224,7 @@ class TarArchiveReader(ArchiveReader):
     self.archive.extract(member=member, path=output_directory)
     return os.path.realpath(os.path.join(output_directory, member))
 
-  def extractall(self, path=None, members=None, trusted=False) -> None:
+  def extractall(self, path, members=None, trusted=False) -> None:
     to_extract = members if members is not None else self.archive.namelist()
     #FIXME(paulsemel): we could try extracting that all.
     for member in to_extract:
@@ -253,7 +253,7 @@ class ZipArchiveReader(ArchiveReader):
   def close(self) -> None:
     self.zip_archive.close()
 
-  def extract(self, member, path=None, trusted=False):
+  def extract(self, member, path, trusted=False):
     # If the output directory is a symlink, get its actual path since we will be
     # doing directory traversal checks later when unpacking the archive.
     output_directory = os.path.realpath(path)
@@ -301,7 +301,7 @@ class ZipArchiveReader(ArchiveReader):
       # In case of errors, we try to extract whatever we can without errors.
       return None
 
-  def extractall(self, path=None, members=None, trusted=False) -> None:
+  def extractall(self, path, members=None, trusted=False) -> None:
     to_extract = members if members is not None else self.zip_archive.namelist()
     for member in to_extract:
       self.extract(member=member, path=path, trusted=trusted)

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -307,27 +307,34 @@ class ZipArchiveReader(ArchiveReader):
       self.extract(member=member, path=path, trusted=trusted)
 
 
-class ArchiveReaderError(Exception):
-  """ArchiveReaderError"""
+class ArchiveError(Exception):
+  """ArchiveError"""
 
 
-def get_archive_reader(archive_path, file_obj=None):
-  """Gets the appropriate archive reader based on the provided path.
+# pylint: disable=redefined-builtin
+def open(archive_path, file_obj=None):
+  """Opens the archive and gets the appropriate archive reader based on the
+  `archive_path`.
 
   Args:
       archive_path (str): the path to the archive.
       file_obj (obj, optional): a object-like containing the archive. Defaults
       to None.
 
+  Raises:
+      this function raises if the file could not be open or if the archive type
+      cannot be handled. See `get_archive_type` to check whether the archive
+      type is handled.
+
   Returns:
-      (ArchiveReader): the archive reader or None if an error occurred.
+      (ArchiveReader): the archive reader.
   """
   archive_type = get_archive_type(archive_path)
   if archive_type == ArchiveType.ZIP:
     return ZipArchiveReader(archive_path or file_obj)
   if archive_type in (ArchiveType.TAR_LZMA, ArchiveType.TAR):
     return TarArchiveReader(archive_path, file_obj=file_obj)
-  raise ArchiveReaderError('Unhandled archive type.')
+  raise ArchiveError('Unhandled archive type.')
 
 
 class ArchiveType:

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -267,14 +267,6 @@ class ArchiveFile:
     self.handle = handle
 
 
-def extracted_size(archive_path, file_match_callback=None):
-  """Return the total extracted size of the archive."""
-  reader = get_archive_reader(archive_path)
-  return sum(f.file_size
-             for f in reader.list_files()
-             if not file_match_callback or file_match_callback(f.filename))
-
-
 def get_archive_type(archive_path):
   """Get the type of the archive."""
 

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -338,15 +338,6 @@ class ArchiveType:
   TAR_LZMA = 3
 
 
-class ArchiveFile:
-  """File in an archive."""
-
-  def __init__(self, name, size, handle):
-    self.name = name
-    self.size = size
-    self.handle = handle
-
-
 def get_archive_type(archive_path):
   """Get the type of the archive."""
 

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -98,6 +98,16 @@ class ArchiveReader:
     except:
       return None
 
+  def get_first_file_matching(self, search_string):
+    for file in self.list_files():
+      if file.filename.startswith('__MACOSX/'):
+        # Exclude MAC resouce forks.
+        continue
+
+      if search_string in file.filename:
+        return file.filename
+    return None
+
   def extractall(self, path=None, members=None, trusted=False) -> None:
     raise NotImplementedError
 
@@ -285,19 +295,6 @@ def get_archive_type(archive_path):
     return ArchiveType.TAR_LZMA
 
   return ArchiveType.UNKNOWN
-
-
-def get_first_file_matching(search_string, archive_obj, archive_path):
-  """Returns the first file with a name matching search string in archive."""
-  reader = get_archive_reader(archive_path, archive_obj)
-  for file in reader.list_files():
-    if file.filename.startswith('__MACOSX/'):
-      # Exclude MAC resouce forks.
-      continue
-
-    if search_string in file.filename:
-      return file.filename
-  return None
 
 
 def is_archive(filename):

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -218,6 +218,12 @@ class TarArchiveReader(ArchiveReader):
       self._archive = tarfile.open(archive_path, mode=mode)
     self._archive_path = archive_path
 
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *args):
+    self._archive.close()
+
   def list_members(self) -> List[ArchiveMemberInfo]:
     return [
         ArchiveMemberInfo(
@@ -262,6 +268,12 @@ class ZipArchiveReader(ArchiveReader):
 
   def __init__(self, file) -> None:
     self._zip_archive = zipfile.ZipFile(file, mode='r')
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *args):
+    self._zip_archive.close()
 
   def list_members(self) -> List[ArchiveMemberInfo]:
     return [

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -107,14 +107,13 @@ class ArchiveReader(abc.ABC):
               path: Union[str, os.PathLike],
               trusted: bool = False) -> str:
     """Extracts `member` out of the archive to the provided path.
-    If `members` is a directory in the archive, only the directory itself will
+    If `member` is a directory in the archive, only the directory itself will
     be extracted, not its content.
 
     Args:
         member: the member name
         path: the path where the member should be extracted.
-        trusted (optional): whether the archive is trusted. Defaults to
-        False.
+        trusted: whether the archive is trusted.
 
     Returns:
         The path to the extracted member
@@ -142,15 +141,14 @@ class ArchiveReader(abc.ABC):
   @abc.abstractmethod
   def extract_all(self,
                   path: Union[str, os.PathLike],
-                  members: List[str] = None,
+                  members: Optional[List[str]] = None,
                   trusted: bool = False) -> None:
     """Extract the whole archive content or the members listed in `members`.
 
     Args:
         path: the path where the members should be extracted.
-        members (optional): the member names. Defaults to None.
-        trusted (optional): whether the archive is trusted or not.
-        Defaults to False.
+        members: the member names.
+        trusted: whether the archive is trusted or not.
     """
     raise NotImplementedError
 
@@ -192,8 +190,7 @@ class ArchiveReader(abc.ABC):
     size of the whole archive.
 
     Args:
-        file_match_callback (optional): the file matching callback. Defaults
-        to None.
+        file_match_callback: the file matching callback.
 
     Returns:
         the sum of the extract size in bytes of members matched with the
@@ -251,7 +248,7 @@ class TarArchiveReader(ArchiveReader):
 
   def extract_all(self,
                   path: Union[str, os.PathLike],
-                  members: List[str] = None,
+                  members: Optional[List[str]] = None,
                   trusted: bool = False) -> None:
     to_extract = members if members is not None else self._archive.namelist()
     for member in to_extract:
@@ -330,13 +327,13 @@ class ZipArchiveReader(ArchiveReader):
       return extracted_path
     except Exception as e:
       # In case of errors, we try to extract whatever we can without errors.
-      logs.log_warn(
-          'An error occured while extracting the archive: %s.' % repr(e))
+      logs.log_warn('An error occured while extracting %s the archive: %s.' %
+                    (member, repr(e)))
       return None
 
   def extract_all(self,
                   path: Union[str, os.PathLike],
-                  members: List[str] = None,
+                  members: Optional[List[str]] = None,
                   trusted: bool = False) -> None:
     to_extract = members if members is not None else self._zip_archive.namelist(
     )
@@ -349,14 +346,15 @@ class ArchiveError(Exception):
 
 
 # pylint: disable=redefined-builtin
-def open(archive_path: str, file_obj: BinaryIO = None) -> ArchiveReader:
+def open(archive_path: str,
+         file_obj: Optional[BinaryIO] = None) -> ArchiveReader:
   """Opens the archive and gets the appropriate archive reader based on the
-  `archive_path`.
+  `archive_path`. If file_obj is not none, the binary file-like object will be
+  used to read the archive instead of opening the file.
 
   Args:
       archive_path: the path to the archive.
-      file_obj (optional): a object-like containing the archive. Defaults
-      to None.
+      file_obj: a object-like containing the archive.
 
   Raises:
       If the file could not be opened or if the archive type cannot be handled.
@@ -433,10 +431,8 @@ def unpack(reader: ArchiveReader,
   Args:
       reader: the archive reader
       output_dir: the output directory to unpack the archive to.
-      trusted (optional): whether the archive is trusted. Defaults to
-      False.
-      file_match_callback (optional): the file matching callback. Defaults to
-      None.
+      trusted: whether the archive is trusted.
+      file_match_callback: the file matching callback.
 
   Returns:
       bool: whether an error occurred.

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -77,7 +77,8 @@ def _is_attempting_path_traversal(archive_name: StrBytesPathLike,
 class ArchiveMemberInfo:
   """Represents an archive member. A member can either be a file or a directory.
   Members:
-    name: the name of the archive member.
+    name: the name of the archive member. It can represent a file or a directory
+    name.
     is_dir: whether this member is a directory.
     size_bytes: the extracted size of the member.
     mode: the mode of the member (file system attributes).
@@ -327,8 +328,8 @@ class ZipArchiveReader(ArchiveReader):
       return extracted_path
     except Exception as e:
       # In case of errors, we try to extract whatever we can without errors.
-      logs.log_warn('An error occured while extracting %s the archive: %s.' %
-                    (member, repr(e)))
+      logs.log_warn('An error occured while extracting %s from the archive: %s.'
+                    % (member, repr(e)))
       return None
 
   def extract_all(self,
@@ -349,12 +350,12 @@ class ArchiveError(Exception):
 def open(archive_path: str,
          file_obj: Optional[BinaryIO] = None) -> ArchiveReader:
   """Opens the archive and gets the appropriate archive reader based on the
-  `archive_path`. If file_obj is not none, the binary file-like object will be
-  used to read the archive instead of opening the file.
+  `archive_path`. If `file_obj` is not none, the binary file-like object will be
+  used to read the archive instead of opening `archive_path`.
 
   Args:
       archive_path: the path to the archive.
-      file_obj: a object-like containing the archive.
+      file_obj: a file-like object containing the archive.
 
   Raises:
       If the file could not be opened or if the archive type cannot be handled.

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -307,6 +307,10 @@ class ZipArchiveReader(ArchiveReader):
       self.extract(member=member, path=path, trusted=trusted)
 
 
+class ArchiveReaderError(Exception):
+  """ArchiveReaderError"""
+
+
 def get_archive_reader(archive_path, file_obj=None):
   """Gets the appropriate archive reader based on the provided path.
 
@@ -319,15 +323,11 @@ def get_archive_reader(archive_path, file_obj=None):
       (ArchiveReader): the archive reader or None if an error occurred.
   """
   archive_type = get_archive_type(archive_path)
-  try:
-    if archive_type == ArchiveType.ZIP:
-      return ZipArchiveReader(archive_path or file_obj)
-    if archive_type in (ArchiveType.TAR_LZMA, ArchiveType.TAR):
-      return TarArchiveReader(archive_path, file_obj=file_obj)
-    return None
-  except:
-    logs.log_error(f"Could not open archive at {archive_path}.")
-    return None
+  if archive_type == ArchiveType.ZIP:
+    return ZipArchiveReader(archive_path or file_obj)
+  if archive_type in (ArchiveType.TAR_LZMA, ArchiveType.TAR):
+    return TarArchiveReader(archive_path, file_obj=file_obj)
+  raise ArchiveReaderError('Unhandled archive type.')
 
 
 class ArchiveType:

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -417,7 +417,7 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         'clusterfuzz._internal.system.shell.clear_temp_directory',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',
         'clusterfuzz._internal.google_cloud_utils.storage.get_object_size',
-        'clusterfuzz._internal.system.archive.get_archive_reader',
+        'clusterfuzz._internal.system.archive.open',
         'clusterfuzz._internal.system.archive.unpack',
         'time.time',
     ])
@@ -578,11 +578,11 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         return True
 
     file_match_callback_checker = FileMatchCallbackChecker()
-    self.mock.get_archive_reader.assert_called_with(
+    self.mock.open.assert_called_with(
         '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/'
         'revisions/file-release-2.zip',)
     self.mock.unpack.assert_called_with(
-        self.mock.get_archive_reader.return_value,
+        self.mock.open.return_value,
         '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions',
         file_match_callback=file_match_callback_checker,
         trusted=True)
@@ -594,11 +594,11 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     # If it was a partial build, the unpack should be called again.
     if unpack_all != 'True':
       self.assertEqual(2, self.mock.unpack.call_count)
-      self.mock.get_archive_reader.assert_called_with(
+      self.mock.open.assert_called_with(
           '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/'
           'revisions/file-release-2.zip',)
       self.mock.unpack.assert_called_with(
-          self.mock.get_archive_reader.return_value,
+          self.mock.open.return_value,
           '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions',
           file_match_callback=file_match_callback_checker,
           trusted=True)
@@ -641,12 +641,12 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     file_match_callback_checker = FileMatchCallbackChecker()
     self.mock.unpack.assert_has_calls([
         mock.call(
-            self.mock.get_archive_reader.return_value,
+            self.mock.open.return_value,
             '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions',
             file_match_callback=file_match_callback_checker,
             trusted=True),
         mock.call(
-            self.mock.get_archive_reader.return_value,
+            self.mock.open.return_value,
             '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions/'
             '__extra_build',
             file_match_callback=file_match_callback_checker,
@@ -662,12 +662,12 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
       self.assertEqual(4, self.mock.unpack.call_count)
       self.mock.unpack.assert_has_calls([
           mock.call(
-              self.mock.get_archive_reader.return_value,
+              self.mock.open.return_value,
               '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions',
               file_match_callback=file_match_callback_checker,
               trusted=True),
           mock.call(
-              self.mock.get_archive_reader.return_value,
+              self.mock.open.return_value,
               '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions/'
               '__extra_build',
               file_match_callback=file_match_callback_checker,
@@ -993,7 +993,7 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
         'clusterfuzz._internal.build_management.build_manager._make_space_for_build',
         'clusterfuzz._internal.system.shell.clear_temp_directory',
         'clusterfuzz._internal.google_cloud_utils.blobs.read_blob_to_disk',
-        'clusterfuzz._internal.system.archive.get_archive_reader',
+        'clusterfuzz._internal.system.archive.open',
         'clusterfuzz._internal.system.archive.unpack',
         'time.sleep',
         'time.time',
@@ -1048,12 +1048,10 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
 
     # For now, we're calling it multiple times because we're not passing the
     # reader object along in the build manager
-    self.mock.get_archive_reader.assert_called_with(
+    self.mock.open.assert_called_with(
         '/builds/job_custom/custom/custom_binary.zip',)
     self.mock.unpack.assert_called_once_with(
-        self.mock.get_archive_reader.return_value,
-        '/builds/job_custom/custom',
-        trusted=True)
+        self.mock.open.return_value, '/builds/job_custom/custom', trusted=True)
 
     self._assert_env_vars()
 
@@ -1080,12 +1078,10 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
 
     # For now, we're calling it multiple times because we're not passing the
     # reader object along in the build manager
-    self.mock.get_archive_reader.assert_called_with(
+    self.mock.open.assert_called_with(
         '/builds/job_custom/custom/custom_binary.zip',)
     self.mock.unpack.assert_called_once_with(
-        self.mock.get_archive_reader.return_value,
-        '/builds/job_custom/custom',
-        trusted=True)
+        self.mock.open.return_value, '/builds/job_custom/custom', trusted=True)
 
     self._assert_env_vars()
     self.assertEqual(os.environ['JOB_NAME'], 'job_share')
@@ -1250,7 +1246,7 @@ class AuxiliaryRegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',
         'clusterfuzz._internal.google_cloud_utils.storage.get_object_size',
         'clusterfuzz._internal.system.archive.unpack',
-        'clusterfuzz._internal.system.archive.get_archive_reader',
+        'clusterfuzz._internal.system.archive.open',
         'time.time',
     ])
 
@@ -1344,11 +1340,11 @@ class AuxiliaryRegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
     self.assertEqual(1, self.mock.unpack.call_count)
     file_match_callback_checker = FileMatchCallbackChecker()
-    self.mock.get_archive_reader.assert_called_with(
+    self.mock.open.assert_called_with(
         '/builds/path_2992e823e35fd34a63e0f8733cdafd6875036a1d/'
         'dataflow/file-dataflow-10.zip',)
     self.mock.unpack.assert_called_with(
-        self.mock.get_archive_reader.return_value,
+        self.mock.open.return_value,
         '/builds/path_2992e823e35fd34a63e0f8733cdafd6875036a1d/dataflow',
         file_match_callback=file_match_callback_checker,
         trusted=True)
@@ -1371,11 +1367,11 @@ class AuxiliaryRegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     else:
       self.assertEqual(2, self.mock.unpack.call_count)
 
-    self.mock.get_archive_reader.assert_called_with(
+    self.mock.open.assert_called_with(
         '/builds/path_2992e823e35fd34a63e0f8733cdafd6875036a1d/'
         'dataflow/file-dataflow-10.zip',)
     self.mock.unpack.assert_called_with(
-        self.mock.get_archive_reader.return_value,
+        self.mock.open.return_value,
         '/builds/path_2992e823e35fd34a63e0f8733cdafd6875036a1d/dataflow',
         file_match_callback=file_match_callback_checker,
         trusted=True)
@@ -1946,7 +1942,7 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
         'clusterfuzz._internal.google_cloud_utils.storage.get_object_size',
         'clusterfuzz._internal.google_cloud_utils.storage.list_blobs',
         'clusterfuzz._internal.google_cloud_utils.storage.read_data',
-        'clusterfuzz._internal.system.archive.get_archive_reader',
+        'clusterfuzz._internal.system.archive.open',
         'clusterfuzz._internal.system.archive.unpack',
         'time.time',
     ])
@@ -2017,11 +2013,11 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
     self._assert_env_vars('target2', 10)
 
     self.assertEqual(1, self.mock.unpack.call_count)
-    self.mock.get_archive_reader.assert_called_with(
+    self.mock.open.assert_called_with(
         '/builds/bucket_subdir_target2_77651789446b3c3a04b9f492ff141f003d437347'
         '/revisions/10.zip',)
     self.mock.unpack.assert_called_with(
-        self.mock.get_archive_reader.return_value,
+        self.mock.open.return_value,
         '/builds/bucket_subdir_target2_77651789446b3c3a04b9f492ff141f003d437347'
         '/revisions',
         file_match_callback=None,
@@ -2045,11 +2041,11 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
     self._assert_env_vars('target1', 8)
 
     self.assertEqual(1, self.mock.unpack.call_count)
-    self.mock.get_archive_reader.assert_called_with(
+    self.mock.open.assert_called_with(
         '/builds/bucket_subdir_target1_77651789446b3c3a04b9f492ff141f003d437347'
         '/revisions/8.zip',)
     self.mock.unpack.assert_called_with(
-        self.mock.get_archive_reader.return_value,
+        self.mock.open.return_value,
         '/builds/bucket_subdir_target1_77651789446b3c3a04b9f492ff141f003d437347'
         '/revisions',
         file_match_callback=None,

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -1048,7 +1048,7 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
 
     # For now, we're calling it multiple times because we're not passing the
     # reader object along in the build manager
-    self.mock.open.assert_called_with(
+    self.mock.open.assert_called_once_with(
         '/builds/job_custom/custom/custom_binary.zip',)
     self.mock.unpack.assert_called_once_with(
         self.mock.open.return_value, '/builds/job_custom/custom', trusted=True)
@@ -1078,7 +1078,7 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
 
     # For now, we're calling it multiple times because we're not passing the
     # reader object along in the build manager
-    self.mock.open.assert_called_with(
+    self.mock.open.assert_called_once_with(
         '/builds/job_custom/custom/custom_binary.zip',)
     self.mock.unpack.assert_called_once_with(
         self.mock.open.return_value, '/builds/job_custom/custom', trusted=True)

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -1400,7 +1400,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
     test_helpers.patch(self, [
         'clusterfuzz._internal.base.utils.is_chromium',
         'clusterfuzz._internal.system.shell.get_free_disk_space',
-        'clusterfuzz._internal.system.archive.extracted_size',
+        'clusterfuzz._internal.system.archive.ArchiveReader',
     ])
 
     test_helpers.patch_environ(self)
@@ -1427,7 +1427,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
 
   def test_make_space_for_build_remove_one_build(self):
     """Test make_space_for_build (remove 1 build)."""
-    self.mock.extracted_size.return_value = 1 * 1024 * 1024 * 1024  # 1 GB
+    self.mock.ArchiveReader.extracted_size.return_value = 1 * 1024 * 1024 * 1024  # 1 GB
     self.mock.get_free_disk_space.side_effect = self._mock_free_disk_space
     self.free_disk_space = [
         9 * 1024 * 1024 * 1024,
@@ -1435,7 +1435,8 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
     ]
 
     self.assertTrue(
-        build_manager._make_space_for_build('/archive.zip', '/builds/build4'))
+        build_manager._make_space_for_build(self.mock.ArchiveReader,
+                                            '/builds/build4'))
 
     self.assertTrue(os.path.isdir('/builds/build1'))
     self.assertFalse(os.path.isdir('/builds/build2'))
@@ -1444,7 +1445,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
 
   def test_make_space_for_build_remove_two_builds(self):
     """Test make_space_for_build (remove 2 builds)."""
-    self.mock.extracted_size.return_value = 1 * 1024 * 1024 * 1024  # 1 GB
+    self.mock.ArchiveReader.extracted_size.return_value = 1 * 1024 * 1024 * 1024  # 1 GB
     self.mock.get_free_disk_space.side_effect = self._mock_free_disk_space
     self.free_disk_space = [
         8 * 1024 * 1024 * 1024,
@@ -1453,7 +1454,8 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
     ]
 
     self.assertTrue(
-        build_manager._make_space_for_build('/archive.zip', '/builds/build4'))
+        build_manager._make_space_for_build(self.mock.ArchiveReader,
+                                            '/builds/build4'))
 
     self.assertTrue(os.path.isdir('/builds/build1'))
     self.assertFalse(os.path.isdir('/builds/build2'))
@@ -1462,7 +1464,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
 
   def test_make_space_for_build_remove_three_builds(self):
     """Test make_space_for_build (remove 3 builds)."""
-    self.mock.extracted_size.return_value = 1 * 1024 * 1024 * 1024  # 1 GB
+    self.mock.ArchiveReader.extracted_size.return_value = 1 * 1024 * 1024 * 1024  # 1 GB
     self.mock.get_free_disk_space.side_effect = self._mock_free_disk_space
     self.free_disk_space = [
         7 * 1024 * 1024 * 1024,
@@ -1472,7 +1474,8 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
     ]
 
     self.assertTrue(
-        build_manager._make_space_for_build('/archive.zip', '/builds/build4'))
+        build_manager._make_space_for_build(self.mock.ArchiveReader,
+                                            '/builds/build4'))
 
     self.assertFalse(os.path.isdir('/builds/build1'))
     self.assertFalse(os.path.isdir('/builds/build2'))
@@ -1481,7 +1484,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
 
   def test_make_space_for_build_fail(self):
     """Test make_space_for_build failure."""
-    self.mock.extracted_size.return_value = 20 * 1024 * 1024 * 1024  # 1 GB
+    self.mock.ArchiveReader.extracted_size.return_value = 20 * 1024 * 1024 * 1024  # 1 GB
     self.mock.get_free_disk_space.side_effect = self._mock_free_disk_space
     self.free_disk_space = [
         12 * 1024 * 1024 * 1024,
@@ -1491,7 +1494,8 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
     ]
 
     self.assertFalse(
-        build_manager._make_space_for_build('/archive.zip', '/builds/build4'))
+        build_manager._make_space_for_build(self.mock.ArchiveReader,
+                                            '/builds/build4'))
 
     self.assertFalse(os.path.isdir('/builds/build1'))
     self.assertFalse(os.path.isdir('/builds/build2'))
@@ -1504,14 +1508,15 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
     shutil.rmtree('/builds/build2')
     shutil.rmtree('/builds/build3')
 
-    self.mock.extracted_size.return_value = 20 * 1024 * 1024 * 1024  # 1 GB
+    self.mock.ArchiveReader.extracted_size.return_value = 20 * 1024 * 1024 * 1024  # 1 GB
     self.mock.get_free_disk_space.side_effect = self._mock_free_disk_space
     self.free_disk_space = [
         18 * 1024 * 1024 * 1024,
     ]
 
     self.assertFalse(
-        build_manager._make_space_for_build('/archive.zip', '/builds/build4'))
+        build_manager._make_space_for_build(self.mock.ArchiveReader,
+                                            '/builds/build4'))
 
 
 class GetFileMatchCallbackTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -417,6 +417,7 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         'clusterfuzz._internal.system.shell.clear_temp_directory',
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',
         'clusterfuzz._internal.google_cloud_utils.storage.get_object_size',
+        'clusterfuzz._internal.system.archive.get_archive_reader',
         'clusterfuzz._internal.system.archive.unpack',
         'time.time',
     ])
@@ -577,9 +578,11 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         return True
 
     file_match_callback_checker = FileMatchCallbackChecker()
-    self.mock.unpack.assert_called_with(
+    self.mock.get_archive_reader.assert_called_with(
         '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/'
-        'revisions/file-release-2.zip',
+        'revisions/file-release-2.zip',)
+    self.mock.unpack.assert_called_with(
+        self.mock.get_archive_reader.return_value,
         '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions',
         file_match_callback=file_match_callback_checker,
         trusted=True)
@@ -591,9 +594,11 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     # If it was a partial build, the unpack should be called again.
     if unpack_all != 'True':
       self.assertEqual(2, self.mock.unpack.call_count)
-      self.mock.unpack.assert_called_with(
+      self.mock.get_archive_reader.assert_called_with(
           '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/'
-          'revisions/file-release-2.zip',
+          'revisions/file-release-2.zip',)
+      self.mock.unpack.assert_called_with(
+          self.mock.get_archive_reader.return_value,
           '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions',
           file_match_callback=file_match_callback_checker,
           trusted=True)
@@ -636,14 +641,12 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     file_match_callback_checker = FileMatchCallbackChecker()
     self.mock.unpack.assert_has_calls([
         mock.call(
-            '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/'
-            'revisions/file-release-2.zip',
+            self.mock.get_archive_reader.return_value,
             '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions',
             file_match_callback=file_match_callback_checker,
             trusted=True),
         mock.call(
-            '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/'
-            'revisions/__extra_build/file-release-2.zip',
+            self.mock.get_archive_reader.return_value,
             '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions/'
             '__extra_build',
             file_match_callback=file_match_callback_checker,
@@ -659,14 +662,12 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
       self.assertEqual(4, self.mock.unpack.call_count)
       self.mock.unpack.assert_has_calls([
           mock.call(
-              '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/'
-              'revisions/file-release-2.zip',
+              self.mock.get_archive_reader.return_value,
               '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions',
               file_match_callback=file_match_callback_checker,
               trusted=True),
           mock.call(
-              '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/'
-              'revisions/__extra_build/file-release-2.zip',
+              self.mock.get_archive_reader.return_value,
               '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions/'
               '__extra_build',
               file_match_callback=file_match_callback_checker,
@@ -992,6 +993,7 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
         'clusterfuzz._internal.build_management.build_manager._make_space_for_build',
         'clusterfuzz._internal.system.shell.clear_temp_directory',
         'clusterfuzz._internal.google_cloud_utils.blobs.read_blob_to_disk',
+        'clusterfuzz._internal.system.archive.get_archive_reader',
         'clusterfuzz._internal.system.archive.unpack',
         'time.sleep',
         'time.time',
@@ -1044,8 +1046,12 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
     self.mock.read_blob_to_disk.assert_called_once_with(
         'key', '/builds/job_custom/custom/custom_binary.zip')
 
+    # For now, we're calling it multiple times because we're not passing the
+    # reader object along in the build manager
+    self.mock.get_archive_reader.assert_called_with(
+        '/builds/job_custom/custom/custom_binary.zip',)
     self.mock.unpack.assert_called_once_with(
-        '/builds/job_custom/custom/custom_binary.zip',
+        self.mock.get_archive_reader.return_value,
         '/builds/job_custom/custom',
         trusted=True)
 
@@ -1072,8 +1078,12 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
     self.mock.read_blob_to_disk.assert_called_once_with(
         'key', '/builds/job_custom/custom/custom_binary.zip')
 
+    # For now, we're calling it multiple times because we're not passing the
+    # reader object along in the build manager
+    self.mock.get_archive_reader.assert_called_with(
+        '/builds/job_custom/custom/custom_binary.zip',)
     self.mock.unpack.assert_called_once_with(
-        '/builds/job_custom/custom/custom_binary.zip',
+        self.mock.get_archive_reader.return_value,
         '/builds/job_custom/custom',
         trusted=True)
 
@@ -1240,6 +1250,7 @@ class AuxiliaryRegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         'clusterfuzz._internal.google_cloud_utils.storage.copy_file_from',
         'clusterfuzz._internal.google_cloud_utils.storage.get_object_size',
         'clusterfuzz._internal.system.archive.unpack',
+        'clusterfuzz._internal.system.archive.get_archive_reader',
         'time.time',
     ])
 
@@ -1333,9 +1344,11 @@ class AuxiliaryRegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
     self.assertEqual(1, self.mock.unpack.call_count)
     file_match_callback_checker = FileMatchCallbackChecker()
-    self.mock.unpack.assert_called_with(
+    self.mock.get_archive_reader.assert_called_with(
         '/builds/path_2992e823e35fd34a63e0f8733cdafd6875036a1d/'
-        'dataflow/file-dataflow-10.zip',
+        'dataflow/file-dataflow-10.zip',)
+    self.mock.unpack.assert_called_with(
+        self.mock.get_archive_reader.return_value,
         '/builds/path_2992e823e35fd34a63e0f8733cdafd6875036a1d/dataflow',
         file_match_callback=file_match_callback_checker,
         trusted=True)
@@ -1358,9 +1371,11 @@ class AuxiliaryRegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     else:
       self.assertEqual(2, self.mock.unpack.call_count)
 
-    self.mock.unpack.assert_called_with(
+    self.mock.get_archive_reader.assert_called_with(
         '/builds/path_2992e823e35fd34a63e0f8733cdafd6875036a1d/'
-        'dataflow/file-dataflow-10.zip',
+        'dataflow/file-dataflow-10.zip',)
+    self.mock.unpack.assert_called_with(
+        self.mock.get_archive_reader.return_value,
         '/builds/path_2992e823e35fd34a63e0f8733cdafd6875036a1d/dataflow',
         file_match_callback=file_match_callback_checker,
         trusted=True)
@@ -1931,6 +1946,7 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
         'clusterfuzz._internal.google_cloud_utils.storage.get_object_size',
         'clusterfuzz._internal.google_cloud_utils.storage.list_blobs',
         'clusterfuzz._internal.google_cloud_utils.storage.read_data',
+        'clusterfuzz._internal.system.archive.get_archive_reader',
         'clusterfuzz._internal.system.archive.unpack',
         'time.time',
     ])
@@ -2001,9 +2017,11 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
     self._assert_env_vars('target2', 10)
 
     self.assertEqual(1, self.mock.unpack.call_count)
-    self.mock.unpack.assert_called_with(
+    self.mock.get_archive_reader.assert_called_with(
         '/builds/bucket_subdir_target2_77651789446b3c3a04b9f492ff141f003d437347'
-        '/revisions/10.zip',
+        '/revisions/10.zip',)
+    self.mock.unpack.assert_called_with(
+        self.mock.get_archive_reader.return_value,
         '/builds/bucket_subdir_target2_77651789446b3c3a04b9f492ff141f003d437347'
         '/revisions',
         file_match_callback=None,
@@ -2027,9 +2045,11 @@ class SplitFuzzTargetsBuildTest(fake_filesystem_unittest.TestCase):
     self._assert_env_vars('target1', 8)
 
     self.assertEqual(1, self.mock.unpack.call_count)
-    self.mock.unpack.assert_called_with(
+    self.mock.get_archive_reader.assert_called_with(
         '/builds/bucket_subdir_target1_77651789446b3c3a04b9f492ff141f003d437347'
-        '/revisions/8.zip',
+        '/revisions/8.zip',)
+    self.mock.unpack.assert_called_with(
+        self.mock.get_archive_reader.return_value,
         '/builds/bucket_subdir_target1_77651789446b3c3a04b9f492ff141f003d437347'
         '/revisions',
         file_match_callback=None,

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -455,7 +455,6 @@ class ZipInMemoryTest(unittest.TestCase):
         fp.write(data)
       unpack_dir = os.path.join(tmp_dir, 'unpack')
       reader = archive.get_archive_reader(archive_path)
-      self.assertIsNotNone(reader)
       archive.unpack(reader, unpack_dir)
       self.assertEqual(sorted(os.listdir(unpack_dir)), sorted(filenames))
 

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -454,7 +454,9 @@ class ZipInMemoryTest(unittest.TestCase):
         data = b''.join(data for data in zip_file)
         fp.write(data)
       unpack_dir = os.path.join(tmp_dir, 'unpack')
-      archive.unpack(archive_path, unpack_dir)
+      reader = archive.get_archive_reader(archive_path)
+      self.assertIsNotNone(reader)
+      archive.unpack(reader, unpack_dir)
       self.assertEqual(sorted(os.listdir(unpack_dir)), sorted(filenames))
 
       unpacked_files = [

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -454,8 +454,8 @@ class ZipInMemoryTest(unittest.TestCase):
         data = b''.join(data for data in zip_file)
         fp.write(data)
       unpack_dir = os.path.join(tmp_dir, 'unpack')
-      reader = archive.open(archive_path)
-      archive.unpack(reader, unpack_dir)
+      with archive.open(archive_path) as reader:
+        archive.unpack(reader, unpack_dir)
       self.assertEqual(sorted(os.listdir(unpack_dir)), sorted(filenames))
 
       unpacked_files = [

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -454,7 +454,7 @@ class ZipInMemoryTest(unittest.TestCase):
         data = b''.join(data for data in zip_file)
         fp.write(data)
       unpack_dir = os.path.join(tmp_dir, 'unpack')
-      reader = archive.get_archive_reader(archive_path)
+      reader = archive.open(archive_path)
       archive.unpack(reader, unpack_dir)
       self.assertEqual(sorted(os.listdir(unpack_dir)), sorted(filenames))
 

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -40,7 +40,8 @@ class UnpackTest(unittest.TestCase):
 
   def test_extract(self):
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
-    self.assertEqual(archive.extracted_size(tar_xz_path), 7)
+    reader = archive.get_archive_reader(tar_xz_path)
+    self.assertEqual(reader.extracted_size(), 7)
 
   def test_file_list(self):
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -30,7 +30,9 @@ class UnpackTest(unittest.TestCase):
     """Test unpack with trusted=False passes with file having './' prefix."""
     tgz_path = os.path.join(TESTDATA_PATH, 'cwd-prefix.tgz')
     output_directory = tempfile.mkdtemp(prefix='cwd-prefix')
-    archive.unpack(tgz_path, output_directory, trusted=False)
+    reader = archive.get_archive_reader(tgz_path)
+    self.assertIsNotNone(reader)
+    archive.unpack(reader, output_directory, trusted=False)
 
     test_file_path = os.path.join(output_directory, 'test')
     self.assertTrue(os.path.exists(test_file_path))

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -47,7 +47,7 @@ class UnpackTest(unittest.TestCase):
   def test_file_list(self):
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
     reader = archive.open(tar_xz_path)
-    self.assertCountEqual([f.filename for f in reader.list_files()],
+    self.assertCountEqual([f.name for f in reader.list_members()],
                           ["archive_dir", "archive_dir/bye", "archive_dir/hi"])
 
 
@@ -60,8 +60,8 @@ class ArchiveReaderTest(unittest.TestCase):
     expected_results = {'archive_dir/hi': b'hi\n', 'archive_dir/bye': b'bye\n'}
     reader = archive.open(tar_xz_path)
     actual_results = {
-        f.filename: reader.open(f.filename).read()
-        for f in reader.list_files()
+        f.name: reader.open(f.name).read()
+        for f in reader.list_members()
         if not f.is_dir
     }
     self.assertEqual(actual_results, expected_results)
@@ -72,8 +72,8 @@ class ArchiveReaderTest(unittest.TestCase):
     expected_results = {'./test': b'abc\n'}
     reader = archive.open(tgz_path)
     actual_results = {
-        f.filename: reader.open(f.filename).read()
-        for f in reader.list_files()
+        f.name: reader.open(f.name).read()
+        for f in reader.list_members()
         if not f.is_dir
     }
     self.assertEqual(actual_results, expected_results)
@@ -89,14 +89,13 @@ class ArchiveReaderTest(unittest.TestCase):
 
     # Get the results we expect from iterator().
     actual_results = []
-    for file in reader.list_files():
+    for file in reader.list_members():
       # This means we can read the file.
-      handle = reader.try_open(file.filename)
+      handle = reader.try_open(file.name)
       if handle is not None:
-        actual_results.append((file.filename, file.file_size_bytes,
-                               handle.read()))
+        actual_results.append((file.name, file.size_bytes, handle.read()))
       else:
-        actual_results.append((file.filename, file.file_size_bytes, None))
+        actual_results.append((file.name, file.size_bytes, None))
 
     # Check that iterator returns what we expect it to.
     expected_results = [

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -63,7 +63,7 @@ class IteratorTest(unittest.TestCase):
     actual_results = {
         f.filename: reader.open(f.filename).read()
         for f in reader.list_files()
-        if not f.is_dir()
+        if not f.is_dir
     }
     self.assertEqual(actual_results, expected_results)
 
@@ -76,7 +76,7 @@ class IteratorTest(unittest.TestCase):
     actual_results = {
         f.filename: reader.open(f.filename).read()
         for f in reader.list_files()
-        if not f.is_dir()
+        if not f.is_dir
     }
     self.assertEqual(actual_results, expected_results)
 
@@ -96,9 +96,10 @@ class IteratorTest(unittest.TestCase):
       # This means we can read the file.
       handle = reader.try_open(file.filename)
       if handle is not None:
-        actual_results.append((file.filename, file.file_size, handle.read()))
+        actual_results.append((file.filename, file.file_size_bytes,
+                               handle.read()))
       else:
-        actual_results.append((file.filename, file.file_size, None))
+        actual_results.append((file.filename, file.file_size_bytes, None))
 
     # Check that iterator returns what we expect it to.
     expected_results = [

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -31,7 +31,6 @@ class UnpackTest(unittest.TestCase):
     tgz_path = os.path.join(TESTDATA_PATH, 'cwd-prefix.tgz')
     output_directory = tempfile.mkdtemp(prefix='cwd-prefix')
     reader = archive.get_archive_reader(tgz_path)
-    self.assertIsNotNone(reader)
     archive.unpack(reader, output_directory, trusted=False)
 
     test_file_path = os.path.join(output_directory, 'test')
@@ -48,12 +47,11 @@ class UnpackTest(unittest.TestCase):
   def test_file_list(self):
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
     reader = archive.get_archive_reader(tar_xz_path)
-    self.assertIsNotNone(reader)
     self.assertCountEqual([f.filename for f in reader.list_files()],
                           ["archive_dir", "archive_dir/bye", "archive_dir/hi"])
 
 
-class IteratorTest(unittest.TestCase):
+class ArchiveReaderTest(unittest.TestCase):
   """Tests for the archive.iterator function."""
 
   def test_tar_xz(self):
@@ -61,7 +59,6 @@ class IteratorTest(unittest.TestCase):
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
     expected_results = {'archive_dir/hi': b'hi\n', 'archive_dir/bye': b'bye\n'}
     reader = archive.get_archive_reader(tar_xz_path)
-    self.assertIsNotNone(reader)
     actual_results = {
         f.filename: reader.open(f.filename).read()
         for f in reader.list_files()
@@ -74,7 +71,6 @@ class IteratorTest(unittest.TestCase):
     tgz_path = os.path.join(TESTDATA_PATH, 'cwd-prefix.tgz')
     expected_results = {'./test': b'abc\n'}
     reader = archive.get_archive_reader(tgz_path)
-    self.assertIsNotNone(reader)
     actual_results = {
         f.filename: reader.open(f.filename).read()
         for f in reader.list_files()
@@ -90,7 +86,6 @@ class IteratorTest(unittest.TestCase):
     archive_name = 'broken-links.tar.xz'
     archive_path = os.path.join(TESTDATA_PATH, archive_name)
     reader = archive.get_archive_reader(archive_path)
-    self.assertIsNotNone(reader)
 
     # Get the results we expect from iterator().
     actual_results = []

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -44,9 +44,10 @@ class UnpackTest(unittest.TestCase):
 
   def test_file_list(self):
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
-    self.assertCountEqual(
-        archive.get_file_list(tar_xz_path),
-        ["archive_dir", "archive_dir/bye", "archive_dir/hi"])
+    reader = archive.get_archive_reader(tar_xz_path)
+    self.assertIsNotNone(reader)
+    self.assertCountEqual([f.filename for f in reader.list_files()],
+                          ["archive_dir", "archive_dir/bye", "archive_dir/hi"])
 
 
 class IteratorTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -38,6 +38,16 @@ class UnpackTest(unittest.TestCase):
 
     shell.remove_directory(output_directory)
 
+  def test_extract(self):
+    tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
+    self.assertEqual(archive.extracted_size(tar_xz_path), 7)
+
+  def test_file_list(self):
+    tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
+    self.assertCountEqual(
+        archive.get_file_list(tar_xz_path),
+        ["archive_dir", "archive_dir/bye", "archive_dir/hi"])
+
 
 class IteratorTest(unittest.TestCase):
   """Tests for the archive.iterator function."""

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -30,7 +30,7 @@ class UnpackTest(unittest.TestCase):
     """Test unpack with trusted=False passes with file having './' prefix."""
     tgz_path = os.path.join(TESTDATA_PATH, 'cwd-prefix.tgz')
     output_directory = tempfile.mkdtemp(prefix='cwd-prefix')
-    reader = archive.get_archive_reader(tgz_path)
+    reader = archive.open(tgz_path)
     archive.unpack(reader, output_directory, trusted=False)
 
     test_file_path = os.path.join(output_directory, 'test')
@@ -41,12 +41,12 @@ class UnpackTest(unittest.TestCase):
 
   def test_extract(self):
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
-    reader = archive.get_archive_reader(tar_xz_path)
+    reader = archive.open(tar_xz_path)
     self.assertEqual(reader.extracted_size(), 7)
 
   def test_file_list(self):
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
-    reader = archive.get_archive_reader(tar_xz_path)
+    reader = archive.open(tar_xz_path)
     self.assertCountEqual([f.filename for f in reader.list_files()],
                           ["archive_dir", "archive_dir/bye", "archive_dir/hi"])
 
@@ -58,7 +58,7 @@ class ArchiveReaderTest(unittest.TestCase):
     """Test that a .tar.xz file is handled properly by iterator()."""
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
     expected_results = {'archive_dir/hi': b'hi\n', 'archive_dir/bye': b'bye\n'}
-    reader = archive.get_archive_reader(tar_xz_path)
+    reader = archive.open(tar_xz_path)
     actual_results = {
         f.filename: reader.open(f.filename).read()
         for f in reader.list_files()
@@ -70,7 +70,7 @@ class ArchiveReaderTest(unittest.TestCase):
     """Test that a .tgz file with cwd prefix is handled."""
     tgz_path = os.path.join(TESTDATA_PATH, 'cwd-prefix.tgz')
     expected_results = {'./test': b'abc\n'}
-    reader = archive.get_archive_reader(tgz_path)
+    reader = archive.open(tgz_path)
     actual_results = {
         f.filename: reader.open(f.filename).read()
         for f in reader.list_files()
@@ -85,7 +85,7 @@ class ArchiveReaderTest(unittest.TestCase):
 
     archive_name = 'broken-links.tar.xz'
     archive_path = os.path.join(TESTDATA_PATH, archive_name)
-    reader = archive.get_archive_reader(archive_path)
+    reader = archive.open(archive_path)
 
     # Get the results we expect from iterator().
     actual_results = []


### PR DESCRIPTION
In chrome, we have very specific needs when it comes to unzipping. For instance, every chrome fuzzers are package with a `.runtime_deps` file that lists all the runtime dependencies needed by the target. We could use this to selectively unpack our archives.

Similarly, we could use ripunzip to improve our zipping process.

This rework will enable those new features more easily, but also make the code clearer on what exactly is going on.