### PR TITLE
Tell users we only accept zip uploads

### DIFF
--- a/docs/using-clusterfuzz/workflows/uploading-a-testcase.md
+++ b/docs/using-clusterfuzz/workflows/uploading-a-testcase.md
@@ -32,7 +32,7 @@ To upload a new testcase:
      - Bundle all the files in an archive. Supported archive formats include *zip* and *tar*.
      - **Exception**: If you want to test multiple testcases at once, you don't
        need to rename them. Just bundle them in an archive, and select the
-       **Test every file in archive independently** checkbox in the form.
+       **Test every file in zip archive independently** checkbox in the form.
 
 3. Click the "Choose File" button and provide the testcase archive in the file chooser dialog.
 4. Select a **Job**. This provides information of which build or application to

--- a/src/appengine/private/components/upload-testcase/upload-form.html
+++ b/src/appengine/private/components/upload-testcase/upload-form.html
@@ -224,7 +224,7 @@
       <template is="dom-if" if="[[fieldValues.isChromium]]">
         <paper-checkbox value="true" checked="{{uploadParams.http}}">Load testcase from HTTP server.</paper-checkbox>
       </template>
-      <paper-checkbox value="true" checked="{{uploadParams.multiple}}">Test every file in archive independently.</paper-checkbox>
+      <paper-checkbox value="true" checked="{{uploadParams.multiple}}">Test every file in zip archive independently.</paper-checkbox>
       <template is="dom-if" if="[[shouldShowIssueSummaryUpdateCheckbox()]]">
         <paper-checkbox value="true" checked="{{uploadParams.updateIssue}}">Update issue's title based on crash result.</paper-checkbox>
       </template>


### PR DESCRIPTION
Avoids https://pantheon.corp.google.com/errors/detail/CIr73p3av9Xe4AE;time=P30D?project=cluster-fuzz&utm_source=error-reporting-notification&utm_medium=email&utm_content=new-error

```
FileNotFoundError: [Errno 2] No such file or directory: '328918912.zip'

at .__init__ ( /layers/google.python.runtime/python/lib/python3.7/zipfile.py:1240 )
at .__init__ ( /srv/clusterfuzz/_internal/system/archive.py:270 )
at .open ( /srv/clusterfuzz/_internal/system/archive.py:381 )
at .guess_input_file ( /srv/handlers/upload_testcase.py:139 )
at .do_post ( /srv/handlers/upload_testcase.py:555 )
at .post ( /srv/handlers/upload_testcase.py:620 )
at .wrapper ( /srv/libs/handler.py:424 )
at .wrapper ( /srv/libs/handler.py:355 )
at .dispatch_request ( /srv/handlers/base_handler.py:278 )
```