### PR TITLE
Instrumenting cronjob exit codes

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -116,9 +116,9 @@ class _FlusherThread(threading.Thread):
 
     should_stop = False
     while True:
-      # Make sure there are no metrics left to flush after monitor.stop() is called
+      # Make sure there are no metrics left to flush after monitor.stop()
       if self.stop_event.wait(FLUSH_INTERVAL_SECONDS):
-          should_stop = True
+        should_stop = True
       try:
         time_series = []
         end_time = time.time()

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -100,6 +100,37 @@ class _MockMetric:
 def _time_series_sort_key(ts):
   return ts.points[-1].interval.start_time
 
+def flush_metrics():
+  project_path = _monitoring_v3_client.common_project_path(  # pylint: disable=no-member
+      utils.get_application_id())
+  try:
+    time_series = []
+    end_time = time.time()
+    for metric, labels, start_time, value in _metrics_store.iter_values():
+      if (metric.metric_kind == metric_pb2.MetricDescriptor.MetricKind.GAUGE  # pylint: disable=no-member
+          ):
+        start_time = end_time
+
+      series = _TimeSeries()
+      metric.monitoring_v3_time_series(series, labels, start_time, end_time,
+                                        value)
+      time_series.append(series)
+
+      if len(time_series) == MAX_TIME_SERIES_PER_CALL:
+        time_series.sort(key=_time_series_sort_key)
+        _create_time_series(project_path, time_series)
+        time_series = []
+
+    if time_series:
+      time_series.sort(key=_time_series_sort_key)
+      _create_time_series(project_path, time_series)
+  except Exception as e:
+    if environment.is_android():
+      # FIXME: This exception is extremely common on Android. We are already
+      # aware of the problem, don't make more noise about it.
+      logs.warning(f'Failed to flush metrics: {e}')
+    else:
+      logs.error(f'Failed to flush metrics: {e}')
 
 class _FlusherThread(threading.Thread):
   """Flusher thread."""
@@ -111,42 +142,12 @@ class _FlusherThread(threading.Thread):
 
   def run(self):
     """Run the flusher thread."""
-    project_path = _monitoring_v3_client.common_project_path(  # pylint: disable=no-member
-        utils.get_application_id())
-
     should_stop = False
     while True:
       # Make sure there are no metrics left to flush after monitor.stop()
       if self.stop_event.wait(FLUSH_INTERVAL_SECONDS):
         should_stop = True
-      try:
-        time_series = []
-        end_time = time.time()
-        for metric, labels, start_time, value in _metrics_store.iter_values():
-          if (metric.metric_kind == metric_pb2.MetricDescriptor.MetricKind.GAUGE  # pylint: disable=no-member
-             ):
-            start_time = end_time
-
-          series = _TimeSeries()
-          metric.monitoring_v3_time_series(series, labels, start_time, end_time,
-                                           value)
-          time_series.append(series)
-
-          if len(time_series) == MAX_TIME_SERIES_PER_CALL:
-            time_series.sort(key=_time_series_sort_key)
-            _create_time_series(project_path, time_series)
-            time_series = []
-
-        if time_series:
-          time_series.sort(key=_time_series_sort_key)
-          _create_time_series(project_path, time_series)
-      except Exception as e:
-        if environment.is_android():
-          # FIXME: This exception is extremely common on Android. We are already
-          # aware of the problem, don't make more noise about it.
-          logs.warning(f'Failed to flush metrics: {e}')
-        else:
-          logs.error(f'Failed to flush metrics: {e}')
+      flush_metrics()
       if should_stop:
         return
 
@@ -564,7 +565,7 @@ def _time_to_timestamp(interval, attr, time_seconds):
   setattr(interval, attr, timestamp)
 
 
-def initialize():
+def initialize(use_flusher_thread=True):
   """Initialize if monitoring is enabled for this bot."""
   global _monitoring_v3_client
   global _flusher_thread
@@ -579,14 +580,17 @@ def initialize():
     _initialize_monitored_resource()
     _monitoring_v3_client = monitoring_v3.MetricServiceClient(
         credentials=credentials.get_default()[0])
-    _flusher_thread = _FlusherThread()
-    _flusher_thread.start()
+    if use_flusher_thread:
+      _flusher_thread = _FlusherThread()
+      _flusher_thread.start()
 
 
 def stop():
   """Stops monitoring and cleans up (only if monitoring is enabled)."""
   if _flusher_thread:
     _flusher_thread.stop()
+  if not _flusher_thread and check_module_loaded(monitoring_v3):
+    flush_metrics()
 
 
 def metrics_store():

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -100,7 +100,9 @@ class _MockMetric:
 def _time_series_sort_key(ts):
   return ts.points[-1].interval.start_time
 
+
 def flush_metrics():
+  """Flushes all metrics stored in _metrics_store"""
   project_path = _monitoring_v3_client.common_project_path(  # pylint: disable=no-member
       utils.get_application_id())
   try:
@@ -108,12 +110,12 @@ def flush_metrics():
     end_time = time.time()
     for metric, labels, start_time, value in _metrics_store.iter_values():
       if (metric.metric_kind == metric_pb2.MetricDescriptor.MetricKind.GAUGE  # pylint: disable=no-member
-          ):
+         ):
         start_time = end_time
 
       series = _TimeSeries()
       metric.monitoring_v3_time_series(series, labels, start_time, end_time,
-                                        value)
+                                       value)
       time_series.append(series)
 
       if len(time_series) == MAX_TIME_SERIES_PER_CALL:
