### PR TITLE
remove the unnecessary free disk space limit

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -1145,7 +1145,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
         24 * 1024 * 1024 * 1024,
     ]
 
-    size = 1 * 1024 * 1024 * 1024  # 1 GB
+    size = 10 * 1024 * 1024 * 1024  # 10 GB
     self.assertTrue(build_manager._make_space(size, '/builds/build4'))
 
     self.assertTrue(os.path.isdir('/builds/build1'))
@@ -1162,7 +1162,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
         12 * 1024 * 1024 * 1024,
     ]
 
-    size = 1 * 1024 * 1024 * 1024  # 1 GB
+    size = 10 * 1024 * 1024 * 1024  # 10 GB
     self.assertTrue(build_manager._make_space(size, '/builds/build4'))
 
     self.assertTrue(os.path.isdir('/builds/build1'))
@@ -1180,7 +1180,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
         14 * 1024 * 1024 * 1024,
     ]
 
-    size = 1 * 1024 * 1024 * 1024  # 1 GB
+    size = 10 * 1024 * 1024 * 1024  # 10 GB
     self.assertTrue(build_manager._make_space(size, '/builds/build4'))
 
     self.assertFalse(os.path.isdir('/builds/build1'))
@@ -1195,10 +1195,10 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
         12 * 1024 * 1024 * 1024,
         17 * 1024 * 1024 * 1024,
         18 * 1024 * 1024 * 1024,
-        24 * 1024 * 1024 * 1024,
+        19 * 1024 * 1024 * 1024,
     ]
 
-    size = 20 * 1024 * 1024 * 1024  # 1 GB
+    size = 20 * 1024 * 1024 * 1024  # 20 GB
     self.assertFalse(build_manager._make_space(size, '/builds/build4'))
 
     self.assertFalse(os.path.isdir('/builds/build1'))
@@ -1217,7 +1217,7 @@ class BuildEvictionTests(fake_filesystem_unittest.TestCase):
         18 * 1024 * 1024 * 1024,
     ]
 
-    size = 20 * 1024 * 1024 * 1024  # 1 GB
+    size = 20 * 1024 * 1024 * 1024  # 20 GB
     self.assertFalse(build_manager._make_space(size, '/builds/build4'))
 
 


### PR DESCRIPTION
With Chromium archive sizes and extracted size being bigger, we cannot afford the 10GB surplus for the build directory.