### PR TITLE
Configurable redis-instance name

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -159,7 +159,9 @@ def main():
   parser_deploy.add_argument(
       '--targets', nargs='*', default=['appengine', 'k8s', 'zips'])
   parser_deploy.add_argument(
-      '--redis-instance-id', default='redis-instance', help='ID for Redis Instance.')
+      '--redis-instance-id',
+      default='redis-instance',
+      help='ID for Redis Instance.')
 
   parser_run_server = subparsers.add_parser(
       'run_server', help='Run the local Clusterfuzz server.')

--- a/butler.py
+++ b/butler.py
@@ -158,6 +158,8 @@ def main():
       '--prod', action='store_true', help='Deploy to production.')
   parser_deploy.add_argument(
       '--targets', nargs='*', default=['appengine', 'k8s', 'zips'])
+  parser_deploy.add_argument(
+      '--redis-instance-id', default='redis-instance', help='ID for Redis Instance.')
 
   parser_run_server = subparsers.add_parser(
       'run_server', help='Run the local Clusterfuzz server.')
@@ -245,6 +247,11 @@ def main():
       type=str,
       default='us-central',
       help='Location for App Engine.')
+  parser_create_config.add_argument(
+      '--redis-instance-id',
+      type=str,
+      default='redis-instance',
+      help='ID for Redis Instance.')
 
   subparsers.add_parser(
       'integration_tests', help='Run end-to-end integration tests.')

--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -98,7 +98,7 @@ else
 
   export CLOUD_SDK_REPO="cloud-sdk"
   export APT_FILE=/etc/apt/sources.list.d/google-cloud-sdk.list
-  export APT_LINE="deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main"
+  export APT_LINE="deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main"
   sudo bash -c "grep -x \"$APT_LINE\" $APT_FILE || (echo $APT_LINE | tee -a $APT_FILE)"
 
   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \

--- a/src/clusterfuzz/_internal/tests/core/local/butler/deploy_test.py
+++ b/src/clusterfuzz/_internal/tests/core/local/butler/deploy_test.py
@@ -197,7 +197,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
 
   def test_app_staging(self):
     """Test deploy app to staging."""
