### PR TITLE
Fix OS custom field updates in Google Issue Tracker

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -96,7 +96,7 @@ def _extract_all_labels(labels: issue_tracker.LabelStore,
 
 def _sanitize_oses(oses: Sequence[str]) -> List[str]:
   """Sanitizes and deduplicates the given OS custom field values."""
-  result = set()
+  deduped = set()
   for os in oses:
     # The OS custom field no longer has the 'Chrome' value.
     # It was replaced by 'ChromeOS'.
@@ -107,9 +107,12 @@ def _sanitize_oses(oses: Sequence[str]) -> List[str]:
     if not os:
       continue
 
-    result.add(os)
+    deduped.add(os)
 
-  return list(result)
+  # Sort the result for deterministic tests.
+  result = list(deduped)
+  result.sort()
+  return result
 
 
 def _extract_label(labels: Sequence[str], prefix: str) -> Optional[str]:

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -103,6 +103,10 @@ def _sanitize_oses(oses: Sequence[str]) -> List[str]:
     if os == 'Chrome':
       os = 'ChromeOS'
 
+    # Skip empty OS values. Workaround for https://crbug.com/366955327.
+    if not os:
+      continue
+
     result.add(os)
 
   return list(result)

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -391,22 +391,17 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call(
             body={
                 'issueState': {
-                    'componentId':
-                        1337,
+                    'componentId': 1337,
                     'ccs': [],
                     'collaborators': [],
                     'hotlistIds': [],
                     'accessLimit': {
                         'accessLevel': issue_tracker.IssueAccessLevel.LIMIT_NONE
                     },
-                    'status':
-                        'NEW',
-                    'title':
-                        'issue title',
-                    'type':
-                        'BUG',
-                    'severity':
-                        'S4',
+                    'status': 'NEW',
+                    'title': 'issue title',
+                    'type': 'BUG',
+                    'severity': 'S4',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -824,22 +819,17 @@ class GoogleIssueTrackerTest(unittest.TestCase):
             issueId='68828938',
             body={
                 'add': {
-                    'customFields': [
-                        {
-                            'customFieldId': '1223084',
-                            'repeatedEnumValue': {
-                                'values': ['Android', 'Linux']
-                            }
-                        },
-                    ],
+                    'customFields': [{
+                        'customFieldId': '1223084',
+                        'repeatedEnumValue': {
+                            'values': ['Android', 'Linux']
+                        }
+                    },],
                 },
-                'addMask':
-                    'customFields',
+                'addMask': 'customFields',
                 'remove': {},
-                'removeMask':
-                    '',
-                'significanceOverride':
-                    'MAJOR',
+                'removeMask': '',
+                'significanceOverride': 'MAJOR',
             },
         ),
         mock.call().execute(http=None, num_retries=3),

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -407,14 +407,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         'BUG',
                     'severity':
                         'S4',
-                    'customFields': [
-                        {
-                            'customFieldId': '1223084',
-                            'repeatedEnumValue': {
-                                'values': []
-                            }
-                        },
-                    ],
                 },
             },
             templateOptions_applyTemplate=True,
@@ -823,6 +815,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue = self.issue_tracker.get_issue(68828938)
     # Adding "empty" OS label here.
     issue.labels.add('OS-')
+    # Also add a real OS label to trigger an API call we can compare against.
+    issue.labels.add('OS-Android')
     issue.save()
 
     self.client.issues().modify.assert_has_calls([
@@ -834,7 +828,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         {
                             'customFieldId': '1223084',
                             'repeatedEnumValue': {
-                                'values': ['Linux']
+                                'values': ['Android', 'Linux']
                             }
                         },
                     ],

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -759,7 +759,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     ])
 
   def test_update_issue_with_empty_os(self):
