### PR TITLE
Fix BadValueError in fuzz_task.py

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1102,7 +1102,7 @@ def _update_testcase_variant_if_needed(group, existing_testcase, crash_revision,
     variant.status = data_types.TestcaseVariantStatus.FLAKY
   else:
     variant.status = data_types.TestcaseVariantStatus.REPRODUCIBLE
-  variant.revision = crash_revision
+  variant.revision = int(crash_revision)
   variant.crash_type = group.main_crash.crash_type
   variant.crash_state = group.main_crash.crash_state
   variant.security_flag = group.main_crash.security_flag


### PR DESCRIPTION
Fixes:

```
google.cloud.ndb.exceptions.BadValueError: Expected integer, got '648623005'

at ._validate ( /mnt/scratch0/clusterfuzz/src/third_party/google/cloud/ndb/model.py:2420 )
at .call ( /mnt/scratch0/clusterfuzz/src/third_party/google/cloud/ndb/model.py:1835 )
at ._call_shallow_validation ( /mnt/scratch0/clusterfuzz/src/third_party/google/cloud/ndb/model.py:1763 )
at ._do_validate ( /mnt/scratch0/clusterfuzz/src/third_party/google/cloud/ndb/model.py:1405 )
at ._set_value ( /mnt/scratch0/clusterfuzz/src/third_party/google/cloud/ndb/model.py:1493 )
at .__set__ ( /mnt/scratch0/clusterfuzz/src/third_party/google/cloud/ndb/model.py:1952 )
at ._update_testcase_variant_if_needed ( /mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py:1103 )
at .postprocess_process_crashes ( /mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py:835 )
at .postprocess ( /mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py:1882 )
at .utask_postprocess ( /mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py:2041 )
```