### PR TITLE
Revert "Update get_battery_level_and_temperature() (#4280)"

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/battery.py
+++ b/src/clusterfuzz/_internal/platforms/android/battery.py
@@ -14,6 +14,7 @@
 """Battery functions."""
 
 import datetime
+import re
 import time
 
 from clusterfuzz._internal.base import dates
@@ -36,22 +37,22 @@ LAST_BATTERY_CHECK_TIME_KEY = 'android_last_battery_check'
 
 def get_battery_level_and_temperature():
   """Return device's battery and temperature levels."""
+  output = adb.run_shell_command(['dumpsys', 'battery'])
 
   # Get battery level.
-  m_battery_level = adb.run_shell_command(['cmd', 'battery', 'get', 'level'])
+  m_battery_level = re.match(r'.*level: (\d+).*', output, re.DOTALL)
   if not m_battery_level:
     logs.error('Error occurred while getting battery status.')
     return None
 
   # Get battery temperature.
-  m_battery_temperature = adb.run_shell_command(
-      ['cmd', 'battery', 'get', 'temp'])
+  m_battery_temperature = re.match(r'.*temperature: (\d+).*', output, re.DOTALL)
   if not m_battery_temperature:
     logs.error('Error occurred while getting battery temperature.')
     return None
 
-  level = int(m_battery_level)
-  temperature = float(m_battery_temperature) / 10.0
+  level = int(m_battery_level.group(1))
+  temperature = float(m_battery_temperature.group(1)) / 10.0
   return {'level': level, 'temperature': temperature}
 
 


### PR DESCRIPTION
A new error group showed up, with the following error:

```
ValueError: invalid literal for int() with base 10: 'E1002 02:47:01.282331199 2716078 ev_epoll1_linux.cc:378] epoll_ctl failed: Invalid argument\n80'

at .get_battery_level_and_temperature ( /home/android-test/3A110DLJH003MB/3A110DLJH003MB/3A110DLJH003MB/bot/clusterfuzz/src/clusterfuzz/_internal/platforms/android/battery.py:53 )
at .wait_until_good_state ( /home/android-test/3A110DLJH003MB/3A110DLJH003MB/3A110DLJH003MB/bot/clusterfuzz/src/clusterfuzz/_internal/platforms/android/battery.py:84 )
at .run ( /home/android-test/3A110DLJH003MB/3A110DLJH003MB/3A110DLJH003MB/bot/clusterfuzz/src/clusterfuzz/_internal/bot/init_scripts/android.py:54 )
at .run_platform_init_scripts ( /home/android-test/3A110DLJH003MB/3A110DLJH003MB/3A110DLJH003MB/bot/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/update_task.py:178 )
at .run ( /home/android-test/3A110DLJH003MB/3A110DLJH003MB/3A110DLJH003MB/bot/clusterfuzz/src/clusterfuzz/_internal/bot/tasks/update_task.py:369 )
```

This seems like a transient one, but I would rather revert this and handle this failure gracefully, to avoid confusion in the codebase