### PR TITLE
Use privileged service account for minimize and certain jobs

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -57,9 +57,8 @@ BatchWorkloadSpec = collections.namedtuple('BatchWorkloadSpec', [
     'machine_type',
 ])
 
-_UNPRIVILEGED_TASKS = {
-    'analyze', 'symbolize', 'regression', 'minimize', 'variant'
-}
+_UNPRIVILEGED_TASKS = {'analyze', 'symbolize', 'regression', 'variant'}
+_PRIVILEGED_JOBS = {'linux_asan_chrome_media', 'linux_d8_dbg_cm'}
 
 
 def _create_batch_client_new():
@@ -276,7 +275,7 @@ def _get_spec_from_config(command, job_name):
   # TODO(metzman): Get rid of this when we stop doing privileged operations in
   # utasks.
   # TODO(metzman): Remove linux_asan_chrome_media part when cl/616752659 lands.
-  if command in _UNPRIVILEGED_TASKS and job_name != 'linux_asan_chrome_media':
+  if command in _UNPRIVILEGED_TASKS and job_name not in _PRIVILEGED_JOBS:
     config_name += '-UNPRIVILEGED'
   batch_config = _get_batch_config()
   instance_spec = batch_config.get('mapping').get(config_name, None)


### PR DESCRIPTION
We need to do this because using unprivileged in these cases is breaking things.
1.  A custom build job. Downloading custom builds doesn't work.
2. Minimize is broken for libFuzzer.