### PR TITLE
Add support for the ReleaseBlock custom field in google_issue_tracker and check substitution mappings

### DIFF
--- a/src/clusterfuzz/_internal/cron/cleanup.py
+++ b/src/clusterfuzz/_internal/cron/cleanup.py
@@ -136,7 +136,7 @@ def cleanup_testcases_and_issues():
       update_fuzz_blocker_label(policy, testcase, issue,
                                 top_crashes_by_project_and_platform_map)
       logs.log('maybe updated fuzz blocker')
-      update_component_labels(testcase, issue)
+      update_component_labels(policy, testcase, issue)
       logs.log('maybe updated component labels')
       update_issue_ccs_from_owners_file(policy, testcase, issue)
       logs.log('maybe updated issueccs')
@@ -1020,7 +1020,7 @@ def update_fuzz_blocker_label(policy, testcase, issue,
   issue.save(new_comment=update_message, notify=True)
 
 
-def update_component_labels(testcase, issue):
+def update_component_labels(policy, testcase, issue):
   """Add components to the issue if needed."""
   if not issue:
     return
@@ -1053,7 +1053,8 @@ def update_component_labels(testcase, issue):
   for filtered_component in filtered_components:
     issue.components.add(filtered_component)
 
-  issue.labels.add(data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_COMPONENTS_LABEL)
+  issue.labels.add(policy.substitution_mapping(
+      data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_COMPONENTS_LABEL))
   label_text = issue.issue_tracker.label_text(
       data_types.CHROMIUM_ISSUE_PREDATOR_WRONG_COMPONENTS_LABEL)
   issue_comment = (
@@ -1218,7 +1219,8 @@ def update_issue_owner_and_ccs_from_predator_results(policy,
 
     # We have high confidence for the single-CL case, so we assign the owner.
     logs.log('Updating issue')
-    issue.labels.add(data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_OWNER_LABEL)
+    issue.labels.add(policy.substitution_mapping(
+      data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_OWNER_LABEL))
     issue.assignee = suspected_cl['author']
     issue.status = policy.status('assigned')
     issue_comment = (
@@ -1277,7 +1279,8 @@ def update_issue_owner_and_ccs_from_predator_results(policy,
 
     label_text = issue.issue_tracker.label_text(
         data_types.CHROMIUM_ISSUE_PREDATOR_WRONG_CL_LABEL)
-    issue.labels.add(data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_CC_LABEL)
+    issue.labels.add(policy.substitution_mapping(
+        data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_CC_LABEL))
     issue_comment += (
         'If this is incorrect, please let us know why and apply the '
         f'{label_text}.')

--- a/src/clusterfuzz/_internal/cron/cleanup.py
+++ b/src/clusterfuzz/_internal/cron/cleanup.py
@@ -1053,8 +1053,9 @@ def update_component_labels(policy, testcase, issue):
   for filtered_component in filtered_components:
     issue.components.add(filtered_component)
 
-  issue.labels.add(policy.substitution_mapping(
-      data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_COMPONENTS_LABEL))
+  issue.labels.add(
+      policy.substitution_mapping(
+          data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_COMPONENTS_LABEL))
   label_text = issue.issue_tracker.label_text(
       data_types.CHROMIUM_ISSUE_PREDATOR_WRONG_COMPONENTS_LABEL)
   issue_comment = (
@@ -1219,8 +1220,9 @@ def update_issue_owner_and_ccs_from_predator_results(policy,
 
     # We have high confidence for the single-CL case, so we assign the owner.
     logs.log('Updating issue')
-    issue.labels.add(policy.substitution_mapping(
-      data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_OWNER_LABEL))
+    issue.labels.add(
+        policy.substitution_mapping(
+            data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_OWNER_LABEL))
     issue.assignee = suspected_cl['author']
     issue.status = policy.status('assigned')
     issue_comment = (
@@ -1279,8 +1281,9 @@ def update_issue_owner_and_ccs_from_predator_results(policy,
 
     label_text = issue.issue_tracker.label_text(
         data_types.CHROMIUM_ISSUE_PREDATOR_WRONG_CL_LABEL)
-    issue.labels.add(policy.substitution_mapping(
-        data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_CC_LABEL))
+    issue.labels.add(
+        policy.substitution_mapping(
+            data_types.CHROMIUM_ISSUE_PREDATOR_AUTO_CC_LABEL))
     issue_comment += (
         'If this is incorrect, please let us know why and apply the '
         f'{label_text}.')

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -31,7 +31,7 @@ _ISSUE_TRACKER_URL = 'https://issuetracker.google.com/issues'
 # These custom fields use repeated enums.
 _CHROMIUM_OS_CUSTOM_FIELD_ID = '1223084'
 _CHROMIUM_COMPONENT_TAGS_CUSTOM_FIELD_ID = '1222907'
-_CHROMIUM_RELEASE_BLOCK_CUSTOM_FIELD_ID = '1223086'  
+_CHROMIUM_RELEASE_BLOCK_CUSTOM_FIELD_ID = '1223086'
 
 # TODO(rmistry): This is using the field ID of Respin because FoundIn has not
 # been created yet. Update it to use the real field ID when it exists.

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -29,7 +29,7 @@ _NUM_RETRIES = 3
 _ISSUE_TRACKER_URL = 'https://issuetracker.google.com/issues'
 
 _CHROMIUM_OS_CUSTOM_FIELD_ID = '1223084'  # Uses Repeated Enums
-_CHROMIUM_COMPONENT_TAGS_CUSTOM_FIELD_ID = '1222907'  # Uses Repated Enums
+_CHROMIUM_COMPONENT_TAGS_CUSTOM_FIELD_ID = '1222907'  # Uses Repeated Enums
 
 # TODO(rmistry): This is using the field ID of Respin because FoundIn has not
 # been created yet. Update it to use the real field ID when it exists.

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -909,6 +909,8 @@ def _get_severity_from_crash_text(crash_severity_text):
 #   issue.labels.add('OS-Android')
 #   issue.labels.add('FoundIn-123')
 #   issue.labels.add('FoundIn-789')
+#   issue.labels.add('ReleaseBlock-Dev')
+#   issue.labels.add('ReleaseBlock-Beta')
 #   issue.components.add('OS>Software>Enterprise>Policies')
 #   issue.components.add('Blink>JavaScript>Compiler>Sparkplug')
 #   issue.apply_extension_fields({
@@ -927,6 +929,8 @@ def _get_severity_from_crash_text(crash_severity_text):
 #   queried_issue.labels.add('OS-ChromeOS')
 #   queried_issue.labels.add('FoundIn-456')
 #   queried_issue.labels.add('FoundIn-6')
+#   queried_issue.labels.add('ReleaseBlock-Beta')
+#   queried_issue.labels.add('ReleaseBlock-Dev')
 #   queried_issue.components.add('Blink>JavaScript>Compiler>Sparkplug')
 #   queried_issue.components.add('OS>Software>Enterprise>ChromeApps')
 #   queried_issue.components.add('OS>Systems>Network>General')

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/cleanup_test.py
@@ -1368,6 +1368,7 @@ class UpdateComponentsTest(unittest.TestCase):
   def setUp(self):
     self.issue = appengine_test_utils.create_generic_issue()
     self.testcase = test_utils.create_generic_testcase()
+    self.policy = issue_tracker_policy.get('test-project')
 
   def test_components_added(self):
     """Ensure that we add components when applicable."""
@@ -1376,7 +1377,7 @@ class UpdateComponentsTest(unittest.TestCase):
             'suspected_components': ['A', 'B>C']
         }})
 
-    cleanup.update_component_labels(self.testcase, self.issue)
+    cleanup.update_component_labels(self.policy, self.testcase, self.issue)
     self.assertIn('A', self.issue.components)
     self.assertIn('B>C', self.issue.components)
     self.assertIn('Test-Predator-Auto-Components', self.issue.labels)
@@ -1392,7 +1393,7 @@ class UpdateComponentsTest(unittest.TestCase):
         labels=['Test-Predator-Auto-Components'])
     self.issue._monorail_issue.comments.append(comment)
 
-    cleanup.update_component_labels(self.testcase, self.issue)
+    cleanup.update_component_labels(self.policy, self.testcase, self.issue)
     self.assertNotIn('A', self.issue.components)
     self.assertNotIn('B>C', self.issue.components)
     self.assertNotIn('Test-Predator-Auto-Components', self.issue.labels)
@@ -1401,7 +1402,7 @@ class UpdateComponentsTest(unittest.TestCase):
     """Ensure that we don't add label when there is no component in result."""
     self.testcase.set_metadata('predator_result', {})
     self.issue.components.add('A')
-    cleanup.update_component_labels(self.testcase, self.issue)
+    cleanup.update_component_labels(self.policy, self.testcase, self.issue)
     self.assertIn('A', self.issue.components)
     self.assertNotIn('Test-Predator-Auto-Components', self.issue.labels)
 
@@ -1414,7 +1415,7 @@ class UpdateComponentsTest(unittest.TestCase):
     self.issue.components.add('A')
     self.issue.components.add('B>C')
     self.issue.components.add('D')
-    cleanup.update_component_labels(self.testcase, self.issue)
+    cleanup.update_component_labels(self.policy, self.testcase, self.issue)
     self.assertIn('A', self.issue.components)
     self.assertIn('B>C', self.issue.components)
     self.assertIn('D', self.issue.components)
@@ -1429,7 +1430,7 @@ class UpdateComponentsTest(unittest.TestCase):
                                }})
     self.issue.components.add('A>B')
     self.issue.components.add('D')
-    cleanup.update_component_labels(self.testcase, self.issue)
+    cleanup.update_component_labels(self.policy, self.testcase, self.issue)
     self.assertNotIn('A', self.issue.components)
     self.assertIn('A>B', self.issue.components)
     self.assertIn('D', self.issue.components)
@@ -1444,7 +1445,7 @@ class UpdateComponentsTest(unittest.TestCase):
                                }})
     self.issue.components.add('A>B')
     self.issue.components.add('D')
