### PR TITLE
Prevent accidental DoS on malformed stacktraces

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -3744,6 +3744,12 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
     self.assertEqual(actual_split_stacktrace, expected_split_stacktrace)
 
+  def test_split_stacktrace_no_dos(self):
+    """Tests that split_stacktrace wont search forever unless there's a very
+    well crafted input."""
+    stacktrace = "S text\n" + " 42 " * 100000 + "j text\n";
+    StackParser.split_stacktrace(stacktrace)
+
   def test_jazzer_js_javascript(self):
     """Test Jazzer.js JS stacktrace."""
     data = self._read_test_data('jazzer_js_javascript.txt')

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -3747,7 +3747,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
   def test_split_stacktrace_no_dos(self):
     """Tests that split_stacktrace wont search forever unless there's a very
     well crafted input."""
-    stacktrace = "S text\n" + " 42 " * 100000 + "j text\n";
+    stacktrace = "S text\n" + " 42 " * 100000 + "j text\n"
     StackParser.split_stacktrace(stacktrace)
 
   def test_jazzer_js_javascript(self):

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -180,7 +180,7 @@ class StackParser:
                             type_filter=lambda s: s,
                             reset=False) -> re.Match or None:
     """Update the specified parts of the state if we have a match."""
-    
+
     match = compiled_regex.match(line)
     if not match:
       return None
@@ -1408,6 +1408,7 @@ def should_ignore_line_for_crash_processing(line, state):
     return True
 
   if len(line) > 1024**2:
+    logs.log_error('Line is too long for a stacktrace.')
     return True
 
   return False

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -180,7 +180,7 @@ class StackParser:
                             type_filter=lambda s: s,
                             reset=False) -> re.Match or None:
     """Update the specified parts of the state if we have a match."""
-
+    
     match = compiled_regex.match(line)
     if not match:
       return None
@@ -1405,6 +1405,9 @@ def should_ignore_line_for_crash_processing(line, state):
 
   # Ignore DEADLYSIGNAL lines from sanitizers.
   if SAN_DEADLYSIGNAL_REGEX.match(line):
+    return True
+
+  if len(line) > 1024**2:
     return True
 
   return False

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -66,8 +66,10 @@ ASSERT_REGEX_GLIBC = re.compile(
 # The 'assertion .* failed' is suffixed with the failure reason. E.g.,
 # 'assertion __dest < len() failed: sample_array[] index out of bounds',
 # 'assertion !full() failed: sample_function() called on an empty vector'
+# Add the lookahead group to prevent DoS, see
+# https://github.com/google/clusterfuzz/issues/3978.
 ASSERT_REGEX_GLIBC_SUFFIXED = re.compile(
-    r'.*\S.*\/.*:\d+:\s*assertion .* failed:\s*(\S.*)')
+    r'(?=.*assertion .* failed:.).*.*\S.*\/.*:\d+:\s*assertion .* failed:\s*(\S.*)')
 ASSERT_NOT_REACHED_REGEX = re.compile(r'^\s*SHOULD NEVER BE REACHED\s*$')
 CENTIPEDE_TIMEOUT_REGEX = re.compile(r'(?:%s)' % '|'.join([
     r'========= Timeout of \d+ seconds exceeded; exiting',
@@ -200,8 +202,10 @@ SAN_CRASH_TYPE_ADDRESS_REGEX = re.compile(
     r'[ ]*([^ ]*|Atomic [^ ]*) of size ([^ ]*) at ([^ ]*)')
 SAN_DEADLYSIGNAL_REGEX = re.compile(
     r'(Address|Leak|Memory|UndefinedBehavior|Thread)Sanitizer:DEADLYSIGNAL')
+# Use the lookahead group to prevent DoS, see
+# https://github.com/google/clusterfuzz/issues/3978.
 CONCATENATED_SAN_DEADLYSIGNAL_REGEX = re.compile(
-    r'\n([^\n]*\S[^\n]*)(' + SAN_DEADLYSIGNAL_REGEX.pattern + r')\n')
+    r'\n(?=.*Sanitizer\:DEADLYSIGNAL.*)([^\n]*\S[^\n]*)(' + SAN_DEADLYSIGNAL_REGEX.pattern + r')\n')
 SPLIT_CONCATENATED_SAN_DEADLYSIGNAL_REGEX = r'\n\1\n\2\n'
 SAN_FPE_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: FPE ')
 SAN_ILL_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: ILL ')

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -69,7 +69,8 @@ ASSERT_REGEX_GLIBC = re.compile(
 # Add the lookahead group to prevent DoS, see
 # https://github.com/google/clusterfuzz/issues/3978.
 ASSERT_REGEX_GLIBC_SUFFIXED = re.compile(
-    r'(?=.*assertion .* failed:.).*.*\S.*\/.*:\d+:\s*assertion .* failed:\s*(\S.*)')
+    r'(?=.*assertion .* failed:.).*.*\S.*\/.*:\d+:\s*assertion .* failed:\s*(\S.*)'  # pylint: disable=line-too-long
+)
 ASSERT_NOT_REACHED_REGEX = re.compile(r'^\s*SHOULD NEVER BE REACHED\s*$')
 CENTIPEDE_TIMEOUT_REGEX = re.compile(r'(?:%s)' % '|'.join([
     r'========= Timeout of \d+ seconds exceeded; exiting',
@@ -205,7 +206,8 @@ SAN_DEADLYSIGNAL_REGEX = re.compile(
 # Use the lookahead group to prevent DoS, see
 # https://github.com/google/clusterfuzz/issues/3978.
 CONCATENATED_SAN_DEADLYSIGNAL_REGEX = re.compile(
-    r'\n(?=.*Sanitizer\:DEADLYSIGNAL.*)([^\n]*\S[^\n]*)(' + SAN_DEADLYSIGNAL_REGEX.pattern + r')\n')
+    r'\n(?=.*Sanitizer\:DEADLYSIGNAL.*)([^\n]*\S[^\n]*)(' +
+    SAN_DEADLYSIGNAL_REGEX.pattern + r')\n')
 SPLIT_CONCATENATED_SAN_DEADLYSIGNAL_REGEX = r'\n\1\n\2\n'
 SAN_FPE_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: FPE ')
 SAN_ILL_REGEX = re.compile(r'.*[a-zA-Z]+Sanitizer: ILL ')


### PR DESCRIPTION
Enormous stacktraces containing a giant array on a single line is causing bots to freeze.
Although fuzztest really should not be printing an input this large, let's try to be resilient when it misbehaves.

Fixes: https://github.com/google/clusterfuzz/issues/3978