### PR TITLE
Use fuzz target name instead of "NULL"

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1764,6 +1764,21 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_sanitizer_signal_abrt_fuzz_target(self):
+    """Same as above, but this time we specify a fuzz target which should
+    then be used as fallback crash state."""
+    os.environ['FUZZ_TARGET'] = 'mock-fuzz-target'
+    data = self._read_test_data('sanitizer_signal_abrt_unknown.txt')
+    expected_type = 'Abrt'
+    expected_address = '0x000000000001'
+    expected_state = 'mock-fuzz-target\n'
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_syzkaller_kasan(self):
     """Test syzkaller kasan."""
     data = self._read_test_data('kasan_syzkaller.txt')

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -36,7 +36,7 @@ class CrashInfo:
     self.crash_stacktrace = ''
     self.crash_categories = set()
     self.frame_count = 0
-    self.process_name = 'NULL'
+    self.process_name = None
     self.process_died = False
 
     # Following fields are for internal use only and subject to change. Do not
@@ -354,10 +354,10 @@ class StackParser:
         else:
           state.crash_state += line[:LINE_LENGTH_CAP] + '\n'
 
-    # Don't return an empty crash state if we have a crash type. Either set
-    # to NULL or use the crashing process name if available.
+    # Don't return an empty crash state if we have a crash type. Use the
+    # process name or fuzz target if available, or set to 'NULL'.
     if state.crash_type and not state.crash_state.strip():
-      state.crash_state = state.process_name
+      state.crash_state = state.process_name or self.fuzz_target or 'NULL'
 
     # For timeout, OOMs, const-input-overwrites in fuzz targets, force use of
     # fuzz target name since stack itself is not usable for deduplication.


### PR DESCRIPTION
If no process name is available but we have a fuzz target name, use that
instead of "NULL".
This hopefully reduces the amount of "Abrt · NULL" reports we are
seeing.
