### PR TITLE
Check substitution mapping before adding any label directly to issue.labels + Update issue tracker URL

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -26,7 +26,7 @@ from clusterfuzz._internal.issue_management.google_issue_tracker import client
 from clusterfuzz._internal.metrics import logs
 
 _NUM_RETRIES = 3
-_ISSUE_TRACKER_URL = 'https://issuetracker.google.com/issues'
+_ISSUE_TRACKER_URL = 'https://issues.chromium.org/issues'
 
 # These custom fields use repeated enums.
 _CHROMIUM_OS_CUSTOM_FIELD_ID = '1223084'

--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -372,18 +372,18 @@ def file_issue(testcase,
   additional_labels = data_handler.get_additional_values_for_variable(
       'AUTOMATIC_LABELS', testcase.job_type, testcase.fuzzer_name)
   for label in additional_labels:
-    issue.labels.add(label)
+    issue.labels.add(policy.substitution_mapping(label))
 
   # Add crash-type-specific label
   crash_type_label = policy.label_for_crash_type(testcase.crash_type)
   if crash_type_label:
-    issue.labels.add(crash_type_label)
+    issue.labels.add(policy.substitution_mapping(crash_type_label))
 
   # Add labels from crash metadata.
   for crash_category in testcase.get_metadata('crash_categories', []):
     crash_category_label = policy.label_for_crash_category(crash_category)
     if crash_category_label:
-      issue.labels.add(crash_category_label)
+      issue.labels.add(policy.substitution_mapping(crash_category_label))
 
   # Add additional components from the job definition and fuzzer.
   automatic_components = data_handler.get_additional_values_for_variable(

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -923,8 +923,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     )
     url = self.issue_tracker.find_issues_url(
         keywords=['abc', 'def'], only_open=False)
-    self.assertEqual(
-        'https://issues.chromium.org/issues?q=%22abc%22+%22def%22', url)
+    self.assertEqual('https://issues.chromium.org/issues?q=%22abc%22+%22def%22',
+                     url)
 
   def test_issue_url(self):
     """Test issue_url."""

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -918,18 +918,18 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     url = self.issue_tracker.find_issues_url(
         keywords=['abc', 'def'], only_open=True)
     self.assertEqual(
-        'https://issuetracker.google.com/issues?q=%22abc%22+%22def%22+status%3Aopen',
+        'https://issues.chromium.org/issues?q=%22abc%22+%22def%22+status%3Aopen',
         url,
     )
     url = self.issue_tracker.find_issues_url(
         keywords=['abc', 'def'], only_open=False)
     self.assertEqual(
-        'https://issuetracker.google.com/issues?q=%22abc%22+%22def%22', url)
+        'https://issues.chromium.org/issues?q=%22abc%22+%22def%22', url)
 
   def test_issue_url(self):
     """Test issue_url."""
     url = self.issue_tracker.issue_url(123)
-    self.assertEqual('https://issuetracker.google.com/issues/123', url)
+    self.assertEqual('https://issues.chromium.org/issues/123', url)
 
   def test_get_severity_from_crash_text(self):
     """Test _get_severity_from_crash_text."""


### PR DESCRIPTION
 It is safe to do substitution mapping everytime because if a mapping is not found then it just returns the original label (see https://github.com/google/clusterfuzz/pull/3554/files)