-    cleanup.update_component_labels(self.testcase, self.issue)
+    cleanup.update_component_labels(self.policy, self.testcase, self.issue)
     self.assertNotIn('A', self.issue.components)
     self.assertIn('A>B', self.issue.components)
     self.assertIn('D', self.issue.components)
@@ -1460,7 +1461,7 @@ class UpdateComponentsTest(unittest.TestCase):
                                }})
     self.issue.components.add('AA>B')
     self.issue.components.add('D')
-    cleanup.update_component_labels(self.testcase, self.issue)
+    cleanup.update_component_labels(self.policy, self.testcase, self.issue)
     self.assertIn('A', self.issue.components)
     self.assertIn('AA>B', self.issue.components)
     self.assertIn('D', self.issue.components)

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -264,8 +264,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call().execute(http=None, num_retries=3),
     ])
 
-  def test_new_issue_with_os_and_foundin_labels(self):
-    """Test new issue creation with os and foundin labels."""
+  def test_new_issue_with_os_foundin_releaseblock_labels(self):
+    """Test new issue creation with os, foundin, releaseblock labels."""
     issue = self.issue_tracker.new_issue()
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee@google.com'
@@ -276,6 +276,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.labels.add('OS-Android')
     issue.labels.add('FoundIn-123')
     issue.labels.add('FoundIn-789')
