### PR TITLE
Make platform_id unnecessary when skipping trusted upload signing

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Handler that uploads a testcase"""
 
+# pylint: disable=wrong-import-order
 import ast
 import datetime
 import io
@@ -392,7 +393,8 @@ class UploadHandlerCommon:
 
     if (not trusted_agreement_signed and
         task_utils.is_remotely_executing_utasks() and
-        (platform_id != 'Linux' or job.platform.lower() != 'linux')):
+        ((platform_id and platform_id != 'Linux') or
+         job.platform.lower() != 'linux')):
       # Trusted agreement was not signed even though the job has privileges and
       # there are other jobs that don't have privileges.
       raise helpers.EarlyExitError(


### PR DESCRIPTION
The original check works for the quick upload form because it passes the platform param.  The full upload form only passes an optional platform param for Android so we shouldn't require it to skip trusted upload signing.  The job.lower should be enough in that case.