### PR TITLE
Migration script

### DIFF
--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -61,7 +61,7 @@ def get_monorail_issuetracker_issue_id_dictionary(file_loc, roll_back):
   # (ex. row: "600469, 40003765")
   with open(file_loc, 'r') as csvfile:
     reader = csv.reader(csvfile)
-    fieldnames = ['key', 'value']
+    fieldnames = ['monorail_id', 'issuetracker_id']
     reader = csv.DictReader(csvfile, fieldnames=fieldnames)
     for row in reader:
       key_id = row[fieldnames[1]] if roll_back else row[fieldnames[0]]

--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -25,7 +25,8 @@ def execute(args):
   and/or group_bug_information fields to reflect the Issue Tracker issue
   id rather than the Monorail issue id."""
 
-  issue_id_dict = get_monorail_issuetracker_issue_id_dictionary(args.file_loc, args.roll_back)
+  issue_id_dict = get_monorail_issuetracker_issue_id_dictionary(
+      args.file_loc, args.roll_back)
 
   testcases = []
 
@@ -63,8 +64,8 @@ def get_monorail_issuetracker_issue_id_dictionary(file_loc, roll_back):
     fieldnames = ['key', 'value']
     reader = csv.DictReader(csvfile, fieldnames=fieldnames)
     for row in reader:
-      key_id = row[fieldnames[1]] if roll_back  else row[fieldnames[0]]
-      value_id = row[fieldnames[0]] if roll_back  else row[fieldnames[1]]
+      key_id = row[fieldnames[1]] if roll_back else row[fieldnames[0]]
+      value_id = row[fieldnames[0]] if roll_back else row[fieldnames[1]]
       issue_id_dictionary[key_id] = value_id
 
   return issue_id_dictionary  # { key_id: value_id }

--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -35,8 +35,8 @@ def execute(args):
   project_name = os.environ.get('PROJECT_NAME')
   if not project_name:
     raise ValueError('Must specify PROJECT_NAME env variable')
-  batch_size = os.environ.get('BATCH_SIZE', DEFAULT_BATCH_SIZE)
-  roll_back = os.environ.get('ROLL_BACK', False)
+  batch_size = int(os.environ.get('BATCH_SIZE', DEFAULT_BATCH_SIZE))
+  roll_back = os.environ.get('ROLL_BACK') == 'True'
 
   issue_id_dict = get_monorail_issuetracker_issue_id_dictionary(
       file_loc, roll_back)

--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -40,8 +40,10 @@ def execute(args):
 
   issue_id_dict = get_monorail_issuetracker_issue_id_dictionary(
       file_loc, roll_back)
+  print(f'Size of issue_id_dict: {len(issue_id_dict)}')
 
   testcases = []
+  count_of_updated = 0
 
   for testcase in data_types.Testcase.query(
       # only target testcases in single project
@@ -63,12 +65,14 @@ def execute(args):
 
     if args.non_dry_run and len(testcases) >= batch_size:
       ndb.put_multi(testcases)
-      print(f'Updated {len(testcases)}')
+      count_of_updated += len(testcases)
+      print(f'Updated {len(testcases)}. Total {count_of_updated}')
       testcases = []
 
   if args.non_dry_run and len(testcases) > 0:
     ndb.put_multi(testcases)
-    print(f'Updated {len(testcases)}')
+    count_of_updated += len(testcases)
+    print(f'Updated {len(testcases)}. Total {count_of_updated}')
 
 
 def get_monorail_issuetracker_issue_id_dictionary(file_loc, roll_back):


### PR DESCRIPTION
This update adds roll_back and batch_size arguments to the monorail/issuetracker migration script.

We need feedback on how best to run this script. It seems that we are intended to run it with butler.py, but it's not clear whether butler supports additional arguments, and it seems to require arguments (like script_name) that we are unsure where we get values for. Thank you for your review, and please advise!