### PR TITLE
Added fix for filing cannot locate symbol issue

### DIFF
--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -1135,6 +1135,13 @@ class StackParser:
             new_type='Missing-library',
             state_from_group=1,
             reset=True)
+        self.update_state_on_match(
+            SYMBOL_NOT_FOUND_REGEX,
+            line,
+            state,
+            new_type='Missing-library',
+            state_from_group=2,
+            reset=True)
 
       if state.fatal_error_occurred:
         error_line_match = self.update_state_on_match(

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -248,6 +248,8 @@ SECURITY_CHECK_FAILURE_REGEX = re.compile(
     r'.*\[[^\]]*[:]([^\](]*).*\].*Security CHECK failed[:]\s*(.*)\.\s*')
 SECURITY_DCHECK_FAILURE_REGEX = re.compile(
     r'.*\[[^\]]*[:]([^\](]*).*\].*Security DCHECK failed[:]\s*(.*)\.\s*')
+SYMBOL_NOT_FOUND_REGEX = re.compile(
+    r'.*: cannot locate symbol ([`\'"])(.*)\1 referenced by')
 TRUSTY_STACK_FRAME_REGEX = re.compile(
     r'(uSP)\+([a-zA-Z0-9]{6}): (0x[a-fA-F0-9]{16}) in (\w+)')
 UBSAN_DIVISION_BY_ZERO_REGEX = re.compile(r'.*division by zero.*')

--- a/src/clusterfuzz/tests/test.py
+++ b/src/clusterfuzz/tests/test.py
@@ -46,3 +46,15 @@ class StacktracesTest(unittest.TestCase):
         'blink::internal::CallClosureTask::performTask\n',
         crash_info.crash_state)
     self.assertEqual(stacktrace, crash_info.crash_stacktrace)
+
+  def test_cannot_locate_symbol(self):
+    """Test for cannont locate symbol issue."""
+    stacktrace = _load_test_data('cannot_locate_symbol_stacktrace.txt')
+    parser = clusterfuzz.stacktraces.StackParser()
+    crash_info = parser.parse(stacktrace)
+
+    self.assertEqual('Missing-library', crash_info.crash_type)
+    self.assertEqual(
+        '_ZN7android26openDeclaredPassthroughHalERKNS_8String16ES2_i\n',
+        crash_info.crash_state)
+    self.assertEqual(stacktrace, crash_info.crash_stacktrace)

--- a/src/clusterfuzz/tests/testdata/cannot_locate_symbol_stacktrace.txt
+++ b/src/clusterfuzz/tests/testdata/cannot_locate_symbol_stacktrace.txt
@@ -1,0 +1,6 @@
+CANNOT LINK EXECUTABLE "/data/fuzz/bot/builds/test-blobs-bucket_fuzzers_target-cuttlefish_asan_android.hardware.confirmationui-service.trusty_fuzzer_77651789446b3c3a04b9f492ff141f003d437347/revisions/android.hardware.confirmationui-service.trusty_fuzzer": cannot locate symbol "_ZN7android26openDeclaredPassthroughHalERKNS_8String16ES2_i" referenced by "/system/lib64/libbinder_ndk.so"...
+
+
+Logcat:
+--------- linker (6045):
+CANNOT LINK EXECUTABLE "/data/fuzz/bot/builds/test-blobs-bucket_fuzzers_target-cuttlefish_asan_android.hardware.confirmationui-service.trusty_fuzzer_77651789446b3c3a04b9f492ff141f003d437347/revisions/android.hardware.confirmationui-service.trusty_fuzzer": cannot locate symbol "_ZN7android26openDeclaredPassthroughHalERKNS_8String16ES2_i" referenced by "/system/lib64/libbinder_ndk.so"...


### PR DESCRIPTION
'SYMBOL_NOT_FOUND_REGEX' added to parse 'cannot locate symbol' issue and file it as Missing-Library issue in clusterfuzz.