### PR TITLE
[pruning][tasks_host] Use uworker_msg_pb2.CrashInfo like corpus_pruning

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -454,6 +454,7 @@ class CorpusPruner:
       if state.crash_state not in crashes:
         security_flag = crash_analyzer.is_security_issue(
             state.crash_stacktrace, state.crash_type, state.crash_address)
+        # TODO(metzman): Get rid of CorpusCrash and replace with CrashInfo.
         crashes[state.crash_state] = CorpusCrash(
             state.crash_state, state.crash_type, state.crash_address,
             state.crash_stacktrace, unit_path, security_flag)

--- a/src/clusterfuzz/_internal/bot/untrusted_runner/tasks_host.py
+++ b/src/clusterfuzz/_internal/bot/untrusted_runner/tasks_host.py
@@ -23,6 +23,7 @@ from clusterfuzz._internal.bot.tasks.utasks import corpus_pruning_task
 from clusterfuzz._internal.bot.untrusted_runner import file_host
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.protos import untrusted_runner_pb2
+from clusterfuzz._internal.protos import uworker_msg_pb2
 from clusterfuzz.fuzz import engine
 
 from . import host
@@ -76,7 +77,7 @@ def do_corpus_pruning(uworker_input, context, revision):
   coverage_info.quarantine_location = response.coverage_info.quarantine_location
 
   crashes = [
-      corpus_pruning_task.CorpusCrash(
+      uworker_msg_pb2.CrashInfo(
           crash_state=crash.crash_state,
           crash_type=crash.crash_type,
           crash_address=crash.crash_address,


### PR DESCRIPTION
Be consistent about the types we use.

Fixes https://pantheon.corp.google.com/errors/detail/CMaFucrr75_x6QE;time=PT6H;locations=global?e=-13802955&mods=logs_tg_prod&project=clusterfuzz-external

```
AttributeError: can't set attribute

at ._update_crash_unit_path ( /mnt/scratch0/bots/oss-fuzz-linux-zone1-host-v10g-8/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py:743 )
at ._upload_corpus_crashes_zip ( /mnt/scratch0/bots/oss-fuzz-linux-zone1-host-v10g-8/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py:754 )
at .utask_main ( /mnt/scratch0/bots/oss-fuzz-linux-zone1-host-v10g-8/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py:1021 )

```