### PR TITLE
Fix e2e subtask duration metric collection

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -60,8 +60,8 @@ def _record_e2e_duration(start: Timestamp, utask_module, job_type: str,
       duration, {
           'task': task_utils.get_command_from_module(utask_module.__name__),
           'job': job_type,
-          'subtask': subtask,
-          'mode': mode,
+          'subtask': subtask.value,
+          'mode': mode.value,
           'platform': environment.platform(),
       })
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -200,7 +200,7 @@ def uworker_main(input_download_url) -> None:
                                                  uworker_output_upload_url)
   logs.log('Finished uworker_main.')
   _record_e2e_duration(start, utask_module,
-                       uworker_output.uworker_input.job_type,
+                       uworker_input.job_type,
                        _Subtask.UWORKER_MAIN, _Mode.BATCH)
   return True
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -55,9 +55,9 @@ def _timestamp_now() -> Timestamp:
 
 def _record_e2e_duration(start: Timestamp, utask_module, job_type: str,
                          subtask: _Subtask, mode: _Mode):
-  duration = start.ToSeconds() - time.time()
+  duration_secs = (time.time_ns() - start.ToNanoseconds()) / 10**9
   monitoring_metrics.UTASK_E2E_DURATION_SECS.add(
-      duration, {
+      duration_secs, {
           'task': task_utils.get_command_from_module(utask_module.__name__),
           'job': job_type,
           'subtask': subtask.value,
@@ -107,7 +107,6 @@ def tworker_preprocess_no_io(utask_module, task_argument, job_type,
 def uworker_main_no_io(utask_module, serialized_uworker_input):
   """Exectues the main part of a utask on the uworker (locally if not using
   remote executor)."""
-  start = _timestamp_now()
   logs.log('Starting utask_main: %s.' % utask_module)
   uworker_input = uworker_io.deserialize_uworker_input(serialized_uworker_input)
 
@@ -118,8 +117,9 @@ def uworker_main_no_io(utask_module, serialized_uworker_input):
   if uworker_output is None:
     return None
   result = uworker_io.serialize_uworker_output(uworker_output)
-  _record_e2e_duration(start, utask_module, uworker_input.job_type,
-                       _Subtask.UWORKER_MAIN, _Mode.QUEUE)
+  _record_e2e_duration(uworker_input.preprocess_start_time, utask_module,
+                       uworker_input.job_type, _Subtask.UWORKER_MAIN,
+                       _Mode.QUEUE)
   return result
 
 
@@ -128,15 +128,15 @@ def tworker_postprocess_no_io(utask_module, uworker_output, uworker_input):
   the same bot as the uworker)."""
   # TODO(metzman): Stop passing module to this function and uworker_main_no_io.
   # Make them consistent with the I/O versions.
-  start = _timestamp_now()
   uworker_output = uworker_io.deserialize_uworker_output(uworker_output)
   # Do this to simulate out-of-band tamper-proof storage of the input.
   uworker_input = uworker_io.deserialize_uworker_input(uworker_input)
   uworker_output.uworker_input.CopyFrom(uworker_input)
   set_uworker_env(uworker_output.uworker_input.uworker_env)
   utask_module.utask_postprocess(uworker_output)
-  _record_e2e_duration(start, utask_module, uworker_input.job_type,
-                       _Subtask.POSTPROCESS, _Mode.QUEUE)
+  _record_e2e_duration(uworker_input.preprocess_start_time, utask_module,
+                       uworker_input.job_type, _Subtask.POSTPROCESS,
+                       _Mode.QUEUE)
 
 
 def tworker_preprocess(utask_module, task_argument, job_type, uworker_env):
@@ -183,7 +183,6 @@ def set_uworker_env(uworker_env: dict) -> None:
 def uworker_main(input_download_url) -> None:
   """Exectues the main part of a utask on the uworker (locally if not using
   remote executor)."""
-  start = _timestamp_now()
   uworker_input = uworker_io.download_and_deserialize_uworker_input(
       input_download_url)
   uworker_output_upload_url = uworker_input.uworker_output_upload_url
@@ -199,8 +198,9 @@ def uworker_main(input_download_url) -> None:
   uworker_io.serialize_and_upload_uworker_output(uworker_output,
                                                  uworker_output_upload_url)
   logs.log('Finished uworker_main.')
-  _record_e2e_duration(start, utask_module, uworker_input.job_type,
-                       _Subtask.UWORKER_MAIN, _Mode.BATCH)
+  _record_e2e_duration(uworker_input.preprocess_start_time, utask_module,
+                       uworker_input.job_type, _Subtask.UWORKER_MAIN,
+                       _Mode.BATCH)
   return True
 
 
@@ -218,12 +218,11 @@ def uworker_bot_main():
 
 def tworker_postprocess(output_download_url) -> None:
   """Executes the postprocess step on the trusted (t)worker."""
-  start = _timestamp_now()
   uworker_output = uworker_io.download_and_deserialize_uworker_output(
       output_download_url)
   set_uworker_env(uworker_output.uworker_input.uworker_env)
   utask_module = get_utask_module(uworker_output.uworker_input.module_name)
   utask_module.utask_postprocess(uworker_output)
-  job_type = uworker_output.uworker_input.job_type
-  _record_e2e_duration(start, utask_module, job_type, _Subtask.POSTPROCESS,
-                       _Mode.BATCH)
+  _record_e2e_duration(uworker_output.uworker_input.preprocess_start_time,
+                       utask_module, uworker_output.uworker_input.job_type,
+                       _Subtask.POSTPROCESS, _Mode.BATCH)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -199,8 +199,7 @@ def uworker_main(input_download_url) -> None:
   uworker_io.serialize_and_upload_uworker_output(uworker_output,
                                                  uworker_output_upload_url)
   logs.log('Finished uworker_main.')
-  _record_e2e_duration(start, utask_module,
-                       uworker_input.job_type,
+  _record_e2e_duration(start, utask_module, uworker_input.job_type,
                        _Subtask.UWORKER_MAIN, _Mode.BATCH)
   return True
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -176,6 +176,7 @@ class GetUtaskModuleTest(unittest.TestCase):
     module_name = analyze_task.__name__
     self.assertEqual(utasks.get_utask_module(module_name), analyze_task)
 
+
 class TworkerPostprocessTest(unittest.TestCase):
   """Tests that tworker_postprocess works as intended."""
 
@@ -189,11 +190,9 @@ class TworkerPostprocessTest(unittest.TestCase):
   def test_success(self):
     download_url = 'https://uworker_output_download_url'
     uworker_output = uworker_msg_pb2.Output(
-        uworker_input=uworker_msg_pb2.Input(
-            job_type='foo-job',
-        ),
-    )
-    self.mock.download_and_deserialize_uworker_output.return_value = (uworker_output)
+        uworker_input=uworker_msg_pb2.Input(job_type='foo-job',),)
+    self.mock.download_and_deserialize_uworker_output.return_value = (
+        uworker_output)
 
     module = mock.MagicMock(__name__='mock_task')
     self.mock.get_utask_module.return_value = module
@@ -202,7 +201,8 @@ class TworkerPostprocessTest(unittest.TestCase):
     utasks.tworker_postprocess(download_url)
     end_time_ns = time.time_ns()
 
-    self.mock.download_and_deserialize_uworker_output.assert_called_with(download_url)
+    self.mock.download_and_deserialize_uworker_output.assert_called_with(
+        download_url)
     module.utask_postprocess.assert_called_with(uworker_output)
 
     durations = monitoring_metrics.UTASK_E2E_DURATION_SECS.get({

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -188,6 +188,8 @@ class TworkerPostprocessTest(unittest.TestCase):
     ])
 
   def test_success(self):
+    """Tests that if utask_postprocess suceeds, uworker_postprocess does too.
+    """
     download_url = 'https://uworker_output_download_url'
     uworker_output = uworker_msg_pb2.Output(
         uworker_input=uworker_msg_pb2.Input(job_type='foo-job',),)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -54,19 +54,19 @@ class TworkerPreprocessTest(unittest.TestCase):
     uworker_input = uworker_msg_pb2.Input(job_type='something')
     module.utask_preprocess.return_value = uworker_input
 
-    time_before = time.time_ns()
+    start_time_ns = time.time_ns()
 
     result = utasks.tworker_preprocess(module, self.TASK_ARGUMENT,
                                        self.JOB_TYPE, self.UWORKER_ENV)
 
-    time_after = time.time_ns()
+    end_time_ns = time.time_ns()
 
     module.utask_preprocess.assert_called_with(self.TASK_ARGUMENT,
                                                self.JOB_TYPE, self.UWORKER_ENV)
 
     self.mock.serialize_and_upload_uworker_input.assert_called_with(uworker_input)
-    self.assertGreaterEqual(uworker_input.preprocess_start_time.ToNanoseconds(), time_before)
-    self.assertLessEqual(uworker_input.preprocess_start_time.ToNanoseconds(), time_after)
+    self.assertGreaterEqual(uworker_input.preprocess_start_time.ToNanoseconds(), start_time_ns)
+    self.assertLessEqual(uworker_input.preprocess_start_time.ToNanoseconds(), end_time_ns)
 
     self.assertEqual(
         (self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL), result)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -64,9 +64,12 @@ class TworkerPreprocessTest(unittest.TestCase):
     module.utask_preprocess.assert_called_with(self.TASK_ARGUMENT,
                                                self.JOB_TYPE, self.UWORKER_ENV)
 
-    self.mock.serialize_and_upload_uworker_input.assert_called_with(uworker_input)
-    self.assertGreaterEqual(uworker_input.preprocess_start_time.ToNanoseconds(), start_time_ns)
-    self.assertLessEqual(uworker_input.preprocess_start_time.ToNanoseconds(), end_time_ns)
+    self.mock.serialize_and_upload_uworker_input.assert_called_with(
+        uworker_input)
+    self.assertGreaterEqual(uworker_input.preprocess_start_time.ToNanoseconds(),
+                            start_time_ns)
+    self.assertLessEqual(uworker_input.preprocess_start_time.ToNanoseconds(),
+                         end_time_ns)
 
     durations = monitoring_metrics.UTASK_E2E_DURATION_SECS.get({
         'task': 'mock',
@@ -76,7 +79,9 @@ class TworkerPreprocessTest(unittest.TestCase):
         'platform': 'LINUX',
     })
     self.assertEqual(durations.count, 1)
-    self.assertLess(durations.sum * 10**9, end_time_ns - uworker_input.preprocess_start_time.ToNanoseconds())
+    self.assertLess(
+        durations.sum * 10**9,
+        end_time_ns - uworker_input.preprocess_start_time.ToNanoseconds())
 
     self.assertEqual(
         (self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL), result)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -68,6 +68,16 @@ class TworkerPreprocessTest(unittest.TestCase):
     self.assertGreaterEqual(uworker_input.preprocess_start_time.ToNanoseconds(), start_time_ns)
     self.assertLessEqual(uworker_input.preprocess_start_time.ToNanoseconds(), end_time_ns)
 
+    durations = monitoring_metrics.UTASK_E2E_DURATION_SECS.get({
+        'task': 'mock',
+        'job': self.JOB_TYPE,
+        'subtask': 'preprocess',
+        'mode': 'batch',
+        'platform': 'LINUX',
+    })
+    self.assertEqual(durations.count, 1)
+    self.assertLess(durations.sum * 10**9, end_time_ns - uworker_input.preprocess_start_time.ToNanoseconds())
+
     self.assertEqual(
         (self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL), result)
 


### PR DESCRIPTION
* Adds unit tests, which reproduced the bugs
* Fixes an inversion in the computation of the task duration, which was always negative
* Records the e2e duration from preprocess start time to subtask end time instead of only the current subtask's duration, as was the intent