### PR TITLE
Re-use existing symbolized release build if possible

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
@@ -107,7 +107,7 @@ def utask_main(uworker_input):
     build_revision = testcase.crash_revision
 
   # Set up a custom or regular build based on revision.
-  build_manager.setup_build(build_revision)
+  build = build_manager.setup_build(build_revision)
 
   # Get crash revision used in setting up build.
   crash_revision = environment.get_value('APP_REVISION')
@@ -159,7 +159,8 @@ def utask_main(uworker_input):
       redzone /= 2
 
   # We should have atleast a symbolized debug or a release build.
-  symbolized_builds = build_manager.setup_symbolized_builds(crash_revision)
+  symbolized_builds = build_manager.setup_symbolized_builds(
+      crash_revision, build)
   if (not symbolized_builds or
       (not build_manager.check_app_path() and
        not build_manager.check_app_path('APP_PATH_DEBUG'))):

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1236,7 +1236,7 @@ def setup_regular_build(revision: int,
                         bucket_path: Optional[str] = None,
                         build_prefix: str = '',
                         target_weights=None,
-                        fuzz_targets=None) -> RegularBuild:
+                        fuzz_targets=None) -> Optional[RegularBuild]:
   """Sets up build with a particular revision."""
   if not bucket_path:
     # Bucket path can be customized, otherwise get it from the default env var.
@@ -1305,7 +1305,7 @@ def setup_regular_build(revision: int,
 
 
 def setup_symbolized_builds(revision: int,
-                            regular_build: Optional[RegularBuild] = None):
+                            regular_build: Optional[RegularBuild] = None) -> Optional[SymbolizedBuild]:
   """Set up symbolized release and debug build at the given revision.
 
   Args:
@@ -1314,6 +1314,9 @@ def setup_symbolized_builds(revision: int,
        path and build URL are the same as the would-be symbolized release
        build's, then it is reused and no additional symbolized release build is
        set up.
+
+  Returns:
+    The build if successful, None otherwise.
   """
   sym_release_build_bucket_path = environment.get_value(
       'SYM_RELEASE_BUILD_BUCKET_PATH')
