### PR TITLE
WIP: Update android discovery API usage to static

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -153,7 +153,7 @@ def get_client():
       'androidbuildinternal',
       'v3',
       credentials=credentials,
-      cache_discovery=False)
+      static_discovery=False)
 
   return client
 


### PR DESCRIPTION
In PR#3749 google-python-api-client was updated. 

Adding as a WIP until a test is added to prevent future breakages.