### PR TITLE
Add logs for TimeSeries object details

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -99,6 +99,11 @@ class _FlusherThread(threading.Thread):
           series = monitoring_v3.types.TimeSeries()  # pylint: disable=no-member
           metric.monitoring_v3_time_series(series, labels, start_time, end_time,
                                            value)
+          # Log the TimeSeries object details for debug purposes.
+          logs.log(f'{utils.current_date_time()} - Monitor_TimeSeries - '
+                   f'metric_kind : {series.metric_kind}, '
+                   f'start_time : {series.points[-1].interval.start_time}, '
+                   f' end_time : {series.points[-1].interval.end_time} ')
           time_series.append(series)
 
           if len(time_series) == MAX_TIME_SERIES_PER_CALL:


### PR DESCRIPTION
Added log to print metric_kind, start_time,
end_time parameters for TimeSeries object.