### PR TITLE
Minimizer: Skip minimization early if not supported

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_creation.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_creation.py
@@ -239,9 +239,15 @@ def create_tasks(testcase):
     testcase.put()
     return
 
-  # Just create the minimize task for now. Once minimization is complete, it
-  # automatically created the rest of the needed tasks.
-  create_minimize_task_if_needed(testcase)
+  if environment.is_minimization_supported():
+    # For supported environments, just create the minimize task for now.
+    # Once minimization is complete, it automatically creates the rest of the
+    # needed tasks.
+    create_minimize_task_if_needed(testcase)
+  else:
+    # Environments that don't support minimization skip directly to other
+    # tasks.
+    create_postminimize_tasks(testcase)
 
 
 def create_postminimize_tasks(testcase):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
@@ -379,7 +379,7 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
       testcase, fuzzer_override=minimize_fuzzer_override)
 
   # TODO(metzman): This should be removed.
-  if not environment.is_libfuzzer_job() and environment.is_engine_fuzzer_job():
+  if not environment.is_minimization_supported():
     # TODO(ochang): More robust check for engine minimization support.
     _skip_minimization(testcase, 'Engine does not support minimization.')
     return None

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -693,6 +693,14 @@ def get_engine_for_job(job_name=None):
   return None
 
 
+def is_minimization_supported():
+  """Return True if the current job supports minimization.
+
+  Currently blackbox-fuzzer jobs or libfuzzer support minimization.
+  """
+  return not is_engine_fuzzer_job() or is_libfuzzer_job()
+
+
 def is_posix():
   """Return True if we are on a posix platform (linux/unix and mac os)."""
   return os.name == 'posix'


### PR DESCRIPTION
This only adds a minimization task if it's supported (black-box fuzzers and libfuzzer). E.g. centipede doesn't support minimization yet and currently minimization errors out, spamming the logs and the test cases.

This gracefully starts all post-minimization tasks from the beginning if minimization is not supported. Existing code for skipping minimization is untouched, since it's still executed when users select minimization explicitly.

This PR doesn't add a test since there are no tests of task_creation yet (and the hurdle for adding the first test seems rather high).