### PR TITLE
Improve preprocessing on task requester

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_creation.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_creation.py
@@ -316,6 +316,9 @@ def preprocess_utasks_and_queue_ttasks(tasks: List[Optional[Task]]):
           task.name, task.argument, task.job, queue=task.queue_for_platform)
       logs.log(f'UTask {task.name} not remote.')
       continue
+    if task.uworker_input is None:
+      logs.log('No uworker_input.')
+      continue
     _preprocess(task)
     yield task
 

--- a/src/clusterfuzz/_internal/cron/schedule_progression_tasks.py
+++ b/src/clusterfuzz/_internal/cron/schedule_progression_tasks.py
@@ -14,10 +14,12 @@
 """Creates progression tasks."""
 
 from clusterfuzz._internal.cron.helpers import tasks_scheduler
+from clusterfuzz._internal.system import environment
 
 
 def main():
   """Creates progression tasks."""
+  environment.set_bot_environment()
   task = 'progression'
   tasks_scheduler.schedule(task)
   return True


### PR DESCRIPTION
1. Ensure cronjob can preprocess (fixes: https://pantheon.corp.google.com/errors/detail/CKzqrvalhs2EgAE;time=P30D?project=google.com:clusterfuzz&utm_source=error-reporting-notification&utm_medium=email&utm_content=new-error&e=-13802955&mods=logs_tg_prod)
2. Deal with preprocess that doesn't return an output.