### PR TITLE
google_issue_tracker: support configurable URLs.

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -30,7 +30,6 @@ from clusterfuzz._internal.issue_management.google_issue_tracker import client
 from clusterfuzz._internal.metrics import logs
 
 _NUM_RETRIES = 3
-_ISSUE_TRACKER_URL = 'https://issues.chromium.org/issues'
 
 # TODO: Make these configuration settings instead of hardcoded values in code.
 # These custom fields use repeated enums.
@@ -951,6 +950,7 @@ class IssueTracker(issue_tracker.IssueTracker):
     self._client = http_client
     self._default_component_id = config['default_component_id']
     self._type = config['type'] if hasattr(config, 'type') else None
+    self._url = config['url']
 
   @property
   def client(self):
@@ -1062,13 +1062,13 @@ class IssueTracker(issue_tracker.IssueTracker):
 
   def find_issues_url(self, keywords=None, only_open=None):
     """Finds issues (web URL)."""
-    return (_ISSUE_TRACKER_URL + '?' + urllib.parse.urlencode({
+    return (self._url + '?' + urllib.parse.urlencode({
         'q': _get_query(keywords, only_open),
     }))
 
   def issue_url(self, issue_id):
     """Returns the issue URL with the given ID."""
-    return _ISSUE_TRACKER_URL + '/' + str(issue_id)
+    return self._url + '/' + str(issue_id)
 
   @property
   def label_type(self):

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -499,6 +499,7 @@ class IssueFilerTests(unittest.TestCase):
         'type': 'google_issue_tracker',
         'default_component_id': '1234567890',
         'component_id': '123',
+        'url': 'https://issues.chromium.org/issues',
     }
     exp_issue_id = 68828938
     self.mock._execute.return_value = {

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -29,6 +29,7 @@ EXTENSION_FIELDS = {
 TEST_CONFIG = {
     'default_component_id': 1337,
     'type': 'google-issue-tracker',
+    'url': 'https://issues.chromium.org/issues',
 }
 
 BASIC_ISSUE = {

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
@@ -90,8 +90,8 @@ class IssueTrackerUtilsUrlTest(unittest.TestCase):
     ])
     self.mock.get.return_value = {
         'type': 'google_issue_tracker',
-        'default_component_id': 123
-        'url': 'https://issues.chromium.org/issues'
+        'default_component_id': 123,
+        'url': 'https://issues.chromium.org/issues',
     }
     self.mock._get_issue_tracker_manager_for_project.return_value = 'test_icm'
     issue_tracker_utils._ISSUE_TRACKER_CONSTRUCTORS = {

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/issue_tracker_utils_test.py
@@ -91,6 +91,7 @@ class IssueTrackerUtilsUrlTest(unittest.TestCase):
     self.mock.get.return_value = {
         'type': 'google_issue_tracker',
         'default_component_id': 123
+        'url': 'https://issues.chromium.org/issues'
     }
     self.mock._get_issue_tracker_manager_for_project.return_value = 'test_icm'
     issue_tracker_utils._ISSUE_TRACKER_CONSTRUCTORS = {


### PR DESCRIPTION
OSS-Fuzz needs something different to avoid an unnecessary redirect.