### PR TITLE
Fix group_bug_information and add a retry mechanism if we go past the allowable transaction limit

### DIFF
--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -115,7 +115,6 @@ def put_multi(testcases):
           # pylint: disable=forgotten-debug-statement
           import pdb
           pdb.set_trace()
-        raise
     else:
       raise
 

--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -92,11 +92,12 @@ def execute(args):
     print(f'Updated {len(testcases)}. Total {count_of_updated}')
 
 
-# Attempts to batch put the specified slice of testcases. If there is
-# a 'payload size exceeds the limit' error then it will halve the
-# testcases and try again. If that does not work then will go into
-# a debugger.
 def put_multi(testcases):
+  """Attempts to batch put the specified slice of testcases.
+
+  If there is a 'payload size exceeds the limit' error then it will halve the
+  testcases and try again. If that does not work then will go into a debugger.
+  """
   try:
     ndb.put_multi(testcases)
   except Exception as e:
@@ -107,8 +108,8 @@ def put_multi(testcases):
       try:
         ndb.put_multi(testcases[:half_batch_size])
         ndb.put_multi(testcases[half_batch_size:])
-      except Exception as e:
-        if PAYLOAD_SIZE_ERROR in str(e):
+      except Exception as ie:
+        if PAYLOAD_SIZE_ERROR in str(ie):
           print(f'Got exception: {e}')
           print('Opening debugger to investigate further:')
           # pylint: disable=forgotten-debug-statement

--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -72,8 +72,8 @@ def execute(args):
     if testcase.group_bug_information and issue_id_dict.get(
         str(testcase.group_bug_information)):
       # group_bug_information is an int unlike bug_information which is a str.
-      testcase.group_bug_information = int(
-          issue_id_dict[str(testcase.group_bug_information)])
+      testcase.group_bug_information = int(issue_id_dict[str(
+          testcase.group_bug_information)])
       testcase_updated = True
 
     if testcase_updated:
@@ -101,11 +101,11 @@ def put_multi(testcases):
     ndb.put_multi(testcases)
   except Exception as e:
     if PAYLOAD_SIZE_ERROR in str(e) and len(testcases) > 1:
-      half_batch_size = len(testcases)//2
+      half_batch_size = len(testcases) // 2
       print('Reached payload size limit. Retrying batch put with half the '
             f'specified batch size: {half_batch_size}')
       try:
-        ndb.put_multi(testcases[0:half_batch_size])
+        ndb.put_multi(testcases[:half_batch_size])
         ndb.put_multi(testcases[half_batch_size:])
       except Exception as e:
         if PAYLOAD_SIZE_ERROR in str(e):

--- a/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
+++ b/src/local/butler/scripts/migration/monorail_to_issuetracker_migrator.py
@@ -34,6 +34,10 @@ from clusterfuzz._internal.datastore import data_types
 # 400 Request payload size exceeds the limit: 11534336 bytes.
 DEFAULT_BATCH_SIZE = 100
 
+# Error returned by ndb when we go past the allowable datastore transaction
+# limit.
+PAYLOAD_SIZE_ERROR = '400 Request payload size exceeds the limit'
+
 
 def execute(args):
   """Query Testcases of a project, and update the bug_information
@@ -66,9 +70,10 @@ def execute(args):
       testcase_updated = True
 
     if testcase.group_bug_information and issue_id_dict.get(
-        testcase.group_bug_information):
-      testcase.group_bug_information = (
-          issue_id_dict[testcase.group_bug_information])
+        str(testcase.group_bug_information)):
+      # group_bug_information is an int unlike bug_information which is a str.
+      testcase.group_bug_information = int(
+          issue_id_dict[str(testcase.group_bug_information)])
       testcase_updated = True
 
     if testcase_updated:
@@ -76,25 +81,42 @@ def execute(args):
       testcases.append(testcase)
 
     if args.non_dry_run and len(testcases) >= batch_size:
+      put_multi(testcases)
+      count_of_updated += len(testcases)
+      print(f'Updated {len(testcases)}. Total {count_of_updated}')
+      testcases = []
+
+  if args.non_dry_run and len(testcases) > 0:
+    put_multi(testcases)
+    count_of_updated += len(testcases)
+    print(f'Updated {len(testcases)}. Total {count_of_updated}')
+
+
+# Attempts to batch put the specified slice of testcases. If there is
+# a 'payload size exceeds the limit' error then it will halve the
+# testcases and try again. If that does not work then will go into
+# a debugger.
+def put_multi(testcases):
+  try:
+    ndb.put_multi(testcases)
+  except Exception as e:
+    if PAYLOAD_SIZE_ERROR in str(e) and len(testcases) > 1:
+      half_batch_size = len(testcases)//2
+      print('Reached payload size limit. Retrying batch put with half the '
+            f'specified batch size: {half_batch_size}')
       try:
-        ndb.put_multi(testcases)
+        ndb.put_multi(testcases[0:half_batch_size])
+        ndb.put_multi(testcases[half_batch_size:])
       except Exception as e:
-        if '400 Request payload size exceeds the limit' in str(e):
+        if PAYLOAD_SIZE_ERROR in str(e):
           print(f'Got exception: {e}')
           print('Opening debugger to investigate further:')
           # pylint: disable=forgotten-debug-statement
           import pdb
           pdb.set_trace()
         raise
-
-      count_of_updated += len(testcases)
-      print(f'Updated {len(testcases)}. Total {count_of_updated}')
-      testcases = []
-
-  if args.non_dry_run and len(testcases) > 0:
-    ndb.put_multi(testcases)
-    count_of_updated += len(testcases)
-    print(f'Updated {len(testcases)}. Total {count_of_updated}')
+    else:
+      raise
 
 
 def get_monorail_issuetracker_issue_id_dictionary(file_loc, roll_back):


### PR DESCRIPTION
* group_bug_information is an int and not a str like bug_information
* If we go past the allowable transaction limit then retry the put with half the specified batch size