### PR TITLE
Fix oss-fuzz failed build issue filing

### DIFF
--- a/src/clusterfuzz/_internal/cron/oss_fuzz_build_status.py
+++ b/src/clusterfuzz/_internal/cron/oss_fuzz_build_status.py
@@ -161,6 +161,9 @@ def close_bug(issue_tracker, issue_id, project_name):
             (project_name, issue_id))
 
   issue = issue_tracker.get_original_issue(issue_id)
+  if issue is None:
+    logs.error(f'Failed to fetch issue {issue_id}, not closing')
+    return
   issue.status = 'Verified'
   issue.save(
       new_comment='The latest build has succeeded, closing this issue.',


### PR DESCRIPTION
We are getting a 403 from buganizer while trying to disclose a 2006 bug, which leads to the issue object to return as None and have the status field be accessed, which leads to a fatal exception. This PR fixes this in order to resolve [issue 12536](https://github.com/google/oss-fuzz/issues/12536).

Error trace:
![image](https://github.com/user-attachments/assets/00ff130a-0339-4206-81b4-89b91fc8f118)

This MIGHT lead to build failures being erased from datastore and tickets remaining open, so it is good to take note on what bugs are failing to fetch from buganizer.
