### PR TITLE
Revert "Catch more transient network issues (#3851)"

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -27,7 +27,6 @@ import uuid
 import google.auth.exceptions
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-import OpenSSL.SSL
 import requests
 import requests.exceptions
 
@@ -88,10 +87,8 @@ _TRANSIENT_ERRORS = [
     ConnectionError,
     requests.exceptions.ConnectionError,
     requests.exceptions.ChunkedEncodingError,
-    requests.exceptions.ReadTimeout,
     ConnectionResetError,
     google.auth.exceptions.TransportError,
-    OpenSSL.SSL.Error,
 ]
 
 


### PR DESCRIPTION
It's causing errors because non-linux bots don't have OpenSSL

https://pantheon.corp.google.com/errors/detail/COaKlsLyl7OAogE;filter=%5B%5D;time=PT1H?project=google.com:clusterfuzz

This reverts commit fb14908dd4a97e13416f4d58c9fc9c8df4454398.