### PR TITLE
Avoid interactive prompts in docker image builds.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -15,7 +15,11 @@
 # Copy some commonly linked library versions from xenial for backwards
 # compatibility with older builds.
 FROM ubuntu:16.04 as xenial
-ENV DEBIAN_FRONTEND noninteractive
+
+# Prevent interactive prompts during package installation. This seems to work
+# better than `ENV DEBIAN_FRONTEND=noninteractive` for some reason.
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt-get update && \
     apt-get install -y \
       libcurl3-gnutls \
@@ -25,10 +29,11 @@ RUN apt-get update && \
 
 FROM ubuntu:20.04
 
+# And again with the newest ubuntu image.
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN mkdir /data
 WORKDIR /data
-
-ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
Turns out that setting `DEBIAN_FRONTEND=noninteractive` does not always work. It specifically fails when installing `keyboard-configuration`, which asks for a keyboard layout interactively.

Using debconf in this way seems to work, OTOH. I built the chromium images successfully this way.

Fixes #3609 and https://crbug.com/41493477.