### PR TITLE
Flushing metrics on ephemeral executions

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -113,17 +113,14 @@ def flush_metrics():
       if (metric.metric_kind == metric_pb2.MetricDescriptor.MetricKind.GAUGE  # pylint: disable=no-member
          ):
         start_time = end_time
-
       series = _TimeSeries()
       metric.monitoring_v3_time_series(series, labels, start_time, end_time,
                                        value)
       time_series.append(series)
-
       if len(time_series) == MAX_TIME_SERIES_PER_CALL:
         time_series.sort(key=_time_series_sort_key)
         _create_time_series(project_path, time_series)
         time_series = []
-
     if time_series:
       time_series.sort(key=_time_series_sort_key)
       _create_time_series(project_path, time_series)
@@ -134,6 +131,8 @@ def flush_metrics():
       logs.warning(f'Failed to flush metrics: {e}')
     else:
       logs.error(f'Failed to flush metrics: {e}')
+
+
 class _MonitoringDaemon():
   """Wrapper for the daemon threads responsible for flushing metrics."""
   def __init__(self, flush_function, tick_interval):

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -101,7 +101,7 @@ def _time_series_sort_key(ts):
   return ts.points[-1].interval.start_time
 
 
-def flush_metrics():
+def _flush_metrics():
   """Flushes all metrics stored in _metrics_store"""
   project_path = _monitoring_v3_client.common_project_path(  # pylint: disable=no-member
       utils.get_application_id())

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -188,11 +188,9 @@ class TestMonitoringDaemon(unittest.TestCase):
     daemon = monitor._MonitoringDaemon(mock_flush, 1)
     daemon.start()
     time.sleep(2)
+    assert calls > 0
     daemon.stop()
     assert not daemon._flushing_thread.is_alive()
-    # We do not exercise fine grained control over the threads
-    # To avoid flakyness, assert flusher being called at least once
-    assert calls > 0
 
   def test_monitoring_daemon_flushes_after_stop(self):
     """Tests that flushes happen during prior to exit."""
@@ -209,9 +207,7 @@ class TestMonitoringDaemon(unittest.TestCase):
     assert calls == 0
     daemon.stop()
     assert not daemon._flushing_thread.is_alive()
-    # We do not exercise fine grained control over the threads
-    # So it is good enough to see the flusher being called once
-    assert calls > 0
+    assert calls == 1
 
 
 @unittest.skip('Skip this because it\'s only used by metzman for debugging.')

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -95,11 +95,12 @@ def handle_sigterm(signo, stack_frame):  #pylint: disable=unused-argument
 def wrap_with_monitoring():
   """Wraps execution so we flush metrics on exit"""
   try:
-      monitor.initialize()
-      signal.signal(signal.SIGTERM, handle_sigterm)
-      yield
+    monitor.initialize()
+    signal.signal(signal.SIGTERM, handle_sigterm)
+    yield
   finally:
     monitor.stop()
+
 
 def schedule_utask_mains():
   """Schedules utask_mains from preprocessed utasks on Google Cloud Batch."""

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -199,7 +199,7 @@ def main():
   environment.set_bot_environment()
   monitor.initialize()
 
-  def handle_sigterm(_signo, _stack_frame):
+  def handle_sigterm(signo, stack_frame):  #pylint: disable=unused-argument
     logs.info('Handling sigterm, stopping monitoring daemon.')
     monitor.stop()
     logs.info('Sigterm handled, metrics flushed. Exiting.')


### PR DESCRIPTION
As things currently stand, metrics are flushed by a background thread every 10m. However, for the batch/swarming use case, we will lose metrics for jobs that finish before this interval.  To handle that, monitor.stop will be called before the bot exits.

Finally, sigterm is handled in run_bot to avoid losing metrics when instances get preempted

This PR is part of #4271.