### PR TITLE
Update DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -42,8 +42,7 @@ STABLE_CUTTLEFISH_BUILD = {
     'target': 'cf_x86_64_phone-next-userdebug'
 }
 
-DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO = (
-    "gs://test-blobs-bucket/fuzzers/target-cuttlefish/stable_build_info.json")
+DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO = "gs://android-haiku/target-cuttlefish/stable_build_info.json"
 
 
 def execute_request_with_retries(request):

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -43,7 +43,7 @@ STABLE_CUTTLEFISH_BUILD = {
 }
 
 DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO = (
-  "gs://android-haiku/target-cuttlefish/stable_build_info.json")
+    "gs://android-haiku/target-cuttlefish/stable_build_info.json")
 
 
 def execute_request_with_retries(request):

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -42,7 +42,8 @@ STABLE_CUTTLEFISH_BUILD = {
     'target': 'cf_x86_64_phone-next-userdebug'
 }
 
-DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO = "gs://android-haiku/target-cuttlefish/stable_build_info.json"
+DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO = (
+  "gs://android-haiku/target-cuttlefish/stable_build_info.json")
 
 
 def execute_request_with_retries(request):


### PR DESCRIPTION
'DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO' points to corrected gcs storage path.