### PR TITLE
Make ProtoFuzzTargetCorpus inherit from FuzzTargetCorpus.

### DIFF
--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -357,7 +357,7 @@ class FuzzTargetCorpus(GcsCorpus):
     return result
 
 
-class ProtoFuzzTargetCorpus(GcsCorpus):
+class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
   """Implementation of GCS corpus that uses protos (uworker-compatible) for fuzz
   targets."""
 


### PR DESCRIPTION
Do this so that it inherits properties for use during backup.