+    issue.labels.add('ReleaseBlock-Dev')
+    issue.labels.add('ReleaseBlock-Beta')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title'
     issue.save()
@@ -305,12 +307,20 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         'issue title',
                     'type':
                         'BUG',
-                    'customFields': [{
+                    'customFields': [
+                      {
                         'customFieldId': '1223084',
                         'repeatedEnumValue': {
                             'values': ['Linux', 'Android']
                         }
-                    },],
+                      },
+                      {
+                        'customFieldId': '1223086',
+                        'repeatedEnumValue': {
+                            'values': ['Dev', 'Beta']
+                        }
+                      },
+                    ],
                     'foundInVersions': ['123', '789'],
                     'severity':
                         'S4',
@@ -553,7 +563,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call().execute(http=None, num_retries=3),
     ])
 
-  def test_update_issue_with_os_foundin_labels(self):
+  def test_update_issue_with_os_foundin_releaseblock_labels(self):
     """Test updating an existing issue with OS and FoundIn labels."""
     self.client.issues().get().execute.return_value = {
         'issueId': '68828938',
@@ -567,6 +577,12 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'customFieldId': '1223084',
                     'repeatedEnumValue': {
                         'values': ['Linux']  # Existing OS-Linux.
+                    },
+                },
+                {
+                    'customFieldId': '1223086',
+                    'repeatedEnumValue': {
+                        'values': ['Dev']  # Existing ReleaseBlock-Dev.
                     },
                 },
             ],
@@ -613,6 +629,9 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.labels.add('OS-Android')
     # Adding FoundIn 789 here (in addition to the 123 already set).
     issue.labels.add('FoundIn-789')
