### PR TITLE
Don't check for platform and queue match for OSS-Fuzz untrusted hosts.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -285,7 +285,7 @@ def process_command_impl(task_name,
     # A misconfiguration led to this point. Clean up the job if necessary.
     # TODO(ochang): Remove the first part of this check once we migrate off the
     # old untrusted worker architecture.
-    if (not environment.is_trusted_host(ensure_connected=False) &&
+    if (not environment.is_trusted_host(ensure_connected=False) and
         job_base_queue_suffix != bot_base_queue_suffix):
       # This happens rarely, store this as a hard exception.
       logs.error('Wrong platform for job %s: job queue [%s], bot queue [%s].' %

--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -283,7 +283,10 @@ def process_command_impl(task_name,
         environment.base_platform(bot_platform))
 
     # A misconfiguration led to this point. Clean up the job if necessary.
-    if job_base_queue_suffix != bot_base_queue_suffix:
+    # TODO(ochang): Remove the first part of this check once we migrate off the
+    # old untrusted worker architecture.
+    if (not environment.is_trusted_host(ensure_connected=False) &&
+        job_base_queue_suffix != bot_base_queue_suffix):
       # This happens rarely, store this as a hard exception.
       logs.error('Wrong platform for job %s: job queue [%s], bot queue [%s].' %
                  (job_name, job_base_queue_suffix, bot_base_queue_suffix))


### PR DESCRIPTION
OSS-Fuzz has project-specific queues, which breaks this.