### PR TITLE
Improve `butler.py weights` script

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -170,6 +170,11 @@ def _add_weights_target_subparser(weights_subparsers):
       '-j', '--jobs', help='Which jobs to list entries for.', nargs='+')
   list_parser.add_argument(
       '-e', '--engines', help='Which engine to list entries for.', nargs='+')
+  list_parser.add_argument(
+      '--format',
+      help='Output format.',
+      choices=['text', 'csv'],
+      default='text')
 
 
 def _add_weights_subparser(toplevel_subparsers):

--- a/butler.py
+++ b/butler.py
@@ -144,6 +144,11 @@ def _add_weights_batches_subparser(weights_subparsers):
       '--platforms',
       help='Which platforms to list entries for.',
       nargs='+')
+  list_parser.add_argument(
+      '--format',
+      help='Output format.',
+      choices=['text', 'csv'],
+      default='text')
 
 
 def _add_weights_target_subparser(weights_subparsers):

--- a/butler.py
+++ b/butler.py
@@ -99,6 +99,7 @@ def _setup_args_for_remote(parser):
 
 
 def _add_weights_fuzzer_subparser(weights_subparsers):
+  """Adds a parser for the `weights fuzzer` command."""
   parser = weights_subparsers.add_parser(
       'fuzzer', help='Interact with FuzzerJob weights.')
   subparsers = parser.add_subparsers(dest='fuzzer_command')
@@ -133,6 +134,7 @@ def _add_weights_fuzzer_subparser(weights_subparsers):
 
 
 def _add_weights_batches_subparser(weights_subparsers):
+  """Adds a parser for the `weights fuzzer-batch` command."""
   parser = weights_subparsers.add_parser(
       'fuzzer-batch',
       help='Interact with FuzzerJobs (FuzzerJob batches) weights.')
@@ -152,6 +154,7 @@ def _add_weights_batches_subparser(weights_subparsers):
 
 
 def _add_weights_target_subparser(weights_subparsers):
+  """Adds a parser for the `weights fuzz-target` command."""
   parser = weights_subparsers.add_parser(
       'fuzz-target', help='Interact with FuzzTargetJob weights.')
   subparsers = parser.add_subparsers(dest='fuzz_target_command')
@@ -170,6 +173,7 @@ def _add_weights_target_subparser(weights_subparsers):
 
 
 def _add_weights_subparser(toplevel_subparsers):
+  """Adds a parser for the `weights` command."""
   parser = toplevel_subparsers.add_parser(
       'weights', help='Interact with fuzzer/job weights.')
 

--- a/butler.py
+++ b/butler.py
@@ -262,7 +262,7 @@ def main():
   weights_dump_parser.add_argument(
       'type',
       help='The type of entries to dump from the database.',
-      choices=['fuzzer_job', 'fuzzer_jobs'])
+      choices=['fuzzer_job', 'fuzzer_jobs', 'fuzz_target_job'])
 
   weights_list_parser = weights_subparsers.add_parser(
       'list', help='List FuzzerJob entries.')

--- a/butler.py
+++ b/butler.py
@@ -144,11 +144,6 @@ def _add_weights_batches_subparser(weights_subparsers):
       '--platforms',
       help='Which platforms to list entries for.',
       nargs='+')
-  list_parser.add_argument(
-      '--format',
-      help='Output format.',
-      choices=['text', 'csv'],
-      default='text')
 
 
 def _add_weights_target_subparser(weights_subparsers):

--- a/butler.py
+++ b/butler.py
@@ -98,6 +98,90 @@ def _setup_args_for_remote(parser):
   subparsers.add_parser('reboot', help='Reboot with `sudo reboot`.')
 
 
