### PR TITLE
Removing build-failure label from oss-fuzz-build-status

### DIFF
--- a/src/clusterfuzz/_internal/cron/oss_fuzz_build_status.py
+++ b/src/clusterfuzz/_internal/cron/oss_fuzz_build_status.py
@@ -145,7 +145,6 @@ def file_bug(issue_tracker, project_name, build_id, ccs, build_type):
       project_name=project_name, build_type=build_type.capitalize())
   issue.body = _get_issue_body(project_name, build_id, build_type)
   issue.status = 'New'
-  issue.labels.add('Type-Build-Failure')
   issue.labels.add('Proj-' + project_name)
 
   for cc in ccs:


### PR DESCRIPTION
This label does not exist anymore, given the monorail-buganizer data mapping, and is causing oss-fuzz-build-status cron to error out, avoiding new bugs being opened:

```
googleapiclient.errors.HttpError: <HttpError 400 when requesting https://issuetracker.googleapis.com/v1/issues?templateOptions.applyTemplate=true&alt=json returned "Invalid value at 'issue.issue_state.type' (type.googleapis.com/google.devtools.issuetracker.v1.Issue.Type), "Build-Failure"". Details: "[{'@type': 'type.googleapis.com/google.rpc.BadRequest', 'fieldViolations': [{'field': 'issue.issue_state.type', 'description': 'Invalid value at \'issue.issue_state.type\' (type.googleapis.com/google.devtools.issuetracker.v1.Issue.Type), "Build-Failure"'}]}]">
```