### PR TITLE
Add index for an improved test-syncer query

### DIFF
--- a/src/appengine/index.yaml
+++ b/src/appengine/index.yaml
@@ -526,6 +526,14 @@ indexes:
     - name: open
     - name: one_time_crasher_flag
 
+- kind: Testcase
+  properties:
+  - name: open
+  - name: status
+  - name: timestamp
+    direction: desc
+  - name: bug_information
+
 - kind: _AE_Pipeline_Record
   properties:
   - name: is_root_pipeline


### PR DESCRIPTION
This prepares relanding a more efficient query to the tests-syncer that also pre-filters the bug information. When testing the new query locally, gae suggests this index to serve the query.

Context: http://b/365801496