### PR TITLE
Do not call stop_cvd when no device is running

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -454,9 +454,10 @@ def stop_cuttlefish_device():
   stop_cvd_cmd = os.path.join(cvd_bin_dir, 'stop_cvd')
   logs.log('stop_cvd_cmd: %s' % str(stop_cvd_cmd))
 
-  execute_command(
+  if get_device_state() == 'device':
+    execute_command(
       stop_cvd_cmd, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
-  time.sleep(STOP_CVD_WAIT)
+    time.sleep(STOP_CVD_WAIT)
 
 
 def restart_cuttlefish_device():

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -456,7 +456,7 @@ def stop_cuttlefish_device():
 
   if get_device_state() == 'device':
     execute_command(
-      stop_cvd_cmd, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
+        stop_cvd_cmd, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
     time.sleep(STOP_CVD_WAIT)
 
 


### PR DESCRIPTION
Validate device state prior to 'stop_cvd' execution; proceed only if the current state is 'device'.