### PR TITLE
Remove fuzz target weight cap.

### DIFF
--- a/src/clusterfuzz/_internal/cron/fuzzer_and_job_weights.py
+++ b/src/clusterfuzz/_internal/cron/fuzzer_and_job_weights.py
@@ -36,7 +36,6 @@ SpecificationMatch = collections.namedtuple('SpecificationMatch',
 DEFAULT_MULTIPLIER = 30.0  # Used for blackbox and jobs that are not yet run.
 DEFAULT_SANITIZER_WEIGHT = 0.1
 DEFAULT_ENGINE_WEIGHT = 1.0
-TARGET_COUNT_WEIGHT_CAP = 100.0
 
 SANITIZER_BASE_WEIGHT = 0.1
 
@@ -382,7 +381,6 @@ def update_job_weights():
       # the default weight in that case to allow for recovery.
       if targets_count and targets_count.count:
         multiplier = targets_count.count
-        multiplier = min(multiplier, TARGET_COUNT_WEIGHT_CAP)
 
     update_job_weight(job.name, multiplier)
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/fuzzer_and_job_weights_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/fuzzer_and_job_weights_test.py
@@ -330,4 +330,4 @@ class TestUpdateJobWeights(unittest.TestCase):
     self.assertEqual(15.0, get_result('asan_blackbox_job').multiplier)
     self.assertEqual(15.0, get_result('libfuzzer_asan_job2').multiplier)
     self.assertEqual(1.0, get_result('honggfuzz_asan_job').multiplier)
-    self.assertEqual(50.0, get_result('libfuzzer_asan_large_job').multiplier)
+    self.assertEqual(500.0, get_result('libfuzzer_asan_large_job').multiplier)


### PR DESCRIPTION
Allow engine fuzzer/job multipliers to keep up with the number of fuzz targets behind each engine/job combination.

This puts fuzz targets on approximately the same footing as blackbox fuzzers. They are still not strictly equivalent, since the logic here sets the engine's weight to the count of fuzz targets behind it, not the sum of those targets' weights. Consider the following scenario:

- fuzzer A: weight = 1.0, multiplier = 5.0
- fuzzer B: weight = 1.0, multiplier = 1.0 
- libfuzzer: weight  = 1.0, multiplier = 2.0
   - target C: weight 5.0
   - target D: weight 1.0

Fuzzer A has a 5/8 chance of being picked for a fuzzing session, whereas even though target C has a weight of 5.0, it still has only a 2/8 * 5/6 chance of being picked for a fuzzing session.

That said, if most multipliers are ~1.0 and most target weights are ~1.0, then a target weight of `x` results in a probability roughly equal to `x / sum(all fuzzer and target weights)`.

Fixes #4019.