### PR TITLE
Remove `linux_asan_chrome_media` from privileged jobs list.

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -61,7 +61,8 @@ _UNPRIVILEGED_TASKS = {
     'analyze', 'symbolize', 'regression', 'variant', 'minimize', 'progression'
 }
 _PRIVILEGED_JOBS = {
-    'linux_asan_chrome_media', 'linux_d8_dbg_cm', 'centipede_v8_asan_dbg_custom'
+    'linux_d8_dbg_cm',
+    'centipede_v8_asan_dbg_custom',
 }
 
 


### PR DESCRIPTION
It no longer pulls builds from a non-public GCS bucket.

See https://crbug.com/331166920 for details.