### PR TITLE
[reland] archive: rework archive classes to make it extendable (#3515)

### DIFF
--- a/src/appengine/handlers/fuzzers.py
+++ b/src/appengine/handlers/fuzzers.py
@@ -97,8 +97,8 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
       executable_path = 'run'  # Check for default.
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
-    return archive.get_first_file_matching(executable_path, reader,
-                                           upload_info.filename)
+    with archive.open(upload_info.filename, reader) as archive_reader:
+      return archive_reader.get_first_file_matching(executable_path)
 
   def _get_launcher_script(self, upload_info):
     """Get launcher script path."""
@@ -113,8 +113,8 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
       return launcher_script
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
-    launcher_script = archive.get_first_file_matching(launcher_script, reader,
-                                                      upload_info.filename)
+    archive_reader = archive.open(upload_info.filename, reader)
+    launcher_script = archive_reader.get_first_file_matching(launcher_script)
     if not launcher_script:
       raise helpers.EarlyExitError(
           'Specified launcher script was not found in archive!', 400)

--- a/src/appengine/handlers/fuzzers.py
+++ b/src/appengine/handlers/fuzzers.py
@@ -113,11 +113,11 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
       return launcher_script
 
     reader = self._read_to_bytesio(upload_info.gcs_path)
-    archive_reader = archive.open(upload_info.filename, reader)
-    launcher_script = archive_reader.get_first_file_matching(launcher_script)
-    if not launcher_script:
-      raise helpers.EarlyExitError(
-          'Specified launcher script was not found in archive!', 400)
+    with archive.open(upload_info.filename, reader) as archive_reader:
+      launcher_script = archive_reader.get_first_file_matching(launcher_script)
+      if not launcher_script:
+        raise helpers.EarlyExitError(
+            'Specified launcher script was not found in archive!', 400)
 
     return launcher_script
 

--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -136,10 +136,10 @@ def guess_input_file(uploaded_file, filename):
   """Guess the main test case file from an archive."""
   for file_pattern in RUN_FILE_PATTERNS:
     blob_reader = _read_to_bytesio(uploaded_file.gcs_path)
-    file_path_input = archive.get_first_file_matching(file_pattern, blob_reader,
-                                                      filename)
-    if file_path_input:
-      return file_path_input
+    with archive.open(filename, blob_reader) as reader:
+      file_path_input = reader.get_first_file_matching(file_pattern)
+      if file_path_input:
+        return file_path_input
 
   return None
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -646,24 +646,28 @@ def unpack_seed_corpus_if_needed(fuzz_target_path,
   if force_unpack:
     logs.log('Forced unpack: %s.' % seed_corpus_archive_path)
 
-  archive_iterator = archive.iterator(seed_corpus_archive_path)
-  # Unpack seed corpus recursively into the root of the main corpus directory.
+  try:
+    reader = archive.open(seed_corpus_archive_path)
+  except:
+    logs.log_error(f'Failed reading archive: {seed_corpus_archive_path}')
+    return
+
   idx = 0
-  for seed_corpus_file in archive_iterator:
-    # Ignore directories.
-    if seed_corpus_file.name.endswith('/'):
-      continue
+  with reader:
+    for file in reader.list_members():
+      if file.is_dir:
+        continue
 
-    # Allow callers to opt-out of unpacking large files.
-    if seed_corpus_file.size > max_bytes:
-      continue
+      if file.size_bytes > max_bytes:
+        continue
 
-    output_filename = '%016d' % idx
-    output_file_path = os.path.join(corpus_directory, output_filename)
-    with open(output_file_path, 'wb') as file_handle:
-      shutil.copyfileobj(seed_corpus_file.handle, file_handle)
+      output_filename = '%016d' % idx
+      output_file_path = os.path.join(corpus_directory, output_filename)
+      with open(output_file_path, 'wb') as file_handle:
+        with reader.open(file.name) as file:
+          shutil.copyfileobj(file, file_handle)
 
-    idx += 1
+      idx += 1
 
   logs.log('Unarchiving %d files from seed corpus %s.' %
            (idx, seed_corpus_archive_path))

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -1372,7 +1372,8 @@ def use_peach_mutator(extra_env, grammar):
   unzipped = os.path.join(peach_dir, 'mutator')
   source = os.path.join(peach_dir, 'peach_mutator.zip')
 
-  archive.unpack(source, unzipped, trusted=True)
+  with archive.open(source) as reader:
+    archive.unpack(reader, unzipped, trusted=True)
 
   # Set LD_PRELOAD.
   peach_path = os.path.join(unzipped, 'peach_mutator', 'src', 'peach.so')

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -383,8 +383,10 @@ def unpack_testcase(testcase, testcase_download_url):
 
   file_list = []
   if archived:
-    archive.unpack(temp_filename, input_directory)
-    file_list = archive.get_file_list(temp_filename)
+    with archive.open(temp_filename) as reader:
+      archive.unpack(reader, input_directory)
+      file_list = [f.name for f in reader.list_members()]
+
     shell.remove_file(temp_filename)
 
     file_exists = False
@@ -594,7 +596,8 @@ def _update_fuzzer(update_input: uworker_msg_pb2.SetupInput,
     return False
 
   try:
-    archive.unpack(archive_path, fuzzer_directory)
+    with archive.open(archive_path) as reader:
+      archive.unpack(reader, fuzzer_directory)
   except Exception:
     error_message = (f'Failed to unpack fuzzer archive {fuzzer.filename} '
                      '(bad archive or unsupported format).')

--- a/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/unpack_task.py
@@ -65,7 +65,8 @@ def execute_task(metadata_id, job_type):
     return
 
   try:
-    archive.unpack(archive_path, testcases_directory)
+    with archive.open(archive_path) as reader:
+      archive.unpack(reader, testcases_directory)
   except:
     logs.log_error('Could not unpack archive for bundle %d.' % metadata_id)
     tasks.add_task('unpack', metadata_id, job_type)
@@ -78,10 +79,9 @@ def execute_task(metadata_id, job_type):
 
   archive_state = data_types.ArchiveStatus.NONE
   bundled = True
-  file_list = archive.get_file_list(archive_path)
 
-  for file_path in file_list:
-    absolute_file_path = os.path.join(testcases_directory, file_path)
+  for f in reader.list_members():
+    absolute_file_path = os.path.join(testcases_directory, f.name)
     filename = os.path.basename(absolute_file_path)
 
     # Only files are actual testcases. Skip directories.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -294,8 +294,8 @@ class Context:
       corpus_backup_output_directory = os.path.join(self.shared_corpus_path,
                                                     project_qualified_name)
       shell.create_directory(corpus_backup_output_directory)
-      result = archive.unpack(corpus_backup_local_path,
-                              corpus_backup_output_directory)
+      with archive.open(corpus_backup_local_path) as reader:
+        result = archive.unpack(reader, corpus_backup_output_directory)
       shell.remove_file(corpus_backup_local_path)
 
       if result:

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1097,7 +1097,8 @@ def setup_user_profile_directory_if_needed(user_profile_directory):
     # Unpack the fuzzPriv extension.
     extension_archive = os.path.join(environment.get_resources_directory(),
                                      'firefox', 'fuzzPriv-extension.zip')
-    archive.unpack(extension_archive, extensions_directory)
+    with archive.open(extension_archive) as reader:
+      archive.unpack(reader, extensions_directory)
 
     # Add this extension in the extensions configuration file.
     extension_config_file_path = os.path.join(user_profile_directory,

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -151,13 +151,12 @@ def _make_space(requested_size, current_build_dir=None):
   return result
 
 
-def _make_space_for_build(build_local_archive,
+def _make_space_for_build(archive_reader,
                           current_build_dir,
                           file_match_callback=None):
   """Make space for extracting the build archive by deleting the least recently
   used builds."""
-  extracted_size = archive.extracted_size(
-      build_local_archive, file_match_callback=file_match_callback)
+  extracted_size = archive_reader.extracted_size(file_match_callback)
 
   return _make_space(extracted_size, current_build_dir=current_build_dir)
 
@@ -540,6 +539,13 @@ class Build(BaseBuild):
 
     unpack_everything = environment.get_value(
         'UNPACK_ALL_FUZZ_TARGETS_AND_FILES')
+
+    try:
+      reader = archive.open(build_local_archive)
+    except:
+      logs.log_error(f'Unable to open build archive {build_local_archive}.')
+      return False
+
     if not unpack_everything:
       # For fuzzing, pick a random fuzz target so that we only un-archive that
       # particular fuzz target and its dependencies and save disk space.  If we
@@ -550,16 +556,14 @@ class Build(BaseBuild):
       # large builds (such as Chrome OS). Defer setting it until after the build
       # has been unpacked.
       self._pick_fuzz_target(
-          self._get_fuzz_targets_from_archive(build_local_archive),
-          target_weights)
+          self._get_fuzz_targets_from_archive(reader), target_weights)
 
     # Actual list of files to unpack can be smaller if we are only unarchiving
     # a particular fuzz target.
     file_match_callback = _get_file_match_callback()
     assert not (unpack_everything and file_match_callback is not None)
 
-    if not _make_space_for_build(build_local_archive, base_build_dir,
-                                 file_match_callback):
+    if not _make_space_for_build(reader, base_build_dir, file_match_callback):
       shell.clear_data_directories()
       logs.log_fatal_and_exit(
           'Failed to make space for build. '
@@ -570,7 +574,7 @@ class Build(BaseBuild):
     trusted = not utils.is_oss_fuzz()
     try:
       archive.unpack(
-          build_local_archive,
+          reader,
           build_dir,
           trusted=trusted,
           file_match_callback=file_match_callback)
@@ -578,6 +582,7 @@ class Build(BaseBuild):
       logs.log_error('Unable to unpack build archive %s.' % build_local_archive)
       return False
 
+    reader.close()
     if unpack_everything:
       # Set a random fuzz target now that the build has been unpacked, if we
       # didn't set one earlier. For an auxiliary build, fuzz target is already
@@ -601,14 +606,14 @@ class Build(BaseBuild):
 
     return True
 
-  def _get_fuzz_targets_from_archive(self, archive_path):
+  def _get_fuzz_targets_from_archive(self, reader):
     """Get iterator of fuzz targets from archive path."""
     # Import here as this path is not available in App Engine context.
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
-    for archive_file in archive.iterator(archive_path):
+    for archive_file in reader.list_members():
       if fuzzer_utils.is_fuzz_target_local(archive_file.name,
-                                           archive_file.handle):
+                                           reader.try_open(archive_file.name)):
         fuzz_target = _normalize_target_name(archive_file.name)
         yield fuzz_target
 
@@ -841,7 +846,8 @@ class CuttlefishKernelBuild(RegularBuild):
     # Extract syzkaller binary.
     syzkaller_path = os.path.join(self.build_dir, 'syzkaller')
     shell.remove_directory(syzkaller_path)
-    archive.unpack(archive_dst_path, syzkaller_path)
+    with archive.open(archive_dst_path) as reader:
+      archive.unpack(reader, syzkaller_path)
     shell.remove_file(archive_dst_path)
 
     environment.set_value('VMLINUX_PATH', self.build_dir)
@@ -959,17 +965,24 @@ class CustomBuild(Build):
     if not blobs.read_blob_to_disk(self.custom_binary_key, build_local_archive):
       return False
 
+    try:
+      reader = archive.open(build_local_archive)
+    except:
+      logs.log_error('Unable to open build archive %s.' % build_local_archive)
+      return False
+
     # If custom binary is an archive, then unpack it.
     if archive.is_archive(self.custom_binary_filename):
-      if not _make_space_for_build(build_local_archive, self.base_build_dir):
+      if not _make_space_for_build(reader, self.base_build_dir):
         # Remove downloaded archive to free up space and otherwise, it won't get
         # deleted until next job run.
+        reader.close()
         shell.remove_file(build_local_archive)
 
         logs.log_fatal_and_exit('Could not make space for build.')
 
       try:
-        archive.unpack(build_local_archive, self.build_dir, trusted=True)
+        archive.unpack(reader, self.build_dir, trusted=True)
       except:
         logs.log_error(
             'Unable to unpack build archive %s.' % build_local_archive)
@@ -978,6 +991,7 @@ class CustomBuild(Build):
       # Remove the archive.
       shell.remove_file(build_local_archive)
 
+    reader.close()
     self._pick_fuzz_target(
         self._get_fuzz_targets_from_dir(self.build_dir), self.target_weights)
     return True

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -612,10 +612,12 @@ class Build(BaseBuild):
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
     for archive_file in reader.list_members():
-      if fuzzer_utils.is_fuzz_target_local(archive_file.name,
-                                           reader.try_open(archive_file.name)):
+      file_handle = reader.try_open(archive_file.name)
+      if fuzzer_utils.is_fuzz_target_local(archive_file.name, file_handle):
         fuzz_target = _normalize_target_name(archive_file.name)
         yield fuzz_target
+      if file_handle:
+        file_handle.close()
 
   def _get_fuzz_targets_from_dir(self, build_dir):
     """Get iterator of fuzz targets from build dir."""

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -86,7 +86,8 @@ def download_latest_build(build_info, image_regexes, image_directory):
 
     for file_path in image_file_paths:
       if file_path.endswith('.zip') or file_path.endswith('.tar.gz'):
-        archive.unpack(file_path, image_directory)
+        with archive.open(file_path) as reader:
+          archive.unpack(reader, image_directory)
 
 
 def flash_to_latest_build_if_needed():

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -169,7 +169,8 @@ def download_system_symbols_if_needed(symbols_directory):
         'Unable to locate symbols archive %s.' % symbols_archive_path)
     return
 
-  archive.unpack(symbols_archive_path, symbols_directory, trusted=True)
+  with archive.open(symbols_archive_path) as reader:
+    archive.unpack(reader, symbols_directory, trusted=True)
   shell.remove_file(symbols_archive_path)
 
   utils.write_data_to_file(build_params, build_params_check_path)

--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -13,9 +13,15 @@
 # limitations under the License.
 """Functions for handling archives."""
 
-import lzma
+import abc
+import dataclasses
 import os
 import tarfile
+from typing import BinaryIO
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import Union
 import zipfile
 
 from clusterfuzz._internal.metrics import logs
@@ -33,6 +39,350 @@ LZMA_FILE_EXTENSIONS = ['.tar.lzma', '.tar.xz']
 ARCHIVE_FILE_EXTENSIONS = (
     ZIP_FILE_EXTENSIONS + TAR_FILE_EXTENSIONS + LZMA_FILE_EXTENSIONS)
 
+StrBytesPathLike = Union[str, bytes, os.PathLike]
+MatchCallback = Callable[[str], bool]
+
+
+def _is_attempting_path_traversal(archive_name: StrBytesPathLike,
+                                  output_dir: StrBytesPathLike,
+                                  filename: StrBytesPathLike) -> bool:
+  """Detects whether there is a path traversal attempt.
+
+  Args:
+      archive_name: the name of the archive.
+      output_dir: the output directory.
+      filename: the name of the file being checked.
+
+  Returns:
+      Whether there is a path traversal attempt
+  """
+  output_dir = os.path.realpath(output_dir)
+  absolute_file_path = os.path.join(output_dir, os.path.normpath(filename))
+  real_file_path = os.path.realpath(absolute_file_path)
+
+  if real_file_path == output_dir:
+    # Workaround for https://bugs.python.org/issue28488.
+    # Ignore directories named '.'.
+    return False
+
+  if real_file_path != absolute_file_path:
+    logs.log_error('Directory traversal attempted while unpacking archive %s '
+                   '(file path=%s, actual file path=%s). Aborting.' %
+                   (archive_name, absolute_file_path, real_file_path))
+    return True
+  return False
+
+
+@dataclasses.dataclass
+class ArchiveMemberInfo:
+  """Represents an archive member. A member can either be a file or a directory.
+  Members:
+    name: the name of the archive member. It can represent a file or a directory
+    name.
+    is_dir: whether this member is a directory.
+    size_bytes: the extracted size of the member.
+    mode: the mode of the member (file system attributes).
+  """
+  name: str
+  is_dir: bool
+  size_bytes: int
+  mode: int
+
+
+class ArchiveReader(abc.ABC):
+  """Abstract class for representing an archive reader.
+  """
+
+  @abc.abstractmethod
+  def list_members(self) -> List[ArchiveMemberInfo]:
+    """Lists all members contained in the archives.
+
+    Returns:
+        List[ArchiveMemberInfo]: All the archive members
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def extract(self,
+              member: str,
+              path: Union[str, os.PathLike],
+              trusted: bool = False) -> str:
+    """Extracts `member` out of the archive to the provided path.
+    If `member` is a directory in the archive, only the directory itself will
+    be extracted, not its content.
+
+    Args:
+        member: the member name
+        path: the path where the member should be extracted.
+        trusted: whether the archive is trusted.
+
+    Returns:
+        The path to the extracted member
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def open(self, member: str) -> BinaryIO:
+    """Opens `member`.
+
+    Args:
+        member: the member name
+
+    Returns:
+        a file-like object that can be `read`.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def close(self) -> None:
+    """Closes the archive.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def extract_all(self,
+                  path: Union[str, os.PathLike],
+                  members: Optional[List[str]] = None,
+                  trusted: bool = False) -> None:
+    """Extract the whole archive content or the members listed in `members`.
+
+    Args:
+        path: the path where the members should be extracted.
+        members: the member names.
+        trusted: whether the archive is trusted or not.
+    """
+    raise NotImplementedError
+
+  def try_open(self, member: str) -> Optional[BinaryIO]:
+    """Tries to open the archive. Does not throw.
+
+    Args:
+        member: the member name
+
+    Returns:
+        a file-like object that can be `read` or None if an error occured.
+    """
+    try:
+      return self.open(member)
+    except:
+      return None
+
+  def get_first_file_matching(self, search_string: str) -> str:
+    """Gets the name of the first matching member.
+
+    Args:
+        search_string: the string to be searched for.
+
+    Returns:
+        the member name that matched.
+    """
+    for file in self.list_members():
+      if file.name.startswith('__MACOSX/'):
+        # Exclude MAC resource forks.
+        continue
+
+      if search_string in file.name:
+        return file.name
+    return None
+
+  def extracted_size(self, file_match_callback: MatchCallback = None) -> int:
+    """Gets the total extracted size of the files matched by
+    file_match_callback. If file_match_callback is None, gets the extracted
+    size of the whole archive.
+
+    Args:
+        file_match_callback: the file matching callback.
+
+    Returns:
+        the sum of the extract size in bytes of members matched with the
+        callback. If the callback isn't specified, returns the extracted size
+        of the whole archive.
+    """
+    return sum(f.size_bytes
+               for f in self.list_members()
+               if not file_match_callback or file_match_callback(f.name))
+
+
+class TarArchiveReader(ArchiveReader):
+  """A tar archive reader. Currently supports TAR and TAR_LZMA archives.
+  """
+
+  def __init__(self,
+               archive_path: Union[str, os.PathLike],
+               file_obj: BinaryIO = None) -> None:
+    if file_obj:
+      self._archive = tarfile.open(fileobj=file_obj)
+    else:
+      archive_type = get_archive_type(archive_path)
+      mode = 'r' if archive_type == ArchiveType.TAR else 'r:xz'
+      self._archive = tarfile.open(archive_path, mode=mode)
+    self._archive_path = archive_path
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *args):
+    self._archive.close()
+
+  def list_members(self) -> List[ArchiveMemberInfo]:
+    return [
+        ArchiveMemberInfo(
+            name=f.name, is_dir=f.isdir(), size_bytes=f.size, mode=f.mode)
+        for f in self._archive.getmembers()
+    ]
+
+  def open(self, member: str):
+    return self._archive.extractfile(member)
+
+  def close(self) -> None:
+    self._archive.close()
+
+  def extract(self,
+              member: str,
+              path: Union[str, os.PathLike],
+              trusted: bool = False):
+    # If the output directory is a symlink, get its actual path since we will be
+    # doing directory traversal checks later when unpacking the archive.
+    output_directory = os.path.realpath(path)
+
+    if not trusted:
+      if (_is_attempting_path_traversal(self._archive_path, output_directory,
+                                        member)):
+        return None
+
+    self._archive.extract(member=member, path=output_directory)
+    return os.path.realpath(os.path.join(output_directory, member))
+
+  def extract_all(self,
+                  path: Union[str, os.PathLike],
+                  members: Optional[List[str]] = None,
+                  trusted: bool = False) -> None:
+    to_extract = members if members is not None else self._archive.namelist()
+    for member in to_extract:
+      self.extract(member=member, path=path, trusted=trusted)
+
+
+class ZipArchiveReader(ArchiveReader):
+  """A zip archive reader.
+  """
+
+  def __init__(self, file) -> None:
+    self._zip_archive = zipfile.ZipFile(file, mode='r')
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *args):
+    self._zip_archive.close()
+
+  def list_members(self) -> List[ArchiveMemberInfo]:
+    return [
+        ArchiveMemberInfo(
+            name=f.filename,
+            is_dir=f.is_dir(),
+            size_bytes=f.file_size,
+            mode=(f.external_attr >> 16) & 0o7777)
+        for f in self._zip_archive.infolist()
+    ]
+
+  def open(self, member):
+    return self._zip_archive.open(name=member)
+
+  def close(self) -> None:
+    self._zip_archive.close()
+
+  def extract(self,
+              member: str,
+              path: Union[str, os.PathLike],
+              trusted: bool = False):
+    # If the output directory is a symlink, get its actual path since we will be
+    # doing directory traversal checks later when unpacking the archive.
+    output_directory = os.path.realpath(path)
+
+    # If the archive is not trusted, do file path checks to make
+    # sure this archive is safe and is not attempting to do path
+    # traversals.
+    if not trusted:
+      if (_is_attempting_path_traversal(self._zip_archive.filename,
+                                        output_directory, member)):
+        return None
+
+    try:
+      extracted_path = self._zip_archive.extract(member, output_directory)
+
+      # Preserve permissions for regular files. 640 is the default
+      # permission for extract. If we need execute permission, we need
+      # to chmod it explicitly. Also, get rid of suid bit for security
+      # reasons.
+      external_attr = self._zip_archive.getinfo(member).external_attr >> 16
+      if oct(external_attr).startswith(FILE_ATTRIBUTE):
+        old_mode = external_attr & 0o7777
+        new_mode = external_attr & 0o777
+        new_mode |= 0o440
+        needs_execute_permission = external_attr & 100
+
+        if new_mode != old_mode or needs_execute_permission:
+          # Default extract condition is 640 which is safe.
+          # |new_mode| might have read+write+execute bit for
+          # others, so remove those.
+          new_mode &= 0o770
+
+          os.chmod(extracted_path, new_mode)
+
+      # Create symlink if needed (only on unix platforms).
+      if (trusted and hasattr(os, 'symlink') and
+          oct(external_attr).startswith(SYMLINK_ATTRIBUTE)):
+        symlink_source = self._zip_archive.read(member)
+        if os.path.exists(extracted_path):
+          os.remove(extracted_path)
+        os.symlink(symlink_source, extracted_path)
+
+      return extracted_path
+    except Exception as e:
+      # In case of errors, we try to extract whatever we can without errors.
+      logs.log_warn('An error occured while extracting %s from the archive: %s.'
+                    % (member, repr(e)))
+      return None
+
+  def extract_all(self,
+                  path: Union[str, os.PathLike],
+                  members: Optional[List[str]] = None,
+                  trusted: bool = False) -> None:
+    to_extract = members if members is not None else self._zip_archive.namelist(
+    )
+    for member in to_extract:
+      self.extract(member=member, path=path, trusted=trusted)
+
+
+class ArchiveError(Exception):
+  """ArchiveError"""
+
+
+# pylint: disable=redefined-builtin
+def open(archive_path: str,
+         file_obj: Optional[BinaryIO] = None) -> ArchiveReader:
+  """Opens the archive and gets the appropriate archive reader based on the
+  `archive_path`. If `file_obj` is not none, the binary file-like object will be
+  used to read the archive instead of opening `archive_path`.
+
+  Args:
+      archive_path: the path to the archive.
+      file_obj: a file-like object containing the archive.
+
+  Raises:
+      If the file could not be opened or if the archive type cannot be handled.
+      See `is_archive()` to check whether the archive type is handled.
+
+  Returns:
+      the archive reader.
+  """
+  archive_type = get_archive_type(archive_path)
+  if archive_type == ArchiveType.ZIP:
+    return ZipArchiveReader(archive_path or file_obj)
+  if archive_type in (ArchiveType.TAR_LZMA, ArchiveType.TAR):
+    return TarArchiveReader(archive_path, file_obj=file_obj)
+  raise ArchiveError('Unhandled archive type.')
+
 
 class ArchiveType:
   """Type of the archive."""
@@ -42,107 +392,15 @@ class ArchiveType:
   TAR_LZMA = 3
 
 
-class ArchiveFile:
-  """File in an archive."""
+def get_archive_type(archive_path: str) -> ArchiveType:
+  """Get the type of the archive.
 
-  def __init__(self, name, size, handle):
-    self.name = name
-    self.size = size
-    self.handle = handle
+  Args:
+      archive_path: the path to the archive.
 
-
-def iterator(archive_path,
-             archive_obj=None,
-             file_match_callback=None,
-             should_extract=True):
-  """Return an iterator for files in an archive. Extracts files if
-  |should_extract| is True."""
-  archive_type = get_archive_type(archive_path)
-
-  if not file_match_callback:
-
-    def file_match_callback_fallback(_):
-      return True
-
-    file_match_callback = file_match_callback_fallback
-
-  def maybe_extract(extract_func, info):
-    """Returns an extracted file or None if it is not supposed to be extracted.
-    """
-    if should_extract:
-      return extract_func(info)
-    return None
-
-  if archive_type == ArchiveType.ZIP:
-    try:
-      with zipfile.ZipFile(archive_obj or archive_path) as zip_file:
-        for info in zip_file.infolist():
-          if not file_match_callback(info.filename):
-            continue
-
-          yield ArchiveFile(info.filename, info.file_size,
-                            maybe_extract(zip_file.open, info))
-
-    except (zipfile.BadZipfile, zipfile.LargeZipFile):
-      logs.log_error('Bad zip file %s.' % archive_path)
-
-  elif archive_type == ArchiveType.TAR:
-    try:
-      if archive_obj:
-        tar_file = tarfile.open(fileobj=archive_obj)
-      else:
-        tar_file = tarfile.open(archive_path)
-
-      for info in tar_file.getmembers():
-        if not file_match_callback(info.name):
-          continue
-
-        yield ArchiveFile(info.name, info.size,
-                          maybe_extract(tar_file.extractfile, info))
-      tar_file.close()
-    except tarfile.TarError:
-      logs.log_error('Bad tar file %s.' % archive_path)
-
-  elif archive_type == ArchiveType.TAR_LZMA:
-    assert archive_obj is None, "LZMAFile doesn't support opening file handles."
-    try:
-      with lzma.LZMAFile(archive_path) as lzma_file, \
-            tarfile.open(fileobj=lzma_file) as tar_file:
-
-        error_filepaths = []
-        for info in tar_file.getmembers():
-          if not file_match_callback(info.name):
-            continue
-
-          try:
-            yield ArchiveFile(info.name, info.size,
-                              maybe_extract(tar_file.extractfile, info))
-
-          except KeyError:  # Handle broken links gracefully.
-            error_filepaths.append(info.name)
-            yield ArchiveFile(info.name, info.size, None)
-
-        if error_filepaths:
-          logs.log_warn(
-              'Check archive %s for broken links.' % archive_path,
-              error_filepaths=error_filepaths)
-
-    except (lzma.LZMAError, tarfile.TarError):
-      logs.log_error('Bad lzma file %s.' % archive_path)
-
-  else:
-    logs.log_error('Unsupported compression type for file %s.' % archive_path)
-
-
-def extracted_size(archive_path, archive_obj=None, file_match_callback=None):
-  """Return the total extracted size of the archive."""
-  return sum(
-      f.size for f in iterator(
-          archive_path, archive_obj, file_match_callback, should_extract=False))
-
-
-def get_archive_type(archive_path):
-  """Get the type of the archive."""
+  Returns:
+      the type of the archive, or ArchiveType.UNKNOWN if unknown.
+  """
 
   def has_extension(extensions):
     """Returns True if |archive_path| endswith an extension in |extensions|."""
@@ -163,171 +421,54 @@ def get_archive_type(archive_path):
   return ArchiveType.UNKNOWN
 
 
-def get_file_list(archive_path, archive_obj=None, file_match_callback=None):
-  """List all files in an archive."""
-  return [
-      f.name for f in iterator(
-          archive_path, archive_obj, file_match_callback, should_extract=False)
-  ]
+def is_archive(filename: str) -> bool:
+  """Return true if the file is an archive.
 
+  Args:
+      filename: the path to a file.
 
-def get_first_file_matching(search_string, archive_obj, archive_path):
-  """Returns the first file with a name matching search string in archive."""
-  for current_file in get_file_list(archive_path, archive_obj):
-    # Exclude MAC resouce forks.
-    if current_file.startswith('__MACOSX/'):
-      continue
-
-    if search_string in current_file:
-      return current_file
-
-  return None
-
-
-def is_archive(filename):
-  """Return true if the file is an archive."""
+  Returns:
+      whether the provided file is an archive.
+  """
   return get_archive_type(filename) != ArchiveType.UNKNOWN
 
 
-def unpack(archive_path,
-           output_directory,
-           trusted=False,
-           file_match_callback=None):
-  """Extracts an archive into the target directory."""
-  if not os.path.exists(archive_path):
-    logs.log_error('Archive %s not found.' % archive_path)
-    return False
+def unpack(reader: ArchiveReader,
+           output_dir: Union[str, os.PathLike],
+           trusted: bool = False,
+           file_match_callback: MatchCallback = None):
+  """Unpacks the current archive opened with `reader`. If `file_match_callback`
+  is None, unpacks all the archive. Otherwise, this only unpacks the files
+  matched by the callback.
 
-  # If the output directory is a symlink, get its actual path since we will be
-  # doing directory traversal checks later when unpacking the archive.
-  output_directory = os.path.realpath(output_directory)
+  Args:
+      reader: the archive reader
+      output_dir: the output directory to unpack the archive to.
+      trusted: whether the archive is trusted.
+      file_match_callback: the file matching callback.
 
-  archive_filename = os.path.basename(archive_path)
-  error_occurred = False
+  Returns:
+      bool: whether an error occurred.
+  """
+  assert reader
 
-  # Choose to unpack all files or ones matching a particular regex.
-  file_list = get_file_list(
-      archive_path, file_match_callback=file_match_callback)
+  file_list = [
+      f.name
+      for f in reader.list_members()
+      if not file_match_callback or file_match_callback(f.name)
+  ]
 
   archive_file_unpack_count = 0
   archive_file_total_count = len(file_list)
 
-  # If the archive is not trusted, do file path checks to make
-  # sure this archive is safe and is not attempting to do path
-  # traversals.
-  if not trusted:
-    for filename in file_list:
-      absolute_file_path = os.path.join(output_directory,
-                                        os.path.normpath(filename))
-      real_file_path = os.path.realpath(absolute_file_path)
-
-      if real_file_path == output_directory:
-        # Workaround for https://bugs.python.org/issue28488.
-        # Ignore directories named '.'.
-        continue
-
-      if real_file_path != absolute_file_path:
-        logs.log_error(
-            'Directory traversal attempted while unpacking archive %s '
-            '(file path=%s, actual file path=%s). Aborting.' %
-            (archive_path, absolute_file_path, real_file_path))
-        return False
-
-  archive_type = get_archive_type(archive_filename)
-
-  # Extract based on file's extension.
-  if archive_type == ArchiveType.ZIP:
-    zip_file_handle = open(archive_path, 'rb')
-    zip_archive = zipfile.ZipFile(zip_file_handle)
-
-    for filename in file_list:
-      try:
-        extracted_path = zip_archive.extract(filename, output_directory)
-
-        # Preserve permissions for regular files. 640 is the default
-        # permission for extract. If we need execute permission, we need
-        # to chmod it explicitly. Also, get rid of suid bit for security
-        # reasons.
-        external_attr = zip_archive.getinfo(filename).external_attr >> 16
-        if oct(external_attr).startswith(FILE_ATTRIBUTE):
-          old_mode = external_attr & 0o7777
-          new_mode = external_attr & 0o777
-          new_mode |= 0o440
-          needs_execute_permission = external_attr & 100
-
-          if new_mode != old_mode or needs_execute_permission:
-            # Default extract condition is 640 which is safe.
-            # |new_mode| might have read+write+execute bit for
-            # others, so remove those.
-            new_mode &= 0o770
-
-            os.chmod(extracted_path, new_mode)
-
-        # Create symlink if needed (only on unix platforms).
-        if (trusted and hasattr(os, 'symlink') and
-            oct(external_attr).startswith(SYMLINK_ATTRIBUTE)):
-          symlink_source = zip_archive.read(filename)
-          if os.path.exists(extracted_path):
-            os.remove(extracted_path)
-          os.symlink(symlink_source, extracted_path)
-
-        # Keep heartbeat happy by updating with our progress.
-        archive_file_unpack_count += 1
-        if archive_file_unpack_count % 1000 == 0:
-          logs.log('Unpacked %d/%d.' % (archive_file_unpack_count,
-                                        archive_file_total_count))
-
-      except:
-        # In case of errors, we try to extract whatever we can without errors.
-        error_occurred = True
-        continue
-
-    logs.log('Unpacked %d/%d.' % (archive_file_unpack_count,
-                                  archive_file_total_count))
-    zip_archive.close()
-    zip_file_handle.close()
-
-    if error_occurred:
-      logs.log_error(
-          'Failed to extract everything from archive %s.' % archive_filename)
-
-  elif archive_type in (ArchiveType.TAR, ArchiveType.TAR_LZMA):
-    if archive_type == ArchiveType.TAR_LZMA:
-      lzma_file = lzma.LZMAFile(archive_path)
-      tar_archive = tarfile.open(fileobj=lzma_file)
-    else:
-      tar_archive = tarfile.open(archive_path)
-
-    try:
-      tar_archive.extractall(path=output_directory)
-    except:
-      # In case of errors, we try to extract whatever we can without errors.
-      error_occurred = True
-      logs.log_error(
-          'Failed to extract everything from archive %s, trying one at a time.'
-          % archive_filename)
-      for filename in file_list:
-        try:
-          tar_archive.extract(filename, output_directory)
-        except:
-          continue
-
-        # Keep heartbeat happy by updating with our progress.
-        archive_file_unpack_count += 1
-        if archive_file_unpack_count % 1000 == 0:
-          logs.log('Unpacked %d/%d.' % (archive_file_unpack_count,
-                                        archive_file_total_count))
-
+  error_occurred = False
+  for file in file_list:
+    error_occurred |= reader.extract(
+        member=file, path=output_dir, trusted=trusted) is None
+    # Keep heartbeat happy by updating with our progress.
+    archive_file_unpack_count += 1
+    if archive_file_unpack_count % 1000 == 0:
       logs.log('Unpacked %d/%d.' % (archive_file_unpack_count,
                                     archive_file_total_count))
-
-    tar_archive.close()
-    if archive_type == ArchiveType.TAR_LZMA:
-      lzma_file.close()
-
-  else:
-    logs.log_error(
-        'Unsupported compression type for file %s.' % archive_filename)
-    return False
 
   return not error_occurred

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -14,12 +14,15 @@
 """update_task tests."""
 import os
 import sys
+import tempfile
 import unittest
+import zipfile
 
 from pyfakefs import fake_filesystem_unittest
 
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot.tasks import update_task
+from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import monitor
 from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.tests.test_libs import helpers
@@ -181,3 +184,79 @@ class GetUrlsTest(unittest.TestCase):
     self.assertEqual(
         'gs://test-deployment-bucket/linux%s.zip' % self.deployment_suffix,
         update_task.get_source_url())
+
+
+@test_utils.slow
+@test_utils.integration
+class UpdateSourceCodeIntegrationTest(unittest.TestCase):
+  """Tests updating clusterfuzz source code."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+    if os.getenv('PARALLEL_TESTS'):
+      self.skipTest('Package testing is disabled when running in parallel.')
+
+    self.temp_directory = self._make_temp_dir()
+    self.bot_tmpdir = self._make_temp_dir()
+    os.environ['ROOT_DIR'] = os.path.join(self.temp_directory, 'child')
+    os.mkdir(os.environ['ROOT_DIR'])
+    os.environ['BOT_TMPDIR'] = self.bot_tmpdir
+    os.environ['TEST_TMPDIR'] = self.bot_tmpdir
+    self.saved_cwd = os.getcwd()
+    os.chdir(os.environ['ROOT_DIR'])
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.process_handler.cleanup_stale_processes',
+        'local.butler.common.is_git_dirty',
+        'clusterfuzz._internal.bot.tasks.update_task.get_source_url',
+        'clusterfuzz._internal.base.utils.read_data_from_file',
+    ])
+    self.mock.get_source_url.return_value = 'gs://clusterfuzz-deployment/test-deployment/linux-3.zip'
+    self.mock.read_data_from_file.return_value = b'version'
+
+  def tearDown(self):
+    os.chdir(self.saved_cwd)
+
+  def _make_temp_dir(self):
+    if not hasattr(self, '_dirs'):
+      self._dirs = []
+    created_dir = tempfile.TemporaryDirectory()
+    dir_name = created_dir.name
+    self._dirs.append(created_dir)
+    return dir_name
+
+  def test_files_have_read_and_write_permissions(self):
+    """Tests that all the extracted files have both read and write permissions."""
+    update_task.update_source_code()
+    for dirpath, _, filenames in os.walk(
+        os.path.join(self.temp_directory, 'clusterfuzz')):
+      for filename in filenames:
+        filepath = os.path.join(dirpath, filename)
+        self.assertTrue(os.access(filepath, os.R_OK))
+        self.assertTrue(os.access(filepath, os.W_OK))
+
+  def test_all_files_are_correctly_unpacked(self):
+    """Tests that all files in the zip archive are correctly unpacked."""
+    update_task.update_source_code()
+    zipfile_path = os.path.join(self._make_temp_dir(), 'linux.zip')
+    storage.copy_file_from(
+        'gs://clusterfuzz-deployment/test-deployment/linux-3.zip', zipfile_path)
+    archive = zipfile.ZipFile(zipfile_path)
+    for file in archive.namelist():
+      if os.path.basename(file) == 'adb':
+        continue
+      self.assertTrue(os.path.exists(os.path.join(self.temp_directory, file)))
+
+  def test_archive_execute_permission_is_respected(self):
+    """Tests that the exectuable bit is correctly propagated to source files."""
+    update_task.update_source_code()
+    zipfile_path = os.path.join(self._make_temp_dir(), 'linux.zip')
+    storage.copy_file_from(
+        'gs://clusterfuzz-deployment/test-deployment/linux-3.zip', zipfile_path)
+    archive = zipfile.ZipFile(zipfile_path)
+    for member in archive.infolist():
+      if os.path.basename(member.filename) == 'adb':
+        continue
+      mode = (member.external_attr >> 16) & 0o7777
+      filepath = os.path.join(self.temp_directory, member.filename)
+      if mode & 0o100:
+        self.assertTrue(os.access(filepath, os.X_OK))

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -210,7 +210,7 @@ class UpdateSourceCodeIntegrationTest(unittest.TestCase):
         'clusterfuzz._internal.bot.tasks.update_task.get_source_url',
         'clusterfuzz._internal.base.utils.read_data_from_file',
     ])
-    self.mock.get_source_url.return_value = 'gs://clusterfuzz-deployment/test-deployment/linux-3.zip'
+    self.mock.get_source_url.return_value = 'gs://clusterfuzz-deployment/linux-3.zip'
     self.mock.read_data_from_file.return_value = b'version'
 
   def tearDown(self):
@@ -238,8 +238,8 @@ class UpdateSourceCodeIntegrationTest(unittest.TestCase):
     """Tests that all files in the zip archive are correctly unpacked."""
     update_task.update_source_code()
     zipfile_path = os.path.join(self._make_temp_dir(), 'linux.zip')
-    storage.copy_file_from(
-        'gs://clusterfuzz-deployment/test-deployment/linux-3.zip', zipfile_path)
+    storage.copy_file_from('gs://clusterfuzz-deployment/linux-3.zip',
+                           zipfile_path)
     archive = zipfile.ZipFile(zipfile_path)
     for file in archive.namelist():
       if os.path.basename(file) == 'adb':
@@ -250,8 +250,8 @@ class UpdateSourceCodeIntegrationTest(unittest.TestCase):
     """Tests that the exectuable bit is correctly propagated to source files."""
     update_task.update_source_code()
     zipfile_path = os.path.join(self._make_temp_dir(), 'linux.zip')
-    storage.copy_file_from(
-        'gs://clusterfuzz-deployment/test-deployment/linux-3.zip', zipfile_path)
+    storage.copy_file_from('gs://clusterfuzz-deployment/linux-3.zip',
+                           zipfile_path)
     archive = zipfile.ZipFile(zipfile_path)
     for member in archive.infolist():
       if os.path.basename(member.filename) == 'adb':

--- a/src/clusterfuzz/_internal/tests/core/system/archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/archive_test.py
@@ -30,7 +30,8 @@ class UnpackTest(unittest.TestCase):
     """Test unpack with trusted=False passes with file having './' prefix."""
     tgz_path = os.path.join(TESTDATA_PATH, 'cwd-prefix.tgz')
     output_directory = tempfile.mkdtemp(prefix='cwd-prefix')
-    archive.unpack(tgz_path, output_directory, trusted=False)
+    with archive.open(tgz_path) as reader:
+      archive.unpack(reader, output_directory, trusted=False)
 
     test_file_path = os.path.join(output_directory, 'test')
     self.assertTrue(os.path.exists(test_file_path))
@@ -38,31 +39,45 @@ class UnpackTest(unittest.TestCase):
 
     shell.remove_directory(output_directory)
 
+  def test_extract(self):
+    tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
+    with archive.open(tar_xz_path) as reader:
+      self.assertEqual(reader.extracted_size(), 7)
 
-class IteratorTest(unittest.TestCase):
+  def test_file_list(self):
+    tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
+    with archive.open(tar_xz_path) as reader:
+      self.assertCountEqual(
+          [f.name for f in reader.list_members()],
+          ["archive_dir", "archive_dir/bye", "archive_dir/hi"])
+
+
+class ArchiveReaderTest(unittest.TestCase):
   """Tests for the archive.iterator function."""
 
   def test_tar_xz(self):
     """Test that a .tar.xz file is handled properly by iterator()."""
     tar_xz_path = os.path.join(TESTDATA_PATH, 'archive.tar.xz')
     expected_results = {'archive_dir/hi': b'hi\n', 'archive_dir/bye': b'bye\n'}
-    actual_results = {
-        archive_file.name: archive_file.handle.read()
-        for archive_file in archive.iterator(tar_xz_path)
-        if archive_file.handle
-    }
-    self.assertEqual(actual_results, expected_results)
+    with archive.open(tar_xz_path) as reader:
+      actual_results = {}
+      for member in reader.list_members():
+        if not member.is_dir:
+          with reader.open(member.name) as f:
+            actual_results[member.name] = f.read()
+      self.assertEqual(actual_results, expected_results)
 
   def test_cwd_prefix(self):
     """Test that a .tgz file with cwd prefix is handled."""
     tgz_path = os.path.join(TESTDATA_PATH, 'cwd-prefix.tgz')
     expected_results = {'./test': b'abc\n'}
-    actual_results = {
-        archive_file.name: archive_file.handle.read()
-        for archive_file in archive.iterator(tgz_path)
-        if archive_file.handle
-    }
-    self.assertEqual(actual_results, expected_results)
+    with archive.open(tgz_path) as reader:
+      actual_results = {}
+      for member in reader.list_members():
+        if not member.is_dir:
+          with reader.open(member.name) as f:
+            actual_results[member.name] = f.read()
+      self.assertEqual(actual_results, expected_results)
 
   def test_tar_xz_broken_links(self):
     """Test that a .tar file with broken links is handled properly by
@@ -71,30 +86,28 @@ class IteratorTest(unittest.TestCase):
 
     archive_name = 'broken-links.tar.xz'
     archive_path = os.path.join(TESTDATA_PATH, archive_name)
+    with archive.open(archive_path) as reader:
 
-    # Get the results we expect from iterator().
-    actual_results = []
-    for archive_file in archive.iterator(archive_path):
-      if archive_file.handle is not None:
-        actual_results.append((archive_file.name, archive_file.size,
-                               archive_file.handle.read()))
-      else:
-        actual_results.append((archive_file.name, archive_file.size, None))
+      # Get the results we expect from iterator().
+      actual_results = []
+      for file in reader.list_members():
+        # This means we can read the file.
+        handle = reader.try_open(file.name)
+        if handle is not None:
+          actual_results.append((file.name, file.size_bytes, handle.read()))
+          handle.close()
+        else:
+          actual_results.append((file.name, file.size_bytes, None))
 
-    # Check that iterator returns what we expect it to.
-    expected_results = [
-        ('testdir', 0, None),
-        ('testdir/1', 0, None),
-        ('testdir/1/a', 12, b'hello world\n'),
-        ('testdir/2', 0, None),
-        ('testdir/2/c', 0, b'hello world\n'),  # Working link
-        ('testdir/2/a', 0, None),
-        ('testdir/2/b', 0, None)
-    ]
+      # Check that iterator returns what we expect it to.
+      expected_results = [
+          ('testdir', 0, None),
+          ('testdir/1', 0, None),
+          ('testdir/1/a', 12, b'hello world\n'),
+          ('testdir/2', 0, None),
+          ('testdir/2/c', 0, b'hello world\n'),  # Working link
+          ('testdir/2/a', 0, None),
+          ('testdir/2/b', 0, None)
+      ]
 
-    self.assertEqual(expected_results, actual_results)
-
-    # Check that iterator calls log_warn on a broken link.
-    self.mock.log_warn.assert_called_with(
-        'Check archive %s for broken links.' % archive_path,
-        error_filepaths=['testdir/2/a', 'testdir/2/b'])
+      self.assertEqual(expected_results, actual_results)


### PR DESCRIPTION
In chrome, we have very specific needs when it comes to unzipping. For
instance, every chrome fuzzers are package with a `.runtime_deps` file
that lists all the runtime dependencies needed by the target. We could
use this to selectively unpack our archives.

Similarly, we could use ripunzip to improve our zipping process.

This rework will enable those new features more easily, but also make
the code clearer on what exactly is going on.