### PR TITLE
[rearchitecture] Handle cases when target is not in zip.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1549,7 +1549,7 @@ class FuzzingSession:
     """Run fuzzing engine."""
     fuzz_target_name = environment.get_value('FUZZ_TARGET')
     if not fuzz_target_name:
-      raise FuzzTaskError('No fuzz targets found.')
+      raise FuzzTaskError('No fuzz targets set.')
     environment.set_value('FUZZER_NAME',
                           self.fuzz_target.fully_qualified_name())
 
@@ -1575,6 +1575,12 @@ class FuzzingSession:
             engine_impl, self.fuzz_target.binary, sync_corpus_directory,
             self.testcase_directory)
       except FuzzTargetNotFoundError:
+        # Ocassionally fuzz targets are deleted. This is pretty rare. Since
+        # ClusterFuzz did nothing wrong, don't bubble up an exception, consider
+        # it as we fuzzed and nothing happened so that new targets can be
+        # recorded and hopefully fuzzed instead. The old targets will eventually
+        # be garbage collected. Log this as an error to keep an eye on it.
+        logs.log_error(f'{self.fuzz_target.binary} is not in the build.')
         return [], {}
 
       fuzzer_metadata.update(current_fuzzer_metadata)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -82,6 +82,7 @@ THREAD_WAIT_TIMEOUT = 1
 class FuzzTaskError(Exception):
   """Fuzz task exception."""
 
+
 class FuzzTargetNotFoundError(Exception):
   """Fuzz target not in build."""
 


### PR DESCRIPTION
We should be able to handle cases when all fuzzers in a build are renamed.