### PR TITLE
Dont save fuzz targets with incorrect names

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -44,7 +44,6 @@ from clusterfuzz._internal.crash_analysis.crash_result import CrashResult
 from clusterfuzz._internal.crash_analysis.stack_parsing import stack_analyzer
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
-from clusterfuzz._internal.datastore import fuzz_target_utils
 from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.fuzzing import corpus_manager
 from clusterfuzz._internal.fuzzing import fuzzer_selection
@@ -1786,10 +1785,14 @@ class FuzzingSession:
       # If we did not pick a fuzz target to fuzz with the engine, then return
       # early to save the fuzz targets that are in the build for the next job to
       # pick.
-      output_to_report_targets = self.record_fuzz_targets_to_output(
-          build_setup_result)
+      self.fuzz_task_output.fuzz_targets.extend(build_setup_result.fuzz_targets)
+      if not self.fuzz_task_output.fuzz_targets:
+        logs.log_error('No fuzz targets.')
+
       if not fuzz_target:
-        return output_to_report_targets
+        return uworker_msg_pb2.Output(
+            fuzz_task_output=self.fuzz_task_output,
+            error_type=uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZ_TARGET_SELECTED)
 
     # Check if we have an application path. If not, our build failed
     # to setup correctly.
@@ -1913,16 +1916,6 @@ class FuzzingSession:
 
     return uworker_msg_pb2.Output(fuzz_task_output=self.fuzz_task_output)
 
-  def record_fuzz_targets_to_output(self, build_setup_result):
-    """Returns a utask output to return for postprocessing."""
-
-    self.fuzz_task_output.fuzz_targets.extend(build_setup_result.fuzz_targets)
-
-    assert self.fuzz_task_output.fuzz_targets
-    return uworker_msg_pb2.Output(
-        fuzz_task_output=self.fuzz_task_output,
-        error_type=uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZ_TARGET_SELECTED)
-
   def postprocess(self, uworker_output):
     """Handles postprocessing."""
     # TODO(metzman): Finish this.
@@ -1999,19 +1992,30 @@ _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
 }).compose_with(uworker_handle_errors.UNHANDLED_ERROR_HANDLER)
 
 
-def pick_fuzz_target(job_type):
+def _pick_fuzz_target():
   """Picks a random fuzz target from job_type for use in fuzzing."""
   if not environment.is_engine_fuzzer_job():
     logs.log('Not engine fuzzer. Not picking fuzz target.')
     return None
   logs.log('Picking fuzz target.')
-  targets = [
-      target_job.fuzz_target_name
-      for target_job in fuzz_target_utils.get_fuzz_target_jobs(job=job_type)
-  ]
   target_weights = fuzzer_selection.get_fuzz_target_weights()
   return build_manager.set_random_fuzz_target_for_fuzzing_if_needed(
-      targets, target_weights)
+      target_weights.keys(), target_weights)
+
+
+def _get_fuzz_target_from_db(engine_name, fuzz_target_binary, job_type):
+  project = data_handler.get_project_name(job_type)
+  qualified_name = data_types.fuzz_target_fully_qualified_name(
+      engine_name, project, fuzz_target_binary)
+  key = ndb.Key(data_types.FuzzTarget, qualified_name)
+  return key.get()
+
+
+def _preprocess_get_fuzz_target(fuzzer_name, job_type):
+  fuzz_target_name = _pick_fuzz_target()
+  if fuzz_target_name:
+    return _get_fuzz_target_from_db(fuzzer_name, fuzz_target_name, job_type)
+  return None
 
 
 def utask_preprocess(fuzzer_name, job_type, uworker_env):
@@ -2020,9 +2024,9 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
   do_multiarmed_bandit_strategy_selection(uworker_env)
   environment.set_value('PROJECT_NAME', data_handler.get_project_name(job_type),
                         uworker_env)
-  fuzz_target_name = pick_fuzz_target(job_type)
+  fuzz_target = _preprocess_get_fuzz_target(fuzzer_name, job_type)
   fuzz_task_input = uworker_msg_pb2.FuzzTaskInput()
