### PR TITLE
Update get_battery_level_and_temperature()

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/battery.py
+++ b/src/clusterfuzz/_internal/platforms/android/battery.py
@@ -40,7 +40,7 @@ def get_battery_level_and_temperature():
   output = adb.run_shell_command(['dumpsys', 'battery'])
 
   # Get battery level.
-  m_battery_level = re.match(r'.*level: (\d+).*', output, re.DOTALL)
+  m_battery_level = re.match(r'.*\n[\t ]*level: (\d+).*', output, re.DOTALL)
   if not m_battery_level:
     logs.error('Error occurred while getting battery status.')
     return None

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/battery_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/battery_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for battery functions."""
 
+from clusterfuzz._internal.platforms.android import adb
 from clusterfuzz._internal.platforms.android import battery
 from clusterfuzz._internal.tests.test_libs import android_helpers
 
@@ -24,8 +25,15 @@ class GetBatteryLevelAndTemperatureTest(android_helpers.AndroidTest):
     """Ensure that get_battery_level_and_temperature returns data in the
     expected form."""
     battery_info = battery.get_battery_level_and_temperature()
+    stats = adb.run_shell_command(['dumpsys', 'battery'])
+    output = [attribute.strip() for attribute in stats.split('\n')]
+    output = dict(item.split(': ') for item in output[1:])
+
     self.assertTrue(isinstance(battery_info, dict))
     self.assertTrue('level' in battery_info)
     self.assertTrue('temperature' in battery_info)
     self.assertTrue(battery_info['level'] > 0)
+    self.assertTrue(battery_info['level'] == int(output.get('level')))
     self.assertTrue(battery_info['temperature'] > 0)
+    self.assertTrue(
+        battery_info['temperature'] == float(output.get('temperature')) / 10)


### PR DESCRIPTION
Update regex to fetch a valid battery 'level' instead of 'Capacity level' to prevent timeout in wait_until_good_state() of battery.py