### PR TITLE
Update install_deps_linux.bash to install google-cloud-cli instead.

### DIFF
--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -113,7 +113,7 @@ fi
 sudo apt-get update
 sudo apt-get install -y \
     docker-ce \
-    google-cloud-sdk \
+    google-cloud-cli \
     openjdk-11-jdk \
     liblzma-dev
 
@@ -144,15 +144,15 @@ if gcloud components install --quiet beta; then
       cloud-datastore-emulator \
       pubsub-emulator
 else
-  # Either Cloud SDK component manager is disabled (default on GCE), or google-cloud-sdk package is
+  # Either Cloud SDK component manager is disabled (default on GCE), or google-cloud-cli package is
   # installed via apt-get.
   sudo apt-get install -y \
-      google-cloud-sdk-app-engine-go \
-      google-cloud-sdk-app-engine-python \
-      google-cloud-sdk-app-engine-python-extras \
-      google-cloud-sdk \
-      google-cloud-sdk-datastore-emulator \
-      google-cloud-sdk-pubsub-emulator
+      google-cloud-cli-app-engine-go \
+      google-cloud-cli-app-engine-python \
+      google-cloud-cli-app-engine-python-extras \
+      google-cloud-cli \
+      google-cloud-cli-datastore-emulator \
+      google-cloud-cli-pubsub-emulator
 fi
 
 dir=$(dirname "$0")


### PR DESCRIPTION
This was renamed to google-cloud-cli. Referencing google-cloud-sdk may even cause old/stale versions to be installed in some setups.