### PR TITLE
Warn when HTTP_PORT_1/2 are already in use

### DIFF
--- a/src/clusterfuzz/_internal/bot/webserver/http_server.py
+++ b/src/clusterfuzz/_internal/bot/webserver/http_server.py
@@ -152,4 +152,4 @@ def start():
   if not port_is_open(http_host, http_port_2):
     start_server_thread(http_host, http_port_2)
   else:
-    logs.log_warn(f"HTTP_PORT_1 ({http_port_1}) already open, not starting server thread.")
+    logs.log_warn(f"HTTP_PORT_2 ({http_port_2}) already open, not starting server thread.")

--- a/src/clusterfuzz/_internal/bot/webserver/http_server.py
+++ b/src/clusterfuzz/_internal/bot/webserver/http_server.py
@@ -19,6 +19,7 @@ import os
 import socket
 import threading
 
+from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
 
@@ -146,5 +147,9 @@ def start():
   http_port_2 = environment.get_value('HTTP_PORT_2', 8080)
   if not port_is_open(http_host, http_port_1):
     start_server_thread(http_host, http_port_1)
+  else:
+    logs.log_warn(f"HTTP_PORT_1 ({http_port_1}) already open, not starting server thread.")
   if not port_is_open(http_host, http_port_2):
     start_server_thread(http_host, http_port_2)
+  else:
+    logs.log_warn(f"HTTP_PORT_1 ({http_port_1}) already open, not starting server thread.")

--- a/src/clusterfuzz/_internal/bot/webserver/http_server.py
+++ b/src/clusterfuzz/_internal/bot/webserver/http_server.py
@@ -148,8 +148,12 @@ def start():
   if not port_is_open(http_host, http_port_1):
     start_server_thread(http_host, http_port_1)
   else:
-    logs.log_warn(f"HTTP_PORT_1 ({http_port_1}) already open, not starting server thread.")
+    logs.log_warn(
+        f"HTTP_PORT_1 ({http_port_1}) already open, not starting server thread."
+    )
   if not port_is_open(http_host, http_port_2):
     start_server_thread(http_host, http_port_2)
   else:
-    logs.log_warn(f"HTTP_PORT_2 ({http_port_2}) already open, not starting server thread.")
+    logs.log_warn(
+        f"HTTP_PORT_2 ({http_port_2}) already open, not starting server thread."
+    )


### PR DESCRIPTION
We faced an issue on android bots were several bots on a host were using the same HTTP server for the test cases, which resulted in the wrong test case being served.

this is mitigated when using the standard start up script (https://github.com/google/clusterfuzz/blob/530f8e342a45374f1afc063a17d76696a812517a/configs/test/bot/setup/android.bash#L33 ), which is not the case here. That start up script wouldn't work anyway because it is invoked once per bot in the android context.

I originally thought about implementing the support for a port range (see below), but in the end  I felt like it did not really had its place here. 

Instead, I'd like us to have at least a clue that something might be wrong, hence adding some logs. And I fixed the port issue in the scripts we are using instead.

```
def start():
  """Initialize the HTTP server on the specified ports."""
  http_host = 'localhost'
  
  def start_on_port(variable_name, default_port):
    http_port_range =[
      int(x) for x in 
      environment.get_value(variable_name, default_port).split('-')]
    for port in range(http_port_range[0], http_port_range[-1]+1):
      if not port_is_open(http_host, port):
        start_server_thread(http_host, port)
        return port
    return None
  start_on_port("HTTP_PORT_1", "8000 - 8020")
  start_on_port('HTTP_PORT_2', "8080 - 8100")
```