### PR TITLE
Delete bot/inputs/mutator-plugins directory

### DIFF
--- a/bot/inputs/mutator-plugins/README.md
+++ b/bot/inputs/mutator-plugins/README.md
@@ -1,1 +1,0 @@
-Placeholder for mutator plugins.


### PR DESCRIPTION
This feature is no longer used.