### PR TITLE
Create merge-wd in /tmp.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -194,7 +194,8 @@ class Engine(engine.Engine):
     """Create a temporary directory suitable for putting into the TMPDIR
     environment variable, which practically speaking sometimes needs to be
     shortish."""
-    new_temp_dir = os.path.join(fuzzer_utils.get_temp_dir(use_fuzz_inputs_disk=False), name)
+    new_temp_dir = os.path.join(
+        fuzzer_utils.get_temp_dir(use_fuzz_inputs_disk=False), name)
     engine_common.recreate_directory(new_temp_dir)
     return new_temp_dir
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -162,9 +162,7 @@ def get_temp_dir(use_fuzz_inputs_disk=True):
     prefix = environment.get_value('FUZZ_INPUTS_DISK', tempfile.gettempdir())
   else:
     prefix = tempfile.gettempdir()
-  temp_directory = os.path.join(
-      prefix,
-      temp_dirname)
+  temp_directory = os.path.join(prefix, temp_dirname)
   shell.create_directory(temp_directory)
   return temp_directory
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -155,11 +155,15 @@ def get_supporting_file(fuzz_target_path, extension_or_suffix):
   return base_fuzz_target_path + extension_or_suffix
 
 
-def get_temp_dir():
+def get_temp_dir(use_fuzz_inputs_disk=True):
   """Return the temp dir."""
   temp_dirname = 'temp-' + str(os.getpid())
+  if use_fuzz_inputs_disk:
+    prefix = environment.get_value('FUZZ_INPUTS_DISK', tempfile.gettempdir())
+  else:
+    prefix = tempfile.gettempdir()
   temp_directory = os.path.join(
-      environment.get_value('FUZZ_INPUTS_DISK', tempfile.gettempdir()),
+      prefix,
       temp_dirname)
   shell.create_directory(temp_directory)
   return temp_directory


### PR DESCRIPTION
During corpus merge, ClusterFuzz has been setting the `TMPDIR` to:

`/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases-disk/temp-<pid>/merge-workdir/`

We have shortened that to:

`/mnt/scratch0/clusterfuzz/bot/inputs/ft-disk/temp-<pid>/merge-wd/`

but it's still too long for Chromium which passes the `TMPDIR` into POSIX functions that have a maximum path length.

This change switches to using a more traditional tempdir, which is likely to be
`/tmp/temp-<pid>/merge-wd`