### PR TITLE
Record task duration metrics even in case of exceptions

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -177,14 +177,13 @@ def tworker_preprocess_no_io(utask_module, task_argument, job_type,
 
 
 def uworker_main_no_io(utask_module, serialized_uworker_input):
-  """Exectues the main part of a utask on the uworker (locally if not using
+  """Executes the main part of a utask on the uworker (locally if not using
   remote executor)."""
   with _MetricRecorder(_Subtask.UWORKER_MAIN, _Mode.QUEUE) as recorder:
     logs.log('Starting utask_main: %s.' % utask_module)
     uworker_input = uworker_io.deserialize_uworker_input(
         serialized_uworker_input)
 
-    # Deal with the environment.
     set_uworker_env(uworker_input.uworker_env)
     uworker_input.uworker_env.clear()
 
@@ -199,16 +198,18 @@ def uworker_main_no_io(utask_module, serialized_uworker_input):
     return uworker_io.serialize_uworker_output(uworker_output)
 
 
+# TODO(metzman): Stop passing module to this function and `uworker_main_no_io`.
+# Make them consistent with the I/O versions.
 def tworker_postprocess_no_io(utask_module, uworker_output, uworker_input):
   """Executes the postprocess step on the trusted (t)worker (in this case it is
   the same bot as the uworker)."""
   with _MetricRecorder(_Subtask.POSTPROCESS, _Mode.QUEUE) as recorder:
-    # TODO(metzman): Stop passing module to this function and
-    # uworker_main_no_io. Make them consistent with the I/O versions.
     uworker_output = uworker_io.deserialize_uworker_output(uworker_output)
+
     # Do this to simulate out-of-band tamper-proof storage of the input.
     uworker_input = uworker_io.deserialize_uworker_input(uworker_input)
     uworker_output.uworker_input.CopyFrom(uworker_input)
+
     set_uworker_env(uworker_output.uworker_input.uworker_env)
 
     recorder.set_task_details(utask_module, uworker_input.job_type,
@@ -245,7 +246,7 @@ def set_uworker_env(uworker_env: dict) -> None:
 
 
 def uworker_main(input_download_url) -> None:
-  """Exectues the main part of a utask on the uworker (locally if not using
+  """Executes the main part of a utask on the uworker (locally if not using
   remote executor)."""
   with _MetricRecorder(_Subtask.UWORKER_MAIN, _Mode.BATCH) as recorder:
     uworker_input = uworker_io.download_and_deserialize_uworker_input(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 """Module for executing the different parts of a utask."""
 
+import contextlib
 import enum
 import importlib
 import time
+from typing import Optional
 
 from google.protobuf import timestamp_pb2
 
@@ -53,17 +55,70 @@ def _timestamp_now() -> Timestamp:
   return ts
 
 
-def _record_e2e_duration(start: Timestamp, utask_module, job_type: str,
-                         subtask: _Subtask, mode: _Mode):
-  duration_secs = (time.time_ns() - start.ToNanoseconds()) / 10**9
-  monitoring_metrics.UTASK_E2E_DURATION_SECS.add(
-      duration_secs, {
-          'task': task_utils.get_command_from_module(utask_module.__name__),
-          'job': job_type,
-          'subtask': subtask.value,
-          'mode': mode.value,
-          'platform': environment.platform(),
-      })
+class _MetricRecorder(contextlib.AbstractContextManager):
+  """Records task execution metrics, even in case of error and exceptions.
+
+  Members:
+    start_time_ns (int): The time at which this recorder was constructed, in
+      nanoseconds since the Unix epoch.
+  """
+
+  def __init__(self, subtask: _Subtask, mode: _Mode):
+    self.start_time_ns = time.time_ns()
+    self._subtask = subtask
+    self._mode = mode
+    self._labels = None
+
+    if subtask == _Subtask.PREPROCESS:
+      self._preprocess_start_time_ns = self.start_time_ns
+    else:
+      self._preprocess_start_time_ns = None
+
+  def set_task_details(self,
+                       utask_module,
+                       job_type: str,
+                       platform: str,
+                       preprocess_start_time: Optional[Timestamp] = None):
+    """Sets task details that might not be known at instantation time.
+
+    Must be called once for metrics to be recorded when exiting the context.
+
+    Args:
+      utask_module: The Python module corresponding to the task being executed.
+      job_type: The name of the job against which the task is being executed.
+      platform: The platform we are executing on, as given by
+        `environment.platform()`.
+      preprocess_start_time: Timestamp at which the preprocess subtask for
+        this task started executing, possibly in a different process. Must be
+        specified iff the subtask is not `Subtask.PREPROCESS`.
+    """
+    self._labels = {
+        'task': task_utils.get_command_from_module(utask_module.__name__),
+        'job': job_type,
+        'subtask': self._subtask.value,
+        'mode': self._mode.value,
+        'platform': platform,
+    }
+
+    if preprocess_start_time is not None:
+      # We already know the start time if the subtask is preprocess.
+      assert self._preprocess_start_time_ns is None
+      self._preprocess_start_time_ns = preprocess_start_time.ToNanoseconds()
+    else:
+      # Ensure we always have a value after this method returns.
+      assert self._preprocess_start_time_ns is not None
+
+  def __exit__(self, _exc_type, _exc_value, _traceback):
+    # Ignore exception details, let Python continue unwinding the stack.
+
+    if self._labels is None:
+      # `set_task_details()` was not called, we are missing information.
+      return
+
+    now = time.time_ns()
+    e2e_duration_ns = now - self._preprocess_start_time_ns
+    monitoring_metrics.UTASK_E2E_DURATION_SECS.add(e2e_duration_ns / 10**9,
+                                                   self._labels)
 
 
 def ensure_uworker_env_type_safety(uworker_env):
@@ -79,12 +134,15 @@ def ensure_uworker_env_type_safety(uworker_env):
     uworker_env[k] = str(uworker_env[k])
 
 
-def _preprocess(utask_module, task_argument, job_type, uworker_env):
+def _preprocess(utask_module, task_argument, job_type, uworker_env,
+                recorder: _MetricRecorder):
   """Shared logic for preprocessing between preprocess_no_io and the I/O
   tworker_preprocess."""
-  start = _timestamp_now()
   ensure_uworker_env_type_safety(uworker_env)
   set_uworker_env(uworker_env)
+
+  recorder.set_task_details(utask_module, job_type, environment.platform())
+
   logs.log('Starting utask_preprocess: %s.' % utask_module)
   uworker_input = utask_module.utask_preprocess(task_argument, job_type,
                                                 uworker_env)
@@ -98,85 +156,86 @@ def _preprocess(utask_module, task_argument, job_type, uworker_env):
   if task_payload:
     uworker_input.uworker_env['INITIAL_TASK_PAYLOAD'] = task_payload
 
-  uworker_input.preprocess_start_time.CopyFrom(start)
+  uworker_input.preprocess_start_time.FromNanoseconds(recorder.start_time_ns)
 
   assert not uworker_input.module_name
   uworker_input.module_name = utask_module.__name__
-  return uworker_input, start
+  return uworker_input
 
 
 def tworker_preprocess_no_io(utask_module, task_argument, job_type,
                              uworker_env):
   """Executes the preprocessing step of the utask |utask_module| and returns the
   serialized output."""
-  result = _preprocess(utask_module, task_argument, job_type, uworker_env)
-  if not result:
-    return None
-  uworker_input, start = result
-  result = uworker_io.serialize_uworker_input(uworker_input)
-  _record_e2e_duration(start, utask_module, job_type, _Subtask.PREPROCESS,
-                       _Mode.QUEUE)
-  return result
+  with _MetricRecorder(_Subtask.PREPROCESS, _Mode.QUEUE) as recorder:
+    uworker_input = _preprocess(utask_module, task_argument, job_type,
+                                uworker_env, recorder)
+    if not uworker_input:
+      return None
+
+    return uworker_io.serialize_uworker_input(uworker_input)
 
 
 def uworker_main_no_io(utask_module, serialized_uworker_input):
   """Exectues the main part of a utask on the uworker (locally if not using
   remote executor)."""
-  logs.log('Starting utask_main: %s.' % utask_module)
-  uworker_input = uworker_io.deserialize_uworker_input(serialized_uworker_input)
+  with _MetricRecorder(_Subtask.UWORKER_MAIN, _Mode.QUEUE) as recorder:
+    logs.log('Starting utask_main: %s.' % utask_module)
+    uworker_input = uworker_io.deserialize_uworker_input(
+        serialized_uworker_input)
 
-  # Deal with the environment.
-  set_uworker_env(uworker_input.uworker_env)
-  uworker_input.uworker_env.clear()
-  uworker_output = utask_module.utask_main(uworker_input)
-  if uworker_output is None:
-    return None
-  result = uworker_io.serialize_uworker_output(uworker_output)
-  _record_e2e_duration(uworker_input.preprocess_start_time, utask_module,
-                       uworker_input.job_type, _Subtask.UWORKER_MAIN,
-                       _Mode.QUEUE)
-  return result
+    # Deal with the environment.
+    set_uworker_env(uworker_input.uworker_env)
+    uworker_input.uworker_env.clear()
+
+    recorder.set_task_details(utask_module, uworker_input.job_type,
+                              environment.platform(),
+                              uworker_input.preprocess_start_time)
+
+    uworker_output = utask_module.utask_main(uworker_input)
+    if uworker_output is None:
+      return None
+
+    return uworker_io.serialize_uworker_output(uworker_output)
 
 
 def tworker_postprocess_no_io(utask_module, uworker_output, uworker_input):
   """Executes the postprocess step on the trusted (t)worker (in this case it is
   the same bot as the uworker)."""
-  # TODO(metzman): Stop passing module to this function and uworker_main_no_io.
-  # Make them consistent with the I/O versions.
-  uworker_output = uworker_io.deserialize_uworker_output(uworker_output)
-  # Do this to simulate out-of-band tamper-proof storage of the input.
-  uworker_input = uworker_io.deserialize_uworker_input(uworker_input)
-  uworker_output.uworker_input.CopyFrom(uworker_input)
-  set_uworker_env(uworker_output.uworker_input.uworker_env)
-  utask_module.utask_postprocess(uworker_output)
-  _record_e2e_duration(uworker_input.preprocess_start_time, utask_module,
-                       uworker_input.job_type, _Subtask.POSTPROCESS,
-                       _Mode.QUEUE)
+  with _MetricRecorder(_Subtask.POSTPROCESS, _Mode.QUEUE) as recorder:
+    # TODO(metzman): Stop passing module to this function and
+    # uworker_main_no_io. Make them consistent with the I/O versions.
+    uworker_output = uworker_io.deserialize_uworker_output(uworker_output)
+    # Do this to simulate out-of-band tamper-proof storage of the input.
+    uworker_input = uworker_io.deserialize_uworker_input(uworker_input)
+    uworker_output.uworker_input.CopyFrom(uworker_input)
+    set_uworker_env(uworker_output.uworker_input.uworker_env)
+
+    recorder.set_task_details(utask_module, uworker_input.job_type,
+                              environment.platform(),
+                              uworker_input.preprocess_start_time)
+
+    utask_module.utask_postprocess(uworker_output)
 
 
 def tworker_preprocess(utask_module, task_argument, job_type, uworker_env):
   """Executes the preprocessing step of the utask |utask_module| and returns the
   signed download URL for the uworker's input and the (unsigned) download URL
   for its output."""
-  result = _preprocess(utask_module, task_argument, job_type, uworker_env)
-  if not result:
-    # Bail if preprocessing failed since we can't proceed.
-    return None
+  with _MetricRecorder(_Subtask.PREPROCESS, _Mode.BATCH) as recorder:
+    uworker_input = _preprocess(utask_module, task_argument, job_type,
+                                uworker_env, recorder)
+    if not uworker_input:
+      # Bail if preprocessing failed since we can't proceed.
+      return None
 
-  uworker_input, start = result
-
-  # Write the uworker's input to GCS and get the URL to download the input in
-  # case the caller needs it.
-  uworker_input_signed_download_url, uworker_output_download_gcs_url = (
-      uworker_io.serialize_and_upload_uworker_input(uworker_input))
-  _record_e2e_duration(start, utask_module, job_type, _Subtask.PREPROCESS,
-                       _Mode.BATCH)
-
-  # Return the uworker_input_signed_download_url for the remote executor to pass
-  # to the batch job and for the local executor to download locally. Return
-  # uworker_output_download_gcs_url for the local executor to download the
-  # output after local execution of the utask_main.
-  return uworker_input_signed_download_url, uworker_output_download_gcs_url
+    # Write the uworker's input to GCS and get the URL to download the input in
+    # case the caller needs it.
+    # Return both the uworker input signed download URL for the remote executor
+    # to pass to the batch job and for the local executor to download locally,
+    # and the uworker output download URL for the local executor to download
+    # the output after local execution of `utask_main`.
+    return uworker_io.serialize_and_upload_uworker_input(uworker_input)
 
 
 def set_uworker_env(uworker_env: dict) -> None:
@@ -188,25 +247,26 @@ def set_uworker_env(uworker_env: dict) -> None:
 def uworker_main(input_download_url) -> None:
   """Exectues the main part of a utask on the uworker (locally if not using
   remote executor)."""
-  uworker_input = uworker_io.download_and_deserialize_uworker_input(
-      input_download_url)
-  uworker_output_upload_url = uworker_input.uworker_output_upload_url
-  uworker_input.ClearField('uworker_output_upload_url')
+  with _MetricRecorder(_Subtask.UWORKER_MAIN, _Mode.BATCH) as recorder:
+    uworker_input = uworker_io.download_and_deserialize_uworker_input(
+        input_download_url)
+    uworker_output_upload_url = uworker_input.uworker_output_upload_url
+    uworker_input.ClearField('uworker_output_upload_url')
 
-  # Deal with the environment.
-  set_uworker_env(uworker_input.uworker_env)
-  uworker_input.uworker_env.clear()
+    set_uworker_env(uworker_input.uworker_env)
+    uworker_input.uworker_env.clear()
 
-  utask_module = get_utask_module(uworker_input.module_name)
-  logs.log('Starting utask_main: %s.' % utask_module)
-  uworker_output = utask_module.utask_main(uworker_input)
-  uworker_io.serialize_and_upload_uworker_output(uworker_output,
-                                                 uworker_output_upload_url)
-  logs.log('Finished uworker_main.')
-  _record_e2e_duration(uworker_input.preprocess_start_time, utask_module,
-                       uworker_input.job_type, _Subtask.UWORKER_MAIN,
-                       _Mode.BATCH)
-  return True
+    utask_module = get_utask_module(uworker_input.module_name)
+    recorder.set_task_details(utask_module, uworker_input.job_type,
+                              environment.platform(),
+                              uworker_input.preprocess_start_time)
+
+    logs.log('Starting utask_main: %s.' % utask_module)
+    uworker_output = utask_module.utask_main(uworker_input)
+    uworker_io.serialize_and_upload_uworker_output(uworker_output,
+                                                   uworker_output_upload_url)
+    logs.log('Finished uworker_main.')
+    return True
 
 
 def get_utask_module(module_name):
@@ -223,11 +283,16 @@ def uworker_bot_main():
 
 def tworker_postprocess(output_download_url) -> None:
   """Executes the postprocess step on the trusted (t)worker."""
-  uworker_output = uworker_io.download_and_deserialize_uworker_output(
-      output_download_url)
-  set_uworker_env(uworker_output.uworker_input.uworker_env)
-  utask_module = get_utask_module(uworker_output.uworker_input.module_name)
-  utask_module.utask_postprocess(uworker_output)
-  _record_e2e_duration(uworker_output.uworker_input.preprocess_start_time,
-                       utask_module, uworker_output.uworker_input.job_type,
-                       _Subtask.POSTPROCESS, _Mode.BATCH)
+  with _MetricRecorder(_Subtask.POSTPROCESS, _Mode.BATCH) as recorder:
+    uworker_output = uworker_io.download_and_deserialize_uworker_output(
+        output_download_url)
+
+    set_uworker_env(uworker_output.uworker_input.uworker_env)
+
+    utask_module = get_utask_module(uworker_output.uworker_input.module_name)
+    recorder.set_task_details(
+        utask_module, uworker_output.uworker_input.job_type,
+        environment.platform(),
+        uworker_output.uworker_input.preprocess_start_time)
+
+    utask_module.utask_postprocess(uworker_output)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -22,6 +22,7 @@ from google.protobuf import timestamp_pb2
 
 from clusterfuzz._internal.bot.tasks import utasks
 from clusterfuzz._internal.bot.tasks.utasks import analyze_task
+from clusterfuzz._internal.metrics import monitor
 from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.protos import uworker_msg_pb2
 from clusterfuzz._internal.tests.test_libs import helpers
@@ -37,6 +38,7 @@ class TworkerPreprocessTest(unittest.TestCase):
   JOB_TYPE = 'libfuzzer_asan'
 
   def setUp(self):
+    monitor.metrics_store().reset_for_testing()
     helpers.patch(self, [
         'clusterfuzz._internal.bot.tasks.utasks.uworker_io.get_uworker_output_urls',
         'clusterfuzz._internal.bot.tasks.utasks.uworker_io.serialize_and_upload_uworker_input',
@@ -48,8 +50,7 @@ class TworkerPreprocessTest(unittest.TestCase):
 
   def test_tworker_preprocess(self):
     """Tests that tworker_preprocess works as intended."""
-    module = mock.MagicMock(__name__='tasks.analyze_task')
-    module.__name__ = 'mock_task'
+    module = mock.MagicMock(__name__='mock_task')
 
     uworker_input = uworker_msg_pb2.Input(job_type='something')
     module.utask_preprocess.return_value = uworker_input
@@ -87,7 +88,7 @@ class TworkerPreprocessTest(unittest.TestCase):
         (self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL), result)
 
   def test_return_none(self):
-    module = mock.MagicMock()
+    module = mock.MagicMock(__name__='mock_task')
     module.utask_preprocess.return_value = None
     self.assertIsNone(
         utasks.tworker_preprocess(module, self.TASK_ARGUMENT, self.JOB_TYPE,
@@ -119,6 +120,7 @@ class UworkerMainTest(unittest.TestCase):
   UWORKER_OUTPUT_UPLOAD_URL = 'https://uworker_output_upload_url'
 
   def setUp(self):
+    monitor.metrics_store().reset_for_testing()
     helpers.patch_environ(self)
     helpers.patch(self, [
         'clusterfuzz._internal.bot.tasks.utasks.uworker_io.download_and_deserialize_uworker_input',
@@ -183,6 +185,7 @@ class TworkerPostprocessTest(unittest.TestCase):
   """Tests that tworker_postprocess works as intended."""
 
   def setUp(self):
+    monitor.metrics_store().reset_for_testing()
     helpers.patch_environ(self)
     helpers.patch(self, [
         'clusterfuzz._internal.bot.tasks.utasks.uworker_io.download_and_deserialize_uworker_output',


### PR DESCRIPTION
Using a context manager class to wrap task execution. Improves on #3698.