### PR TITLE
Fix appending of newlines

### DIFF
--- a/src/clusterfuzz/_internal/tests/appengine/handlers/crash_query_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/crash_query_test.py
@@ -144,6 +144,6 @@ class CrashQueryTest(unittest.TestCase):
     self.assertEqual({
         'result': 'new',
         'type': 'Out-of-memory',
-        'state': 'target\n',
+        'state': 'target',
         'security': False,
     }, response.json)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/upload_testcase_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/upload_testcase_test.py
@@ -156,7 +156,7 @@ class UploadOAuthTest(unittest.TestCase):
         'crash_address': '',
         'crash_revision': 1337,
         'crash_stacktrace': stacktrace,
-        'crash_state': 'target\n',
+        'crash_state': 'target',
         'crash_type': 'Out-of-memory',
         'disable_ubsan': False,
         'duplicate_of': None,
@@ -383,7 +383,7 @@ class UploadOAuthTest(unittest.TestCase):
     """Test uploading a duplicate."""
     existing = data_types.Testcase(
         crash_address='',
-        crash_state='target\n',
+        crash_state='target',
         crash_type='Out-of-memory',
         project_name='proj',
         minimized_keys='NA',
@@ -419,7 +419,7 @@ class UploadOAuthTest(unittest.TestCase):
         'crash_address': '',
         'crash_revision': 1337,
         'crash_stacktrace': stacktrace,
-        'crash_state': 'target\n',
+        'crash_state': 'target',
         'crash_type': 'Out-of-memory',
         'disable_ubsan': False,
         'duplicate_of': 2,

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -247,7 +247,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('android_null_stack.txt')
     expected_type = 'UNKNOWN'
     expected_address = '0xb6e43000'
-    expected_state = 'Surfaceflinger\n'
+    expected_state = 'Surfaceflinger'
     expected_stacktrace = data
     expected_security_flag = True
 
@@ -2454,7 +2454,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('oom4.txt')
     expected_type = 'Out-of-memory'
     expected_address = ''
-    expected_state = 'pdf_jpx_fuzzer\n'
+    expected_state = 'pdf_jpx_fuzzer'
     expected_stacktrace = data
     expected_security_flag = False
 
@@ -2539,7 +2539,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('libfuzzer_timeout.txt')
     expected_type = 'Timeout'
     expected_address = ''
-    expected_state = 'pdfium_fuzzer\n'
+    expected_state = 'pdfium_fuzzer'
     expected_stacktrace = data
     expected_security_flag = False
     expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
@@ -2570,7 +2570,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('libfuzzer_oom.txt')
     expected_type = 'Out-of-memory'
     expected_address = ''
-    expected_state = 'freetype2_fuzzer\n'
+    expected_state = 'freetype2_fuzzer'
     expected_stacktrace = data
     expected_security_flag = False
     expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
@@ -2594,7 +2594,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('libfuzzer_oom.txt')
     expected_type = 'Out-of-memory'
     expected_address = ''
-    expected_state = 'freetype2_fuzzer\n'
+    expected_state = 'freetype2_fuzzer'
     expected_stacktrace = data
     expected_security_flag = False
     expected_categories = {'Fuzzer-exit', 'Fuzzer-crash-state'}
@@ -3173,7 +3173,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('libfuzzer_overwrites_const_input.txt')
     expected_type = 'Overwrites-const-input'
     expected_address = ''
-    expected_state = 'ap-mgmt\n'
+    expected_state = 'ap-mgmt'
 
     expected_stacktrace = data
     expected_security_flag = False

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -343,7 +343,8 @@ class StackParser:
       if state.crash_type not in ['V8 correctness failure']:
         state.crash_state = filter_addresses_and_numbers(state.crash_state)
 
-      # Truncate each line in the crash state to avoid excessive length.
+      # Truncate each line in the crash state to avoid excessive length. This
+      # also ensures a trailing '\n' in the crash state.
       original_crash_state = state.crash_state
       state.crash_state = ''
       for line in original_crash_state.splitlines():
@@ -365,11 +366,6 @@ class StackParser:
         'Out-of-memory', 'Timeout', 'Overwrites-const-input'
     ]:
       state.crash_state = self.fuzz_target
-
-    # Add a trailing \n if it does not exist in crash state.
-    if (state.crash_state and state.crash_state != 'NULL' and
-        state.crash_state[-1] != '\n'):
-      state.crash_state += '\n'
 
     # Normalize access size parameter if greater than 16 bytes.
     m = re.match('([^0-9]+)([0-9]+)', state.crash_type, re.DOTALL)


### PR DESCRIPTION
If the crash_state holds multiple lines, we already append a '\n' also after the last line. If we use 'NULL' for the state, we do not append a '\n'. Hence also do not append the newline if the fuzz target is being used as the crash state.