+def _add_weights_fuzzer_subparser(weights_subparsers):
+  parser = weights_subparsers.add_parser(
+      'fuzzer', help='Interact with FuzzerJob weights.')
+  subparsers = parser.add_subparsers(dest='fuzzer_command')
+
+  subparsers.add_parser(
+      'platforms', help='List distinct platform field values.')
+
+  list_parser = subparsers.add_parser('list', help='List FuzzerJob entries.')
+  list_parser.add_argument(
+      '-p',
+      '--platforms',
+      help='Which platforms to list entries for.',
+      nargs='+')
+  list_parser.add_argument(
+      '-f', '--fuzzers', help='Which fuzzers to list entries for.', nargs='+')
+  list_parser.add_argument(
+      '-j', '--jobs', help='Which jobs to list entries for.', nargs='+')
+  list_parser.add_argument(
+      '--format',
+      help='Output format.',
+      choices=['text', 'csv'],
+      default='text')
+
+  aggregate_parser = subparsers.add_parser(
+      'aggregate', help='Aggregate matching FuzzerJob entries.')
+  aggregate_parser.add_argument(
+      '-p', '--platform', help='Which platform to query.', required=True)
+  aggregate_parser.add_argument(
+      '-f', '--fuzzers', help='Which fuzzers to aggregate.', nargs='+')
+  aggregate_parser.add_argument(
+      '-j', '--jobs', help='Which jobs to aggregate.', nargs='+')
+
+
+def _add_weights_batches_subparser(weights_subparsers):
+  parser = weights_subparsers.add_parser(
+      'fuzzer-batch',
+      help='Interact with FuzzerJobs (FuzzerJob batches) weights.')
+  subparsers = parser.add_subparsers(dest='fuzzer_batch_command')
+
+  list_parser = subparsers.add_parser('list', help='List FuzzerJobs entries.')
+  list_parser.add_argument(
+      '-p',
+      '--platforms',
+      help='Which platforms to list entries for.',
+      nargs='+')
+  list_parser.add_argument(
+      '--format',
+      help='Output format.',
+      choices=['text', 'csv'],
+      default='text')
+
+
+def _add_weights_target_subparser(weights_subparsers):
+  parser = weights_subparsers.add_parser(
+      'fuzz-target', help='Interact with FuzzTargetJob weights.')
+  subparsers = parser.add_subparsers(dest='fuzz_target_command')
+
+  list_parser = subparsers.add_parser(
+      'list', help='List FuzzerTargetJob entries.')
+  list_parser.add_argument(
+      '-t',
+      '--targets',
+      help='Which fuzz target names to list entries for.',
+      nargs='+')
+  list_parser.add_argument(
+      '-j', '--jobs', help='Which jobs to list entries for.', nargs='+')
+  list_parser.add_argument(
+      '-e', '--engines', help='Which engine to list entries for.', nargs='+')
+
+
+def _add_weights_subparser(toplevel_subparsers):
+  parser = toplevel_subparsers.add_parser(
+      'weights', help='Interact with fuzzer/job weights.')
+
+  parser.add_argument(
+      '-c', '--config-dir', required=True, help='Path to application config.')
+
+  subparsers = parser.add_subparsers(dest='weights_command')
+  _add_weights_fuzzer_subparser(subparsers)
+  _add_weights_batches_subparser(subparsers)
+  _add_weights_target_subparser(subparsers)
+
+
 def main():
   """Parse the command-line args and invoke the right command."""
   parser = _ArgumentParser(
@@ -249,41 +333,7 @@ def main():
   subparsers.add_parser(
       'integration_tests', help='Run end-to-end integration tests.')
 
-  parser_weights = subparsers.add_parser(
-      'weights', help='Interact with fuzzer/job weights.')
-  parser_weights.add_argument(
-      '-c', '--config-dir', required=True, help='Path to application config.')
-
-  weights_subparsers = parser_weights.add_subparsers(dest='weights_command')
-  weights_subparsers.add_parser('platforms', help='List platforms.')
-
-  weights_dump_parser = weights_subparsers.add_parser(
-      'dump', help='Dump database entries.')
-  weights_dump_parser.add_argument(
-      'type',
-      help='The type of entries to dump from the database.',
-      choices=['fuzzer_job', 'fuzzer_jobs', 'fuzz_target_job'])
-
-  weights_list_parser = weights_subparsers.add_parser(
-      'list', help='List FuzzerJob entries.')
-  weights_list_parser.add_argument(
-      '-p',
-      '--platforms',
-      help='Which platforms to list entries for.',
-      nargs='+')
-  weights_list_parser.add_argument(
-      '-f', '--fuzzers', help='Which fuzzers to list entries for.', nargs='+')
-  weights_list_parser.add_argument(
-      '-j', '--jobs', help='Which jobs to list entries for.', nargs='+')
-
-  weights_aggregate_parser = weights_subparsers.add_parser(
-      'aggregate', help='Aggregate matching FuzzerJob entries.')
-  weights_aggregate_parser.add_argument(
-      '-p', '--platform', help='Which platform to query.', required=True)
-  weights_aggregate_parser.add_argument(
-      '-f', '--fuzzers', help='Which fuzzers to aggregate.', nargs='+')
-  weights_aggregate_parser.add_argument(
-      '-j', '--jobs', help='Which jobs to aggregate.', nargs='+')
+  _add_weights_subparser(subparsers)
 
   args = parser.parse_args()
   if not args.command:

--- a/butler.py
+++ b/butler.py
@@ -176,6 +176,25 @@ def _add_weights_target_subparser(weights_subparsers):
       choices=['text', 'csv'],
       default='text')
 
