### PR TITLE
[_sign_url] Try to reduce use of expired credentials. 

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -425,6 +425,7 @@ def _sign_url(remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES, method='GET'):
         access_token=access_token,
         service_account_email=signing_creds.service_account_email)
   except google.auth.exceptions.TransportError:
+    logs.log('_sign_url: Trying to renew credentials.')
     _new_signing_creds()
     return blob.generate_signed_url(
         version='v4',
@@ -748,8 +749,11 @@ def _storage_client():
 
 
 def _new_signing_creds():
-  _local.signing_creds_expiration = datetime.datetime.now(
-  ) + datetime.timedelta(minutes=40)
+  now = datetime.datetime.now()
+  new_expiry = now + datetime.timedelta(minutes=40)
+  logs.log(f'Credentials expiring: {_local.signing_creds_expiration}. '
+           f'New: {now}.')
+  _local.signing_creds_expiration = new_expiry
   _local.signing_creds = credentials.get_signing_credentials()
 
 

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -752,7 +752,7 @@ def _new_signing_creds():
   now = datetime.datetime.now()
   new_expiry = now + datetime.timedelta(minutes=40)
   logs.log(f'Credentials expiring: {_local.signing_creds_expiration}. '
-           f'New: {now}.')
+           f'New: {new_expiry}.')
   _local.signing_creds_expiration = new_expiry
   _local.signing_creds = credentials.get_signing_credentials()
 


### PR DESCRIPTION
1. Reduce time to renew from 45 minutes to 40 minutes (we technically have an hour)
2. Immediately renew credentials when _sign_url fails (reduce
retries for other reasons).
3. Log when credentials are renewed so we can understand why
we are failing.