### PR TITLE
Improve use of credentials for signed URLs

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/credentials.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/credentials.py
@@ -16,8 +16,10 @@ import os
 
 from google.auth import compute_engine
 from google.auth import credentials
+from google.auth import impersonated_credentials
 from google.auth.transport import requests
 from google.oauth2 import service_account
+
 
 from clusterfuzz._internal.base import retry
 from clusterfuzz._internal.system import environment
@@ -57,10 +59,10 @@ def get_default(scopes=None):
   return google.auth.default(scopes=scopes)
 
 
-@retry.wrap(
-    retries=FAIL_RETRIES,
-    delay=FAIL_WAIT,
-    function='google_cloud_utils.credentials.get_signing_credentials')
+# @retry.wrap(
+#     retries=FAIL_RETRIES,
+#     delay=FAIL_WAIT,
+#     function='google_cloud_utils.credentials.get_signing_credentials')
 def get_signing_credentials():
   """Returns signing credentials for signing URLs."""
   if _use_anonymous_credentials():
@@ -68,16 +70,18 @@ def get_signing_credentials():
 
   google_application_credentials = os.getenv('GOOGLE_APPLICATION_CREDENTIALS',
                                              None)
-  if google_application_credentials is None:
-    # The normal case, when we are on GCE.
-    creds, _ = get_default()
-    request = requests.Request()
-    creds.refresh(request)
-    signing_creds = compute_engine.IDTokenCredentials(
-        request, '', service_account_email=creds.service_account_email)
-  else:
+  if google_application_credentials is not None:
     # Handle cases like android and Mac where bots are run outside of Google
     # Cloud Platform and don't have access to metadata server.
-    signing_creds = service_account.Credentials.from_service_account_file(
-        google_application_credentials)
-  return signing_creds
+    creds = service_account.Credentials.from_service_account_file(
+        google_application_credentials, scopes=['https://www.googleapis.com/auth/cloud-platform', 'https://www.googleapis.com/auth/prodxmon'])
+  else:
+    # The normal case, when we are on GCE.
+    creds, _ = get_default()
+
+  request = requests.Request()
+  creds.refresh(request)
+
+  signing_creds = compute_engine.IDTokenCredentials(
+    request, '', service_account_email=creds.service_account_email)
+  return signing_creds, creds.token

--- a/src/clusterfuzz/_internal/google_cloud_utils/credentials.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/credentials.py
@@ -77,7 +77,7 @@ def get_signing_credentials():
     # Handle cases like android and Mac where bots are run outside of Google
     # Cloud Platform and don't have access to metadata server.
     signing_creds = service_account.Credentials.from_service_account_file(
-      google_application_credentials, scopes=_SCOPES)
+        google_application_credentials, scopes=_SCOPES)
     token = signing_creds.token
   else:
     # The normal case, when we are on GCE.
@@ -87,6 +87,6 @@ def get_signing_credentials():
     creds.refresh(request)
 
     signing_creds = compute_engine.IDTokenCredentials(
-      request, '', service_account_email=creds.service_account_email)
+        request, '', service_account_email=creds.service_account_email)
     token = creds.token
   return signing_creds, token

--- a/src/clusterfuzz/_internal/google_cloud_utils/credentials.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/credentials.py
@@ -34,6 +34,8 @@ except ImportError:
 FAIL_RETRIES = 5
 FAIL_WAIT = 10
 
+_SCOPES = ['https://www.googleapis.com/auth/cloud-platform', 'https://www.googleapis.com/auth/prodxmon']
+
 
 def _use_anonymous_credentials():
   """Returns whether or not to use anonymous credentials."""
@@ -59,10 +61,10 @@ def get_default(scopes=None):
   return google.auth.default(scopes=scopes)
 
 
-# @retry.wrap(
-#     retries=FAIL_RETRIES,
-#     delay=FAIL_WAIT,
-#     function='google_cloud_utils.credentials.get_signing_credentials')
+@retry.wrap(
+    retries=FAIL_RETRIES,
+    delay=FAIL_WAIT,
+    function='google_cloud_utils.credentials.get_signing_credentials')
 def get_signing_credentials():
   """Returns signing credentials for signing URLs."""
   if _use_anonymous_credentials():
@@ -74,7 +76,7 @@ def get_signing_credentials():
     # Handle cases like android and Mac where bots are run outside of Google
     # Cloud Platform and don't have access to metadata server.
     creds = service_account.Credentials.from_service_account_file(
-        google_application_credentials, scopes=['https://www.googleapis.com/auth/cloud-platform', 'https://www.googleapis.com/auth/prodxmon'])
+        google_application_credentials, scopes=_SCOPES)
   else:
     # The normal case, when we are on GCE.
     creds, _ = get_default()

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -408,7 +408,7 @@ def _sign_url(remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES, method='GET'):
     return remote_path
   minutes = datetime.timedelta(minutes=minutes)
   bucket_name, object_path = get_bucket_name_and_path(remote_path)
-  signing_creds = _signing_creds()
+  signing_creds, access_token = _signing_creds()
   client = _storage_client()
   bucket = client.bucket(bucket_name)
   blob = bucket.blob(object_path)
@@ -416,7 +416,9 @@ def _sign_url(remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES, method='GET'):
       version='v4',
       expiration=minutes,
       method=method,
-      credentials=signing_creds)
+      credentials=signing_creds,
+      access_token=access_token,
+      service_account_email=signing_creds.service_account_email)
   return url
 
 


### PR DESCRIPTION
1. Refresh access tokens after 45 minutes (time limit is one hour).
2. Only get tokens once per map call.