### PR TITLE
Skip the fuzzer output junk for engine fuzzers.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -709,7 +709,7 @@ def store_fuzzer_run_results(testcase_file_paths, fuzzer, fuzzer_command,
   """Store fuzzer run results in database."""
   # Upload fuzzer script output to bucket.
   if not environment.is_engine_fuzzer_job():
-      return
+    return None
   fuzzer_logs.upload_script_log(
       fuzzer_output, signed_upload_url=fuzz_task_input.script_log_upload_url)
 
@@ -773,7 +773,7 @@ def preprocess_store_fuzzer_run_results(fuzz_task_input):
 def postprocess_store_fuzzer_run_results(output):
   """Postprocess store_fuzzer_run_results."""
   if not environment.is_engine_fuzzer_job():
-      return
+    return
   if not output.fuzz_task_output.fuzzer_run_results:
     return
   uworker_input = output.uworker_input

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -708,6 +708,8 @@ def store_fuzzer_run_results(testcase_file_paths, fuzzer, fuzzer_command,
                              generated_testcase_string, fuzz_task_input):
   """Store fuzzer run results in database."""
   # Upload fuzzer script output to bucket.
+  if not environment.is_engine_fuzzer_job():
+      return
   fuzzer_logs.upload_script_log(
       fuzzer_output, signed_upload_url=fuzz_task_input.script_log_upload_url)
 
@@ -718,7 +720,6 @@ def store_fuzzer_run_results(testcase_file_paths, fuzzer, fuzzer_command,
   # 4. Return code is non-zero and was not found before.
   # 5. Testcases generated were fewer than expected in this run and zero return
   #    code did occur before and zero generated testcases didn't occur before.
-  # TODO(mbarbella): Break this up for readability.
   # pylint: disable=consider-using-in
   save_test_results = (
       not fuzzer.result or not fuzzer.result_timestamp or
@@ -759,6 +760,8 @@ def store_fuzzer_run_results(testcase_file_paths, fuzzer, fuzzer_command,
 def preprocess_store_fuzzer_run_results(fuzz_task_input):
   """Does preprocessing for store_fuzzer_run_results. More specifically, gets
   URLs to upload a sample testcase and the logs."""
+  if not environment.is_engine_fuzzer_job():
+    return
   fuzz_task_input.sample_testcase_upload_key = blobs.generate_new_blob_name()
   fuzz_task_input.sample_testcase_upload_url = blobs.get_signed_upload_url(
       fuzz_task_input.sample_testcase_upload_key)
@@ -769,6 +772,8 @@ def preprocess_store_fuzzer_run_results(fuzz_task_input):
 
 def postprocess_store_fuzzer_run_results(output):
   """Postprocess store_fuzzer_run_results."""
+  if not environment.is_engine_fuzzer_job():
+      return
   if not output.fuzz_task_output.fuzzer_run_results:
     return
   uworker_input = output.uworker_input

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
@@ -1490,6 +1490,8 @@ class PreprocessStoreFuzzerRunResultsTest(unittest.TestCase):
     self.mock._sign_url.side_effect = (
         lambda remote_path, method, minutes: remote_path)
     self.mock.get_signed_upload_url.return_value = self.SIGNED_URL
+    helpers.patch_environ(self)
+    os.environ['JOB_NAME'] = 'libfuzzer_chrome_asan'
 
   def test_preprocess_store_fuzzer_run_results(self):
     fuzz_task_input = uworker_msg_pb2.FuzzTaskInput()
@@ -1506,6 +1508,8 @@ class PostprocessStoreFuzzerRunResultsTest(unittest.TestCase):
 
   def test_postprocess_store_fuzzer_run_results(self):
     """Tests postprocess_store_fuzzer_run_results."""
+    helpers.patch_environ(self)
+    os.environ['JOB_NAME'] = 'libfuzzer_chrome_asan'
     fuzzer_name = 'myfuzzer'
     revision = 1
     fuzzer = data_types.Fuzzer(name=fuzzer_name, revision=revision)


### PR DESCRIPTION
It's intended for blackbox fuzzers, it's not needed at all (should probably be deprecated though some chrome folks use it), and seems to be having a hand in the contention breaking parts of oss-fuzz
Mitigates https://github.com/google/clusterfuzz/issues/4238