### PR TITLE
Reduce wait times on user-requested tasks. 

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -523,11 +523,14 @@ class UploadHandlerCommon:
           metadata.fuzzer_binary_name = target_name
           metadata.put()
 
+          # Use wait_time=None to execute the task ASAP, since it is
+          # user-facing.
           tasks.add_task(
               'unpack',
               str(metadata.key.id()),
               job_type,
-              queue=tasks.queue_for_job(job_type))
+              queue=tasks.queue_for_job(job_type),
+              wait_time=None)
 
           # Create a testcase metadata object to show the user their upload.
           upload_metadata = data_types.TestcaseUploadMetadata()

--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -523,14 +523,14 @@ class UploadHandlerCommon:
           metadata.fuzzer_binary_name = target_name
           metadata.put()
 
-          # Use wait_time=None to execute the task ASAP, since it is
+          # Use wait_time=0 to execute the task ASAP, since it is
           # user-facing.
           tasks.add_task(
               'unpack',
               str(metadata.key.id()),
               job_type,
               queue=tasks.queue_for_job(job_type),
-              wait_time=None)
+              wait_time=0)
 
           # Create a testcase metadata object to show the user their upload.
           upload_metadata = data_types.TestcaseUploadMetadata()

--- a/src/clusterfuzz/_internal/base/tasks.py
+++ b/src/clusterfuzz/_internal/base/tasks.py
@@ -698,8 +698,8 @@ def redo_testcase(testcase, tasks, user_email):
       keys_only=True)
   ndb_utils.delete_multi(notifications)
 
-  # Use wait_time=None to execute the task ASAP, since it is user-facing.
-  wait_time = None
+  # Use wait_time=0 to execute the task ASAP, since it is user-facing.
+  wait_time = 0
 
   # If we are re-doing minimization, other tasks will be done automatically
   # after minimization completes. So, don't add those tasks.

--- a/src/clusterfuzz/_internal/base/tasks.py
+++ b/src/clusterfuzz/_internal/base/tasks.py
@@ -698,31 +698,51 @@ def redo_testcase(testcase, tasks, user_email):
       keys_only=True)
   ndb_utils.delete_multi(notifications)
 
-    # Use wait_time=None to execute the task ASAP, since it is user-facing.
+  # Use wait_time=None to execute the task ASAP, since it is user-facing.
   wait_time = None
 
   # If we are re-doing minimization, other tasks will be done automatically
   # after minimization completes. So, don't add those tasks.
   if minimize:
-    add_task('minimize', testcase_id, testcase.job_type,
-             queue_for_testcase(testcase), wait_time=wait_time)
+    add_task(
+        'minimize',
+        testcase_id,
+        testcase.job_type,
+        queue_for_testcase(testcase),
+        wait_time=wait_time)
     return
 
   if regression:
-    add_task('regression', testcase_id, testcase.job_type,
-             queue_for_testcase(testcase), wait_time=wait_time)
+    add_task(
+        'regression',
+        testcase_id,
+        testcase.job_type,
+        queue_for_testcase(testcase),
+        wait_time=wait_time)
 
   if progression:
-    add_task('progression', testcase_id, testcase.job_type,
-             queue_for_testcase(testcase), wait_time=wait_time)
+    add_task(
+        'progression',
+        testcase_id,
+        testcase.job_type,
+        queue_for_testcase(testcase),
+        wait_time=wait_time)
 
   if impact:
-    add_task('impact', testcase_id, testcase.job_type,
-             queue_for_testcase(testcase), wait_time=wait_time)
+    add_task(
+        'impact',
+        testcase_id,
+        testcase.job_type,
+        queue_for_testcase(testcase),
+        wait_time=wait_time)
 
   if blame:
-    add_task('blame', testcase_id, testcase.job_type,
-             queue_for_testcase(testcase), wait_time=wait_time)
+    add_task(
+        'blame',
+        testcase_id,
+        testcase.job_type,
+        queue_for_testcase(testcase),
+        wait_time=wait_time)
 
 
 def get_task_payload():

--- a/src/clusterfuzz/_internal/base/tasks.py
+++ b/src/clusterfuzz/_internal/base/tasks.py
@@ -629,7 +629,8 @@ def queue_for_job(job_name, is_high_end=False):
 
 
 def redo_testcase(testcase, tasks, user_email):
-  """Redo specific tasks for a testcase."""
+  """Redo specific tasks for a testcase. This is requested by the user from the
+  web interface."""
   for task in tasks:
     if task not in VALID_REDO_TASKS:
       raise InvalidRedoTask(task)
@@ -697,27 +698,31 @@ def redo_testcase(testcase, tasks, user_email):
       keys_only=True)
   ndb_utils.delete_multi(notifications)
 
+    # Use wait_time=None to execute the task ASAP, since it is user-facing.
+  wait_time = None
+
   # If we are re-doing minimization, other tasks will be done automatically
   # after minimization completes. So, don't add those tasks.
   if minimize:
     add_task('minimize', testcase_id, testcase.job_type,
-             queue_for_testcase(testcase))
-  else:
-    if regression:
-      add_task('regression', testcase_id, testcase.job_type,
-               queue_for_testcase(testcase))
+             queue_for_testcase(testcase), wait_time=wait_time)
+    return
 
-    if progression:
-      add_task('progression', testcase_id, testcase.job_type,
-               queue_for_testcase(testcase))
+  if regression:
+    add_task('regression', testcase_id, testcase.job_type,
+             queue_for_testcase(testcase), wait_time=wait_time)
 
-    if impact:
-      add_task('impact', testcase_id, testcase.job_type,
-               queue_for_testcase(testcase))
+  if progression:
+    add_task('progression', testcase_id, testcase.job_type,
+             queue_for_testcase(testcase), wait_time=wait_time)
 
-    if blame:
-      add_task('blame', testcase_id, testcase.job_type,
-               queue_for_testcase(testcase))
+  if impact:
+    add_task('impact', testcase_id, testcase.job_type,
+             queue_for_testcase(testcase), wait_time=wait_time)
+
+  if blame:
+    add_task('blame', testcase_id, testcase.job_type,
+             queue_for_testcase(testcase), wait_time=wait_time)
 
 
 def get_task_payload():

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1396,8 +1396,8 @@ def create_user_uploaded_testcase(key,
   metadata.put()
 
   # Create the job to analyze the testcase.
-  # Use wait_time=None to execute the task ASAP, since it is user-facing.
-  tasks.add_task('analyze', testcase_id, job.name, queue, wait_time=None)
+  # Use wait_time=0 to execute the task ASAP, since it is user-facing.
+  tasks.add_task('analyze', testcase_id, job.name, queue, wait_time=0)
   return testcase.key.id()
 
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1396,7 +1396,8 @@ def create_user_uploaded_testcase(key,
   metadata.put()
 
   # Create the job to analyze the testcase.
-  tasks.add_task('analyze', testcase_id, job.name, queue)
+  # Use wait_time=None to execute the task ASAP, since it is user-facing.
+  tasks.add_task('analyze', testcase_id, job.name, queue, wait_time=None)
   return testcase.key.id()
 
 


### PR DESCRIPTION
Delays on user-requested tasks are harmful as they make users wait
and make ClusterFuzz less usable.
They probably don't provide much value on user-requested tasks since
these are unlikely to be requesting so many per second that a delay
prevents DoS.
Stop deferring tasks to prevent delays.
Potential TODO: Create mechanism for delay-less utasks, since the utask puller can be pulling other utasks for up to 60 seconds, and then might spend time preprocessing
