### PR TITLE
Use the "Component Tags" custom field to store additional components in google_issue_tracker

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -29,7 +29,7 @@ _NUM_RETRIES = 3
 _ISSUE_TRACKER_URL = 'https://issuetracker.google.com/issues'
 
 _CHROMIUM_OS_CUSTOM_FIELD_ID = '1223084'  # Uses Repeated Enums
-_CHROMIUM_COMPONENT_TAGS_CUSTOM_FIELD_ID = '1222907'  # Uses Repated Enums
+_CHROMIUM_COMPONENT_TAGS_CUSTOM_FIELD_ID = '1222907'  # Uses Repeated Enums
 
 # TODO(rmistry): This is using the field ID of Respin because FoundIn has not
 # been created yet. Update it to use the real field ID when it exists.

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -367,20 +367,17 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         'issue title',
                     'type':
                         'BUG',
-                    'customFields': [
-                      {
+                    'customFields': [{
                         'customFieldId': '1223084',
                         'repeatedEnumValue': {
                             'values': ['Linux', 'Android']
-                          },
-                      },
-                      {
+                        },
+                    }, {
                         'customFieldId': '1222907',
                         'repeatedEnumValue': {
                             'values': ['ABC>DEF', 'IJK>XYZ']
                         }
-                      }
-                    ],
+                    }],
                     'foundInVersions': ['123', '789'],
                     'severity':
                         'S4',
@@ -659,13 +656,12 @@ class GoogleIssueTrackerTest(unittest.TestCase):
   def test_update_issue_with_component_tags(self):
     """Test updating an existing issue with component tags."""
     self.client.issues().get().execute.return_value = {
-        'issueId': '68828938',
-        'customFields': [
-          {
+        'issueId':
+            '68828938',
+        'customFields': [{
             'customFieldId': '1222907',
             'enumValues': ['ABC>DEF', 'IJK', 'XYZ'],
-          }
-        ],
+        }],
         'issueState': {
             'componentId':
                 '29002',
@@ -698,13 +694,16 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             'retention':
                 'COMPONENT_DEFAULT',
         },
-        'createdTime': '2019-06-25T01:29:30.021Z',
-        'modifiedTime': '2019-06-25T01:29:30.021Z',
+        'createdTime':
+            '2019-06-25T01:29:30.021Z',
+        'modifiedTime':
+            '2019-06-25T01:29:30.021Z',
         'userData': {},
         'accessLimit': {
             'accessLevel': 'INTERNAL'
         },
-        'etag': 'TmpnNE1qZzVNemd0TUMweA==',
+        'etag':
+            'TmpnNE1qZzVNemd0TUMweA==',
         'lastModifier': {
             'emailAddress': 'user1@google.com',
             'userGaiaStatus': 'ACTIVE'
@@ -749,13 +748,10 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         }
                     },],
                 },
-                'addMask':
-                    'status,assignee,reporter,title,ccs,customFields',
+                'addMask': 'status,assignee,reporter,title,ccs,customFields',
                 'remove': {},
-                'removeMask':
-                    '',
-                'significanceOverride':
-                    'MAJOR',
+                'removeMask': '',
+                'significanceOverride': 'MAJOR',
             },
         ),
         mock.call().execute(http=None, num_retries=3),

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -116,7 +116,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     self.assertTrue(issue.is_open)
     self.assertEqual('NEW', issue.status)
     self.assertCountEqual([], issue.labels)
-    self.assertCountEqual(['29002'], issue.components)
+    self.assertCountEqual([], issue.components)
     self.assertCountEqual([], issue.ccs)
     self.assertEqual('test body', issue.body)
 
@@ -227,7 +227,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title'
@@ -254,7 +253,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId': 9001,
+                    'componentId': 1337,
                     'hotlistIds': [12345],
                     'type': 'BUG',
                     'severity': 'S4',
@@ -272,7 +271,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.labels.add('OS-Linux')
     issue.labels.add('OS-Android')
@@ -286,7 +284,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             body={
                 'issueState': {
                     'componentId':
-                        9001,
+                        1337,
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
@@ -326,6 +324,76 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call().execute(http=None, num_retries=3),
     ])
 
+  def test_new_issue_with_component_tags(self):
+    """Test new issue creation with component tags."""
+    issue = self.issue_tracker.new_issue()
+    issue.reporter = 'reporter@google.com'
+    issue.assignee = 'assignee@google.com'
+    issue.body = 'issue body'
+    issue.ccs.add('cc@google.com')
+    issue.labels.add('12345')
+    issue.labels.add('OS-Linux')
+    issue.labels.add('OS-Android')
+    issue.labels.add('FoundIn-123')
+    issue.labels.add('FoundIn-789')
+    issue.components.add('ABC>DEF')
+    issue.components.add('IJK>XYZ')
+    issue.status = 'ASSIGNED'
+    issue.title = 'issue title'
+    issue.save()
+    self.client.issues().create.assert_has_calls([
+        mock.call(
+            body={
+                'issueState': {
+                    'componentId':
+                        1337,
+                    'ccs': [{
+                        'emailAddress': 'cc@google.com'
+                    }],
+                    'collaborators': [],
+                    'hotlistIds': [12345],
+                    'accessLimit': {
+                        'accessLevel': issue_tracker.IssueAccessLevel.LIMIT_NONE
+                    },
+                    'reporter': {
+                        'emailAddress': 'reporter@google.com'
+                    },
+                    'assignee': {
+                        'emailAddress': 'assignee@google.com'
+                    },
+                    'status':
+                        'ASSIGNED',
+                    'title':
+                        'issue title',
+                    'type':
+                        'BUG',
+                    'customFields': [
+                      {
+                        'customFieldId': '1223084',
+                        'repeatedEnumValue': {
+                            'values': ['Linux', 'Android']
+                          },
+                      },
+                      {
+                        'customFieldId': '1222907',
+                        'repeatedEnumValue': {
+                            'values': ['ABC>DEF', 'IJK>XYZ']
+                        }
+                      }
+                    ],
+                    'foundInVersions': ['123', '789'],
+                    'severity':
+                        'S4',
+                },
+                'issueComment': {
+                    'comment': 'issue body'
+                },
+            },
+            templateOptions_applyTemplate=True,
+        ),
+        mock.call().execute(http=None, num_retries=3),
+    ])
+
   def test_new_security_issue(self):
     """Test creation of security issue."""
     issue = self.issue_tracker.new_issue()
