### PR TITLE
Add centipede to DEFAULT_ENGINES

### DIFF
--- a/src/clusterfuzz/_internal/cron/project_setup.py
+++ b/src/clusterfuzz/_internal/cron/project_setup.py
@@ -201,7 +201,7 @@ JOB_MAP = {
 
 DEFAULT_ARCHITECTURES = ['x86_64']
 DEFAULT_SANITIZERS = ['address', 'undefined']
-DEFAULT_ENGINES = ['libfuzzer', 'afl', 'honggfuzz']
+DEFAULT_ENGINES = ['libfuzzer', 'afl', 'honggfuzz', 'centipede']
 
 
 def _to_experimental_job(job_info):

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -539,12 +539,14 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertCountEqual(job.templates, ['engine_asan', 'centipede'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
-        'gs://clusterfuzz-builds/lib1/lib1-address-([0-9]+).zip\n'
+        'gs://clusterfuzz-builds-centipede/lib1/lib1-none-([0-9]+).zip\n'
         'PROJECT_NAME = lib1\n'
         'SUMMARY_PREFIX = lib1\n'
         'MANAGED = True\n'
+        'EXTRA_BUILD_BUCKET_PATH = '
+        'gs://clusterfuzz-builds-centipede/lib1/lib1-address-([0-9]+).zip\n'
         'REVISION_VARS_URL = https://commondatastorage.googleapis.com/'
-        'clusterfuzz-builds/lib1/lib1-address-%s.srcmap.json\n'
+        'clusterfuzz-builds-centipede/lib1/lib1-address-%s.srcmap.json\n'
         'FUZZ_LOGS_BUCKET = lib1-logs.clusterfuzz-external.appspot.com\n'
         'CORPUS_BUCKET = lib1-corpus.clusterfuzz-external.appspot.com\n'
         'QUARANTINE_BUCKET = lib1-quarantine.clusterfuzz-external.appspot.com\n'

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -584,6 +584,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     centipede = data_types.Fuzzer.query(
         data_types.Fuzzer.name == 'centipede').get()
     self.assertCountEqual(centipede.jobs, [
+        'centipede_asan_lib1',
         'centipede_asan_lib9',
     ])
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -536,7 +536,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib1')
     self.assertEqual(job.platform, 'LIB1_LINUX')
-    self.assertCountEqual(job.templates, ['engine_asan', 'centipede', 'prune'])
+    self.assertCountEqual(job.templates, ['engine_asan', 'centipede'])
     self.assertEqual(
         job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
         'gs://clusterfuzz-builds/lib1/lib1-address-([0-9]+).zip\n'

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -532,6 +532,27 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         'FILE_GITHUB_ISSUE = False\n')
 
     job = data_types.Job.query(
+        data_types.Job.name == 'centipede_asan_lib1').get()
+    self.assertIsNotNone(job)
+    self.assertEqual(job.project, 'lib1')
+    self.assertEqual(job.platform, 'LIB1_LINUX')
+    self.assertCountEqual(job.templates, ['engine_asan', 'centipede', 'prune'])
+    self.assertEqual(
+        job.environment_string, 'RELEASE_BUILD_BUCKET_PATH = '
+        'gs://clusterfuzz-builds/lib1/lib1-address-([0-9]+).zip\n'
+        'PROJECT_NAME = lib1\n'
+        'SUMMARY_PREFIX = lib1\n'
+        'MANAGED = True\n'
+        'REVISION_VARS_URL = https://commondatastorage.googleapis.com/'
+        'clusterfuzz-builds/lib1/lib1-address-%s.srcmap.json\n'
+        'FUZZ_LOGS_BUCKET = lib1-logs.clusterfuzz-external.appspot.com\n'
+        'CORPUS_BUCKET = lib1-corpus.clusterfuzz-external.appspot.com\n'
+        'QUARANTINE_BUCKET = lib1-quarantine.clusterfuzz-external.appspot.com\n'
+        'BACKUP_BUCKET = lib1-backup.clusterfuzz-external.appspot.com\n'
+        'AUTOMATIC_LABELS = Proj-lib1,Engine-centipede\n'
+        'FILE_GITHUB_ISSUE = False\n')
+
+    job = data_types.Job.query(
         data_types.Job.name == 'centipede_asan_lib9').get()
     self.assertIsNotNone(job)
     self.assertEqual(job.project, 'lib9')
@@ -1318,6 +1339,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         ('LIB7_LINUX', 'libFuzzer', 'libfuzzer_asan_lib7'),
         ('LIB8_LINUX', 'libFuzzer', 'libfuzzer_nosanitizer_i386_lib8'),
         ('LIB8_LINUX', 'libFuzzer', 'libfuzzer_nosanitizer_lib8'),
+        ('LIB1_LINUX', 'centipede', 'centipede_asan_lib1'),
         ('LIB9_LINUX', 'centipede', 'centipede_asan_lib9'),
     ])
 
@@ -1571,6 +1593,27 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'email': 'primary@example.com',
             'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
             'auto_cc': 1
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'centipede_asan_lib1',
+            'email': 'primary@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'centipede_asan_lib1',
+            'email': 'user@example.com'
+        },
+        {
+            'entity_kind': 1,
+            'is_prefix': False,
+            'auto_cc': 1,
+            'entity_name': 'centipede_asan_lib1',
+            'email': 'user2@googlemail.com'
         },
         {
             'entity_kind': 1,


### PR DESCRIPTION
Fixes #11964.
@kasper93 kindly pointed out a misconfiguration of `Centipede,` which blocked `Centipede` from being used on all projects by default.
This PR fixes it.