### PR TITLE
filter_stacktrace uploads using a signed url when provided

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -217,12 +217,23 @@ def get_crash_type_string(testcase):
                                  CRASH_TYPE_DIMENSION_MAP[crash_type])
 
 
-def filter_stacktrace(stacktrace):
+def filter_stacktrace(stacktrace, blob_name=None, signed_upload_url=None):
   """Filters stacktrace and returns content appropriate for storage as an
   appengine entity."""
   unicode_stacktrace = utils.decode_to_unicode(stacktrace)
   if len(unicode_stacktrace) <= data_types.STACKTRACE_LENGTH_LIMIT:
     return unicode_stacktrace
+  if signed_upload_url:
+    try:
+      storage.upload_signed_url(
+          unicode_stacktrace.encode('utf-8'), signed_upload_url)
+      logs.log('Uploaded stacktrace using signed url.')
+    except Exception:
+      print("uplaod failed")
+      logs.log_error('Unable to upload crash stacktrace to signed url.')
+      return unicode_stacktrace[(-1 * data_types.STACKTRACE_LENGTH_LIMIT):]
+
+    return '%s%s' % (data_types.BLOBSTORE_STACK_PREFIX, blob_name)
 
   tmpdir = environment.get_value('BOT_TMPDIR')
   tmp_stacktrace_file = os.path.join(tmpdir, 'stacktrace.tmp')


### PR DESCRIPTION
Hi @jonathanmetzman,

I added the ability to upload using a signed_url. I will migrate tasks using filter_stacktrace one by one. Then I will remove the previous behaviour that uses `blobs.write_blob`. 