### PR TITLE
Allow higher RSS limits for merge.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -334,7 +334,7 @@ class Runner:
 
       custom_rss_limit = libfuzzer_arguments.get(
           'rss_limit_mb', constructor=int)
-      if custom_rss_limit and custom_rss_limit < rss_limit:
+      if custom_rss_limit:
         rss_limit = custom_rss_limit
 
       custom_max_len = libfuzzer_arguments.get('max_len', constructor=int)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
@@ -303,7 +303,7 @@ class CorpusPruningTest(unittest.TestCase, BaseTest):
         os.path.join(self.build_dir, 'test_get_libfuzzer_flags.options'))
     flags = runner.get_libfuzzer_flags()
     expected_custom_flags = [
-        '-timeout=5', '-rss_limit_mb=2560', '-max_len=1337', '-detect_leaks=0',
+        '-timeout=5', '-rss_limit_mb=31337', '-max_len=1337', '-detect_leaks=0',
         '-use_value_profile=1'
     ]
     self.assertCountEqual(flags, expected_custom_flags)


### PR DESCRIPTION
Some of our fuzzers now require > 2560MB to run the merge task (specifically, all the fuzzers based on browser tests which run a full instance of Chromium).

Until now, custom RSS limits have only been obeyed if they are less than 2560MB. We will need to allow higher RSS limits for merging/corpus pruning to work with these fuzzers.

Bug: https://crbug.com/348520451