### PR TITLE
Fix progression task no-crash error message.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -536,8 +536,7 @@ def find_fixed_range(uworker_input):
     return error
 
   if result and not result.is_crash():
-    error_message = (
-        f'Minimum revision r{min_revision} did not crash.')
+    error_message = (f'Minimum revision r{min_revision} did not crash.')
     progression_task_output.crash_revision = int(min_revision)
     return uworker_msg_pb2.Output(
         progression_task_output=progression_task_output,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -537,7 +537,7 @@ def find_fixed_range(uworker_input):
 
   if result and not result.is_crash():
     error_message = (
-        f'Known crash revision {known_crash_revision} did not crash')
+        f'Minimum revision r{min_revision} did not crash.')
     progression_task_output.crash_revision = int(min_revision)
     return uworker_msg_pb2.Output(
         progression_task_output=progression_task_output,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -536,7 +536,7 @@ def find_fixed_range(uworker_input):
     return error
 
   if result and not result.is_crash():
-    error_message = (f'Minimum revision r{min_revision} did not crash.')
+    error_message = f'Minimum revision r{min_revision} did not crash.'
     progression_task_output.crash_revision = int(min_revision)
     return uworker_msg_pb2.Output(
         progression_task_output=progression_task_output,


### PR DESCRIPTION
`known_crash_revision` is not guaranteed to be equal to `min_revision`, which is what is being tested. Include the right revision in the error message if the crash does not reproduce at `min_revision`.

Bug: crbug.com/40229463