### PR TITLE
Remove deprecated clouddebugger api

### DIFF
--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -34,7 +34,6 @@ _REQUIRED_SERVICES = (
     'bigquery-json.googleapis.com',
     'cloudapis.googleapis.com',
     'cloudbuild.googleapis.com',
-    'clouddebugger.googleapis.com',
     'clouderrorreporting.googleapis.com',
     'cloudprofiler.googleapis.com',
     'cloudresourcemanager.googleapis.com',


### PR DESCRIPTION
I ran into the same issue as [here](https://github.com/google/clusterfuzz/pull/3298) while trying to setup tag v2.60. That pr never went in so I'll offer this up.

There are other issues I ran into that I'll try to fix, but this is the first.

