### PR TITLE
Use environment.get_value instead of os.environ

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1900,7 +1900,7 @@ class FuzzingSession:
 
     logs.log(f'Raw crash count: {len(crashes)}')
 
-    project_name = os.environ['PROJECT_NAME']
+    project_name = environment.get_value('PROJECT_NAME')
 
     # Process and save crashes to datastore.
     bot_name = environment.get_value('BOT_NAME')


### PR DESCRIPTION
It's more consistent and it can be important when things like ints are put into the environment.