### PR TITLE
Remove migrated cron jobs from AppEngine, k8s jobs fix and tf examples

### DIFF
--- a/configs/test/gae/prod3/cron.yaml
+++ b/configs/test/gae/prod3/cron.yaml
@@ -14,21 +14,6 @@
 
 cron:
   # Python crons start here.
-  - description: Backup
-    url: /backup
-    schedule: every day 01:47
-    target: cron-service
-
-  - description: Batch FuzzerJobs.
-    url: /batch-fuzzer-jobs
-    schedule: every 30 minutes
-    target: cron-service
-
-  - description: Build crash stats.
-    url: /build-crash-stats
-    schedule: every 5 minutes
-    target: cron-service
-
   - description: Cleanup.
     url: /cleanup
     schedule: every 1 minutes
@@ -53,31 +38,6 @@ cron:
   - description: Load important stats from yesterday into the cache.
     url: /fuzzer-stats/preload
     schedule: every day 04:30
-    target: cron-service
-
-  - description: Adjust target and job weights based on fuzzer stats.
-    url: /fuzzer-and-job-weights
-    schedule: every day 03:00
-    target: cron-service
-
-  - description: Adjust strategy selection weights based on strategy stats.
-    url: /fuzz-strategy-selection
-    schedule: every day 05:00
-    target: cron-service
-
-  - description: Load BigQuery stats.
-    url: /load-bigquery-stats
-    schedule: every day 01:00
-    target: cron-service
-
-  - description: Manage VMs.
-    url: /manage-vms
-    schedule: every 30 minutes
-    target: cron-service
-
-  - description: Schedule corpus pruning task.
-    url: /schedule-corpus-pruning
-    schedule: every day 19:00
     target: cron-service
 
   - description: Schedule impact tasks.
@@ -109,10 +69,5 @@ cron:
 
   - description: File bugs for open test cases.
     url: /triage
-    schedule: every 1 hours
-    target: cron-service
-
-  - description: Sync admin users.
-    url: /sync-admins
     schedule: every 1 hours
     target: cron-service

--- a/infra/k8s/backup.yaml
+++ b/infra/k8s/backup.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/batch-fuzzer-jobs.yaml
+++ b/infra/k8s/batch-fuzzer-jobs.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/build-crash-stats.yaml
+++ b/infra/k8s/build-crash-stats.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/fuzz-strategy-selection.yaml
+++ b/infra/k8s/fuzz-strategy-selection.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/fuzzer-and-job-weights.yaml
+++ b/infra/k8s/fuzzer-and-job-weights.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/load-bigquery-stats.yaml
+++ b/infra/k8s/load-bigquery-stats.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/manage-vms.yaml
+++ b/infra/k8s/manage-vms.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/schedule-corpus-pruning.yaml
+++ b/infra/k8s/schedule-corpus-pruning.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/schedule-progression-tasks.yaml
+++ b/infra/k8s/schedule-progression-tasks.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/k8s/sync-admins.yaml
+++ b/infra/k8s/sync-admins.yaml
@@ -35,5 +35,7 @@ spec:
               value: "true"
             - name: DISABLE_MOUNTS
               value: "true"
+            - name: REDIS_HOST
+              value: $REDIS_HOST
           restartPolicy: OnFailure
       backoffLimit: 3

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,37 @@
+### Terraform config example
+
+Example main.tf in your_project/terraform/main.tf configuration:
+
+```
+locals {
+  project_id    = "YOUR_FUZZER_PROJECT"
+  region        = "us-central1"
+  subnet_name   = "default"
+  network_name  = "default"
+  ip_cidr_range = "$YOUR_NETWORK_SUBNET_FOR_GIVEN_REGION"
+}
+
+module "clusterfuzz" {
+  source        = "CLUSTERFUZZ_SOURCE_PATH/terraform/modules/main.tf"
+  project_id    = local.project_id
+  region        = local.region
+  subnet_name   = local.subnet_name
+  network_name  = local.network_name
+  ip_cidr_range = local.ip_cidr_range
+}
+```
+
+### Terraform resourcers manual import
+
+On initial bootstrap is possible to use existing resources instead of creating them.
+This is required because Connector name is hard-coded in ClusterFuzz code but it also simplifies new deployments 
+```
+terraform import module.clusterfuzz.google_compute_network.vpc default
+terraform import module.clusterfuzz.google_compute_subnetwork.subnet default
+terraform import module.clusterfuzz.google_compute_router.router router
+terraform import module.clusterfuzz.google_redis_instance.memorystore_redis_instance redis-instance
+terraform import module.clusterfuzz.google_container_cluster.primary "us-central1/clusterfuzz-cronjobs-gke"
+terraform import module.clusterfuzz.google_container_node_pool.primary_nodes "us-central1/clusterfuzz-cronjobs-gke/clusterfuzz-cronjobs-gke"
+terraform import module.clusterfuzz.google_compute_router_nat.nat_config "us-central1/router/nat-config"
+```
+


### PR DESCRIPTION
- Removing cron jobs migrated to k8s workloads.
- Adding missing REDIS_HOST in k8s workflows yaml definitions. Without this, [envsubst](https://github.com/google/clusterfuzz/blob/master/src/local/butler/deploy.py#L468) will not work and workload jobs will fail.
- Adding Terraform main.tf example along with resource import command
