### PR TITLE
Don't index jobs for Fuzzer entities.

### DIFF
--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -56,8 +56,8 @@ def _job_to_dict(job):
   result = job.to_dict()
   result['id'] = job.key.id()
   # Adding all associated fuzzers with each job.
-  fuzzers = data_types.Fuzzer.query().filter(data_types.Fuzzer.jobs == job.name)
-  result['fuzzers'] = [fuzzer.name for fuzzer in fuzzers]
+  fuzzers = data_types.Fuzzer.query().filter()
+  result['fuzzers'] = [fuzzer.name for fuzzer in fuzzers if job.name in fuzzer.jobs]
   return result
 
 

--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -57,7 +57,9 @@ def _job_to_dict(job):
   result['id'] = job.key.id()
   # Adding all associated fuzzers with each job.
   fuzzers = data_types.Fuzzer.query().filter()
-  result['fuzzers'] = [fuzzer.name for fuzzer in fuzzers if job.name in fuzzer.jobs]
+  result['fuzzers'] = [
+      fuzzer.name for fuzzer in fuzzers if job.name in fuzzer.jobs
+  ]
   return result
 
 

--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -56,7 +56,7 @@ def _job_to_dict(job):
   result = job.to_dict()
   result['id'] = job.key.id()
   # Adding all associated fuzzers with each job.
-  fuzzers = data_types.Fuzzer.query().filter()
+  fuzzers = data_types.Fuzzer.query()
   result['fuzzers'] = [
       fuzzer.name for fuzzer in fuzzers if job.name in fuzzer.jobs
   ]

--- a/src/clusterfuzz/_internal/base/external_users.py
+++ b/src/clusterfuzz/_internal/base/external_users.py
@@ -36,7 +36,10 @@ def _fuzzers_for_job(job_type, include_parents):
   fuzzers = []
   engine_fuzzers = data_handler.get_fuzzing_engines()
 
-  for fuzzer in data_types.Fuzzer.query(data_types.Fuzzer.jobs == job_type):
+  for fuzzer in data_types.Fuzzer.query():
+    if job_type not in fuzzer.jobs:
+      continue
+
     # Add this if we're including all parents or this is not an engine fuzzer
     # with fuzz targets.
     if include_parents or fuzzer.name not in engine_fuzzers:

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -320,7 +320,7 @@ class Fuzzer(Model):
   sample_testcase = ndb.StringProperty()
 
   # Job types for this fuzzer.
-  jobs = ndb.StringProperty(repeated=True)
+  jobs = ndb.StringProperty(repeated=True, indexed=False)
 
   # Is the fuzzer coming from an external contributor ? Useful for adding
   # reward flags.

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -320,7 +320,7 @@ class Fuzzer(Model):
   sample_testcase = ndb.StringProperty()
 
   # Job types for this fuzzer.
-  jobs = ndb.StringProperty(repeated=True, indexed=False)
+  jobs = ndb.TextProperty(repeated=True)
 
   # Is the fuzzer coming from an external contributor ? Useful for adding
   # reward flags.

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -64,7 +64,11 @@ def update_mappings_for_fuzzer(fuzzer, mappings=None):
 
 def update_mappings_for_job(job, mappings):
   """Clear existing mappings for a job, and replace them."""
-  existing_fuzzers = {fuzzer.name: fuzzer for fuzzer in existing_fuzzers_query if job.name in fuzzer.jobs}
+  existing_fuzzers = {
+      fuzzer.name: fuzzer
+      for fuzzer in data_types.Fuzzer.query()
+      if job.name in fuzzer.jobs
+  }
   modified_fuzzers = []
 
   for fuzzer_name in mappings:

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -64,9 +64,7 @@ def update_mappings_for_fuzzer(fuzzer, mappings=None):
 
 def update_mappings_for_job(job, mappings):
   """Clear existing mappings for a job, and replace them."""
-  existing_fuzzers_query = data_types.Fuzzer.query(
-      data_types.Fuzzer.jobs == job.name)
-  existing_fuzzers = {fuzzer.name: fuzzer for fuzzer in existing_fuzzers_query}
+  existing_fuzzers = {fuzzer.name: fuzzer for fuzzer in existing_fuzzers_query if job.name in fuzzer.jobs}
   modified_fuzzers = []
 
   for fuzzer_name in mappings:

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/fuzzer_selection_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/fuzzer_selection_test.py
@@ -34,8 +34,11 @@ def _get_job_list_for_fuzzer(fuzzer):
 
 def _get_fuzzer_list_for_job(job):
   """Helper function to return the mappings for a job as a list."""
-  fuzzers = data_types.Fuzzer.query().filter(data_types.Fuzzer.jobs == job.name)
-  return [fuzzer.name for fuzzer in fuzzers]
+  return [
+      fuzzer.name
+      for fuzzer in data_types.Fuzzer.query()
+      if job.name in fuzzer.jobs
+  ]
 
 
 @test_utils.with_cloud_emulators('datastore')


### PR DESCRIPTION
Some of our deployments are hitting index limits, so we can't do this anymore.

Generally this shouldn't impact performance very much, because there are not too many Fuzzer entities in all of our deployments. 

For the existing usages of this index, just loop through and filter out the Fuzzer entities that match.

Three usages are impacted:

- Jobs page: Tested and verified that this doesn't impact performance much (due to pagination).
- update_mappings_for_job: Whenever a Fuzzer/Job association is modified. Will monitor the performance of our project setup cron jobs.
- external_users: This only impacts fuzzer stats, testcase upload, which are both one-off loads that shouldn't impact performance much. 

For #3618.