### PR TITLE
Fixing oss-fuzz-apply-ccs

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -601,7 +601,7 @@ class Issue(issue_tracker.Issue):
     self.labels.remove_by_prefix('ReleaseBlock-')
 
     # Special case: OSS-Fuzz "Reported" custom field.
-    added_reported = _get_oss_fuzz_reported_value(self.labels.added)
+    added_reported = _get_oss_fuzz_reported_value(self.labels)
     if added_reported:
       custom_field_entries.append({
           'customFieldId': _OSS_FUZZ_REPORTED_CUSTOM_FIELD_ID,
@@ -609,7 +609,7 @@ class Issue(issue_tracker.Issue):
       })
 
     # Special case: OSS-Fuzz "Project" custom field.
-    added_project = _extract_label(self.labels.added, 'Proj-')
+    added_project = _extract_label(self.labels, 'Proj-')
     if added_project:
       # Assume there is only one.
       custom_field_entries.append({

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 """Executes update task locally, so we can run it through a debugger."""
 
-import os
-
-from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.cron import oss_fuzz_apply_ccs
+from clusterfuzz._internal.system import environment
 
-def execute(args):
+
+def execute(args):  #pylint: disable=unused-argument
   """Build keywords."""
   environment.set_bot_environment()
   oss_fuzz_apply_ccs.main()

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -15,12 +15,10 @@
 
 import os
 
-from clusterfuzz._internal.bot.tasks import update_task
 from clusterfuzz._internal.system import environment
+from clusterfuzz._internal.cron import oss_fuzz_apply_ccs
 
-
-def execute():
+def execute(args):
   """Build keywords."""
   environment.set_bot_environment()
-  os.environ['USE_TEST_DEPLOYMENT'] = '1'
-  update_task.update_source_code()
+  oss_fuzz_apply_ccs.main()


### PR DESCRIPTION
The cron oss-fuzz-apply-ccs has been broken for a bit. It boils down to this error:

```
'dict_values' object has no attribute 'remove'
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py", line 120, in _extract_label
    labels.remove(label)
    ^^^^^^^^^^^^^
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py", line 137, in _get_oss_fuzz_reported_value
    added_reported = _extract_label(labels, 'Reported-')
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py", line 604, in _update_issue
    added_reported = _get_oss_fuzz_reported_value(self.labels.added)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py", line 824, in save
    result = self._update_issue(new_comment=new_comment, notify=notify)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/src/clusterfuzz/_internal/cron/oss_fuzz_apply_ccs.py", line 95, in main
    issue.save(new_comment=comment, notify=True)
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/src/local/butler/scripts/run_cron.py", line 24, in execute
    oss_fuzz_apply_ccs.main()
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/src/local/butler/run.py", line 48, in execute
    script.execute(args)
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/butler.py", line 388, in main
    return command.execute(args)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/vitorguidi/projects/clusterfuzz/butler.py", line 402, in <module>
    sys.exit(main())
             ^^^^^^
AttributeError: 'dict_values' object has no attribute 'remove'
```

This happens because _extract_labels expects a LabelStore, which implements remove(), but it is being passed LabelStore.added, which is a dict_values. This PR fixes it, and also adds some scripts to facilitate debugging cronjobs.

To run locally, follow [instructions](https://github.com/google/clusterfuzz/blame/9fd8a61b04483efdb3486ff54e040c9d516469d8/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py#L1131) on how to pass a SA credential through the environment to the debugger, and use the following debug target in vscode:

```
{
            "name": "Debug a forced run command",
            "type": "debugpy",
            "request": "launch",
            "program": "${workspaceFolder}/butler.py",
            "console": "integratedTerminal",
            "args": "run run_cron --config-dir=$HOME/projects/clusterfuzz-config/configs/$CONF_FOLDER",
            "env": {
                "CONFIG_DIR_OVERRIDE": "/usr/local/google/home/vitorguidi/projects/clusterfuzz-config/configs/$CONF_FOLDER",
                "BATCH_TEST_CONFIG_PATH": "/usr/local/google/home/vitorguidi/projects/clusterfuzz-config/configs/$CONF_FOLDER",
                "GOOGLE_APPLICATION_CREDENTIALS": "$PATH_TO_SA_JSON_FILE",
            },
        },
```

