### PR TITLE
[build_manager] add support for remote zip

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
@@ -132,15 +132,15 @@ class ChromeBuildArchiveSelectiveUnpack(unittest.TestCase):
     test_helpers.patch(self, [
         'clusterfuzz._internal.system.archive.ArchiveReader',
         'clusterfuzz._internal.system.archive.open',
-        'clusterfuzz._internal.bot.fuzzers.utils.is_fuzz_target_local',
+        'clusterfuzz._internal.bot.fuzzers.utils.is_fuzz_target',
     ])
     self.mock.open.return_value.list_members.return_value = []
-    self.mock.is_fuzz_target_local.side_effect = self._mock_is_fuzz_target_local
+    self.mock.is_fuzz_target.side_effect = self._mock_is_fuzz_target
     self.build = build_archive.ChromeBuildArchive(self.mock.open.return_value)
     self._declared_fuzzers = []
     self.maxDiff = None
 
-  def _mock_is_fuzz_target_local(self, target, _=None):
+  def _mock_is_fuzz_target(self, target, _=None):
     target = os.path.basename(target)
     return target in self._declared_fuzzers
 

--- a/src/clusterfuzz/fuzz/__init__.py
+++ b/src/clusterfuzz/fuzz/__init__.py
@@ -42,9 +42,9 @@ def get_engine(name):
   return engine_impl
 
 
-def is_fuzz_target(file_path, file_handle=None):
+def is_fuzz_target(file_path, file_opener=None):
   """Returns whether |file_path| is a fuzz target."""
-  return utils.is_fuzz_target_local(file_path, file_handle)
+  return utils.is_fuzz_target(file_path, file_opener)
 
 
 def get_fuzz_targets(directory):


### PR DESCRIPTION
This adds support for remote ZIP.

As of now, performances are quite good locally, and the read ahead mechanism should keep reasonable performance. Also, given that the ClusterFuzz bots are having HDD, numbers might even be better there, as we're only storing on disk when unpacking the build.

The memory consumption of this new feature is contant: it uses at most (and most of the time) 50 MB of RAM.