### PR TITLE
Pointing k8s cronjobs to the prod code release and a non hacky docker image

### DIFF
--- a/infra/k8s/backup.yaml
+++ b/infra/k8s/backup.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: backup
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py backup"
             - name: IS_K8S_ENV

--- a/infra/k8s/batch-fuzzer-jobs.yaml
+++ b/infra/k8s/batch-fuzzer-jobs.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: batch-fuzzer-jobs
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py batch_fuzzer_jobs"
             - name: IS_K8S_ENV

--- a/infra/k8s/build-crash-stats.yaml
+++ b/infra/k8s/build-crash-stats.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: build-crash-stats
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py build_crash_stats"
             - name: IS_K8S_ENV

--- a/infra/k8s/fuzz-strategy-selection.yaml
+++ b/infra/k8s/fuzz-strategy-selection.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: fuzz-strategy-selection
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py fuzz_strategy_selection"
             - name: IS_K8S_ENV

--- a/infra/k8s/fuzzer-and-job-weights.yaml
+++ b/infra/k8s/fuzzer-and-job-weights.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: fuzzer-and-job-weights
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py fuzzer_and_job_weights"
             - name: IS_K8S_ENV

--- a/infra/k8s/load-bigquery-stats.yaml
+++ b/infra/k8s/load-bigquery-stats.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: load-bigquery-stats
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py load_bigquery_stats"
             - name: IS_K8S_ENV

--- a/infra/k8s/manage-vms.yaml
+++ b/infra/k8s/manage-vms.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: manage-vms
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py manage_vms"
             - name: IS_K8S_ENV

--- a/infra/k8s/schedule-corpus-pruning.yaml
+++ b/infra/k8s/schedule-corpus-pruning.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: schedule-corpus-pruning
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py schedule_corpus_pruning"
             - name: IS_K8S_ENV

--- a/infra/k8s/schedule-progression-tasks.yaml
+++ b/infra/k8s/schedule-progression-tasks.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: schedule-progression-tasks
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py schedule_progression_tasks"
             - name: IS_K8S_ENV

--- a/infra/k8s/sync-admins.yaml
+++ b/infra/k8s/sync-admins.yaml
@@ -26,11 +26,11 @@ spec:
         spec:
           containers:
           - name: sync-admins
-            image: gcr.io/clusterfuzz-images/base:vguidi_py311_testing_v1
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
             imagePullPolicy: Always
             env:
             - name: CLUSTERFUZZ_RELEASE
-              value: "candidate"
+              value: "prod"
             - name: RUN_CMD
               value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py sync_admins"
             - name: IS_K8S_ENV


### PR DESCRIPTION
Docker images were temporarily set to vguidi_py311_testing_v1 to execute the migration process for 311.

This PR sets it to a proper tag, and makes the cronjobs pull from the production release instead of k8s.

This operation should not touch the clusterfuzz source code repository, we need to move these resources to an internal config repo (and kill butler deploy for kubernetes resources, swap for argo)