### PR TITLE
Dont treat jazzerjs as a fuzz target

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -41,6 +41,7 @@ FUZZ_TARGET_ALLOWLISTED_PREFIXES = [
     'jazzer_agent_deploy.jar',
     'jazzer_driver',
     'jazzer_driver_with_sanitizer',
+    'jazzerjs.node',
     'llvm-symbolizer',
     # crbug.com/1471427: chrome_crashpad_handler is needed for fuzzers that are
     # spawning the full chrome browser.


### PR DESCRIPTION
It's incorrect to do so. Also, the file extension (.node) breaks ClusterFuzz very badly because CF thinks the "fuzz target" is missing. Fixes: https://pantheon.corp.google.com/errors/detail/CIqR3rOw3IDLzgE;service=;version=;filter=%5B%22nonetype%22%5D?project=clusterfuzz-external
```
AttributeError: 'NoneType' object has no attribute 'endswith'
.get_supporting_file ( /mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/bot/fuzzers/utils.py:151
```
Related: https://github.com/google/oss-fuzz/issues/11538