### PR TITLE
Revert "Workaround to use fuzzed_keys instead of minimized_keys for m…

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -348,14 +348,8 @@ def _get_testcase_key_and_archive_status(testcase):
   """Returns the testcase's key and whether or not it is archived."""
   if _is_testcase_minimized(testcase):
     key = testcase.minimized_keys
-    # TODO(alhijazi): Remove this check once the issue with blob cleanup
-    # in minimize postprocess is resolved.
-    if storage.get(blobs.get_gcs_path(key)):
-      archived = bool(
-          testcase.archive_state & data_types.ArchiveStatus.MINIMIZED)
-      return key, archived
-    logs.log(f'blob key {key} does not exist in storage'
-             'for the minimized_task, will use the fuzzed_key.')
+    archived = bool(testcase.archive_state & data_types.ArchiveStatus.MINIMIZED)
+    return key, archived
 
   key = testcase.fuzzed_keys
   archived = bool(testcase.archive_state & data_types.ArchiveStatus.FUZZED)


### PR DESCRIPTION
…issing m… (#3798)"

This change is no longer needed as the root cause was fixed in 7075f772ebc763f9748218e26b4ec06162237455. This reverts commit 5971346e448e4e8d78f1d56aa2d5bd0ba1f18b0d.