### PR TITLE
Ensure that uworker_env only has string keys.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -21,6 +21,14 @@ from clusterfuzz._internal.system import environment
 
 
 def ensure_uworker_env_type_safety(uworker_env):
+  """Converts all values in |uworker_env| to str types.
+  ClusterFuzz parses env var values so that the type implied by the value
+  (which in every OS I've seen is a string), is the Python type of the value.
+  E.g. if "DO_BLAH=1" in the environment, environment.get_value('DO_BLAH') is 1,
+  not '1'. This is dangerous when using protos because the environment is a
+  proto map, and values in these can only have one type, which in this case is
+  string. Therefore we must make sure values in uworker_envs are always strings
+  so we don't try to save an int to a string map."""
   for k in uworker_env:
     uworker_env[k] = str(uworker_env[k])
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -20,11 +20,17 @@ from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
 
+def ensure_uworker_env_type_safety(uworker_env):
+  for k in uworker_env:
+    uworker_env[k] = str(uworker_env[k])
+
+
 def tworker_preprocess_no_io(utask_module, task_argument, job_type,
                              uworker_env):
   """Executes the preprocessing step of the utask |utask_module| and returns the
   serialized output."""
   logs.log('Starting utask_preprocess: %s.' % utask_module)
+  ensure_uworker_env_type_safety(uworker_env)
   set_uworker_env(uworker_env)
   uworker_input = utask_module.utask_preprocess(task_argument, job_type,
                                                 uworker_env)
@@ -67,6 +73,7 @@ def tworker_preprocess(utask_module, task_argument, job_type, uworker_env):
   signed download URL for the uworker's input and the (unsigned) download URL
   for its output."""
   logs.log('Starting utask_preprocess: %s.' % utask_module)
+  ensure_uworker_env_type_safety(uworker_env)
   set_uworker_env(uworker_env)
   # Do preprocessing.
   uworker_input = utask_module.utask_preprocess(task_argument, job_type,


### PR DESCRIPTION
Otherwise we will get errors when adding it to to a proto. This bug pattern is very likely in ClusterFuzz because ClusterFuzz's env vars don't need to be strings (this seems like the wrong decision IMO), but their representation in proto must be strings since they must be a single type.

This fixes an error introduced here:
https://github.com/google/clusterfuzz/pull/3536
This fixes this bug: https://pantheon.corp.google.com/errors/detail/CPCzn83Hxtr1ag;service=;version=;filter=%5B%22%5C%22_collections_abc.py%5C%22%22%5D?e=-13802955&mods=logs_tg_prod&project=google.com:cluster-fuzz