### PR TITLE
Fixing access to named tuple

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -159,7 +159,7 @@ def _get_task_spec(batch_workload_spec):
   runnable = batch.Runnable()
   runnable.container = batch.Runnable.Container()
   runnable.container.image_uri = batch_workload_spec.docker_image
-  clusterfuzz_release = batch_workload_spec['clusterfuzz_release']
+  clusterfuzz_release = batch_workload_spec.clusterfuzz_release
   runnable.container.options = (
       '--memory-swappiness=40 --shm-size=1.9g --rm --net=host '
       '-e HOST_UID=1337 -P --privileged --cap-add=all '


### PR DESCRIPTION
Simple mistake on accessing named tuples as I would access a dict, fixing for proper access

```
>>> # Create an instance of the named tuple
>>> x = something(lol=1, bol=2)
>>> 
>>> # Access the fields of the instance
>>> print(x.lol)  # Output: 1
1
>>> print(x.bol)  # Output: 2
2
>>> print(x['lol'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: tuple indices must be integers or slices, not str
>>> 
```

Error that showed up:

```
 Traceback (most recent call last):
  File "/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py", line 136, in task_loop
    schedule_utask_mains()
  File "/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py", line 105, in schedule_utask_mains
    batch.create_uworker_main_batch_jobs(batch_tasks)
  File "/mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/google_cloud_utils/batch.py", line 140, in create_uworker_main_batch_jobs
    jobs.append(_create_job(spec, input_urls_portion))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/google_cloud_utils/batch.py", line 222, in _create_job
    task_group.task_spec = _get_task_spec(spec)
                           ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/google_cloud_utils/batch.py", line 162, in _get_task_spec
    clusterfuzz_release = batch_workload_spec['clusterfuzz_release']
                          ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
TypeError: tuple indices must be integers or slices, not str
```