@@ -1352,7 +1355,7 @@ def setup_symbolized_builds(revision: int,
   return None
 
 
-def setup_custom_binary(target_weights=None):
+def setup_custom_binary(target_weights=None) -> Optional[CustomBuild]:
   """Set up the custom binary for a particular job."""
   # Check if this build is dependent on any other custom job. If yes,
   # then fake out our job name for setting up the build.
@@ -1390,7 +1393,7 @@ def setup_custom_binary(target_weights=None):
   return None
 
 
-def setup_system_binary():
+def setup_system_binary() -> Optional[SystemBuild]:
   """Set up a build that we assume is already installed on the system."""
   system_binary_directory = environment.get_value('SYSTEM_BINARY_DIR', '')
   build = SystemBuild(system_binary_directory)
@@ -1400,7 +1403,7 @@ def setup_system_binary():
   return None
 
 
-def setup_build(revision=0, target_weights=None):
+def setup_build(revision: int = 0, target_weights=None) -> Optional[Build]:
   """Set up a custom or regular build based on revision."""
   # For custom binaries we always use the latest version. Revision is ignored.
   custom_binary = environment.get_value('CUSTOM_BINARY')

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -775,6 +775,8 @@ class SymbolizedBuild(Build):
       downloaded, if any.
     debug_build_url (Optional[str]): The URL from which the debug build is
       downloaded, if any.
+    reuse_release_build (bool): Whether the release build is re-used from an
+      existing build instead of downloaded anew.
   """
 
   def __init__(self,
@@ -823,6 +825,10 @@ class SymbolizedBuild(Build):
   @property
   def build_dir(self):
     return self._build_dir
+
+  @property
+  def reuse_release_build(self):
+    return self._reuse_release_build
 
   def _unpack_builds(self):
     """Download and unpack builds."""

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -983,6 +983,89 @@ class SymbolizedBuildTest(fake_filesystem_unittest.TestCase):
     self.assertTrue(
         os.path.isdir('/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025'))
 
+  def test_reuse_release_build_true(self):
+    """Check reuse_release_build is true when existing build matches."""
+    base_dir = "base/build/dir"
+    revision = 12
+    build_url = "gs://path/file-release-12.zip"
+
+    existing_build = build_manager.RegularBuild(base_dir, revision, build_url)
+    symbolized_build = build_manager.SymbolizedBuild(
+        base_dir, revision, build_url, None, existing_build)
+
+    self.assertTrue(symbolized_build.reuse_release_build)
+    self.assertEqual(symbolized_build.release_build_dir,
+                     existing_build.build_dir)
+
+  def test_reuse_release_build_no_existing_build(self):
+    """Check reuse_release_build is false when there is no existing build."""
+    base_dir = "base/build/dir"
+    revision = 12
+    build_url = "gs://path/file-release-12.zip"
+
+    symbolized_build = build_manager.SymbolizedBuild(base_dir, revision,
+                                                     build_url, None, None)
+
+    self.assertFalse(symbolized_build.reuse_release_build)
+
+  def test_reuse_release_build_wrong_class(self):
+    """Check reuse_release_build is false when the existing build is not a
+    regular build.
+    """
+    base_dir = "base/build/dir"
+    revision = 12
+    build_url = "gs://path/file-release-12.zip"
+
+    existing_build = build_manager.SystemBuild("system/bin/dir")
+    symbolized_build = build_manager.SymbolizedBuild(
+        base_dir, revision, build_url, None, existing_build)
+
+    self.assertFalse(symbolized_build.reuse_release_build)
+
+  def test_reuse_release_build_wrong_base(self):
+    """Check reuse_release_build is false when the existing build has a
+    different base_build_dir.
+    """
+    base_dir = "base/build/dir"
+    revision = 12
+    build_url = "gs://path/file-release-12.zip"
+
+    existing_build = build_manager.RegularBuild("wrong/build/dir", revision,
+                                                build_url)
+    symbolized_build = build_manager.SymbolizedBuild(
+        base_dir, revision, build_url, None, existing_build)
+
+    self.assertFalse(symbolized_build.reuse_release_build)
+
+  def test_reuse_release_build_wrong_url(self):
+    """Check reuse_release_build is false when the existing build has a
+    different build_url.
+    """
+    base_dir = "base/build/dir"
+    revision = 12
+    build_url = "gs://path/file-release-12.zip"
+
+    existing_build = build_manager.RegularBuild(base_dir, revision,
+                                                "gs://path/file-debug-12.zip")
+    symbolized_build = build_manager.SymbolizedBuild(
+        base_dir, revision, build_url, None, existing_build)
+
+    self.assertFalse(symbolized_build.reuse_release_build)
+
+  def test_reuse_release_build_wrong_revision(self):
+    """Check reuse_release_build is false when the existing build has a
+    different revision.
+    """
+    base_dir = "base/build/dir"
+    revision = 12
+    build_url = "gs://path/file-release.zip"
+
+    existing_build = build_manager.RegularBuild(base_dir, 1337, build_url)
+    symbolized_build = build_manager.SymbolizedBuild(
+        base_dir, revision, build_url, None, existing_build)
+
+    self.assertFalse(symbolized_build.reuse_release_build)
+
 
 class ProductionBuildTest(fake_filesystem_unittest.TestCase):
   """Tests for production build setup."""


### PR DESCRIPTION
Symbolize task first downloads a regular build to run under ASAN a few times with larger redzones in an attempt to refine the crash type, before downloading symbolized release and debug builds to gather symbolized stack traces. Sometimes, as seen in a Chrome fuzzing job, the regular build is the same as the symbolized release build: downloading and extracting it twice wastes valuable disk space.

This changes makes `SymbolizedBuild` re-use the existing build if it determines it to be compatible: that is, it is extracted to the same base build directory, shares the same revision and came from the same URL. I believe (though I am not certain) that both `RegularBuild` and `SymbolizedBuild` extract their zips in similar-enough fashions such that the build can really be re-used.

See also https://crbug.com/333014970#comment2.