### PR TITLE
Fix autohealing policy update logic.

### DIFF
--- a/src/clusterfuzz/_internal/cron/manage_vms.py
+++ b/src/clusterfuzz/_internal/cron/manage_vms.py
@@ -21,6 +21,7 @@ import json
 import logging
 
 from google.cloud import ndb
+from tuping import Optional
 
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.config import local_config
@@ -156,6 +157,31 @@ def _template_needs_update(current_template, new_template, resource_name):
   return False
 
 
+def _update_auto_healing_policy(
+    instance_group: bot_manager.InstanceGroup,
+    new_policy: Optional[compute_engine_projects.AutoHealingPolicy]):
+  # Check if needs to update health check URL in autoHealingPolicies.
+  old_policy = None
+  old_policies = instance_group_body.get('autoHealingPolicies')
+  if old_policies:
+    old_policy = compute_engine_projects.AutoHealingPolicy(
+        health_check=old_policies[0].get('healthCheck'),
+        initial_delay_sec=old_policies[0].get('initialDelaySec'))
+
+  if old_policy == new_policy:
+    return
+
+  logging.info('Updating auto-healing policy from ' +
+               f'{repr(old_policy)} to {repr(new_policy)}')
+
+  try:
+    instance_group.patch_auto_healing_policies(
+        auto_healing_policy=new_policy.to_json_dict(), wait_for_instances=False)
+  except bot_manager.OperationError as e:
+    logging.error('Failed to patch auto-healing policies for instance group ' +
+                  f'{instance_group["name"]}: {e}')
+
+
 class ClustersManager:
   """Manager for clusters in a project."""
 
@@ -253,49 +279,7 @@ class ClustersManager:
         else:
           logging.info('No instance group size changes needed.')
 
-        # Check if needs to update autoHealingPolicies.
-        auto_healing_policy = {}
-        # Check if needs to update health check URL in autoHealingPolicies.
-        old_url = instance_group_body.get('auto_healing_policy',
-                                          {}).get('health_check')
-        new_url = cluster.auto_healing_policy.get('health_check')
-
-        if new_url != old_url:
-          logging.info(
-              'Updating the health check URL in auto_healing_policy'
-              'of instance group %s from %s to %s.', resource_name, old_url,
-              new_url)
-          auto_healing_policy['healthCheck'] = new_url
-
-        # Check if needs to update initial delay in autoHealingPolicies.
-        old_delay = instance_group_body.get('auto_healing_policy',
-                                            {}).get('initial_delay_sec')
-        new_delay = cluster.auto_healing_policy.get('initial_delay_sec')
-
-        if new_delay != old_delay:
-          logging.info(
-              'Updating the health check initial delay in auto_healing_policy'
-              'of instance group %s from %s seconds to %s seconds.',
-              resource_name, old_delay, new_delay)
-          auto_healing_policy['initialDelaySec'] = new_delay
-
-        # Send one request to update either or both if needed
-        if auto_healing_policy:
-          if new_url is None or new_delay is None:
-            auto_healing_policy = {}
-            if new_url is not None or new_delay is not None:
-              logging.warning(
-                  'Deleting auto_healing_policy '
-                  'because its two values (health_check, initial_delay_sec) '
-                  'should never exist independently: (%s, %s)', new_url,
-                  new_delay)
-          try:
-            instance_group.patch_auto_healing_policies(
-                auto_healing_policy=auto_healing_policy,
-                wait_for_instances=False)
-          except bot_manager.OperationError as e:
-            logging.error('Failed to create instance group %s: %s',
-                          resource_name, str(e))
+        _update_auto_healing_policy(instance_group, cluster.auto_healing_policy)
         return
 
     if template_needs_update:

--- a/src/clusterfuzz/_internal/cron/manage_vms.py
+++ b/src/clusterfuzz/_internal/cron/manage_vms.py
@@ -158,9 +158,8 @@ def _template_needs_update(current_template, new_template, resource_name):
 
 
 def _update_auto_healing_policy(
-    instance_group: bot_manager.InstanceGroup,
+    instance_group: bot_manager.InstanceGroup, instance_group_body,
     new_policy: Optional[compute_engine_projects.AutoHealingPolicy]):
-  # Check if needs to update health check URL in autoHealingPolicies.
   old_policy_dict = None
   policies = instance_group_body.get('autoHealingPolicies')
   if policies:
@@ -169,8 +168,8 @@ def _update_auto_healing_policy(
   new_policy_dict = None
   if new_policy is not None:
     new_policy_dict = {
-        "healthCheck": new_policy.health_check,
-        "initialDelaySec": new_policy.initial_delay_sec,
+        'healthCheck': new_policy.health_check,
+        'initialDelaySec': new_policy.initial_delay_sec,
     }
 
   if new_policy_dict == old_policy_dict:
@@ -184,7 +183,7 @@ def _update_auto_healing_policy(
         auto_healing_policy=new_policy_dict, wait_for_instances=False)
   except bot_manager.OperationError as e:
     logging.error('Failed to patch auto-healing policies for instance group ' +
-                  f'{instance_group["name"]}: {e}')
+                  f'{instance_group.name}: {e}')
 
 
 class ClustersManager:

--- a/src/clusterfuzz/_internal/google_cloud_utils/compute_engine_projects.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/compute_engine_projects.py
@@ -15,6 +15,7 @@
 
 from collections import namedtuple
 import dataclasses
+import logging
 import os
 from typing import Any
 from typing import Dict
@@ -84,10 +85,10 @@ class AutoHealingPolicy:
 
     if health_check is None or initial_delay_sec is None:
       logging.warning(
-          'Ignoring auto_healing_policy ' +
-          'because its two values (health_check, initial_delay_sec) ' +
-          'should never exist independently: ' +
-          f'({health_check}, {initial_delay_sec})')
+          'Ignoring auto_healing_policy '
+          'because its two values (health_check, initial_delay_sec) '
+          'should never exist independently: (%s, %s)', health_check,
+          initial_delay_sec)
       return None
 
     assert isinstance(health_check, str), repr(health_check)

--- a/src/clusterfuzz/_internal/google_cloud_utils/compute_engine_projects.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/compute_engine_projects.py
@@ -95,13 +95,6 @@ class AutoHealingPolicy:
 
     return cls(health_check=health_check, initial_delay_sec=initial_delay_sec)
 
-  def to_json_dict(self) -> Dict[str, Any]:
-    """Returns this policy as an API-compatible dict."""
-    return {
-        "healthCheck": self.health_check,
-        "initialDelaySec": self.initial_delay_sec,
-    }
-
 
 def _process_instance_template(instance_template):
   """Process instance template, normalizing some of metadata key values."""


### PR DESCRIPTION
There are two logic fixes:

1. API field names are in `camelCase`, not `snake_case`.
2. Previously, we would treat trying to update a single field as an error and delete the policy.
   It is only an error to *supply* a single field in the config, but we may legitimately find a single field needs updating.

Also moved config validation to loading time. It would likely be best to explode if the auto-healing policy in the config has a single field set, instead of ignoring it with a warning, but this preserves behavior for now.