### PR TITLE
Revert "Move more tasks to untrusted service account (#3833)"

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -296,7 +296,7 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
 
   initialize_testcase_for_main(testcase, job_type)
 
-  setup_input = setup.preprocess_setup_testcase(testcase, with_deps=False)
+  setup_input = setup.preprocess_setup_testcase(testcase)
   analyze_task_input = get_analyze_task_input()
   return uworker_msg_pb2.Input(
       testcase_upload_metadata=uworker_io.entity_to_protobuf(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -415,7 +415,7 @@ def utask_preprocess(testcase_id: str, job_type: str,
 
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
-  setup_input = setup.preprocess_setup_testcase(testcase, with_deps=False)
+  setup_input = setup.preprocess_setup_testcase(testcase)
 
   task_input = uworker_msg_pb2.RegressionTaskInput(
       bad_revisions=build_manager.get_job_bad_revisions())

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
@@ -61,7 +61,7 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
   data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
   # Setup testcase and its dependencies.
-  setup_input = setup.preprocess_setup_testcase(testcase, with_deps=False)
+  setup_input = setup.preprocess_setup_testcase(testcase)
 
   old_crash_stacktrace = data_handler.get_stacktrace(testcase)
   return uworker_msg_pb2.Input(

--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -57,7 +57,7 @@ BatchWorkloadSpec = collections.namedtuple('BatchWorkloadSpec', [
     'machine_type',
 ])
 
-_UNPRIVILEGED_TASKS = {'variant', 'symbolize', 'analyze'}
+_UNPRIVILEGED_TASKS = {'variant'}
 
 
 def _create_batch_client_new():

--- a/src/clusterfuzz/_internal/tests/core/google_cloud_utils/batch_test.py
+++ b/src/clusterfuzz/_internal/tests/core/google_cloud_utils/batch_test.py
@@ -32,7 +32,7 @@ class GetSpecFromConfigTest(unittest.TestCase):
     expected."""
     job = data_types.Job(name='libfuzzer_chrome_asan', platform='LINUX')
     job.put()
-    spec = batch._get_spec_from_config('minimize', job.name)  # pylint: disable=protected-access
+    spec = batch._get_spec_from_config('regression', job.name)  # pylint: disable=protected-access
     expected_spec = batch.BatchWorkloadSpec(
         docker_image='gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654',
         user_data='file://linux-init.yaml',


### PR DESCRIPTION
It doesn't seem to be working.

This reverts commit ae8a270a5f11a76ad86cdb81e66e765eb7caaa06.