### PR TITLE
Logging skipped files on normalized file set

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -221,7 +221,10 @@ def update_source_code():
     if os.path.altsep:
       absolute_filepath = absolute_filepath.replace(os.path.altsep, os.path.sep)
 
-    if os.path.realpath(absolute_filepath) != absolute_filepath:
+    real_path = os.path.realpath(absolute_filepath)
+    if real_path != absolute_filepath:
+      logs.info(f'Mismatch between absolute and real filepath. ' +
+                'Not adding on normalized set: {real_path}')
       continue
 
     normalized_file_set.add(absolute_filepath)


### PR DESCRIPTION
### Motivation

During the python 3.11 upgrade, a behavior change from 3.7 to 3.11 in os.path.realpath made clusterfuzz delete all its files, during update task, when paths with mismatching case in the C: drive were compared raw. In order to recover historical context as to why we choose to delete files that have a mismatch between real and absolute path, this log will be introduced.

Part of this [initiative](https://github.com/google/clusterfuzz/issues/4059)