-  if fuzz_target_name:
+  if fuzz_target:
     fuzz_task_input.fuzz_target.CopyFrom(
         uworker_io.entity_to_protobuf(fuzz_target))
 
@@ -2041,7 +2045,7 @@ def save_fuzz_targets(output):
   if not output.fuzz_task_output.fuzz_targets:
     return
 
-  logs.info(f'Saving fuzz targets: {output.fuzz_task_output.fuzz_targets}.')
+  logs.log(f'Saving fuzz targets: {output.fuzz_task_output.fuzz_targets}.')
   data_handler.record_fuzz_targets(output.uworker_input.fuzzer_name,
                                    output.fuzz_task_output.fuzz_targets,
                                    output.uworker_input.job_type)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -2023,8 +2023,6 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
   fuzz_target_name = pick_fuzz_target(job_type)
   fuzz_task_input = uworker_msg_pb2.FuzzTaskInput()
   if fuzz_target_name:
-    fuzz_target = data_handler.record_fuzz_target(fuzzer_name, fuzz_target_name,
-                                                  job_type)
     fuzz_task_input.fuzz_target.CopyFrom(
         uworker_io.entity_to_protobuf(fuzz_target))
 
@@ -2042,6 +2040,8 @@ def save_fuzz_targets(output):
   """Saves fuzz targets that were seen in the build to the database."""
   if not output.fuzz_task_output.fuzz_targets:
     return
+
+  logs.info(f'Saving fuzz targets: {output.fuzz_task_output.fuzz_targets}.')
   data_handler.record_fuzz_targets(output.uworker_input.fuzzer_name,
                                    output.fuzz_task_output.fuzz_targets,
                                    output.uworker_input.job_type)

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1593,6 +1593,23 @@ FUZZ_TARGET_UPDATE_FAIL_RETRIES = 5
 FUZZ_TARGET_UPDATE_FAIL_DELAY = 2
 
 
+def record_fuzz_target(engine_name, binary_name, job_type):
+  """Records exsistence of fuzz target to the DB."""
+  result = record_fuzz_targets(engine_name, [binary_name], job_type)[0]
+
+  project = get_project_name(job_type)
+  key_name = data_types.fuzz_target_fully_qualified_name(
+      engine_name, project, binary_name)
+
+  logs.log(
+      'Recorded use of fuzz target %s.' % key_name,
+      project=project,
+      engine=engine_name,
+      binary_name=binary_name,
+      job_type=job_type)
+  return result
+
+
 def get_or_create_multi_entities_from_keys(mapping):
   """Gets or creates multiple db entities."""
   keys = list(mapping.keys())

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1593,23 +1593,6 @@ FUZZ_TARGET_UPDATE_FAIL_RETRIES = 5
 FUZZ_TARGET_UPDATE_FAIL_DELAY = 2
 
 
-def record_fuzz_target(engine_name, binary_name, job_type):
-  """Records exsistence of fuzz target to the DB."""
-  result = record_fuzz_targets(engine_name, [binary_name], job_type)[0]
-
-  project = get_project_name(job_type)
-  key_name = data_types.fuzz_target_fully_qualified_name(
-      engine_name, project, binary_name)
-
-  logs.log(
-      'Recorded use of fuzz target %s.' % key_name,
-      project=project,
-      engine=engine_name,
-      binary_name=binary_name,
-      job_type=job_type)
-  return result
-
-
 def get_or_create_multi_entities_from_keys(mapping):
   """Gets or creates multiple db entities."""
   keys = list(mapping.keys())

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -164,8 +164,8 @@ def get_fuzz_target_weights():
   weights = {}
   for fuzz_target, target_job in zip(fuzz_targets, target_jobs):
     if not fuzz_target:
-      logs.log_error('Skipping weight assignment for fuzz target %s.' %
-                     target_job.fuzz_target_name)
+      logs.log_error('Skipping weight assignment for fuzz target '
+                     f'{target_job.fuzz_target_name}.')
       continue
 
     weights[fuzz_target.binary] = target_job.weight


### PR DESCRIPTION
The "name" at this point is a qualified named. Don't save this so we don't end up with fuzz targets like libFuzzer_libFuzzer...
We save the actual name of the binary later on. Just use that.