+    # Adding ReleaseBlock Beta and Stable (in addition to Dev already set).
+    issue.labels.add('ReleaseBlock-Beta')
+    issue.labels.add('ReleaseBlock-Stable')
     issue.save()
 
     self.client.issues().modify.assert_has_calls([
@@ -633,12 +652,20 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
-                    'customFields': [{
+                    'customFields': [
+                      {
                         'customFieldId': '1223084',
                         'repeatedEnumValue': {
                             'values': ['Linux', 'Android']
                         }
-                    },],
+                      },
+                      {
+                        'customFieldId': '1223086',
+                        'repeatedEnumValue': {
+                            'values': ['Dev', 'Beta', 'Stable']
+                        }
+                      },
+                    ],
                     'foundInVersions': ['123', '789'],
                 },
                 'addMask':

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -367,20 +367,17 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         'issue title',
                     'type':
                         'BUG',
-                    'customFields': [
-                      {
+                    'customFields': [{
                         'customFieldId': '1223084',
                         'repeatedEnumValue': {
                             'values': ['Linux', 'Android']
-                          },
-                      },
-                      {
+                        },
+                    }, {
                         'customFieldId': '1222907',
                         'repeatedEnumValue': {
                             'values': ['ABC>DEF', 'IJK>XYZ']
                         }
-                      }
-                    ],
+                    }],
                     'foundInVersions': ['123', '789'],
                     'severity':
                         'S4',
@@ -659,13 +656,12 @@ class GoogleIssueTrackerTest(unittest.TestCase):
   def test_update_issue_with_component_tags(self):
     """Test updating an existing issue with component tags."""
     self.client.issues().get().execute.return_value = {
-        'issueId': '68828938',
-        'customFields': [
-          {
+        'issueId':
+            '68828938',
+        'customFields': [{
             'customFieldId': '1222907',
             'enumValues': ['ABC>DEF', 'IJK', 'XYZ'],
-          }
-        ],
+        }],
         'issueState': {
             'componentId':
                 '29002',
@@ -698,13 +694,16 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             'retention':
                 'COMPONENT_DEFAULT',
         },
-        'createdTime': '2019-06-25T01:29:30.021Z',
-        'modifiedTime': '2019-06-25T01:29:30.021Z',
+        'createdTime':
+            '2019-06-25T01:29:30.021Z',
+        'modifiedTime':
+            '2019-06-25T01:29:30.021Z',
         'userData': {},
         'accessLimit': {
             'accessLevel': 'INTERNAL'
         },
-        'etag': 'TmpnNE1qZzVNemd0TUMweA==',
+        'etag':
+            'TmpnNE1qZzVNemd0TUMweA==',
         'lastModifier': {
             'emailAddress': 'user1@google.com',
             'userGaiaStatus': 'ACTIVE'
@@ -749,13 +748,10 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         }
                     },],
                 },
-                'addMask':
-                    'status,assignee,reporter,title,ccs,customFields',
+                'addMask': 'status,assignee,reporter,title,ccs,customFields',
                 'remove': {},
-                'removeMask':
-                    '',
-                'significanceOverride':
-                    'MAJOR',
+                'removeMask': '',
+                'significanceOverride': 'MAJOR',
             },
         ),
         mock.call().execute(http=None, num_retries=3),

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -308,18 +308,18 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'type':
                         'BUG',
                     'customFields': [
-                      {
-                        'customFieldId': '1223084',
-                        'repeatedEnumValue': {
-                            'values': ['Linux', 'Android']
-                        }
-                      },
-                      {
-                        'customFieldId': '1223086',
-                        'repeatedEnumValue': {
-                            'values': ['Dev', 'Beta']
-                        }
-                      },
+                        {
+                            'customFieldId': '1223084',
+                            'repeatedEnumValue': {
+                                'values': ['Linux', 'Android']
+                            }
+                        },
+                        {
+                            'customFieldId': '1223086',
+                            'repeatedEnumValue': {
+                                'values': ['Dev', 'Beta']
+                            }
+                        },
                     ],
                     'foundInVersions': ['123', '789'],
                     'severity':
@@ -653,18 +653,18 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         'emailAddress': 'cc@google.com'
                     }],
                     'customFields': [
-                      {
-                        'customFieldId': '1223084',
-                        'repeatedEnumValue': {
-                            'values': ['Linux', 'Android']
-                        }
-                      },
-                      {
-                        'customFieldId': '1223086',
-                        'repeatedEnumValue': {
-                            'values': ['Dev', 'Beta', 'Stable']
-                        }
-                      },
+                        {
+                            'customFieldId': '1223084',
+                            'repeatedEnumValue': {
+                                'values': ['Linux', 'Android']
+                            }
+                        },
+                        {
+                            'customFieldId': '1223086',
+                            'repeatedEnumValue': {
+                                'values': ['Dev', 'Beta', 'Stable']
+                            }
+                        },
                     ],
                     'foundInVersions': ['123', '789'],
                 },

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -116,7 +116,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     self.assertTrue(issue.is_open)
     self.assertEqual('NEW', issue.status)
     self.assertCountEqual([], issue.labels)
