### PR TITLE
Fix fuzz task run method log message

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1787,7 +1787,7 @@ class FuzzingSession:
     self.testcase_directory = environment.get_value('FUZZ_INPUTS')
 
     if self.fuzz_target:
-      logs.log('Setting fuzz target {fuzz_target}.')
+      logs.log(f'Setting fuzz target {self.fuzz_target}.')
       environment.set_value('FUZZ_TARGET', self.fuzz_target.binary)
     build_setup_result = build_manager.setup_build(
         environment.get_value('APP_REVISION'),


### PR DESCRIPTION
Fixing log message to include actual fuzz target in log message instead of raw stirng