### PR TITLE
Dont omit stats

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1964,10 +1964,8 @@ class FuzzingSession:
           id=uworker_input.job_type, count=new_targets_count).put()
 
     for testcase_run in uworker_output.fuzz_task_output.testcase_run_jsons:
-      testcase_run = json.loads(testcase_run)
-      testcase_run = fuzzer_stats.TestcaseRun(
-          testcase_run['fuzzer'], testcase_run['job'],
-          testcase_run['build_revision'], testcase_run['timestamp'])
+      testcase_run = fuzzer_stats.BaseRun.from_json(
+        json.loads(testcase_run))
       upload_testcase_run_stats(testcase_run)
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1964,8 +1964,7 @@ class FuzzingSession:
           id=uworker_input.job_type, count=new_targets_count).put()
 
     for testcase_run in uworker_output.fuzz_task_output.testcase_run_jsons:
-      testcase_run = fuzzer_stats.BaseRun.from_json(
-        json.loads(testcase_run))
+      testcase_run = fuzzer_stats.BaseRun.from_json(json.loads(testcase_run))
       upload_testcase_run_stats(testcase_run)
 
 


### PR DESCRIPTION
This should fix a recent breakage where stats are being recorded, but are essentially empty. When I made this mistake, I assumed all of the stats fields in the class definitions were all that mattered, in fact they are a minimum, and many more stats matter.