### PR TITLE
Log when corpus minimization merge starts

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -518,6 +518,7 @@ class Engine(engine.Engine):
     runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path)
     merge_tmp_dir = self._create_temp_dir('merge-wd')
+    logs.log('Starting merge with timeout %d.' % max_time)
 
     try:
       result = runner.merge(


### PR DESCRIPTION
We are currently facing a mystery about why this task sometimes times out after 4 minutes instead of the expected 30. Add logging to help diagnose.