### PR TITLE
Fully qualify autohealing policy URLs.

### DIFF
--- a/configs/test/gce/clusters.yaml
+++ b/configs/test/gce/clusters.yaml
@@ -28,6 +28,9 @@ test-clusterfuzz:
       instance_count: 2   # Change to actual number of instances needed.
       instance_template: clusterfuzz-linux-pre
       distribute: False
+      auto_healing_policy:
+        health_check: global/healthChecks/test-check
+        initial_delay_sec: 300
 
     # These can be uncommented as needed.
     #

--- a/src/clusterfuzz/_internal/tests/core/google_cloud_utils/compute_engine_projects_test.py
+++ b/src/clusterfuzz/_internal/tests/core/google_cloud_utils/compute_engine_projects_test.py
@@ -24,5 +24,33 @@ class LoadProjectTest(unittest.TestCase):
   def test_load_test_project(self):
     """Test that test config (project test-clusterfuzz) loads without any
     exceptions."""
-    self.assertIsNotNone(
-        compute_engine_projects.load_project('test-clusterfuzz'))
+    project = compute_engine_projects.load_project('test-clusterfuzz')
+    self.assertIsNotNone(project)
+
+    self.assertEqual(project.project_id, 'test-clusterfuzz')
+    self.assertEqual(project.clusters, [
+        compute_engine_projects.Cluster(
+            name='clusterfuzz-linux',
+            gce_zone='gce-zone',
+            instance_count=1,
+            instance_template='clusterfuzz-linux',
+            distribute=False,
+            worker=False,
+            high_end=False,
+            auto_healing_policy=None,
+        ),
+        compute_engine_projects.Cluster(
+            name='clusterfuzz-linux-pre',
+            gce_zone='gce-zone',
+            instance_count=2,
+            instance_template='clusterfuzz-linux-pre',
+            distribute=False,
+            worker=False,
+            high_end=False,
+            auto_healing_policy=compute_engine_projects.AutoHealingPolicy(
+                health_check='https://www.googleapis.com/compute/v1/projects/' +
+                'test-clusterfuzz/global/healthChecks/test-check',
+                initial_delay_sec=300,
+            ),
+        ),
+    ])


### PR DESCRIPTION
URLs returned by the GCE API are fully-qualified, so we should fully qualify URLs from our configs before comparing them for equality in `manage_vms`.

Bug: https://crbug.com/371829507