### PR TITLE
Ensure the fuzzer job entity is updated.

### DIFF
--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -50,7 +50,7 @@ def update_mappings_for_fuzzer(fuzzer, mappings=None):
       mapping = data_types.FuzzerJob()
     mapping.fuzzer = fuzzer.name
     mapping.job = job_name
-    mapping.platform = job.platform
+    mapping.platform = jobs[job_name].platform
     new_mappings.append(mapping)
 
   ndb_utils.put_multi(new_mappings)

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -42,8 +42,8 @@ def update_mappings_for_fuzzer(fuzzer, mappings=None):
 
   new_mappings = []
   if mappings:
-    jobs = ndb_utils.get_all_from_query(
-      data_types.Job.query().filter(data_types.Job.name.IN(mappings)))
+    jobs = ndb_utils.get_all_from_query(data_types.Job.query().filter(
+        data_types.Job.name.IN(mappings)))
     jobs = {job.name: job for job in jobs}
   else:
     jobs = {}

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -41,9 +41,12 @@ def update_mappings_for_fuzzer(fuzzer, mappings=None):
     old_mappings[fuzzer_job.job] = fuzzer_job
 
   new_mappings = []
-  jobs = ndb_utils.get_all_from_query(
-      data_types.Job.query(data_types.Job.name.IN(mappings)))
-  jobs = {job.name: job for job in jobs}
+  if mappings:
+    jobs = ndb_utils.get_all_from_query(
+      data_types.Job.query().filter(data_types.Job.name.IN(mappings)))
+    jobs = {job.name: job for job in jobs}
+  else:
+    jobs = {}
   for job_name in mappings:
     mapping = old_mappings.pop(job_name, None)
     if not mapping:


### PR DESCRIPTION
Ensure that the fuzzer job entity is updated when the job definition is updated. Otherwise the fuzzerjob will never be updated.
e.g. I have a job with platform linux, ClusterFuzz creates a fuzzerjob i change the platform windows because I made a mistake. The FuzzerJob should be updated so that my fuzzer has a chance to run on windows.
This PR tries to keep the FuzzerJob and Job consistent. But I think a better fix would be to not have two sources of truth about a job.