### PR TITLE
Delete regular build before symbolization.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
@@ -107,7 +107,7 @@ def utask_main(uworker_input):
     build_revision = testcase.crash_revision
 
   # Set up a custom or regular build based on revision.
-  build_manager.setup_build(build_revision)
+  build = build_manager.setup_build(build_revision)
 
   # Get crash revision used in setting up build.
   crash_revision = environment.get_value('APP_REVISION')
@@ -157,6 +157,10 @@ def utask_main(uworker_input):
           break
 
       redzone /= 2
+
+  # We no longer need this build, delete it to save some disk space. We will
+  # download a symbolized release build to perform the symbolization.
+  build.delete()
 
   # We should have atleast a symbolized debug or a release build.
   symbolized_builds = build_manager.setup_symbolized_builds(crash_revision)


### PR DESCRIPTION
Alternative attempt to fix issues identified in https://crbug.com/333014970, as suggested by @alhijazi on #3925. 

After the bot downloads a regular build and uses it to try reproducing the crash with larger ASAN redzone sizes, this change makes the bot delete said regular build. It will then download a symbolized release build and (optionally) a symbolized debug build.

This is still a bit silly in the case where the regular build and symbolized release build are one and the same: we download and unpack the same (potentially-large) zip twice. However, it is much less complex and risky than #3925, which is a good tradeoff.