### PR TITLE
Fix various issue_tracker issues for OSS-Fuzz.

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -126,7 +126,7 @@ def _get_labels(labels: Sequence[str], prefix: str) -> List[str]:
   return results
 
 
-def _get_oss_fuzz_reported_value(labels: Sequence[str]) -> Optional[str]:
+def _get_oss_fuzz_reported_value(labels: Sequence[str]) -> Optional[dict]:
   """Return OSS-Fuzz Reported custom field value."""
   added_reported = _extract_label(labels, 'Reported-')
   if not added_reported:


### PR DESCRIPTION
- Fix incorrect IDs for custom fields.
- Properly account for custom fields when creating new issues.
- Use string value for access level enum in request body.