### PR TITLE
Use _extract_label instead for google_issue_tracker.

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -571,7 +571,7 @@ class Issue(issue_tracker.Issue):
     self.labels.remove_by_prefix('ReleaseBlock-')
 
     # Special case: OSS-Fuzz "Reported" custom field.
-    added_reported = _get_labels(self.labels.added, 'Reported-')
+    added_reported = _extract_label(self.labels, 'Reported-')
     if added_reported:
       try:
         # Assume there is only one entry.
@@ -588,7 +588,7 @@ class Issue(issue_tracker.Issue):
         logs.warning(f'Invalid date format for Reported-{added_reported[0]}')
 
     # Special case: OSS-Fuzz "Project" custom field.
-    added_projects = _get_labels(self.labels.added, 'Project-')
+    added_projects = _extract_label(self.labels, 'Project-')
     if added_projects:
       # Assume there is only one.
       custom_field_entries.append({

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -575,7 +575,7 @@ class Issue(issue_tracker.Issue):
     if added_reported:
       try:
         # Assume there is only one entry.
-        year, month, day = _parse_date_label(added_reported[0])
+        year, month, day = _parse_date_label(added_reported)
         custom_field_entries.append({
             'customFieldId': _OSS_FUZZ_REPORTED_CUSTOM_FIELD_ID,
             'dateValue': {
@@ -588,12 +588,12 @@ class Issue(issue_tracker.Issue):
         logs.warning(f'Invalid date format for Reported-{added_reported[0]}')
 
     # Special case: OSS-Fuzz "Project" custom field.
-    added_projects = _extract_label(self.labels, 'Project-')
-    if added_projects:
+    added_project = _extract_label(self.labels, 'Project-')
+    if added_project:
       # Assume there is only one.
       custom_field_entries.append({
           'customFieldId': _OSS_FUZZ_PROJECT_CUSTOM_FIELD_ID,
-          'textValue': added_projects[0]
+          'textValue': added_project
       })
 
     # Special case Component Tags custom field.


### PR DESCRIPTION
Otherwise we'll try to add the label as a hotlist.