### PR TITLE
Always do the substitution mapping of a label if it exists

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -246,7 +246,7 @@ def apply_substitutions(policy, label, testcase, security_severity=None):
       ]
 
   # No match found. Return mapped value if it exists else the original label
-  # will be returned..
+  # will be returned.
   return [policy.substitution_mapping(label)]
 
 

--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -245,8 +245,9 @@ def apply_substitutions(policy, label, testcase, security_severity=None):
           for label in handler(label, testcase, security_severity)
       ]
 
-  # No match found. Return unmodified label.
-  return [label]
+  # No match found. Return mapped value if it exists else the original label
+  # will be returned..
+  return [policy.substitution_mapping(label)]
 
 
 def get_label_pattern(label):


### PR DESCRIPTION
 [Config change](https://team-review.git.corp.google.com/c/gosst/clusterfuzz-config/+/2097721) to add hotlist mappings was submitted and deployed. But the `Security_Impact-*` labels are still not getting mapped to the specified hotlists.

I traced through the code and found that the substitution mapping only happens if it contains one of the known hardcoded wildcards- https://github.com/google/clusterfuzz/blob/6877dd76c50cc5b25807f91d8534a31f125197e1/src/clusterfuzz/_internal/issue_management/issue_filer.py#L244

This was unexpected because we have specified a couple more labels in the substitutions part of the config assuming they would be replaced by their hotlist IDs which will not work. Eg: `External-Fuzzer-Contribution` and `reward-topanel`.

This PR will always return the substitution mapping of a label if it exists. If no substitution mapping exists then the original label will be returned.