### PR TITLE
Fix issues in ClusterFuzz

### DIFF
--- a/src/appengine/handlers/viewer.py
+++ b/src/appengine/handlers/viewer.py
@@ -48,13 +48,13 @@ class Handler(base_handler.Handler):
         raise helpers.AccessDeniedError()
 
     blob_size = blobs.get_blob_size(key)
-    if blob_size > MAX_ALLOWED_CONTENT_SIZE:
-      raise helpers.EarlyExitError('Content exceeds max allowed size.', 400)
+    if blob_size:
+      if blob_size > MAX_ALLOWED_CONTENT_SIZE:
+        raise helpers.EarlyExitError('Content exceeds max allowed size.', 400)
 
     # TODO(mbarbella): Workaround for an issue in the Cloud Storage API. Remove
     # once it is fixed properly upstream:
     # https://github.com/googleapis/google-cloud-python/issues/6572
-    if blob_size:
       try:
         content = blobs.read_key(key).decode('utf-8', errors='replace')
       except Exception:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -366,6 +366,8 @@ class Runner:
       return
 
     asan_options = environment.get_memory_tool_options('ASAN_OPTIONS')
+    if not asan_options:
+      return
     asan_options.update(overrides)
     environment.set_memory_tool_options('ASAN_OPTIONS', asan_options)
 

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -73,7 +73,7 @@ def download_artifact(client, bid, target, attempt_id, name, output_directory,
     logs.log_error(
         'Artifact unreachable with name %s, target %s and build id %s.' %
         (name, target, bid))
-    return False
+    return None
 
   # Lucky us, we always have the size.
   size = int(artifact['size'])
@@ -244,7 +244,7 @@ def run_script(client, bid, target, regex, output_directory, output_filename):
   if not artifacts:
     logs.log_error('Artifact could not be fetched for target %s, build id %s.' %
                    (target, bid))
-    return False
+    return None
 
   regex = re.compile(regex)
   result = []

--- a/src/clusterfuzz/_internal/platforms/android/logger.py
+++ b/src/clusterfuzz/_internal/platforms/android/logger.py
@@ -60,7 +60,7 @@ def filter_log_output(output):
     # {log_level}/{process_name}({process_id}): {message}
     m_line = re.match(r'^[VDIWEFS]/(.+)\(\s*(\d+)\)[:](.*)$', line)
     if not m_line:
-      logs.log_error('Failed to parse logcat line: %s' % line)
+      logs.log('Failed to parse logcat line: %s' % line)
       continue
 
     process_name = m_line.group(1).strip()

--- a/src/clusterfuzz/_internal/system/process_handler.py
+++ b/src/clusterfuzz/_internal/system/process_handler.py
@@ -639,7 +639,7 @@ def terminate_processes_matching_cmd_line(match_strings,
     except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
       continue
 
-    if any(x in process_path for x in match_strings):
+    if any(x in process_path for x in match_strings if x):
       if not any([x in process_path for x in exclude_strings]):
         terminate_process(process_info['pid'], kill)
 


### PR DESCRIPTION
The following issues have been fixed:
1. TypeError: 'in <string>' requires string as left operand, not NoneType
2. TypeError: '>' not supported between instances of 'NoneType' and 'int'
3. Failed to parse logcat line: (11285): strips
4. AttributeError: 'NoneType' object has no attribute 'update'
5. AttributeError: 'bool' object has no attribute 'endswith'