### PR TITLE
Add `llvm-symbolizer` to PATH for `Centipede`

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -42,7 +42,7 @@ class CentipedeError(Exception):
 
 
 def _find_llvm_symbolizer() -> Optional[str]:
-  """Locate llvm-symbolizer from various sources."""
+  """Locates llvm-symbolizer."""
   # llvm-symbolizer should be in both BUILD_DIR or EXTRA_BUILD_DIR.
   build_dir = environment.get_value('BUILD_DIR', fuzzer_utils.EXTRA_BUILD_DIR)
   llvm_symbolizer_path = os.path.join(build_dir, 'llvm-symbolizer')
@@ -60,7 +60,7 @@ def _find_llvm_symbolizer() -> Optional[str]:
 
 
 def _add_llvm_symbolizer():
-  """Add llvm-symbolizer to PATH."""
+  """Adds llvm-symbolizer to PATH."""
   llvm_symbolizer_path = _find_llvm_symbolizer()
   if llvm_symbolizer_path is not None:
     # Copy it to /bin to ensure Centipede can use it.

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -39,8 +39,35 @@ class CentipedeError(Exception):
   """Base exception class."""
 
 
+def _find_llvm_symbolizer() -> Optional[str]:
+  """Locate llvm-symbolizer from various sources."""
+  # llvm-symbolizer should be in both BUILD_DIR or EXTRA_BUILD_DIR.
+  build_dir = environment.get_value('BUILD_DIR', fuzzer_utils.EXTRA_BUILD_DIR)
+  llvm_symbolizer_path = os.path.join(build_dir, 'llvm-symbolizer')
+  if os.path.isfile(llvm_symbolizer_path):
+    return llvm_symbolizer_path
+  logs.log_warn('Unable to find llvm-symbolizer at BUILD_DIR or '
+                f'EXTRA_BUILD_DIR: {llvm_symbolizer_path}')
+
+  llvm_symbolizer_path = environment.get_llvm_symbolizer_path()
+  if llvm_symbolizer_path and os.path.isfile(llvm_symbolizer_path):
+    return llvm_symbolizer_path
+  logs.log_warn('Unable to find llvm-symbolizer at: '
+                f'{environment.get_llvm_symbolizer_path()}')
+  return None
+
+
+def _add_llvm_symbolizer():
+  """Add llvm-symbolizer to PATH."""
+  llvm_symbolizer_path = _find_llvm_symbolizer()
+  if llvm_symbolizer_path is not None:
+    # Copy it to /bin to ensure Centipede can use it.
+    shutil.copy(llvm_symbolizer_path, '/bin/')
+
+
 def _get_runner(target_path):
   """Gets the Centipede runner."""
+  _add_llvm_symbolizer()
   centipede_path = pathlib.Path(target_path).parent / 'centipede'
   if not centipede_path.exists():
     raise CentipedeError('Centipede not found in build')

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -13,20 +13,19 @@
 # limitations under the License.
 """Centipede engine interface."""
 
-from collections import namedtuple
 import os
 import pathlib
 import re
 import shutil
+from collections import namedtuple
+from typing import Optional
 
-from clusterfuzz._internal.bot.fuzzers import dictionary_manager
-from clusterfuzz._internal.bot.fuzzers import engine_common
+from clusterfuzz._internal.bot.fuzzers import dictionary_manager, engine_common
 from clusterfuzz._internal.bot.fuzzers import options as fuzzer_options
 from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 from clusterfuzz._internal.bot.fuzzers.centipede import constants
 from clusterfuzz._internal.metrics import logs
-from clusterfuzz._internal.system import environment
-from clusterfuzz._internal.system import new_process
+from clusterfuzz._internal.system import environment, new_process
 from clusterfuzz.fuzz import engine
 
 _CLEAN_EXIT_SECS = 10

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -13,19 +13,21 @@
 # limitations under the License.
 """Centipede engine interface."""
 
+from collections import namedtuple
 import os
 import pathlib
 import re
 import shutil
-from collections import namedtuple
 from typing import Optional
 
-from clusterfuzz._internal.bot.fuzzers import dictionary_manager, engine_common
+from clusterfuzz._internal.bot.fuzzers import dictionary_manager
+from clusterfuzz._internal.bot.fuzzers import engine_common
 from clusterfuzz._internal.bot.fuzzers import options as fuzzer_options
 from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 from clusterfuzz._internal.bot.fuzzers.centipede import constants
 from clusterfuzz._internal.metrics import logs
-from clusterfuzz._internal.system import environment, new_process
+from clusterfuzz._internal.system import environment
+from clusterfuzz._internal.system import new_process
 from clusterfuzz.fuzz import engine
 
 _CLEAN_EXIT_SECS = 10


### PR DESCRIPTION
Addresses [#12124](https://github.com/google/oss-fuzz/issues/12124).
Unlikely local test runs, cloud VM cannot find `llvm-symbolizer`; this PR adds it to `/bin` to ensure `Centipede` can use it.