### PR TITLE
progression: Fix handling of errors.BuildNotFound in build_setup.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -315,7 +315,16 @@ def _testcase_reproduces_in_revision(
   """Tests to see if a test case reproduces in the specified revision.
   Returns a tuple containing the (result, error) depending on whether
   there was an error."""
-  build_manager.setup_build(revision)
+  try:
+    build_manager.setup_build(revision)
+  except errors.BuildNotFoundError as e:
+    # Build no longer exists, so we need to mark this testcase as invalid.
+    error_message = f'Build not found at r{e.revision}'
+    return None, uworker_msg_pb2.Output(
+        error_message=error_message,
+        progression_task_output=progression_task_output,
+        error_type=uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND)
+
   if not build_manager.check_app_path():
     # Let postprocess handle the failure and reschedule the task if needed.
     error_message = f'Build setup failed at r{revision}'

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -17,6 +17,7 @@ import time
 from typing import List
 
 from clusterfuzz._internal.base import bisection
+from clusterfuzz._internal.base import errors
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -321,10 +321,10 @@ def _testcase_reproduces_in_revision(
   except errors.BuildNotFoundError as e:
     # Build no longer exists, so we need to mark this testcase as invalid.
     error_message = f'Build not found at r{e.revision}'
-    return None, uworker_msg_pb2.Output(
+    return None, uworker_msg_pb2.Output(  # pylint: disable=no-member
         error_message=error_message,
         progression_task_output=progression_task_output,
-        error_type=uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND)
+        error_type=uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND)  # pylint: disable=no-member
 
   if not build_manager.check_app_path():
     # Let postprocess handle the failure and reschedule the task if needed.


### PR DESCRIPTION
This was necessary to properly close testcases where the build is no longer valid (e.g. a deleted fuzz target).

`errors.BuildNotFound` can be raised in `build_manager.build_setup()`, but it isn't handled properly. This was previously handled here prior to the utask refactor: https://github.com/google/clusterfuzz/blob/0149b701bf4143451ba3fc5251d76ceb121bbe93/src/clusterfuzz/_internal/bot/tasks/progression_task.py#L458

Context: https://github.com/google/clusterfuzz/pull/2490