+  set_parser = subparsers.add_parser(
+      'set', help='Set the weight of a FuzzTargetJob entry.')
+  set_parser.add_argument(
+      '-t',
+      '--target',
+      help='The fuzz_target_name field of the entry to modify.',
+      required=True)
+  set_parser.add_argument(
+      '-j',
+      '--job',
+      help='The job field of the entry to modify.',
+      required=True)
+  set_parser.add_argument(
+      '-w',
+      '--weight',
+      help='The new weight to set.',
+      type=float,
+      required=True)
+
 
 def _add_weights_subparser(toplevel_subparsers):
   """Adds a parser for the `weights` command."""

--- a/butler.py
+++ b/butler.py
@@ -160,7 +160,7 @@ def _add_weights_target_subparser(weights_subparsers):
   subparsers = parser.add_subparsers(dest='fuzz_target_command')
 
   list_parser = subparsers.add_parser(
-      'list', help='List FuzzerTargetJob entries.')
+      'list', help='List FuzzTargetJob entries.')
   list_parser.add_argument(
       '-t',
       '--targets',

--- a/butler.py
+++ b/butler.py
@@ -137,7 +137,11 @@ def _add_weights_batches_subparser(weights_subparsers):
   """Adds a parser for the `weights fuzzer-batch` command."""
   parser = weights_subparsers.add_parser(
       'fuzzer-batch',
-      help='Interact with FuzzerJobs (FuzzerJob batches) weights.')
+      help='Interact with FuzzerJobs weights. FuzzerJobs database entries ' +
+      'consist of batches of FuzzerJob entries that share the same platform. ' +
+      'These are periodically generated from FuzzerJob entries. Bots read ' +
+      'from FuzzerJobs batches in production instead of reading directly ' +
+      'from FuzzerJob entries.')
   subparsers = parser.add_subparsers(dest='fuzzer_batch_command')
 
   list_parser = subparsers.add_parser('list', help='List FuzzerJobs entries.')

