### PR TITLE
Reduce the severity of HWASAN not being supported by sanitizer.py

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/sanitizer.py
+++ b/src/clusterfuzz/_internal/platforms/android/sanitizer.py
@@ -57,13 +57,13 @@ def get_options_file_path(sanitizer_tool_name):
   # Reduce the log severity for HWASAN
   # TODO(crbug.com/329346758) properly handle HWASAN options.
   if sanitizer_tool_name.lower() == "hwasan":
-    logs.log('Unsupported sanitizer: ' + sanitizer_tool_name)
+    logs.log(f'Unable to set options for sanitizer: {sanitizer_tool_name}')
     return None
 
   sanitizer_filename = SANITIZER_TOOL_TO_FILE_MAPPINGS.get(
       sanitizer_tool_name.lower())
   if sanitizer_filename is None:
-    logs.log_error('Unsupported sanitizer: ' + sanitizer_tool_name)
+    logs.log_error(f'Unable to set options for sanitizer: {sanitizer_tool_name}')
     return None
 
   return os.path.join(sanitizer_directory, sanitizer_filename)

--- a/src/clusterfuzz/_internal/platforms/android/sanitizer.py
+++ b/src/clusterfuzz/_internal/platforms/android/sanitizer.py
@@ -63,7 +63,8 @@ def get_options_file_path(sanitizer_tool_name):
   sanitizer_filename = SANITIZER_TOOL_TO_FILE_MAPPINGS.get(
       sanitizer_tool_name.lower())
   if sanitizer_filename is None:
-    logs.log_error(f'Unable to set options for sanitizer: {sanitizer_tool_name}')
+    logs.log_error(
+        f'Unable to set options for sanitizer: {sanitizer_tool_name}')
     return None
 
   return os.path.join(sanitizer_directory, sanitizer_filename)

--- a/src/clusterfuzz/_internal/platforms/android/sanitizer.py
+++ b/src/clusterfuzz/_internal/platforms/android/sanitizer.py
@@ -54,6 +54,12 @@ def get_options_file_path(sanitizer_tool_name):
   sanitizer_directory = ('/system' if settings.get_sanitizer_tool_name() else
                          constants.DEVICE_TMP_DIR)
 
+  # Reduce the log severity for HWASAN
+  # TODO(crbug.com/329346758) properly handle HWASAN options.
+  if sanitizer_tool_name.lower() == "hwasan":
+    logs.log('Unsupported sanitizer: ' + sanitizer_tool_name)
+    return None
+    
   sanitizer_filename = SANITIZER_TOOL_TO_FILE_MAPPINGS.get(
       sanitizer_tool_name.lower())
   if sanitizer_filename is None:

--- a/src/clusterfuzz/_internal/platforms/android/sanitizer.py
+++ b/src/clusterfuzz/_internal/platforms/android/sanitizer.py
@@ -59,7 +59,7 @@ def get_options_file_path(sanitizer_tool_name):
   if sanitizer_tool_name.lower() == "hwasan":
     logs.log('Unsupported sanitizer: ' + sanitizer_tool_name)
     return None
-    
+
   sanitizer_filename = SANITIZER_TOOL_TO_FILE_MAPPINGS.get(
       sanitizer_tool_name.lower())
   if sanitizer_filename is None:

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/sanitizer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/sanitizer_test.py
@@ -100,6 +100,14 @@ class SetOptionsTest(android_helpers.AndroidTest):
     """Test that options are not set with an invalid sanitizer name."""
     sanitizer.set_options('invalid', 'a=b:c=d')
     self.assertEqual(1, self.mock.log_error.call_count)
+      
+  def test_hwasan(self):
+    """Test that options are not set with hwasan sanitizer, and no errors
+    are logged."""
+    sanitizer.set_options('HWASAN', 'a=b:c=d')
+    self.assertFalse(adb.file_exists('/data/local/tmp/asan.options'))
+    self.assertFalse(adb.file_exists('/data/local/tmp/hwasan.options'))
+    self.assertEqual(0, self.mock.log_error.call_count)
 
 
 class SetupASanIfNeededTest(android_helpers.AndroidTest):

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/sanitizer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/sanitizer_test.py
@@ -100,7 +100,7 @@ class SetOptionsTest(android_helpers.AndroidTest):
     """Test that options are not set with an invalid sanitizer name."""
     sanitizer.set_options('invalid', 'a=b:c=d')
     self.assertEqual(1, self.mock.log_error.call_count)
-      
+
   def test_hwasan(self):
     """Test that options are not set with hwasan sanitizer, and no errors
     are logged."""


### PR DESCRIPTION
@jonathanmetzman noticed a spike in these errors, we are tracking the action of fixing the option handling in https://issues.chromium.org/u/2/issues/329346758, meanwhile, we can reduce the severity of the log.

I am not sure of the actual fix, the HWAsan documentation is a bit lacking. It seems we might be able to set those as an environment variable in a wrap.sh. Can/should this be done by clusterfuzz is to be determined. 

Engine fuzzers are not uzing this (most of android fuzzing IIUC?)