### PR TITLE
tasks: add support for both 'jobs-android' and device specific subqueues

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/util.py
+++ b/src/clusterfuzz/_internal/platforms/android/util.py
@@ -82,3 +82,24 @@ def can_testcase_run_on_platform(testcase_platform_id, current_platform_id):
     return True
 
   return False
+
+
+def should_schedule_on_generic_queue(testcase_platform_id, current_platform_id):
+  """Whether the testcase should be scheduled on the generic queue or the
+  default queue."""
+  if not environment.get_value('QUEUE_OVERRIDE'):
+    return False
+
+  testcase_fields = testcase_platform_id.split(':')
+  current_platform_fields = current_platform_id.split(':')
+
+  if len(testcase_fields) != 3 or len(current_platform_fields) != 3:
+    return False
+
+  testcase_codename = testcase_fields[1].split('_')
+  current_platform_codename = current_platform_fields.split('_')
+
+  if len(testcase_codename) != 2 or len(current_platform_codename) != 2:
+    return False
+
+  return testcase_codename[0] != testcase_codename[1]


### PR DESCRIPTION
In chrome, we need to have generic jobs that can be scheduled on any devices. This PR will make sure generic tasks keep getting pulled even when subqueues are set-up. This PR is preliminary work for us to add subqueues on our android devices.