### PR TITLE
Revert Kubernetes cronjob instrumentation

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -551,11 +551,11 @@ def _initialize_monitored_resource():
 
   # Use bot name here instance as that's more useful to us.
   if environment.is_running_on_k8s():
-    pod_name = environment.get_value('HOSTNAME')
-    _monitored_resource.labels['pod_name'] = pod_name
-  else:
     bot_name = environment.get_value('BOT_NAME')
     _monitored_resource.labels['instance_id'] = bot_name
+  else:
+    pod_name = environment.get_value('HOSTNAME')
+    _monitored_resource.labels['pod_name'] = pod_name
   if compute_metadata.is_gce():
     # Returned in the form projects/{id}/zones/{zone}
     zone = compute_metadata.get('instance/zone').split('/')[-1]

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -550,13 +550,12 @@ def _initialize_monitored_resource():
   _monitored_resource.labels['project_id'] = utils.get_application_id()
 
   # Use bot name here instance as that's more useful to us.
-  # In case it is in Kubernetes, we use the pod name
   if environment.is_running_on_k8s():
-    instance_name = environment.get_value('HOSTNAME')
+    pod_name = environment.get_value('HOSTNAME')
+    _monitored_resource.labels['pod_name'] = pod_name
   else:
-    instance_name = environment.get_value('BOT_NAME')
-  _monitored_resource.labels['instance_id'] = instance_name
-
+    bot_name = environment.get_value('BOT_NAME')
+    _monitored_resource.labels['instance_id'] = bot_name
   if compute_metadata.is_gce():
     # Returned in the form projects/{id}/zones/{zone}
     zone = compute_metadata.get('instance/zone').split('/')[-1]

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -296,9 +296,8 @@ class Metric:
       metric.labels[key] = str(value)
 
     # Default labels.
-    if not environment.is_running_on_k8s():
-      bot_name = environment.get_value('BOT_NAME', None)
-      metric.labels['region'] = _get_region(bot_name)
+    bot_name = environment.get_value('BOT_NAME')
+    metric.labels['region'] = _get_region(bot_name)
 
     return metric
 
@@ -550,12 +549,8 @@ def _initialize_monitored_resource():
   _monitored_resource.labels['project_id'] = utils.get_application_id()
 
   # Use bot name here instance as that's more useful to us.
-  if environment.is_running_on_k8s():
-    bot_name = environment.get_value('BOT_NAME')
-    _monitored_resource.labels['instance_id'] = bot_name
-  else:
-    pod_name = environment.get_value('HOSTNAME')
-    _monitored_resource.labels['pod_name'] = pod_name
+  _monitored_resource.labels['instance_id'] = environment.get_value('BOT_NAME')
+
   if compute_metadata.is_gce():
     # Returned in the form projects/{id}/zones/{zone}
     zone = compute_metadata.get('instance/zone').split('/')[-1]

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -200,13 +200,3 @@ ANDROID_UPTIME = monitor.CounterMetric(
         monitor.StringField('platform'),
     ],
 )
-
-# Cron metrics
-
-# 0 value means healthy, 1 unhealthy
-CLUSTERFUZZ_CRON_EXIT_CODE = monitor.GaugeMetric(
-    'clusterfuzz_cron_exit_code',
-    description='Tracks successful completion of cronjobs',
-    field_spec=[
-        monitor.StringField('cron_name'),
-    ])

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -54,11 +54,6 @@ COMMON_SANITIZER_OPTIONS = {
 }
 
 
-def is_running_on_k8s():
-  """Returns whether or not we're running on K8s."""
-  return os.getenv('IS_K8S_ENV') == 'true'
-
-
 def _eval_value(value_string):
   """Returns evaluated value."""
   try:


### PR DESCRIPTION
As far as Kubernetes cronjobs go, successful terminations can be obtained through log base metrics in GCP, with the following query:

```
jsonPayload.involvedObject.name =~ "${cronjob_name}"
jsonPayload.message = "Job completed"
resource.type="k8s_cluster"
```

This metric suffices to alert on, since the abscence of successful runs for 24h suffices to signal that a cron is broken. It is obtained from kubernetes events (kubectl get events), so we can rely on the Kubernetes control plane for cronjob instrumentation instead of rolling our own.

Thus, this PR will revert the previous metrics added to Kubernetes cronjobs, for the sake of simplifying the codebase.