### PR TITLE
Fix incorrect consumption of .options files

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -269,8 +269,8 @@ class Engine(engine.Engine):
     Returns:
       A FuzzResult object.
     """
-    runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path, fuzz_options=options)
+    runner = libfuzzer.get_runner(target_path)
 
     # Directory to place new units.
     if options.merge_back_new_testcases:


### PR DESCRIPTION
Ensures that changes made by set_sanitizer_options() are reflected in the configuration during the initial fuzzer run.