### PR TITLE
Make untrusted_host use timestamps instead of dates

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -955,7 +955,7 @@ def _save_coverage_information(output):
 def _get_proto_timestamp(initial_timestamp):
   timestamp = timestamp_pb2.Timestamp()  # pylint: disable=no-member
   timestamp.FromDatetime(initial_timestamp)
-  return timestampe
+  return timestamp
 
 
 def _extract_coverage_information(context, result):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -952,13 +952,18 @@ def _save_coverage_information(output):
         'Failed to save corpus pruning result: %s.' % repr(e))
 
 
+def _get_proto_timestamp(initial_timestamp):
+  timestamp = timestamp_pb2.Timestamp()  # pylint: disable=no-member
+  timestamp.FromDatetime(initial_timestamp)
+  return timestampe
+
+
 def _extract_coverage_information(context, result):
   """Extracts and stores the coverage information in a proto."""
   coverage_info = uworker_msg_pb2.CoverageInformation()  # pylint: disable=no-member
   coverage_info.project_name = context.fuzz_target.project_qualified_name()
-  timestamp = timestamp_pb2.Timestamp()  # pylint: disable=no-member
-  timestamp.FromDatetime(result.coverage_info.date)
-  coverage_info.timestamp.CopyFrom(timestamp)
+  proto_timestamp = _get_proto_timestamp(result.coverage_info.date)
+  coverage_info.timestamp.CopyFrom(proto_timestamp)
   # Intentionally skip edge and function coverage values as those would come
   # from fuzzer coverage cron task.
   coverage_info.corpus_size_units = result.coverage_info.corpus_size_units

--- a/src/clusterfuzz/_internal/bot/untrusted_runner/tasks_host.py
+++ b/src/clusterfuzz/_internal/bot/untrusted_runner/tasks_host.py
@@ -39,6 +39,10 @@ def _fuzz_target_to_proto(fuzz_target):
   )
 
 
+def _get_date():
+  return datetime.datetime.utcnow()
+
+
 def do_corpus_pruning(uworker_input, context, revision):
   """Do corpus pruning on untrusted worker."""
   cross_pollinate_fuzzers = [

--- a/src/clusterfuzz/_internal/bot/untrusted_runner/tasks_host.py
+++ b/src/clusterfuzz/_internal/bot/untrusted_runner/tasks_host.py
@@ -39,7 +39,7 @@ def _fuzz_target_to_proto(fuzz_target):
   )
 
 
-def _get_date():
+def _get_datetime():
   return datetime.datetime.utcnow()
 
 
@@ -62,7 +62,7 @@ def do_corpus_pruning(uworker_input, context, revision):
   response = host.stub().PruneCorpus(request)
 
   project_qualified_name = context.fuzz_target.project_qualified_name()
-  today_date = datetime.datetime.utcnow().date()
+  today_date = _get_datetime()
   coverage_info = data_types.CoverageInformation(
       fuzzer=project_qualified_name, date=today_date)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
@@ -586,6 +586,14 @@ class CorpusPruningTestUntrusted(
     return compare
 
 
+class GetProtoTimestampTest(unittest.TestCase):
+
+  def test_get_proto_timestamp_utcnow(self):
+    """Tests that _get_proto_timestamp works with utcnow. It should not be used
+    with date()."""
+    corpus_pruning_task._get_proto_timestamp(datetime.datetime.utcnow())
+
+
 @test_utils.supported_platforms('LINUX')
 @test_utils.with_cloud_emulators('datastore')
 class CrashProcessingTest(unittest.TestCase, BaseTest):


### PR DESCRIPTION
It's simpler to use timestamps with protos, and we've been doing this already in chrome and internal google.
Fixes: https://pantheon.corp.google.com/errors/detail/CM3Hppa8wfSgCQ;time=PT6H;locations=global?e=-13802955&mods=logs_tg_prod&project=clusterfuzz-external
```

AttributeError: 'datetime.date' object has no attribute 'utctimetuple'

at .FromDatetime ( /mnt/scratch0/bots/oss-fuzz-linux-zone5-host-9xqb-0/clusterfuzz/src/third_party/google/protobuf/internal/well_known_types.py:270 )
at ._extract_coverage_information ( /mnt/scratch0/bots/oss-fuzz-linux-zone5-host-9xqb-0/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py:960 )
at .utask_main ( /mnt/scratch0/bots/oss-fuzz-linux-zone5-host-9xqb-0/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py:1024 )
```