-    """Test updating an existing issue with OS and FoundIn labels."""
+    """Test updating an existing issue with an "empty" OS label."""
     self.client.issues().get().execute.return_value = {
         'issueId': '68828938',
         'issueState': {

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -357,7 +357,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         {
                             'customFieldId': '1223084',
                             'repeatedEnumValue': {
-                                'values': ['Linux', 'Android']
+                                'values': ['Android', 'Linux']
                             }
                         },
                         {
@@ -380,6 +380,48 @@ class GoogleIssueTrackerTest(unittest.TestCase):
         mock.call().execute(http=None, num_retries=3),
     ])
 
+  def test_new_issue_with_empty_os_label(self):
+    """Test new issue creation with "empty" OS label."""
+    issue = self.issue_tracker.new_issue()
+    issue.status = 'NEW'
+    issue.title = 'issue title'
+    issue.labels.add('OS-')
+    issue.save()
+    self.client.issues().create.assert_has_calls([
+        mock.call(
+            body={
+                'issueState': {
+                    'componentId':
+                        1337,
+                    'ccs': [],
+                    'collaborators': [],
+                    'hotlistIds': [],
+                    'accessLimit': {
+                        'accessLevel': issue_tracker.IssueAccessLevel.LIMIT_NONE
+                    },
+                    'status':
+                        'NEW',
+                    'title':
+                        'issue title',
+                    'type':
+                        'BUG',
+                    'severity':
+                        'S4',
+                    'customFields': [
+                        {
+                            'customFieldId': '1223084',
+                            'repeatedEnumValue': {
+                                'values': []
+                            }
+                        },
+                    ],
+                },
+            },
+            templateOptions_applyTemplate=True,
+        ),
+        mock.call().execute(http=None, num_retries=3),
+    ])
+
   def test_new_issue_with_component_tags(self):
     """Test new issue creation with component tags."""
     self.client.components().get().execute.return_value = {
@@ -393,8 +435,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     issue.body = 'issue body'
     issue.ccs.add('cc@google.com')
     issue.labels.add('12345')
-    issue.labels.add('OS-Linux')
-    issue.labels.add('OS-Android')
     issue.labels.add('FoundIn-123')
     issue.labels.add('FoundIn-789')
     issue.components.add('ABC>DEF')
@@ -434,11 +474,6 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'type':
                         'BUG',
                     'customFields': [{
-                        'customFieldId': '1223084',
-                        'repeatedEnumValue': {
-                            'values': ['Linux', 'Android']
-                        },
-                    }, {
                         'customFieldId': '1222907',
                         'repeatedEnumValue': {
                             'values': ['ABC>DEF', 'Component ABC', 'IJK>XYZ']
@@ -712,7 +747,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         {
                             'customFieldId': '1223084',
                             'repeatedEnumValue': {
-                                'values': ['Linux', 'Android']
+                                'values': ['Android', 'Linux']
                             }
                         },
                         {
@@ -726,6 +761,86 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                 },
                 'addMask':
                     'status,assignee,reporter,title,ccs,customFields,foundInVersions',
+                'remove': {},
+                'removeMask':
+                    '',
+                'significanceOverride':
+                    'MAJOR',
+            },
+        ),
+        mock.call().execute(http=None, num_retries=3),
+    ])
+
+  def test_update_issue_with_empty_os(self):
+    """Test updating an existing issue with OS and FoundIn labels."""
+    self.client.issues().get().execute.return_value = {
+        'issueId': '68828938',
+        'issueState': {
+            'componentId':
+                '29002',
+            'type':
+                'BUG',
+            'customFields': [
+                {
+                    'customFieldId': '1223084',
+                    'repeatedEnumValue': {
+                        'values': ['Linux']  # Existing OS-Linux.
+                    },
+                },
+            ],
+            'status':
+                'NEW',
+            'priority':
+                'P2',
+            'severity':
+                'S2',
+            'title':
+                'test',
+            'reporter': {
+                'emailAddress': 'user1@google.com',
+                'userGaiaStatus': 'ACTIVE'
+            },
+            'assignee': {
+                'emailAddress': 'assignee@google.com',
+                'userGaiaStatus': 'ACTIVE'
+            },
+            'retention':
+                'COMPONENT_DEFAULT',
+        },
+        'createdTime': '2019-06-25T01:29:30.021Z',
+        'modifiedTime': '2019-06-25T01:29:30.021Z',
+        'userData': {},
+        'accessLimit': {
+            'accessLevel': 'INTERNAL'
+        },
+        'etag': 'TmpnNE1qZzVNemd0TUMweA==',
+        'lastModifier': {
+            'emailAddress': 'user1@google.com',
+            'userGaiaStatus': 'ACTIVE'
+        },
+    }
+
+    issue = self.issue_tracker.get_issue(68828938)
+    # Adding "empty" OS label here.
+    issue.labels.add('OS-')
+    issue.save()
+
+    self.client.issues().modify.assert_has_calls([
+        mock.call(
+            issueId='68828938',
+            body={
+                'add': {
+                    'customFields': [
+                        {
+                            'customFieldId': '1223084',
+                            'repeatedEnumValue': {
+                                'values': ['Linux']
+                            }
+                        },
+                    ],
+                },
+                'addMask':
+                    'customFields',
                 'remove': {},
                 'removeMask':
                     '',


### PR DESCRIPTION
Skip empty OS custom fields in API calls to Google Issue Tracker, since those are rejected.
Also deduplicate values while we're at it.

The continuing duplication of code between new issues and updated issues makes me sad,
but this PR does not improve anything on that front.

Fixes: https://crbug.com/366955327
Bug: https://crbug.com/367205692