### PR TITLE
Include 'chromium-testing' in testcase chromium checks.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_creation.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_creation.py
@@ -76,7 +76,7 @@ def create_blame_task_if_needed(testcase):
     return
 
   # Blame is only applicable to chromium project, otherwise bail out.
-  if testcase.project_name != 'chromium':
+  if testcase.is_chromium():
     return
 
   # We cannot run blame job for custom binaries since we don't have any context

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -576,11 +576,14 @@ class Testcase(Model):
   # Note that the number is specific to the repository.
   github_issue_num = ndb.IntegerProperty()
 
+  def is_chromium(self):
+    return self.project_name in ('chromium', 'chromium-testing')
+
   def has_blame(self):
-    return self.project_name == 'chromium'
+    return self.is_chromium()
 
   def has_impacts(self):
-    return self.project_name == 'chromium' and not self.one_time_crasher_flag
+    return self.is_chromium()
 
   def impacts_production(self):
     return (bool(self.impact_extended_stable_version) or


### PR DESCRIPTION
This should make e.g. blame task (which calls Predator) work.