### PR TITLE
Revert "Delete unneeded lint exemption (#4140)": It's actually needed.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -35,7 +35,8 @@ disable=
   raise-missing-from,
   super-with-arguments,
   consider-using-generator,
-  consider-using-f-string  # Too many legacy usages.
+  consider-using-f-string,  # Too many legacy usages.
+  unspecified-encoding  # Too many legacy usage.
 
 [BASIC]
 


### PR DESCRIPTION
This reverts commit e75ae2c433d60c518ec05fd12b87888c20da20a2.