### PR TITLE
Skip appending 'next' to target.

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -58,6 +58,8 @@ PRODUCT_TO_KERNEL = {
 
 RELEASE_CONFIGURATION = 'next'
 
+NO_RELEASE_CONFIGURATION_TARGET_LIST = ['shiba_fullmte', 'husky_fullmte']
+
 DEPRECATED_DEVICE_LIST = [
     'sailfish',  # Pixel
     'marlin',  # Pixel XL

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -141,7 +141,8 @@ def download_system_symbols_if_needed(symbols_directory):
   build_id = build_params.get('build_id')
   target = build_params.get('target')
   build_type = build_params.get('type')
-  if environment.is_android():
+  if environment.is_android(
+  ) and target not in constants.NO_RELEASE_CONFIGURATION_TARGET_LIST:
     build_type = constants.RELEASE_CONFIGURATION + '-' + build_type
   if not build_id or not target or not build_type:
     logs.error('Null build parameters found, exiting.')


### PR DESCRIPTION
Avoid appending 'next-' to 'shiba_fullmte' and 'husky_fullmte' target to prevent inaccurate querying of AB/API.