@@ -131,6 +133,7 @@ def flush_metrics():
       logs.warning(f'Failed to flush metrics: {e}')
     else:
       logs.error(f'Failed to flush metrics: {e}')
+
 
 class _FlusherThread(threading.Thread):
   """Flusher thread."""

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -209,5 +209,4 @@ CLUSTERFUZZ_CRON_EXIT_CODE = monitor.GaugeMetric(
     description='Tracks successful completion of cronjobs',
     field_spec=[
         monitor.StringField('cron_name'),
-    ]
-)
+    ])

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -200,3 +200,14 @@ ANDROID_UPTIME = monitor.CounterMetric(
         monitor.StringField('platform'),
     ],
 )
+
+# Cron metrics
+
+# 0 value means healthy, 1 unhealthy
+CLUSTERFUZZ_CRON_EXIT_CODE = monitor.GaugeMetric(
+    'clusterfuzz_cron_exit_code',
+    description='Tracks successful completion of cronjobs',
+    field_spec=[
+        monitor.StringField('cron_name'),
+    ]
+)

--- a/src/python/bot/startup/run_cron.py
+++ b/src/python/bot/startup/run_cron.py
@@ -57,7 +57,7 @@ def main():
   except ImportError:
     pass
 
-  monitor.initialize()
+  monitor.initialize(use_flusher_thread=False)
 
   task = sys.argv[1]
 

--- a/src/python/bot/startup/run_cron.py
+++ b/src/python/bot/startup/run_cron.py
@@ -63,24 +63,27 @@ def main():
 
   task_module_name = f'clusterfuzz._internal.cron.{task}'
   labels = {
-    'cron_name': task,
+      'cron_name': task,
   }
-  
+
+  return_code = 0
+
   with ndb_init.context():
     task_module = importlib.import_module(task_module_name)
     exception = None
-    return_code = 0
     try:
       return_code = 0 if task_module.main() else 1
     except Exception as e:
       return_code = 1
       exception = e
     finally:
-      monitoring_metrics.CLUSTERFUZZ_CRON_EXIT_CODE.set(return_code, labels=labels)
+      monitoring_metrics.CLUSTERFUZZ_CRON_EXIT_CODE.set(
+          return_code, labels=labels)
       monitor.stop()
       if exception:
         raise exception
-      return return_code
+
+  return return_code
 
 
 if __name__ == '__main__':

--- a/src/python/bot/startup/run_cron.py
+++ b/src/python/bot/startup/run_cron.py
@@ -27,6 +27,8 @@ import sys
 from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.datastore import ndb_init
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.metrics import monitor
+from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.system import environment
 
 
@@ -55,12 +57,30 @@ def main():
   except ImportError:
     pass
 
+  monitor.initialize()
+
   task = sys.argv[1]
 
   task_module_name = f'clusterfuzz._internal.cron.{task}'
+  labels = {
+    'cron_name': task,
+  }
+  
   with ndb_init.context():
     task_module = importlib.import_module(task_module_name)
-    return 0 if task_module.main() else 1
+    exception = None
+    return_code = 0
+    try:
+      return_code = 0 if task_module.main() else 1
+    except Exception as e:
+      return_code = 1
+      exception = e
+    finally:
+      monitoring_metrics.CLUSTERFUZZ_CRON_EXIT_CODE.set(return_code, labels=labels)
+      monitor.stop()
+      if exception:
+        raise exception
+      return return_code
 
 
 if __name__ == '__main__':

--- a/src/python/bot/startup/run_cron.py
+++ b/src/python/bot/startup/run_cron.py
@@ -57,6 +57,8 @@ def main():
   except ImportError:
     pass
 
+  # Few metrics get collected per job run, so
+  # no need for a thread to continuously push those
   monitor.initialize(use_flusher_thread=False)
 
   task = sys.argv[1]


### PR DESCRIPTION
### Motivation

Kubernetes signals that cronjobs fail, after retries, through [events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/).

GKE does not make it easy to alert on this failure mode. For cronjobs without retries, the failure will be evident in the GCP panel. For cronjobs with retries, there will be a success indicator for the last successful cronjob, and the failure will be registered under the events panel.

### Alternatives considered

Options available to monitor failing cronjobs are:

- the container/restart_count metric, from [GKE](https://cloud.google.com/monitoring/api/metrics_kubernetes). This will be flaky, since a job might succeed on the third attempt. Also, it is not easy to pinpoint the cronjob, since we get the container name as a label
- alert on a log based metric from the cluster events. The output of kubectl get events gets dumped to cloud logging, so we can create a metric on events of the form "Saw completed job: oss-fuzz-apply-ccs-28786460, status: Failed". However this requires regex manipulation, has to be manually applied across all projects, and also makes it hard to derive the failing cronjob from the container name. It also adds a hard dependency on kubernetes.

### Solution

The proposed solution is to reuse the builtin clusterfuzz metrics implementation, and add a gauge metric CLUSTERFUZZ_CRON_EXIT_CODE, with the cron name as a label.

 If the metric is at 1, then the cronjob is unhealthy, otherwise it is healthy. An alert must be set for when it reaches the 1 state, for every label.
 
 Since cronjobs are ephemeral, there is no need for a thread to continuously flush metrics. The option to use monitoring without a flushing thread was added. The same approach can be used to fix metrics for swarming/batch.
 
 Also, the flusher thread was changed to make sure that leftover metrics are flushed before it stops.
 
 Note: this PR is part of this [initiative](https://github.com/google/clusterfuzz/issues/4271)