### PR TITLE
Added 'None' check for testcase_id in issue_redirector.py

### DIFF
--- a/src/appengine/handlers/issue_redirector.py
+++ b/src/appengine/handlers/issue_redirector.py
@@ -14,6 +14,7 @@
 """Handler for redirecting to the issue url (given a testcase). See
   crbug.com/665652 on why we need it."""
 
+# pylint: disable=wrong-import-order
 from clusterfuzz._internal.issue_management import issue_tracker_utils
 from handlers import base_handler
 from libs import helpers
@@ -24,7 +25,9 @@ class Handler(base_handler.Handler):
 
   def get(self, testcase_id=None):
     """Redirect user to the correct URL."""
-    testcase = helpers.get_testcase(testcase_id)
+    testcase = None
+    if testcase_id:
+      testcase = helpers.get_testcase(testcase_id)
     issue_url = helpers.get_or_exit(
         lambda: issue_tracker_utils.get_issue_url(testcase),
         'Issue tracker for testcase (id=%s) is not found.' % testcase_id,


### PR DESCRIPTION
Redirect the page to 'Testcase not found' instead of reporting error log when accessing issue with None testcase_id