### PR TITLE
Fix FileExistsError

### DIFF
--- a/src/clusterfuzz/_internal/bot/untrusted_runner/file_host.py
+++ b/src/clusterfuzz/_internal/bot/untrusted_runner/file_host.py
@@ -176,8 +176,7 @@ def copy_directory_from_worker(worker_directory, host_directory, replace=False):
       return False
 
     host_file_directory = os.path.dirname(host_file_path)
-    if not os.path.exists(host_file_directory):
-      os.makedirs(host_file_directory)
+    os.makedirs(host_file_directory, exist_ok=True)
 
     if not copy_file_from_worker(worker_file_path, host_file_path):
       logs.warning('Failed to copy %s from worker.' % worker_file_path)


### PR DESCRIPTION
There seems to be a race condition where the existence of a directory is checked and if it doesn't exist it is created. But somehow this directory is getting created in between these two steps. Maybe it is because of multiple processes running on hosts. Replace check with exist_ok=True.

Fixes: https://pantheon.corp.google.com/errors/detail/CO_5v-P9kpbcoQE;locations=global?e=-13802955&mods=logs_tg_prod&project=clusterfuzz-external