### PR TITLE
Rename `environment.get_value_string()` to `get_value_raw()`.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1172,11 +1172,10 @@ def process_crashes(crashes: List[Crash], context: Context,
 
 def _get_issue_metadata_from_environment(variable_name):
   """Get issue metadata from environment."""
-  values = str(environment.get_value_string(variable_name, '')).split(',')
+  values = environment.get_value_raw(variable_name, '').split(',')
   # Allow a variation with a '_1' to specified. This is needed in cases where
   # this is specified in both the job and the bot environment.
-  values.extend(
-      str(environment.get_value_string(variable_name + '_1', '')).split(','))
+  values.extend(environment.get_value_raw(variable_name + '_1', '').split(','))
   return [value.strip() for value in values if value.strip()]
 
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -20,6 +20,7 @@ import re
 import socket
 import subprocess
 import sys
+from typing import Optional
 
 import yaml
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -600,9 +600,9 @@ def get_ubsan_disabled_options():
   }
 
 
-def get_value_string(environment_variable, default_value=None):
-  """Get environment variable (as a string)."""
-  return os.getenv(environment_variable, default_value)
+def get_value_raw(var: str, default: Optional[str] = None) -> Optional[str]:
+  """Returns environment variable `var` directly, without evaluating it."""
+  return os.environ.get(var, default)
 
 
 def get_value(environment_variable, default_value=None, env=None):

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -21,6 +21,8 @@ import socket
 import subprocess
 import sys
 from typing import Optional
+from typing import TypeVar
+from typing import Union
 
 import yaml
 
@@ -601,7 +603,12 @@ def get_ubsan_disabled_options():
   }
 
 
-def get_value_raw(var: str, default: Optional[str] = None) -> Optional[str]:
+# This allows the type checker to notice that if the default value passed to
+# `get_value_raw()` is not None, then the function will never return None.
+_MaybeStr = TypeVar('MaybeStr', bound=Optional[str])
+
+
+def get_value_raw(var: str, default: _MaybeStr = None) -> Union[str, _MaybeStr]:
   """Returns environment variable `var` directly, without evaluating it."""
   return os.environ.get(var, default)
 


### PR DESCRIPTION
This is a prelude to fixing type errors in `environment.py`.

One of the big sources of type errors so far has been the fact that `environment.get_value()` is ~untyped. Many places in the codebase assume that it returns e.g. a string, or an int. We can introduce `get_value_int()` for example for ints that checks at runtime that the environment variable evaluated to an int, and use that instead where applicable to appease the
type checker (and surface errors earlier at runtime).

There is a need for a `get_value_string()` that tries to evaluate environment variable contents, i.e. supports quoted values. Many variables are expected to be strings, yet the pervasive use of `environment.get_value()` and `environment.set_value()` means it is hard to tell whether they are sometimes quoted or not.

This PR renames the current `get_value_string()` function to make space for a future `get_value_string()` that evaluates variables.