### PR TITLE
Quit bot process when we can't contact metadata server.

### DIFF
--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -27,6 +27,8 @@ import sys
 import time
 import traceback
 
+import google.auth.exceptions
+
 from clusterfuzz._internal.base import dates
 from clusterfuzz._internal.base import errors
 from clusterfuzz._internal.base import task_utils
@@ -156,6 +158,10 @@ def task_loop():
     except task_utils.UworkerMsgParseError:
       logs.log_error('Task cannot be retried because of utask parse error.')
       task.dont_retry()
+      exception_occurred = True
+      stacktrace = traceback.format_exc()
+    except google.auth.exceptions:
+      logs.log_error('Metadata refresh failed.')
       exception_occurred = True
       stacktrace = traceback.format_exc()
     except Exception:

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -160,7 +160,7 @@ def task_loop():
       task.dont_retry()
       exception_occurred = True
       stacktrace = traceback.format_exc()
-    except google.auth.exceptions:
+    except google.auth.exceptions.RefreshError:
       logs.log_error('Metadata refresh failed.')
       exception_occurred = True
       stacktrace = traceback.format_exc()


### PR DESCRIPTION
Nothing can be done in the process so quit and try again.

Tries to fix:

```
 "AuthMetadataPluginCallback "<google.auth.transport.grpc.AuthMetadataPlugin object at 0x000001D8BDC56108>" raised exception!
Traceback (most recent call last):
  File "c:\clusterfuzz\src\third_party\google\auth\compute_engine\credentials.py", line 111, in refresh
    self._retrieve_info(request)
  File "c:\clusterfuzz\src\third_party\google\auth\compute_engine\credentials.py", line 88, in _retrieve_info
    request, service_account=self._service_account_email
  File "c:\clusterfuzz\src\third_party\google\auth\compute_engine\_metadata.py", line 234, in get_service_account_info
    return get(request, path, params={"recursive": "true"})
  File "c:\clusterfuzz\src\third_party\google\auth\compute_engine\_metadata.py", line 165, in get
    "metadata service. Compute Engine Metadata server unavailable".format(url)
google.auth.exceptions.TransportError: Failed to retrieve http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/my-clusterfuzz-service-account@project.gserviceaccount.com/?recursive=true from the Google Compute Enginemetadata service. Compute Engine Metadata server unavailable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "c:\clusterfuzz\src\third_party\grpc\_plugin_wrapping.py", line 78, in __call__
    context, _AuthMetadataPluginCallback(callback_state, callback))
  File "c:\clusterfuzz\src\third_party\google\auth\transport\grpc.py", line 104, in __call__
    callback(self._get_authorization_headers(context), None)
  File "c:\clusterfuzz\src\third_party\google\auth\transport\grpc.py", line 91, in _get_authorization_headers
    self._request, context.method_name, context.service_url, headers
  File "c:\clusterfuzz\src\third_party\google\auth\credentials.py", line 133, in before_request
    self.refresh(request)
  File "c:\clusterfuzz\src\third_party\google\auth\compute_engine\credentials.py", line 117, in refresh
    six.raise_from(new_exc, caught_exc)
  File "<string>", line 3, in raise_from
google.auth.exceptions.RefreshError: Failed to retrieve http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/my-clusterfuzz-service-account@project.gserviceaccount.com/?recursive=true from the Google Compute Enginemetadata service. Compute Engine Metadata server unavailable
"
```