-    self.assertCountEqual(['29002'], issue.components)
+    self.assertCountEqual([], issue.components)
     self.assertCountEqual([], issue.ccs)
     self.assertEqual('test body', issue.body)
 
@@ -227,7 +227,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title'
@@ -254,7 +253,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'assignee': {
                         'emailAddress': 'assignee@google.com'
                     },
-                    'componentId': 9001,
+                    'componentId': 1337,
                     'hotlistIds': [12345],
                     'type': 'BUG',
                     'severity': 'S4',
@@ -272,7 +271,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.labels.add('OS-Linux')
     issue.labels.add('OS-Android')
@@ -286,7 +284,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             body={
                 'issueState': {
                     'componentId':
-                        9001,
+                        1337,
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
@@ -326,6 +324,76 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call().execute(http=None, num_retries=3),
     ])
 
+  def test_new_issue_with_component_tags(self):
+    """Test new issue creation with component tags."""
+    issue = self.issue_tracker.new_issue()
+    issue.reporter = 'reporter@google.com'
+    issue.assignee = 'assignee@google.com'
+    issue.body = 'issue body'
+    issue.ccs.add('cc@google.com')
+    issue.labels.add('12345')
+    issue.labels.add('OS-Linux')
+    issue.labels.add('OS-Android')
+    issue.labels.add('FoundIn-123')
+    issue.labels.add('FoundIn-789')
+    issue.components.add('ABC>DEF')
+    issue.components.add('IJK>XYZ')
+    issue.status = 'ASSIGNED'
+    issue.title = 'issue title'
+    issue.save()
+    self.client.issues().create.assert_has_calls([
+        mock.call(
+            body={
+                'issueState': {
+                    'componentId':
+                        1337,
+                    'ccs': [{
+                        'emailAddress': 'cc@google.com'
+                    }],
+                    'collaborators': [],
+                    'hotlistIds': [12345],
+                    'accessLimit': {
+                        'accessLevel': issue_tracker.IssueAccessLevel.LIMIT_NONE
+                    },
+                    'reporter': {
+                        'emailAddress': 'reporter@google.com'
+                    },
+                    'assignee': {
+                        'emailAddress': 'assignee@google.com'
+                    },
+                    'status':
+                        'ASSIGNED',
+                    'title':
+                        'issue title',
+                    'type':
+                        'BUG',
+                    'customFields': [
+                      {
+                        'customFieldId': '1223084',
+                        'repeatedEnumValue': {
+                            'values': ['Linux', 'Android']
+                          },
+                      },
+                      {
+                        'customFieldId': '1222907',
+                        'repeatedEnumValue': {
+                            'values': ['ABC>DEF', 'IJK>XYZ']
+                        }
+                      }
+                    ],
+                    'foundInVersions': ['123', '789'],
+                    'severity':
+                        'S4',
+                },
+                'issueComment': {
+                    'comment': 'issue body'
+                },
+            },
+            templateOptions_applyTemplate=True,
+        ),
+        mock.call().execute(http=None, num_retries=3),
+    ])
+
   def test_new_security_issue(self):
     """Test creation of security issue."""
     issue = self.issue_tracker.new_issue()
@@ -338,7 +406,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.assignee = 'assignee@google.com'
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.labels.add('67890')
     issue.status = 'ASSIGNED'
@@ -350,7 +417,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             body={
                 'issueState': {
                     'componentId':
-                        9001,
+                        1337,
                     'ccs': [{
                         'emailAddress': 'cc@google.com'
                     }],
@@ -398,7 +465,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         'issueId': '68828938',
         'issueState': {
             'componentId':
-                '9001',
+                '1337',
             'type':
                 'ASSIGNED',
             'status':
@@ -443,7 +510,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title2'
@@ -479,10 +545,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             body={'hotlistEntry': {
                 'issueId': '68828938'
             }}, hotlistId='12345'),
-        mock.call().execute(http=None, num_retries=3),
-    ])
-    self.client.issues().move.assert_has_calls([
-        mock.call(body={'componentId': 9001}, issueId='68828938'),
         mock.call().execute(http=None, num_retries=3),
     ])
     # Update again, removing the label we just added.
