### PR TITLE
Swapping pod_name for instance_id in monitored_resource_pb2

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -550,12 +550,13 @@ def _initialize_monitored_resource():
   _monitored_resource.labels['project_id'] = utils.get_application_id()
 
   # Use bot name here instance as that's more useful to us.
+  # In case it is in Kubernetes, we use the pod name
   if environment.is_running_on_k8s():
-    pod_name = environment.get_value('HOSTNAME')
-    _monitored_resource.labels['pod_name'] = pod_name
+    instance_name = environment.get_value('HOSTNAME')
   else:
-    bot_name = environment.get_value('BOT_NAME')
-    _monitored_resource.labels['instance_id'] = bot_name
+    instance_name = environment.get_value('BOT_NAME')
+  _monitored_resource.labels['instance_id'] = instance_name
+
   if compute_metadata.is_gce():
     # Returned in the form projects/{id}/zones/{zone}
     zone = compute_metadata.get('instance/zone').split('/')[-1]


### PR DESCRIPTION
This PR fixes this error
![image](https://github.com/user-attachments/assets/72c1edea-1d2f-4be0-976c-1543ab9f15be)

the monitoring resource class demands instance_id as label, not really flexible
https://ethanbao.readthedocs.io/en/latest/google.api.monitored_resource_pb2.html