### PR TITLE
Set consistent minimization keys also when minimization is skipped

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_creation.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_creation.py
@@ -247,6 +247,9 @@ def create_tasks(testcase):
   else:
     # Environments that don't support minimization skip directly to other
     # tasks.
+    testcase = data_handler.get_testcase_by_id(testcase_id)
+    testcase.minimized_keys = 'NA'
+    testcase.put()
     create_postminimize_tasks(testcase)
 
 


### PR DESCRIPTION
The _skip_minimization routine in minimize_task sets the minimized_keys before bailing out. This was missing in PR https://github.com/google/clusterfuzz/pull/3787.  Various other things in Clusterfuzz check these keys, e.g. the grouping task waits for minimization to finish by checking for content in minimized_keys. Without this fix, grouping never runs on respective test cases and non-grouped tests don't show up in the testcases list.

This doesn't retain the previous behavior, which set minimized_keys to fuzzed_keys. Setting an 'NA' string is more intuitive and is also used in a few other places already that mark minimization as not available.