### PR TITLE
Add Tunk Stable versions to deprecated testcase check

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/util.py
+++ b/src/clusterfuzz/_internal/platforms/android/util.py
@@ -81,4 +81,11 @@ def can_testcase_run_on_platform(testcase_platform_id, current_platform_id):
   if current_platform_id_fields[2] == 'm':
     return True
 
+  # Check for the trunk stable versions - Z, A, B.
+  # Source: go/release-version_trunk-stable#examples
+  # If the current version is 'Z', 'A' or 'B', run the test case
+  android_trunk_stable_versions = ['Z', 'A', 'B']
+  if current_platform_id_fields[2] in android_trunk_stable_versions:
+    return True
+
   return False


### PR DESCRIPTION
Updated can_testcase_run_on_platform to check for
Android Trunk Stable versions - 'Z', 'A' and 'B'