### PR TITLE
Make progression a UTask

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -187,7 +187,7 @@ COMMAND_TYPES = {
     'fuzz': UTaskLocalExecutor,
     'impact': TrustedTask,
     'minimize': UTaskLocalExecutor,
-    'progression': UTaskLocalExecutor,
+    'progression': UTask,
     'regression': UTaskLocalExecutor,
     'symbolize': UTaskCombined,
     'unpack': TrustedTask,

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -187,7 +187,7 @@ COMMAND_TYPES = {
     'fuzz': UTaskLocalExecutor,
     'impact': TrustedTask,
     'minimize': UTaskLocalExecutor,
-    'progression': UTask,
+    'progression': UTaskCombined,
     'regression': UTaskLocalExecutor,
     'symbolize': UTaskCombined,
     'unpack': TrustedTask,


### PR DESCRIPTION
Progression will be hard to combine tasks into jobs because there's so many of them that are started by a single instance.
Instead, just create each batch job. This should work according to my math because progression runs 3-6X less often than variant.