### PR TITLE
Log output in android.run_command to dump bad build logs

### DIFF
--- a/src/clusterfuzz/_internal/system/process_handler.py
+++ b/src/clusterfuzz/_internal/system/process_handler.py
@@ -176,7 +176,8 @@ def run_process(cmdline,
     android.logger.clear_log()
 
     # Run the app.
-    adb_output = android.adb.run_command(cmdline, timeout=timeout)
+    adb_output = android.adb.run_command(
+        cmdline, timeout=timeout, log_output=True)
   else:
     cmd = shell.get_command(cmdline)
 


### PR DESCRIPTION
This will help debug crbug.com/334940028.