### PR TITLE
Fix update task errors due to source files lacking write permissions

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -250,7 +250,7 @@ def update_source_code():
                      'version.' % absolute_filepath)
 
     try:
-      # Make sure we can override files without prior write permission
+      # Make sure we can override files without prior write permission.
       target_destination = os.path.join(cf_source_root_parent_dir, file.name)
       try:
         os.chmod(target_destination, 0o755)

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -213,7 +213,6 @@ def update_source_code():
     return
 
   src_directory = os.path.join(root_directory, 'src')
-  third_party_directory = os.path.join(src_directory, 'third_party')
   error_occurred = False
   normalized_file_set = set()
   for file in reader.list_members():
@@ -260,10 +259,9 @@ def update_source_code():
       extracted_path = reader.extract(
           file.name, cf_source_root_parent_dir, trusted=True)
       os.chmod(extracted_path, 0o755)
-      assert(extracted_path == target_destination)
-    except Exception as e:
+    except Exception:
       error_occurred = True
-      logs.log_error(f'Failed to extract file {file.name} from source archive. Exception = ', e)
+      logs.log_error(f'Failed to extract file {file.name} from source archive.')
 
   reader.close()
 

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -252,16 +252,15 @@ def update_source_code():
 
     try:
       # Make sure we can override files without prior write permission
+      target_destination = os.path.join(cf_source_root_parent_dir, file.name)
+      try:
+        os.chmod(target_destination, 0o755)
+      except FileNotFoundError:
+        pass
       extracted_path = reader.extract(
           file.name, cf_source_root_parent_dir, trusted=True)
       os.chmod(extracted_path, 0o755)
-    except PermissionError:
-      logs.log_info('Attempted to unzip {} in {}, failed. Setting +w on {}',
-                    file.name, cf_source_root_parent_dir, absolute_filepath)
-      os.chmod(absolute_filepath, 0o755)
-      extracted_path = reader.extract(
-          file.name, cf_source_root_parent_dir, trusted=True)
-      os.chmod(extracted_path, 0o755)
+      assert(extracted_path == target_destination)
     except Exception as e:
       error_occurred = True
       logs.log_error(f'Failed to extract file {file.name} from source archive. Exception = ', e)

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -213,6 +213,7 @@ def update_source_code():
     return
 
   src_directory = os.path.join(root_directory, 'src')
+  third_party_directory = os.path.join(src_directory, 'third_party')
   error_occurred = False
   normalized_file_set = set()
   for file in reader.list_members():
@@ -255,13 +256,15 @@ def update_source_code():
           file.name, cf_source_root_parent_dir, trusted=True)
       os.chmod(extracted_path, 0o755)
     except PermissionError:
+      logs.log_info('Attempted to unzip {} in {}, failed. Setting +w on {}',
+                    file.name, cf_source_root_parent_dir, absolute_filepath)
       os.chmod(absolute_filepath, 0o755)
       extracted_path = reader.extract(
           file.name, cf_source_root_parent_dir, trusted=True)
       os.chmod(extracted_path, 0o755)
-    except:
+    except Exception as e:
       error_occurred = True
-      logs.log_error(f'Failed to extract file {file.name} from source archive.')
+      logs.log_error(f'Failed to extract file {file.name} from source archive. Exception = ', e)
 
   reader.close()
 

--- a/src/local/butler/scripts/run_locally.py
+++ b/src/local/butler/scripts/run_locally.py
@@ -1,0 +1,32 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Build attributes of every testcase."""
+
+import datetime
+import sys
+import os
+
+from clusterfuzz._internal.base import tasks
+from clusterfuzz._internal.datastore import data_handler
+from clusterfuzz._internal.bot.tasks import update_task
+from clusterfuzz._internal.system import environment
+# from local.butler.run_bot
+
+def execute(args):
+  """Build keywords."""
+  environment.set_bot_environment()
+  # analyze 5121608552873984
+  os.environ['USE_TEST_DEPLOYMENT']='1'
+  update_task.update_source_code()
+  pass

--- a/src/local/butler/scripts/run_locally.py
+++ b/src/local/butler/scripts/run_locally.py
@@ -13,20 +13,14 @@
 # limitations under the License.
 """Build attributes of every testcase."""
 
-import datetime
-import sys
 import os
 
-from clusterfuzz._internal.base import tasks
-from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.bot.tasks import update_task
 from clusterfuzz._internal.system import environment
-# from local.butler.run_bot
 
-def execute(args):
+
+def execute():
   """Build keywords."""
   environment.set_bot_environment()
-  # analyze 5121608552873984
-  os.environ['USE_TEST_DEPLOYMENT']='1'
+  os.environ['USE_TEST_DEPLOYMENT'] = '1'
   update_task.update_source_code()
-  pass

--- a/src/local/butler/scripts/run_locally.py
+++ b/src/local/butler/scripts/run_locally.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Build attributes of every testcase."""
+"""Executes update task locally, so we can run it through a debugger."""
 
 import os
 


### PR DESCRIPTION
### Motivation

This error would show up, after dependencies upgrade, during upgrade task:
```
Traceback (most recent call last):
  File "/mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/update_task.py", line 256, in update_source_code
TypeError: chmod: path should be string, bytes, os.PathLike or integer, not NoneType
```

This happened before in #3249 , and the root cause is that the protobuf wheel would containe files without the write bit set, thus failing to overwrite from new source zips. This PR attempts to fix it

### Testing strategy

Ran the command 
```
butler run run_locally --config-dir=$HOME/projects/clusterfuzz-config/configs/internal
```
without the change, and verified the issue happened during a local update task. After the change, the error did not manifest again.