@@ -338,7 +406,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.labels.add('67890')
     issue.status = 'ASSIGNED'
@@ -350,7 +417,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             body={
                 'issueState': {
                     'componentId':
-                        9001,
+                        1337,
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
@@ -398,7 +465,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         'issueId': '68828938',
         'issueState': {
             'componentId':
-                '9001',
+                '1337',
             'type':
                 'ASSIGNED',
             'status':
@@ -443,7 +510,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title2'
@@ -479,10 +545,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             body={'hotlistEntry': {
                 'issueId': '68828938'
             }}, hotlistId='12345'),
-        mock.call().execute(http=None, num_retries=3),
-    ])
-    self.client.issues().move.assert_has_calls([
-        mock.call(body={'componentId': 9001}, issueId='68828938'),
         mock.call().execute(http=None, num_retries=3),
     ])
     # Update again, removing the label we just added.
@@ -547,7 +609,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title2'
@@ -595,6 +656,111 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call().execute(http=None, num_retries=3),
     ])
 
+  def test_update_issue_with_component_tags(self):
+    """Test updating an existing issue with component tags."""
+    self.client.issues().get().execute.return_value = {
+        'issueId': '68828938',
+        'customFields': [
+          {
+            'customFieldId': '1222907',
+            'enumValues': ['ABC>DEF', 'IJK', 'XYZ'],
+          }
+        ],
+        'issueState': {
+            'componentId':
+                '29002',
+            'type':
+                'BUG',
+            'customFields': [
+                {
+                    'customFieldId': '1222907',
+                    'repeatedEnumValue': {
+                        'values': ['ABC>DEF']  # Existing Component Tag.
+                    },
+                },
+            ],
+            'status':
+                'NEW',
+            'priority':
+                'P2',
+            'severity':
+                'S2',
+            'title':
+                'test',
+            'reporter': {
+                'emailAddress': 'user1@google.com',
+                'userGaiaStatus': 'ACTIVE'
+            },
+            'assignee': {
+                'emailAddress': 'assignee@google.com',
+                'userGaiaStatus': 'ACTIVE'
+            },
+            'retention':
+                'COMPONENT_DEFAULT',
+        },
+        'createdTime': '2019-06-25T01:29:30.021Z',
+        'modifiedTime': '2019-06-25T01:29:30.021Z',
+        'userData': {},
+        'accessLimit': {
+            'accessLevel': 'INTERNAL'
+        },
+        'etag': 'TmpnNE1qZzVNemd0TUMweA==',
+        'lastModifier': {
+            'emailAddress': 'user1@google.com',
+            'userGaiaStatus': 'ACTIVE'
+        },
+    }
+    issue = self.issue_tracker.get_issue(68828938)
+    issue.reporter = 'reporter@google.com'
+    issue.assignee = 'assignee2@google.com'
+    issue.ccs.add('cc@google.com')
+    issue.labels.add('12345')
+    issue.status = 'ASSIGNED'
+    issue.title = 'issue title2'
+    # Adding three more Component Tags here.
+    issue.components.add('IJK')
+    issue.components.add('XYZ')
+    # Will be rejected because it is not in allowed enum values.
+    issue.components.add('AAA')
+    issue.save()
+
+    self.client.issues().modify.assert_has_calls([
+        mock.call(
+            issueId='68828938',
+            body={
+                'add': {
+                    'status':
+                        'ASSIGNED',
+                    'assignee': {
+                        'emailAddress': 'assignee2@google.com'
+                    },
+                    'reporter': {
+                        'emailAddress': 'reporter@google.com'
+                    },
+                    'title':
+                        'issue title2',
+                    'ccs': [{
+                        'emailAddress': 'cc@google.com'
+                    }],
+                    'customFields': [{
+                        'customFieldId': '1222907',
+                        'repeatedEnumValue': {
+                            'values': ['ABC>DEF', 'IJK', 'XYZ']
+                        }
+                    },],
+                },
+                'addMask':
+                    'status,assignee,reporter,title,ccs,customFields',
+                'remove': {},
+                'removeMask':
+                    '',
+                'significanceOverride':
+                    'MAJOR',
+            },
+        ),
+        mock.call().execute(http=None, num_retries=3),
+    ])
+
   def test_update_issue_to_security(self):
     """Test updating an existing issue."""
     self.client.issues().get().execute.return_value = BASIC_ISSUE
@@ -602,7 +768,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         'issueId': '68828938',
         'issueState': {
             'componentId':
-                '9001',
+                '1337',
             'type':
                 'ASSIGNED',
             'status':
@@ -651,7 +817,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title2'


### PR DESCRIPTION
Google Issue Tracker has support for only one component per issue. The Chrome-on-Buganizer team has added a "Component Tags" custom field with which each issue can have multiple components (similar to behavior in Monorail).

This required refactoring of how components are handled in google_issue_tracker.

More context is in b/315853316