### PR TITLE
Remove job mappings info logs

### DIFF
--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -154,7 +154,6 @@ def get_fuzz_task_payload(platform=None):
   if not mappings:
     return None, None
 
-  logs.info(f'Mappings: {mappings}.')
   selected_mappings = mappings
   # The environment variable containing a list of comma-separated jobs.
   # E.g: "libfuzzer_asan_android_host,afl_asan_android_host,..."
@@ -162,8 +161,6 @@ def get_fuzz_task_payload(platform=None):
   if jobs_selection:
     jobs = get_job_list(jobs_selection)
     selected_mappings = [entity for entity in mappings if entity.job in jobs]
-
-  logs.info(f'Selected mappings: {selected_mappings}.')
 
   if not selected_mappings:
     return None, None


### PR DESCRIPTION
HOST_JOB_SELECTION is working as intended. The mappings are chosen based on the environment variable. Hence remove the info logs to reduce clutter