-    deploy._staging_deployment_helper()
+    deploy._staging_deployment_helper('redis-instance')
 
     self.mock.execute.assert_has_calls([
         mock.call(

--- a/src/clusterfuzz/_internal/tests/core/local/butler/deploy_test.py
+++ b/src/clusterfuzz/_internal/tests/core/local/butler/deploy_test.py
@@ -92,7 +92,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
     if 'app describe' in command:
       return (0, b'us-central')
 
-    if 'describe redis-instance' in command:
+    if 'redis instances describe' in command:
       return (0, b'redis-ip')
 
     if 'describe' in command:

--- a/src/clusterfuzz/_internal/tests/core/local/butler/deploy_test.py
+++ b/src/clusterfuzz/_internal/tests/core/local/butler/deploy_test.py
@@ -143,7 +143,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
 
   def test_app(self):
     """Test deploy app."""
-    deploy._prod_deployment_helper('/config_dir', 'redis-instance',
+    deploy._prod_deployment_helper('/config_dir',
                                    ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([
@@ -197,7 +197,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
 
   def test_app_staging(self):
     """Test deploy app to staging."""
-    deploy._staging_deployment_helper('redis-instance')
+    deploy._staging_deployment_helper()
 
     self.mock.execute.assert_has_calls([
         mock.call(
@@ -217,7 +217,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
     """Test deploy app with retries."""
     self.deploy_failure_count = 1
 
-    deploy._prod_deployment_helper('/config_dir', 'redis-instance',
+    deploy._prod_deployment_helper('/config_dir',
                                    ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([
@@ -282,7 +282,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
     self.deploy_failure_count = 4
 
     with self.assertRaises(SystemExit):
-      deploy._prod_deployment_helper('/config_dir', 'redis-instance',
+      deploy._prod_deployment_helper('/config_dir',
                                      ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([

--- a/src/clusterfuzz/_internal/tests/core/local/butler/deploy_test.py
+++ b/src/clusterfuzz/_internal/tests/core/local/butler/deploy_test.py
@@ -143,7 +143,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
 
   def test_app(self):
     """Test deploy app."""
-    deploy._prod_deployment_helper('/config_dir',
+    deploy._prod_deployment_helper('/config_dir', 'redis-instance',
                                    ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([
@@ -217,7 +217,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
     """Test deploy app with retries."""
     self.deploy_failure_count = 1
 
-    deploy._prod_deployment_helper('/config_dir',
+    deploy._prod_deployment_helper('/config_dir', 'redis-instance',
                                    ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([
@@ -282,7 +282,7 @@ class DeployTest(fake_filesystem_unittest.TestCase):
     self.deploy_failure_count = 4
 
     with self.assertRaises(SystemExit):
-      deploy._prod_deployment_helper('/config_dir',
+      deploy._prod_deployment_helper('/config_dir', 'redis-instance',
                                      ['/windows.zip', '/mac.zip', '/linux.zip'])
 
     self.mock.run.assert_has_calls([

--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -198,7 +198,8 @@ def deploy_appengine(gcloud, config_dir, appengine_location, redis_instance_id):
 
   subprocess.check_call([
       'python', 'butler.py', 'deploy', '--force', '--targets', 'appengine',
-      '--prod', '--config-dir', config_dir, '--redis-instance-id', redis_instance_id
+      '--prod', '--config-dir', config_dir, '--redis-instance-id',
+      redis_instance_id
   ])
 
 
@@ -278,8 +279,8 @@ def execute(args):
 
   # Deploy App Engine and finish verification of domain.
   os.chdir(prev_dir)
-  deploy_appengine(
-      gcloud, args.new_config_dir, args.appengine_location, args.redis_instance_id)
+  deploy_appengine(gcloud, args.new_config_dir, args.appengine_location,
+                   args.redis_instance_id)
   verifier.verify(appspot_domain)
 
   # App Engine service account requires:

--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -188,7 +188,7 @@ def create_new_config(gcloud, project_id, new_config_dir,
       replace_file_contents(file_path, replacements)
 
 
-def deploy_appengine(gcloud, config_dir, appengine_location):
+def deploy_appengine(gcloud, config_dir, appengine_location, redis_instance_id):
   """Deploy to App Engine."""
   try:
     gcloud.run('app', 'describe')
@@ -198,7 +198,7 @@ def deploy_appengine(gcloud, config_dir, appengine_location):
 
   subprocess.check_call([
       'python', 'butler.py', 'deploy', '--force', '--targets', 'appengine',
-      '--prod', '--config-dir', config_dir
+      '--prod', '--config-dir', config_dir, '--redis-instance-id', redis_instance_id
   ])
 
 
@@ -279,7 +279,7 @@ def execute(args):
   # Deploy App Engine and finish verification of domain.
   os.chdir(prev_dir)
   deploy_appengine(
-      gcloud, args.new_config_dir, appengine_location=args.appengine_location)
+      gcloud, args.new_config_dir, args.appengine_location, args.redis_instance_id)
   verifier.verify(appspot_domain)
 
   # App Engine service account requires:

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -72,7 +72,8 @@ def _get_redis_ip(project, redis_instance_id='redis-instance'):
   return_code, ip = common.execute(
       'gcloud redis instances describe {redis_instance_id} '
       '--project={project} --region={region} '
-      '--format="value(host)"'.format(redis_instance_id=redis_instance_id, project=project, region=region))
+      '--format="value(host)"'.format(
+          redis_instance_id=redis_instance_id, project=project, region=region))
 
   if return_code:
     raise RuntimeError('Failed to get redis IP.')

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -378,7 +378,8 @@ def is_diff_origin_master():
   return diff_output.strip() or remote_sha.strip() != local_sha.strip()
 
 
-def _staging_deployment_helper(redis_instance_id, python3=True):
+def _staging_deployment_helper(python3=True,
+                               redis_instance_id='redis-instance'):
   """Helper for staging deployment."""
   config = local_config.Config(local_config.GAE_CONFIG_PATH)
   project = config.get('application_id')
@@ -399,11 +400,11 @@ def _staging_deployment_helper(redis_instance_id, python3=True):
 
 def _prod_deployment_helper(config_dir,
                             package_zip_paths,
-                            redis_instance_id,
                             deploy_appengine=True,
                             deploy_k8s=True,
                             python3=True,
-                            test_deployment=False):
+                            test_deployment=False,
+                            redis_instance_id='redis-instance'):
   """Helper for production deployment."""
   config = local_config.Config()
   deployment_bucket = config.get('project.deployment.bucket')
@@ -565,16 +566,17 @@ def execute(args):
     sys.exit(1)
 
   if args.staging:
-    _staging_deployment_helper(args.redis_instance_id, python3=is_python3)
+    _staging_deployment_helper(
+        python3=is_python3, redis_instance_id=args.redis_instance_id)
   else:
     _prod_deployment_helper(
         args.config_dir,
         package_zip_paths,
-        args.redis_instance_id,
         deploy_appengine,
         deploy_k8s,
         python3=is_python3,
-        test_deployment=test_deployment)
+        test_deployment=test_deployment,
+        redis_instance_id=args.redis_instance_id)
 
   with open(constants.PACKAGE_TARGET_MANIFEST_PATH) as f:
     print('Source updated to %s' % f.read())


### PR DESCRIPTION
### Summary
Currently the redis instance needs to be called `redis-instance`. Allow users to customize this and default to `redis-instance` if not provided.

Adds a fix to the cloud_sdk install which appears to be broken on Ubuntu20.04 (http -> https)

### Testing
I only tested the prod deploy workflow and not staging, but it should be equivalent.
I didn't touch `_deploy_k8s` which calls `_get_redis_ip`, but this should default to the default `redis-instance` case