### PR TITLE
Remove extra call to upload_job_run_stats

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1865,12 +1865,6 @@ class FuzzingSession:
               f'{fuzz_task_output.fully_qualified_fuzzer_name}')
     uworker_input = uworker_output.uworker_input
     postprocess_process_crashes(uworker_input, uworker_output)
-    upload_job_run_stats(
-        fuzz_task_output.fully_qualified_fuzzer_name, self.job_type,
-        fuzz_task_output.crash_revision, fuzz_task_output.job_run_timestamp,
-        fuzz_task_output.new_crash_count, fuzz_task_output.known_crash_count,
-        fuzz_task_output.testcases_executed, fuzz_task_output.crash_groups)
-
     if not environment.is_engine_fuzzer_job():
       return
 


### PR DESCRIPTION
Fixes https://pantheon.corp.google.com/errors/detail/CMSUgs7V_IybqwE;time=PT6H?e=-13802955&mods=logs_tg_prod&project=google.com:clusterfuzz Old call references deleted attributes.