--- a/src/local/butler/weights.py
+++ b/src/local/butler/weights.py
@@ -20,7 +20,6 @@ Usage:
 """
 
 import csv
-import enum
 import os
 import statistics
 import sys
@@ -93,6 +92,7 @@ def _query_fuzz_target_jobs(
     jobs: Optional[Sequence[str]] = None,
     engines: Optional[Sequence[str]] = None,
 ) -> Sequence[data_types.FuzzTargetJob]:
+  """Queries Datastore for matching FuzzTargetJob entries."""
   query = data_types.FuzzTargetJob.query()
 
   if targets:
@@ -115,9 +115,10 @@ def _print_with_prefix(prefix: str) -> Callable[[str], None]:
   return _print
 
 
-def _list_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob], prefix='') -> None:
+def _list_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob],
+                      prefix='') -> None:
   """Lists the given FuzzerJob entries on stdout."""
-  _print = _print_with_prefix(prefix)
+  printer = _print_with_prefix(prefix)
 
   fuzzer_jobs = list(fuzzer_jobs)
   fuzzer_jobs.sort(key=lambda fj: fj.actual_weight, reverse=True)
@@ -127,19 +128,20 @@ def _list_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob], prefix='') ->
   for fuzzer_job in fuzzer_jobs:
     probability = fuzzer_job.actual_weight / total_weight
 
-    _print("FuzzerJob:")
-    _print(f'  Fuzzer: {fuzzer_job.fuzzer}')
-    _print(f'  Job: {fuzzer_job.job}')
-    _print(f'  Platform: {fuzzer_job.platform}')
-    _print(f'  Weight: {fuzzer_job.actual_weight} = ' +
-          f'{fuzzer_job.weight} * {fuzzer_job.multiplier}')
-    _print(f'  Probability: {_display_prob(probability)}')
+    printer("FuzzerJob:")
+    printer(f'  Fuzzer: {fuzzer_job.fuzzer}')
+    printer(f'  Job: {fuzzer_job.job}')
+    printer(f'  Platform: {fuzzer_job.platform}')
+    printer(f'  Weight: {fuzzer_job.actual_weight} = ' +
+            f'{fuzzer_job.weight} * {fuzzer_job.multiplier}')
+    printer(f'  Probability: {_display_prob(probability)}')
 
-  _print(f'Count: {len(fuzzer_jobs)}')
-  _print(f'Total weight: {total_weight}')
+  printer(f'Count: {len(fuzzer_jobs)}')
+  printer(f'Total weight: {total_weight}')
 
 
 def _list_fuzzer_jobs_batches(batches: Sequence[data_types.FuzzerJobs]) -> None:
+  """Lists the given FuzzerJobs entries on stdout."""
   count = 0
   for batch in batches:
     count += 1
@@ -199,8 +201,6 @@ def _dump_fuzzer_jobs_batches(batches: Sequence[data_types.FuzzerJobs]) -> None:
 def _dump_fuzz_target_jobs(
     fuzz_target_jobs: Sequence[data_types.FuzzTargetJob]) -> None:
   """Dumps FuzzTargetJob entries from the database to stdout in CSV format."""
-  entries = _query_fuzz_target_jobs()
-
   writer = csv.DictWriter(
       sys.stdout,
       fieldnames=[
@@ -291,6 +291,7 @@ def _aggregate_fuzzer_jobs(
 
 
 def _execute_fuzzer_command(args) -> None:
+  """Executes the `fuzzer` command."""
   cmd = args.fuzzer_command
   if cmd == 'platforms':
     list_platforms()
@@ -310,6 +311,7 @@ def _execute_fuzzer_command(args) -> None:
 
 
 def _execute_fuzzer_batch_command(args) -> None:
+  """Executes the `fuzzer-batch` command."""
   cmd = args.fuzzer_batch_command
   if cmd == 'list':
     batches = _query_fuzzer_jobs_batches(platforms=args.platforms)
@@ -324,6 +326,7 @@ def _execute_fuzzer_batch_command(args) -> None:
 
 
 def _execute_fuzz_target_command(args) -> None:
+  """Executes the `fuzz-target` command."""
   cmd = args.fuzz_target_command
   if cmd == 'list':
     _dump_fuzz_target_jobs(
@@ -334,6 +337,7 @@ def _execute_fuzz_target_command(args) -> None:
 
 
 def _execute_command(args) -> None:
+  """Executes the `weights` command."""
   cmd = args.weights_command
   if cmd == 'fuzzer':
     _execute_fuzzer_command(args)

--- a/src/local/butler/weights.py
+++ b/src/local/butler/weights.py
@@ -38,6 +38,7 @@ from src.clusterfuzz._internal.datastore import ndb_init
 class EntryType(enum.Enum):
   FUZZER_JOB = 'fuzzer_job'
   FUZZER_JOBS = 'fuzzer_jobs'
+  FUZZ_TARGET_JOB = 'fuzz_target_job'
 
 
 def _iter_weights(
@@ -162,12 +163,43 @@ def _dump_fuzzer_jobs_batches() -> None:
       writer.writerow(fields)
 
 
+def _query_fuzz_target_jobs() -> Sequence[data_types.FuzzTargetJob]:
+  return data_types.FuzzTargetJob.query()
+
+
+def _dump_fuzz_target_jobs() -> None:
+  """Dumps FuzzTargetJob entries from the database to stdout in CSV format."""
+  entries = _query_fuzz_target_jobs()
+
+  writer = csv.DictWriter(
+      sys.stdout,
+      fieldnames=[
+          'fuzz_target_name',
+          'job',
+          'engine',
+          'weight',
+          'last_run',
+      ])
+  writer.writeheader()
+
+  for entry in entries:
+    writer.writerow({
+        'fuzz_target_name': entry.fuzz_target_name,
+        'job': entry.job,
+        'engine': entry.engine,
+        'weight': entry.weight,
+        'last_run': entry.last_run,
+    })
+
+
 def _dump_entries(entry_type: EntryType) -> None:
   """Dumps entries of the given type from the database to stdout."""
   if entry_type == EntryType.FUZZER_JOB:
     _dump_fuzzer_jobs()
   elif entry_type == EntryType.FUZZER_JOBS:
     _dump_fuzzer_jobs_batches()
+  elif entry_type == EntryType.FUZZ_TARGET_JOB:
+    _dump_fuzz_target_jobs()
 
 
 def _fuzzer_job_matches(

--- a/src/local/butler/weights.py
+++ b/src/local/butler/weights.py
@@ -130,7 +130,7 @@ def _display_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob],
   for fuzzer_job in fuzzer_jobs:
     probability = fuzzer_job.actual_weight / total_weight
 
-    printer("FuzzerJob:")
+    printer('FuzzerJob:')
     printer(f'  Fuzzer: {fuzzer_job.fuzzer}')
     printer(f'  Job: {fuzzer_job.job}')
     printer(f'  Platform: {fuzzer_job.platform}')

--- a/src/local/butler/weights.py
+++ b/src/local/butler/weights.py
@@ -51,7 +51,7 @@ def _display_prob(probability: float) -> str:
   return f'{probability:0.04f} = {probability * 100:0.02f}%'
 
 
-def list_platforms() -> None:
+def _display_platforms() -> None:
   # Query only distinct platform values from the database.
   fuzzer_jobs = data_types.FuzzerJob.query(
       projection=[data_types.FuzzerJob.platform], distinct=True)
@@ -117,8 +117,8 @@ def _print_with_prefix(prefix: str) -> Callable[[str], None]:
   return _print
 
 
-def _list_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob],
-                      prefix='') -> None:
+def _display_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob],
+                         prefix='') -> None:
   """Lists the given FuzzerJob entries on stdout."""
   printer = _print_with_prefix(prefix)
 
@@ -142,7 +142,8 @@ def _list_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob],
   printer(f'Total weight: {total_weight}')
 
 
-def _list_fuzzer_jobs_batches(batches: Sequence[data_types.FuzzerJobs]) -> None:
+def _display_fuzzer_jobs_batches(
+    batches: Sequence[data_types.FuzzerJobs]) -> None:
   """Lists the given FuzzerJobs entries on stdout."""
   count = 0
   for batch in batches:
@@ -151,12 +152,12 @@ def _list_fuzzer_jobs_batches(batches: Sequence[data_types.FuzzerJobs]) -> None:
     print('FuzzerJobs:')
     print(f'  ID: {batch.key.id()}')
     print(f'  Platform: {batch.platform}')
-    _list_fuzzer_jobs(batch.fuzzer_jobs, prefix='  ')
+    _display_fuzzer_jobs(batch.fuzzer_jobs, prefix='  ')
 
   print(f'Count: {count}')
 
 
-def _list_fuzz_target_jobs(
+def _display_fuzz_target_jobs(
     fuzz_target_jobs: Sequence[data_types.FuzzTargetJob]) -> None:
   """Lists the given FuzzTargetJob entries on stdout."""
   fuzz_target_jobs = list(fuzz_target_jobs)
@@ -203,7 +204,7 @@ def _fuzzer_job_to_dict(
 
 
 def _dump_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob]) -> None:
-  """Dumps FuzzerJob entries from the database to stdout in CSV format."""
+  """Dumps the provided FuzzerJob entries to stdout in CSV format."""
   writer = csv.DictWriter(sys.stdout, fieldnames=_FUZZER_JOB_FIELDS)
   writer.writeheader()
 
@@ -212,7 +213,7 @@ def _dump_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob]) -> None:
 
 
 def _dump_fuzzer_jobs_batches(batches: Sequence[data_types.FuzzerJobs]) -> None:
-  """Dumps FuzzerJobs entries from the database to stdout in CSV format."""
+  """Dumps the provided FuzzerJobs entries to stdout in CSV format."""
   writer = csv.DictWriter(sys.stdout, fieldnames=['batch'] + _FUZZER_JOB_FIELDS)
   writer.writeheader()
 
@@ -225,7 +226,7 @@ def _dump_fuzzer_jobs_batches(batches: Sequence[data_types.FuzzerJobs]) -> None:
 
 def _dump_fuzz_target_jobs(
     fuzz_target_jobs: Sequence[data_types.FuzzTargetJob]) -> None:
-  """Dumps FuzzTargetJob entries from the database to stdout in CSV format."""
+  """Dumps the provided FuzzTargetJob entries to stdout in CSV format."""
   writer = csv.DictWriter(
       sys.stdout,
       fieldnames=[
@@ -349,12 +350,12 @@ def _execute_fuzzer_command(args) -> None:
   """Executes the `fuzzer` command."""
   cmd = args.fuzzer_command
   if cmd == 'platforms':
-    list_platforms()
+    _display_platforms()
   elif cmd == 'list':
     fuzzer_jobs = _query_fuzzer_jobs(
         platforms=args.platforms, fuzzers=args.fuzzers, jobs=args.jobs)
     if args.format == 'text':
-      _list_fuzzer_jobs(fuzzer_jobs)
+      _display_fuzzer_jobs(fuzzer_jobs)
     elif args.format == 'csv':
       _dump_fuzzer_jobs(fuzzer_jobs)
     else:
@@ -371,7 +372,7 @@ def _execute_fuzzer_batch_command(args) -> None:
   if cmd == 'list':
     batches = _query_fuzzer_jobs_batches(platforms=args.platforms)
     if args.format == 'text':
-      _list_fuzzer_jobs_batches(batches)
+      _display_fuzzer_jobs_batches(batches)
     elif args.format == 'csv':
       _dump_fuzzer_jobs_batches(batches)
     else:
@@ -387,7 +388,7 @@ def _execute_fuzz_target_command(args) -> None:
     fuzz_target_jobs = _query_fuzz_target_jobs(
         targets=args.targets, jobs=args.jobs, engines=args.engines)
     if args.format == 'text':
-      _list_fuzz_target_jobs(fuzz_target_jobs)
+      _display_fuzz_target_jobs(fuzz_target_jobs)
     elif args.format == 'csv':
       _dump_fuzz_target_jobs(fuzz_target_jobs)
     else:

--- a/src/local/butler/weights.py
+++ b/src/local/butler/weights.py
@@ -149,10 +149,8 @@ def _fuzzer_job_to_dict(
   }
 
 
-def _dump_fuzzer_jobs() -> None:
+def _dump_fuzzer_jobs(fuzzer_jobs: Sequence[data_types.FuzzerJob]) -> None:
   """Dumps FuzzerJob entries from the database to stdout in CSV format."""
-  fuzzer_jobs = _query_fuzzer_jobs()
-
   writer = csv.DictWriter(sys.stdout, fieldnames=_FUZZER_JOB_FIELDS)
   writer.writeheader()
 
@@ -271,10 +269,14 @@ def _execute_fuzzer_command(args) -> None:
   if cmd == 'platforms':
     list_platforms()
   elif cmd == 'list':
-    #_dump_entries(EntryType(args.type))
-    _list_fuzzer_jobs(
-        _query_fuzzer_jobs(
-            platforms=args.platforms, fuzzers=args.fuzzers, jobs=args.jobs))
+    fuzzer_jobs = _query_fuzzer_jobs(
+        platforms=args.platforms, fuzzers=args.fuzzers, jobs=args.jobs)
+    if args.format == 'text':
+      _list_fuzzer_jobs(fuzzer_jobs)
+    elif args.format == 'csv':
+      _dump_fuzzer_jobs(fuzzer_jobs)
+    else:
+      raise TypeError(f'--format {repr(args.format)} unrecognized')
   elif cmd == 'aggregate':
     _aggregate_fuzzer_jobs(args.platform, fuzzers=args.fuzzers, jobs=args.jobs)
   else:


### PR DESCRIPTION
Add support for:

- fuzz target weights, i.e. `FuzzTargetJob` db entries
  - notably including `fuzz-target set`
- listing `FuzzerJobs` entries in text format

Rework the command-line interface:

- rename data types: `fuzzer_job` -> `fuzzer`, `fuzzer_jobs` -> `fuzzer-batch`
- invert the data type and the subcommand: `list fuzzer_job` -> `fuzzer list`
- fold `dump` into `list` and add a `--format={text,csv}` argument to toggle between them
- extract the code setting up the CLI in `butler.py` for better readability