### PR TITLE
Marking closed build issues as Fixed to avoid having a verifier/assignee

### DIFF
--- a/src/clusterfuzz/_internal/cron/oss_fuzz_build_status.py
+++ b/src/clusterfuzz/_internal/cron/oss_fuzz_build_status.py
@@ -161,7 +161,7 @@ def close_bug(issue_tracker, issue_id, project_name):
             (project_name, issue_id))
 
   issue = issue_tracker.get_original_issue(issue_id)
-  issue.status = 'Verified'
+  issue.status = 'Fixed'
   issue.save(
       new_comment='The latest build has succeeded, closing this issue.',
       notify=True)


### PR DESCRIPTION
While trying to close bugs through the oss-fuzz-build-stats cron, we get a 400 reply from buganizer complaining about invalid input. This boils down to:

```
[redacted] Issues with status VERIFIED must have an assignee, Issues with status VERIFIED must have a verifier
```

To avoid this, we change these to be fixed instead.