### PR TITLE
[analyze][rearchitecture] Reduce delays on untrusted parts of analyze

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -144,10 +144,14 @@ class LowLatencyUTask(UTask):
   """Represents an untrusted task. This is the same as UTask except the task is
   scheduled to run on batch immediately, skipping the utask_main queue. This
   reduces task latency."""
+
   def request_remote_execution(self, command, download_url, job_type):
     del command
-    batch.create_uworker_main_batch_job(self.module.__name__, job_type,
-                                        download_url)
+    batch.create_uworker_main_batch_job(
+        self.module.__name__,
+        job_type,
+        download_url,
+        priority=batch.HIGH_PRIORITY)
 
 
 class PostprocessTask(BaseTask):

--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -93,9 +93,9 @@ class BatchTask:
 
 
 def create_uworker_main_batch_job(module,
-                                  job_type,
-                                  input_download_url,
-                                  priority=None):
+                                  job_type: str,
+                                  input_download_url: str,
+                                  priority: Optional[int] = None):
   command = task_utils.get_command_from_module(module)
   batch_tasks = [BatchTask(command, job_type, input_download_url)]
   result = create_uworker_main_batch_jobs(batch_tasks, priority)


### PR DESCRIPTION
Instead of preprocessing and then putting on the queue for scheduling,
schedule right away. This eliminates up to 1 minute of time spent
pulling tasks from the queue and can improve execution speed on batch
by:
1. Allowing us to set a higher priority for the job.
2. Causing batch to schedule the job earlier because the job
requires less CPUs than jobs with many tasks. These CPUs may not
be available in times of high-usage.