### PR TITLE
Updating jdk from 15 to 21

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -86,15 +86,14 @@ RUN curl -sS https://releases.nixos.org/patchelf/patchelf-0.9/patchelf-0.9.tar.b
     make install && \
     rm -rf /tmp/patchelf-*
 
-# Install OpenJDK 15 for Jazzer (Java fuzzer).
-# Copied from gcr.io/oss-fuzz-base/base-runner.
-ENV JAVA_HOME=/usr/lib/jvm/java-15-openjdk-amd64
+# Install OpenJDK 21 for Jazzer (Java fuzzer).
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 ENV JVM_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
 ENV PATH=$PATH:$JAVA_HOME/bin
-RUN wget https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz -O /tmp/openjdk-15.0.2_linux-x64_bin.tar.gz && \
+RUN wget https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz -O /tmp/openjdk-21.0.2_linux-x64_bin.tar.gz && \
     cd /tmp && \
     mkdir -p $JAVA_HOME && \
-    tar -xzv --strip-components=1 -f openjdk-15.0.2_linux-x64_bin.tar.gz --directory $JAVA_HOME && \
+    tar -xzv --strip-components=1 -f openjdk-21.0.2_linux-x64_bin.tar.gz --directory $JAVA_HOME && \
     rm -rf openjdk*.tar.gz $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
 
 # Install Python 3.11


### PR DESCRIPTION
We are getting a lot of these exceptions:

```
...
Exception in thread "main" java.lang.UnsupportedClassVersionError: HeaderTokenizerFuzzer has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 59.0
...
```

This attempts to fix issue [12496](https://github.com/google/oss-fuzz/issues/12496)
Evidence that this does install java. Simple standalone dockerfile

```
from ubuntu:16.04 as xenial

RUN apt update && apt install -y wget

ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
ENV JVM_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
ENV PATH=$PATH:$JAVA_HOME/bin
RUN wget https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz -O /tmp/openjdk-21.0.2_linux-x64_bin.tar.gz && \
    cd /tmp && \
    mkdir -p $JAVA_HOME && \
    tar -xzv --strip-components=1 -f openjdk-21.0.2_linux-x64_bin.tar.gz --directory $JAVA_HOME && \
    rm -rf openjdk*.tar.gz $JAVA_HOME/jmods $JAVA_HOME/lib/src.zip
```

```
docker build .
...
Successfully built 42d640a26255
vitorguidi@vitorguidi0:~/Desktop/javatest$ docker run -it 42d640a26255 /bin/bash
root@9cc12e52f918:/# java --version
openjdk 21.0.2 2024-01-16
OpenJDK Runtime Environment (build 21.0.2+13-58)
OpenJDK 64-Bit Server VM (build 21.0.2+13-58, mixed mode, sharing)
root@9cc12e52f918:/# javac --version
javac 21.0.2
```