### PR TITLE
Ensure correct ordering of 'time_series' list.

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -74,6 +74,10 @@ class _MockMetric:
     return self._mock_method
 
 
+def _time_series_sort_key(ts):
+  return ts.points[-1].interval.start_time
+
+
 class _FlusherThread(threading.Thread):
   """Flusher thread."""
 
@@ -81,9 +85,6 @@ class _FlusherThread(threading.Thread):
     super().__init__()
     self.daemon = True
     self.stop_event = threading.Event()
-
-  def time_series_sort_key(self, ts):
-    return ts.points[-1].interval.start_time
 
   def run(self):
     """Run the flusher thread."""
@@ -120,12 +121,12 @@ class _FlusherThread(threading.Thread):
           time_series.append(series)
 
           if len(time_series) == MAX_TIME_SERIES_PER_CALL:
-            time_series.sort(key=self.time_series_sort_key)
+            time_series.sort(key=_time_series_sort_key)
             create_time_series(name=project_path, time_series=time_series)
             time_series = []
 
         if time_series:
-          time_series.sort(key=self.time_series_sort_key)
+          time_series.sort(key=_time_series_sort_key)
           create_time_series(name=project_path, time_series=time_series)
       except Exception:
         if environment.is_android():

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -116,8 +116,8 @@ class _FlusherThread(threading.Thread):
                    f'start_time: {metric_st_sec}.{metric_st_ns}, '
                    f'end_time: {metric_et_sec}.{metric_et_ns}')
 
-          if (series.metric_kind ==
-              metric_pb2.MetricDescriptor.MetricKind.GAUGE):
+          if (series.metric_kind == metric_pb2.MetricDescriptor.MetricKind.GAUGE  # pylint: disable=no-member
+             ):
             gauge_series.append(series)
           else:
             time_series.append(series)

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -111,27 +111,23 @@ class _FlusherThread(threading.Thread):
           metric_et_sec = series.points[-1].interval.end_time.second
           metric_et_ns = series.points[-1].interval.end_time.nanosecond
           logs.info(f'Monitor_TimeSeries - '
-                   f'metric_kind: {series.metric_kind}, '
-                   f'start_time: {metric_st_sec}.{metric_st_ns}, '
-                   f'end_time: {metric_et_sec}.{metric_et_ns}')
+                    f'metric_kind: {series.metric_kind}, '
+                    f'start_time: {metric_st_sec}.{metric_st_ns}, '
+                    f'end_time: {metric_et_sec}.{metric_et_ns}')
           time_series.append(series)
 
           if len(time_series) == MAX_TIME_SERIES_PER_CALL:
             time_series.sort(
-                key=lambda ts: (
-                    ts.points[-1].interval.start_time.second,
-                    ts.points[-1].interval.start_time.nanosecond
-                )
+                key=
+                lambda ts: (ts.points[-1].interval.start_time.second, ts.points[-1].interval.start_time.nanosecond)  # pylint: disable=line-too-long
             )
             create_time_series(name=project_path, time_series=time_series)
             time_series = []
 
         if time_series:
           time_series.sort(
-              key=lambda ts: (
-                  ts.points[-1].interval.start_time.second,
-                  ts.points[-1].interval.start_time.nanosecond
-              )
+              key=
+              lambda ts: (ts.points[-1].interval.start_time.second, ts.points[-1].interval.start_time.nanosecond)  # pylint: disable=line-too-long
           )
           create_time_series(name=project_path, time_series=time_series)
       except Exception:

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -16,7 +16,6 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from clusterfuzz._internal.metrics import monitor
@@ -176,30 +175,25 @@ class MonitorTest(unittest.TestCase):
 
 
 class TestFlusherThread(unittest.TestCase):
+  """Sets up the flusher thread and mocks MetricServiceClient."""
 
   @patch(
-      'clusterfuzz._internal.metrics.monitor.monitoring_v3.MetricServiceClient.create_time_series'
-  )
-  def test_flush(self, mock_create_time_series):
-    """Sets up the flusher thread and mocks create_time_series."""
-    monitor.credentials._use_anonymous_credentials = lambda: False
-    monitor._monitoring_v3_client = monitor.monitoring_v3.MetricServiceClient(
-        credentials=monitor.credentials.get_default()[0])
+      'clusterfuzz._internal.metrics.monitor.monitoring_v3.MetricServiceClient')
+  def test_flusher_thread(self, mock_client):
+    """Sets up the flusher thread and calls run()."""
+
+    monitor._monitoring_v3_client = mock_client.return_value
     monitor._flusher_thread = monitor._FlusherThread()
     monitor.FLUSH_INTERVAL_SECONDS = 1
-    monitoring_metrics.HOST_INCONSISTENT_COUNT.increment()
     monitoring_metrics.BOT_COUNT.set(1, {'revision': '1'})
     monitoring_metrics.HOST_INCONSISTENT_COUNT.increment()
-    monitor.utils.get_application_id = lambda: 'google.com:clusterfuzz'
     os.environ['BOT_NAME'] = 'bot-1'
-    monitor._initialize_monitored_resource()
-    monitor._monitored_resource.labels['zone'] = 'us-central1-b'
 
     monitor._flusher_thread.start()
+    mock_create_time_series = mock_client.return_value.create_time_series
     while not mock_create_time_series.called:
       pass
-    else:
-      monitor._flusher_thread.stop()
+    monitor._flusher_thread.stop()
     time_series = mock_create_time_series.mock_calls[0][2]['time_series']
     for i in range(1, len(time_series)):
       self.assertLessEqual(time_series[i - 1].points[0].interval.start_time,

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -157,6 +157,21 @@ class MonitorTest(unittest.TestCase):
         2,
     ], result.buckets)
 
+  def test_gauge_metric_success(self):
+    """Test gauge metric success."""
+    self.assertIsInstance(
+        monitor.GaugeMetric('g', 'desc', field_spec=None), monitor._GaugeMetric)
+
+  def test_gauge_metric_failure(self):
+    """Test gauge metric failure."""
+    self.mock.check_module_loaded.return_value = False
+    gauge = monitor.GaugeMetric(
+        'g', 'desc', field_spec=[
+            monitor.StringField('name'),
+        ])
+    gauge.set(5)
+    self.assertIsInstance(gauge, monitor._MockMetric)
+
 
 @unittest.skip('Skip this because it\'s only used by metzman for debugging.')
 class JonathanDebugTest(unittest.TestCase):


### PR DESCRIPTION
Maintain separate 'gauge_series' for gauge metrics. Combined gauge series with the main 'time_series' list only before the flush operation ensuring that all metric are in order based on corresponding 'start_time' in 'time_series' list