### PR TITLE
Improve batch

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -208,7 +208,7 @@ def preprocess_setup_testcase(testcase, fuzzer_override=None):
   fuzzer_name = fuzzer_override or testcase.fuzzer_name
   testcase_id = testcase.key.id()
   if fuzzer_name and not with_deps:
-    logs.log('Skipping fuzzer preprocess.')
+    logs.log(f'Skipping fuzzer preprocess: {fuzzer_name}.')
   if fuzzer_name and with_deps:
     # This branch is taken when we assume fuzzer needs to be set up for a
     # testcase to be executed (i.e. when a testcase was found by a fuzzer).

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -207,7 +207,9 @@ def preprocess_setup_testcase(testcase, fuzzer_override=None):
   """Preprocessing for setup_testcase function."""
   fuzzer_name = fuzzer_override or testcase.fuzzer_name
   testcase_id = testcase.key.id()
-  if fuzzer_name:
+  if fuzzer_name and not with_deps:
+    logs.log('Skipping fuzzer preprocess.')
+  if fuzzer_name and with_deps:
     # This branch is taken when we assume fuzzer needs to be set up for a
     # testcase to be executed (i.e. when a testcase was found by a fuzzer).
     # It's not the case for testcases uploaded by users.

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -203,7 +203,7 @@ def handle_setup_testcase_error(uworker_output: uworker_msg_pb2.Output):
 HANDLED_ERRORS = [uworker_msg_pb2.ErrorType.TESTCASE_SETUP]
 
 
-def preprocess_setup_testcase(testcase, fuzzer_override=None):
+def preprocess_setup_testcase(testcase, fuzzer_override=None, with_deps=True):
   """Preprocessing for setup_testcase function."""
   fuzzer_name = fuzzer_override or testcase.fuzzer_name
   testcase_id = testcase.key.id()

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -71,7 +71,7 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
   # a different fuzzing engine.
   original_job_type = testcase.job_type
   testcase = _get_variant_testcase_for_job(testcase, job_type)
-  setup_input = setup.preprocess_setup_testcase(testcase)
+  setup_input = setup.preprocess_setup_testcase(testcase, with_deps=False)
   uworker_input = uworker_msg_pb2.Input(
       job_type=job_type,
       original_job_type=original_job_type,

--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -31,9 +31,8 @@ from . import credentials
 
 _local = threading.local()
 
-MAX_DURATION = '3600s'
-RETRY_COUNT = 1
-TASK_COUNT = 1
+MAX_DURATION = f'{int(60 * 60 * 2.5)}s'
+RETRY_COUNT = 0
 
 # Controls how many containers (ClusterFuzz tasks) can run on a single VM.
 # THIS SHOULD BE 1 OR THERE WILL BE SECURITY PROBLEMS.


### PR DESCRIPTION
1. Don't retry tasks.
2. Set longer timeout so variant can complete.