### PR TITLE
Show warning message for untrusted uploads for all jobs

### DIFF
--- a/src/appengine/private/components/upload-testcase/upload-form-simplified.html
+++ b/src/appengine/private/components/upload-testcase/upload-form-simplified.html
@@ -145,15 +145,13 @@
           </div>
         </template>
       </div>
-      <template is="dom-if" if="[[showWarning(uploadParams.job)]]">
-        <div class="warning">
-          <b>WARNING</b>: ClusterFuzz doesn't support untrusted workloads.<br>
-          Only upload testcases that you trust enough to run on your own
-          machine. Note that some jobs do not use the Chrome sandbox, the
-          following jobs do:<br>
-          [[formatSandboxedJobs(fieldValues.sandboxedJobs)]]
-        </div>
-      </template>
+      <div class="warning">
+        <b>WARNING</b>: ClusterFuzz doesn't support untrusted workloads.<br>
+        Only upload testcases that you trust enough to run on your own
+        machine. Note that the following jobs do use the Chrome sandbox
+        but this is not a guarantee of protection:<br>
+        [[formatSandboxedJobs(fieldValues.sandboxedJobs)]]
+      </div>
       <div class="inline wide">
         <paper-dropdown-menu
             class="dropdown-filter"

--- a/src/appengine/private/components/upload-testcase/upload-form.html
+++ b/src/appengine/private/components/upload-testcase/upload-form.html
@@ -192,15 +192,13 @@
           </paper-dropdown-menu>
         </template>
       </div>
-      <template is="dom-if" if="[[showWarning(uploadParams.job)]]">
-        <div class="warning">
-          <b>WARNING</b>: ClusterFuzz doesn't support untrusted workloads.<br>
-          Only upload testcases that you trust enough to run on your own
-          machine. Note that some jobs do not use the Chrome sandbox, the
-          following jobs do:<br>
-          [[formatSandboxedJobs(fieldValues.sandboxedJobs)]]
-        </div>
-      </template>
+      <div class="warning">
+        <b>WARNING</b>: ClusterFuzz doesn't support untrusted workloads.<br>
+        Only upload testcases that you trust enough to run on your own
+        machine. Note that the following jobs do use the Chrome sandbox,
+        but this is not a guarantee of protection:<br>
+        [[formatSandboxedJobs(fieldValues.sandboxedJobs)]]
+      </div>
       <div class="inline narrow">
         <template is="dom-if" if="[[shouldShowIssueField()]]">
           <paper-input value="{{uploadParams.issue}}" label="Issue ID (optional)" title="Issue ID in the associated project's tracker to update for this test case."></paper-input>


### PR DESCRIPTION
Update the warning to make it clear to the user that uploads should be done with chare