### PR TITLE
Fix instance creation logic.

### DIFF
--- a/src/clusterfuzz/_internal/cron/manage_vms.py
+++ b/src/clusterfuzz/_internal/cron/manage_vms.py
@@ -160,8 +160,15 @@ def _template_needs_update(current_template, new_template, resource_name):
 
 
 def _auto_healing_policy_to_dict(
-    policy: compute_engine_projects.AutoHealingPolicy) -> Dict[str, Any]:
-  """Converts `policy` into its JSON API representation."""
+    policy: Optional[compute_engine_projects.AutoHealingPolicy]
+) -> Optional[Dict[str, Any]]:
+  """Converts `policy` into its JSON API representation.
+
+  Returns None if `policy` is None.
+  """
+  if policy is None:
+    return None
+
   return {
       'healthCheck': policy.health_check,
       'initialDelaySec': policy.initial_delay_sec,
@@ -177,9 +184,7 @@ def _update_auto_healing_policy(
   if policies:
     old_policy_dict = policies[0]
 
-  new_policy_dict = None
-  if new_policy is not None:
-    new_policy_dict = _auto_healing_policy_to_dict(new_policy)
+  new_policy_dict = _auto_healing_policy_to_dict(new_policy)
 
   if new_policy_dict == old_policy_dict:
     return


### PR DESCRIPTION
New instance groups may not have auto-healing policies. This broke `manage_vms`.

I broke it in https://github.com/google/clusterfuzz/pull/4264 - who knew integration tests would have been a good idea?

Fixes: https://issues.chromium.org/371829507


