### PR TITLE
Skip trusted upload restriction on job platform type

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -392,7 +392,8 @@ class UploadHandlerCommon:
         'trustedAgreement') == TRUSTED_AGREEMENT_TEXT.strip()
 
     if (not trusted_agreement_signed and
-        task_utils.is_remotely_executing_utasks() and platform_id != 'Linux'):
+        task_utils.is_remotely_executing_utasks() and
+        (platform_id != 'Linux' or job.platform.lower() != 'linux')):
       # Trusted agreement was not signed even though the job has privileges and
       # there are other jobs that don't have privileges.
       raise helpers.EarlyExitError(


### PR DESCRIPTION
platform_id is set for "quick upload" mode but not reliably for the regular upload mode - expanding check to use the job