### PR TITLE
Update severity field on existing Google IssueTracker issues

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -17,6 +17,9 @@
 
 import datetime
 import enum
+from typing import List
+from typing import Optional
+from typing import Sequence
 import urllib.parse
 
 from google.auth import exceptions
@@ -53,7 +56,8 @@ class IssueTrackerPermissionError(IssueTrackerError):
   """Permission error."""
 
 
-def _extract_all_labels(labels, prefix):
+def _extract_all_labels(labels: issue_tracker.LabelStore,
+                        prefix: str) -> List[str]:
   """Extract all label values."""
   results = []
   labels_to_remove = []
@@ -67,7 +71,7 @@ def _extract_all_labels(labels, prefix):
   return results
 
 
-def _sanitize_oses(oses):
+def _sanitize_oses(oses: List[str]):
   """Sanitize the OS custom field values.
 
   The OS custom field no longer has the 'Chrome' value.
@@ -78,7 +82,8 @@ def _sanitize_oses(oses):
       oses[i] = 'ChromeOS'
 
 
-def _extract_label(labels, prefix):
+def _extract_label(labels: issue_tracker.LabelStore,
+                   prefix: str) -> Optional[str]:
   """Extract a label value."""
   for label in labels:
     if not label.startswith(prefix):
@@ -89,10 +94,10 @@ def _extract_label(labels, prefix):
   return None
 
 
-def _get_labels(labels_dict, prefix):
-  """Return all label values from labels.added or labels.removed"""
+def _get_labels(labels: Sequence[str], prefix: str) -> List[str]:
+  """Return the values of all labels with the given prefix."""
   results = []
-  for label in labels_dict:
+  for label in labels:
     if not label.startswith(prefix):
       continue
     results.append(label[len(prefix):])

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -680,9 +680,8 @@ class Issue(issue_tracker.Issue):
         self._data['issueState']['foundInVersions'] = foundin_values
 
       severity = _get_severity_from_labels(self.labels) or _DEFAULT_SEVERITY
-      if severity is not None:
-        self._set_severity(severity)
-        self.labels.remove_by_prefix(_SEVERITY_LABEL_PREFIX)
+      self._set_severity(severity)
+      self.labels.remove_by_prefix(_SEVERITY_LABEL_PREFIX)
 
       # Make sure self.labels contains only hotlist IDs.
       self._filter_labels()

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -810,6 +810,76 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call().execute(http=None, num_retries=3),
     ])
 
+  def test_update_issue_with_severity_label(self):
+    """Test updating an existing issue with a new severity label."""
+    self.client.issues().get().execute.return_value = BASIC_ISSUE
+    self.client.issues().modify().execute.return_value = {
+        'issueId': '68828938',
+        'issueState': {
+            'componentId':
+                '1337',
+            'type':
+                'ASSIGNED',
+            'status':
+                'NEW',
+            'priority':
+                'P2',
+            'severity':
+                'S0',
+            'title':
+                'issue title2',
+            'accessLimit': {
+                'accessLevel': issue_tracker.IssueAccessLevel.LIMIT_NONE
+            },
+            'reporter': {
+                'emailAddress': 'reporter@google.com',
+                'userGaiaStatus': 'ACTIVE',
+            },
+            'assignee': {
+                'emailAddress': 'assignee2@google.com',
+                'userGaiaStatus': 'ACTIVE',
+            },
+            'retention':
+                'COMPONENT_DEFAULT',
+            'ccs': [{
+                'emailAddress': 'cc@google.com',
+                'userGaiaStatus': 'ACTIVE'
+            },],
+            'hotlistIds': ['12345',],
+        },
+        'createdTime': '2019-06-25T01:29:30.021Z',
+        'modifiedTime': '2019-06-25T01:29:30.021Z',
+        'userData': {},
+        'accessLimit': {
+            'accessLevel': 'INTERNAL'
+        },
+        'lastModifier': {
+            'emailAddress': 'user1@google.com',
+            'userGaiaStatus': 'ACTIVE',
+        },
+    }
+
+    issue = self.issue_tracker.get_issue(68828938)
+    issue.labels.add('Security_Severity-Critical')
+    issue.save()
+
+    self.assertEqual(68828938, issue.id)
+    self.client.issues().modify.assert_has_calls([
+        mock.call(
+            body={
+                'add': {
+                    'severity': 'S0'
+                },
+                'removeMask': '',
+                'addMask': 'severity',
+                'remove': {},
+                'significanceOverride': 'MAJOR',
+            },
+            issueId='68828938',
+        ),
+        mock.call().execute(http=None, num_retries=3),
+    ])
+
   def test_update_issue_to_security(self):
     """Test updating an existing issue."""
     self.client.issues().get().execute.return_value = BASIC_ISSUE

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -1001,8 +1001,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     url = self.issue_tracker.issue_url(123)
     self.assertEqual('https://issues.chromium.org/issues/123', url)
 
-  def test_get_severity_from_crash_text(self):
-    """Test _get_severity_from_crash_text."""
+  def test_get_severity_from_label_value(self):
+    """Test _get_severity_from_label_value."""
     testcases = [
         {
             'name': 'Empty input',
@@ -1029,10 +1029,15 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             'input': 'Low',
             'expected': 'S3'
         },
+        {
+            'name': 'low input',
+            'input': 'low',
+            'expected': 'S3'
+        },
     ]
     for case in testcases:
       # pylint: disable=protected-access
-      actual = issue_tracker._get_severity_from_crash_text(case['input'])
+      actual = issue_tracker._get_severity_from_label_value(case['input'])
       self.assertEqual(
           case['expected'], actual, 'failed test %s. expected %s. actual %s' %
           (case['name'], case['expected'], actual))


### PR DESCRIPTION
This seems to have never worked.

It's unclear to me whether we should support the label being removed as well or not. I can't find out whether the severity field is translated to a severity label when reading back from the tracker, in which case edits to remove the label should probably be reflected in the severity field. Otherwise, I think we can only add the label.

Also adds an error log in the case where there are too many severity labels, so we can notice and diagnose such issues.

Doing this revealed a subtle bug in the existing custom handling code for other "fake" labels, like OS. Label values are found with a case-sensitive match in `_extract_label()` or `_get_labels()`, but removed with a case-insensitive match in `LabelStore.remove_by_prefix()`. This should probably be fixed, but I did not want to change existing behavior beyond the scope of this fix.

Fixes https://crbug.com/332396351.