### PR TITLE
Take CORPUS_FUZZER_NAME_OVERRIDE into account when generating backup …

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -1056,12 +1056,13 @@ def _create_backup_urls(fuzz_target: data_types.FuzzTarget,
     return
 
   timestamp = str(utils.utcnow().date())
+  engine_name = environment.get_value('CORPUS_FUZZER_NAME_OVERRIDE',
+                                      fuzz_target.engine)
   dated_backup_gcs_url = corpus_manager.gcs_url_for_backup_file(
-      backup_bucket_name, fuzz_target.engine,
-      fuzz_target.project_qualified_name(), timestamp)
+      backup_bucket_name, engine_name, fuzz_target.project_qualified_name(),
+      timestamp)
   latest_backup_gcs_url = corpus_manager.gcs_url_for_backup_file(
-      backup_bucket_name, fuzz_target.engine,
-      fuzz_target.project_qualified_name(),
+      backup_bucket_name, engine_name, fuzz_target.project_qualified_name(),
       corpus_manager.LATEST_BACKUP_TIMESTAMP)
 
   dated_backup_signed_url = storage.get_signed_upload_url(dated_backup_gcs_url)


### PR DESCRIPTION
…signed urls

This fixes the issue introduced in
https://github.com/google/clusterfuzz/pull/3946/files#diff-4e357c1cb796c84a085445e5c0182c2a0bc5d46c0271c1fe594a7d41947ed9d8L511

Before the change above, we used the corpus.engine for the backup url which took into account the CORPUS_FUZZER_NAME_OVERRIDE.
