### PR TITLE
Use mirror for syncing blink web tests

### DIFF
--- a/src/python/other-bots/chromium-tests-syncer/run.py
+++ b/src/python/other-bots/chromium-tests-syncer/run.py
@@ -235,20 +235,11 @@ def main():
   shell.create_directory(crash_testcases_directory)
   unpack_crash_testcases(crash_testcases_directory)
 
-  # Sync web tests.
-  logs.info('Syncing web tests.')
-  src_directory = os.path.join(tests_directory, 'src')
-  gclient_file_path = os.path.join(tests_directory, '.gclient')
-  if not os.path.exists(gclient_file_path):
-    subprocess.check_call(
-        ['fetch', '--no-history', 'chromium', '--nosvn=True'],
-        cwd=tests_directory)
-  if os.path.exists(src_directory):
-    subprocess.check_call(['gclient', 'revert'], cwd=src_directory)
-    subprocess.check_call(['git', 'pull'], cwd=src_directory)
-    subprocess.check_call(['gclient', 'sync'], cwd=src_directory)
-  else:
-    raise Exception('Unable to checkout web tests.')
+  # FIXME: Find a way to rename LayoutTests to web_tests without breaking
+  # compatibility with older testcases.
+  clone_git_repository(tests_directory, 'LayoutTests',
+                       ('https://chromium.googlesource.com'
+                        '/chromium/src/third_party/blink/web_tests'))
 
   clone_git_repository(tests_directory, 'v8',
                        'https://chromium.googlesource.com/v8/v8')
@@ -285,11 +276,6 @@ def main():
   create_symbolic_link(tests_directory, 'gecko-dev/js/src/tests',
                        'spidermonkey')
   create_symbolic_link(tests_directory, 'ChakraCore/test', 'chakra')
-
-  # FIXME: Find a way to rename LayoutTests to web_tests without breaking
-  # compatibility with older testcases.
-  create_symbolic_link(tests_directory, 'src/third_party/blink/web_tests',
-                       'LayoutTests')
 
   subprocess.check_call(
       [


### PR DESCRIPTION
This uses a copybara mirror of the blink web tests instead of a full Chrome checkout, which is too slow.

Blocked on http://b/366371137