### PR TITLE
Fix deadline in manage_vms

### DIFF
--- a/infra/k8s/manage-vms.yaml
+++ b/infra/k8s/manage-vms.yaml
@@ -21,7 +21,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      activeDeadlineSeconds: 43200  # 12 hours.
+      activeDeadlineSeconds: 86400  # 24 hours.
       template:
         spec:
           containers:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1193,9 +1193,13 @@ def run_engine_fuzzer(engine_impl, target_name, sync_corpus_directory,
   """Run engine for fuzzing."""
   if environment.is_trusted_host():
     from clusterfuzz._internal.bot.untrusted_runner import tasks_host
-    return tasks_host.engine_fuzz(engine_impl, target_name,
-                                  sync_corpus_directory, testcase_directory)
+    logs.info('Running remote engine fuzz.')
+    result = tasks_host.engine_fuzz(engine_impl, target_name,
+                                    sync_corpus_directory, testcase_directory)
+    logs.info('Done remote engine fuzz.')
+    return result
 
+  logs.info('Worker engine fuzz.')
   build_dir = environment.get_value('BUILD_DIR')
   target_path = engine_common.find_fuzzer_path(build_dir, target_name)
   if target_path is None:

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/manage_vms_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/manage_vms_test.py
@@ -1084,6 +1084,14 @@ class OssFuzzDistributeCpusTest(unittest.TestCase):
     self.assertEqual(3571, sum(result))
 
 
+class ReversePairsTest(unittest.TestCase):
+  """Tests reverse_pairs."""
+
+  def test_reverse_pairs(self):
+    l = list(range(6))
+    self.assertEqual(manage_vms.reverse_pairs(l), [4, 5, 2, 3, 0, 1])
+
+
 @test_utils.with_cloud_emulators('datastore')
 class AssignHostWorkerTest(unittest.TestCase):
   """Tests host -> worker assignment."""


### PR DESCRIPTION
Fix problem in oss-fuzz where manage_vms doesn't complete, causing old VMs/containers to hang around.
Do this by increasing the deadline to 24 hours for manage_vms to compelte. Also, temporarily change the order of manage_vms so that the previously unresized groups will be resized first. This should hopefully get rid of weird errors we are seeing.