@@ -547,7 +609,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title2'
@@ -595,6 +656,111 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call().execute(http=None, num_retries=3),
     ])
 
+  def test_update_issue_with_component_tags(self):
+    """Test updating an existing issue with component tags."""
+    self.client.issues().get().execute.return_value = {
+        'issueId': '68828938',
+        'customFields': [
+          {
+            'customFieldId': '1222907',
+            'enumValues': ['ABC>DEF', 'IJK', 'XYZ'],
+          }
+        ],
+        'issueState': {
+            'componentId':
+                '29002',
+            'type':
+                'BUG',
+            'customFields': [
+                {
+                    'customFieldId': '1222907',
+                    'repeatedEnumValue': {
+                        'values': ['ABC>DEF']  # Existing Component Tag.
+                    },
+                },
+            ],
+            'status':
+                'NEW',
+            'priority':
+                'P2',
+            'severity':
+                'S2',
+            'title':
+                'test',
+            'reporter': {
+                'emailAddress': 'user1@google.com',
+                'userGaiaStatus': 'ACTIVE'
+            },
+            'assignee': {
+                'emailAddress': 'assignee@google.com',
+                'userGaiaStatus': 'ACTIVE'
+            },
+            'retention':
+                'COMPONENT_DEFAULT',
+        },
+        'createdTime': '2019-06-25T01:29:30.021Z',
+        'modifiedTime': '2019-06-25T01:29:30.021Z',
+        'userData': {},
+        'accessLimit': {
+            'accessLevel': 'INTERNAL'
+        },
+        'etag': 'TmpnNE1qZzVNemd0TUMweA==',
+        'lastModifier': {
+            'emailAddress': 'user1@google.com',
+            'userGaiaStatus': 'ACTIVE'
+        },
+    }
+    issue = self.issue_tracker.get_issue(68828938)
+    issue.reporter = 'reporter@google.com'
+    issue.assignee = 'assignee2@google.com'
+    issue.ccs.add('cc@google.com')
+    issue.labels.add('12345')
+    issue.status = 'ASSIGNED'
+    issue.title = 'issue title2'
+    # Adding three more Component Tags here.
+    issue.components.add('IJK')
+    issue.components.add('XYZ')
+    # Will be rejected because it is not in allowed enum values.
+    issue.components.add('AAA')
+    issue.save()
+
+    self.client.issues().modify.assert_has_calls([
+        mock.call(
+            issueId='68828938',
+            body={
+                'add': {
+                    'status':
+                        'ASSIGNED',
+                    'assignee': {
+                        'emailAddress': 'assignee2@google.com'
+                    },
+                    'reporter': {
+                        'emailAddress': 'reporter@google.com'
+                    },
+                    'title':
+                        'issue title2',
+                    'ccs': [{
+                        'emailAddress': 'cc@google.com'
+                    }],
+                    'customFields': [{
+                        'customFieldId': '1222907',
+                        'repeatedEnumValue': {
+                            'values': ['ABC>DEF', 'IJK', 'XYZ']
+                        }
+                    },],
+                },
+                'addMask':
+                    'status,assignee,reporter,title,ccs,customFields',
+                'remove': {},
+                'removeMask':
+                    '',
+                'significanceOverride':
+                    'MAJOR',
+            },
+        ),
+        mock.call().execute(http=None, num_retries=3),
+    ])
+
   def test_update_issue_to_security(self):
     """Test updating an existing issue."""
     self.client.issues().get().execute.return_value = BASIC_ISSUE
@@ -602,7 +768,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         'issueId': '68828938',
         'issueState': {
             'componentId':
-                '9001',
+                '1337',
             'type':
                 'ASSIGNED',
             'status':
@@ -651,7 +817,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.reporter = 'reporter@google.com'
     issue.assignee = 'assignee2@google.com'
     issue.ccs.add('cc@google.com')
-    issue.components.add('9001')
     issue.labels.add('12345')
     issue.status = 'ASSIGNED'
     issue.title = 'issue title2'


### PR DESCRIPTION
Add support for the ReleaseBlock custom field in google_issue_tracker. The "ReleaseBlock-Beta" label is added [here](https://github.com/google/clusterfuzz/blob/d439a7a9f8ce0ed8f79b33506a0833f1868e8f90/src/clusterfuzz/_internal/cron/cleanup.py#L1009) it will be now converted into a custom field for use in google_issue_tracker.

Also, check substitution mappings before adding Predator labels.