### PR TITLE
Delete SHARE_BUILD_WITH_JOB_TYPE feature.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -119,12 +119,6 @@ def update_environment_for_job(environment_string):
   for key, value in env.items():
     environment.set_value(key, value)
 
-  # If we share the build with another job type, force us to be a custom binary
-  # job type.
-  if environment.get_value('SHARE_BUILD_WITH_JOB_TYPE'):
-    environment.set_value('CUSTOM_BINARY', True)
-    uworker_env['CUSTOM_BINARY'] = 'True'
-
   # Allow the default FUZZ_TEST_TIMEOUT and MAX_TESTCASES to be overridden on
   # machines that are preempted more often.
   fuzz_test_timeout_override = environment.get_value(

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1279,17 +1279,7 @@ def setup_symbolized_builds(revision):
 
 def setup_custom_binary(target_weights=None):
   """Set up the custom binary for a particular job."""
-  # Check if this build is dependent on any other custom job. If yes,
-  # then fake out our job name for setting up the build.
-  old_job_name = ''
-  share_build_job_type = environment.get_value('SHARE_BUILD_WITH_JOB_TYPE')
-  if share_build_job_type:
-    job_name = share_build_job_type
-    old_job_name = environment.get_value('JOB_NAME', '')
-    environment.set_value('JOB_NAME', job_name)
-  else:
-    job_name = environment.get_value('JOB_NAME', '')
-
+  job_name = environment.get_value('JOB_NAME')
   # Verify that this is really a custom binary job.
   job = data_types.Job.query(data_types.Job.name == job_name).get()
   if not job or not job.custom_binary_key or not job.custom_binary_filename:
@@ -1304,10 +1294,6 @@ def setup_custom_binary(target_weights=None):
       job.custom_binary_filename,
       job.custom_binary_revision,
       target_weights=target_weights)
-
-  # Revert back the actual job name.
-  if share_build_job_type:
-    environment.set_value('JOB_NAME', old_job_name)
 
   if build.setup():
     return build

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -1068,29 +1068,6 @@ class CustomBuildTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(self.mock.open.return_value.unpack.call_count, 1)
     self._assert_env_vars()
 
-  def test_setup_shared(self):
-    """Test setting up a custom binary (shared)."""
-    os.environ['JOB_NAME'] = 'job_share'
-    os.environ['SHARE_BUILD_WITH_JOB_TYPE'] = 'job_custom'
-
-    self.mock.time.return_value = 1000.0
-    build = build_manager.setup_custom_binary()
-    self.assertIsInstance(build, build_manager.CustomBuild)
-    self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
-
-    self.mock.read_blob_to_disk.assert_called_once_with(
-        'key', '/builds/job_custom/custom/custom_binary.zip')
-
-    # For now, we're calling it multiple times because we're not passing the
-    # reader object along in the build manager
-    self.mock.open.assert_called_once_with(
-        archive_path='/builds/job_custom/custom/custom_binary.zip')
-    self.mock.open.return_value.unpack.assert_called_once_with(
-        '/builds/job_custom/custom', trusted=True)
-
-    self._assert_env_vars()
-    self.assertEqual(os.environ['JOB_NAME'], 'job_share')
-
   def test_delete(self):
     """Test deleting this build."""
     os.environ['JOB_NAME'] = 'job_custom'


### PR DESCRIPTION
It's a clever feature that needs bad complexity to support and doesn't appear to be used.
Fixes: https://github.com/google/clusterfuzz/issues/4195