### PR TITLE
Revert "Allow updating batch tasks so looping ones can be fixed (#3861)"

### DIFF
--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -118,14 +118,12 @@ def task_loop():
     # This caches the current environment on first run. Don't move this.
     environment.reset_environment()
     try:
-      # Run regular updates.
-      # TODO(metzman): Move this after utask_main execution so that utasks can't
-      # be updated on subsequent attempts.
-      update_task.run()
-      update_task.track_revision()
       if environment.is_uworker():
         # Batch tasks only run one at a time.
         sys.exit(utasks.uworker_bot_main())
+      # Run regular updates.
+      update_task.run()
+      update_task.track_revision()
 
       if environment.get_value('SCHEDULE_UTASK_MAINS'):
         # If the bot is configured to schedule utask_mains, don't run any other


### PR DESCRIPTION
This reverts commit b8725f8aea0f5a5fc5ab2cea8382effc5b7d4876.

Reverting because it is incompatible with untrusted service account for now, because of the way it downloads layout tests.