### PR TITLE
use request host value instead of auth domain when proxying

### DIFF
--- a/src/appengine/handlers/auth.py
+++ b/src/appengine/handlers/auth.py
@@ -33,7 +33,7 @@ class Handler(base_handler.Handler):
     """Handle a get request."""
     # We use `request.url` which is already the full URL.
     del extra
-    target_url = request.url.replace(auth.auth_domain(),
+    target_url = request.url.replace(request.host,
                                      auth.real_auth_domain(), 1)
     logging.info('Forwarding auth request to: %s', target_url)
     response = requests.get(target_url, timeout=60)

--- a/src/appengine/handlers/auth.py
+++ b/src/appengine/handlers/auth.py
@@ -33,8 +33,7 @@ class Handler(base_handler.Handler):
     """Handle a get request."""
     # We use `request.url` which is already the full URL.
     del extra
-    target_url = request.url.replace(request.host,
-                                     auth.real_auth_domain(), 1)
+    target_url = request.url.replace(request.host, auth.real_auth_domain(), 1)
     logging.info('Forwarding auth request to: %s', target_url)
     response = requests.get(target_url, timeout=60)
     gzip_response = gzip.compress(response.text.encode('utf-8'))


### PR DESCRIPTION
This modifies how the target URL for proxying auth requests is instantiated, instead of using auth.auth_domain, it uses request.host which achieves the same behavior, but is more robust in the sense that it'd allow setups that are behind some kind of beyond corp/zero trust proxy more easily.