### PR TITLE
Fix various build setup checks.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -101,7 +101,9 @@ def setup_build(testcase: data_types.Testcase, bad_revisions,
     revision = revision_list[revision_index]
 
   fuzz_target = fuzz_target.binary if fuzz_target else None
-  build_manager.setup_build(revision, fuzz_target)
+  if not build_manager.setup_build(revision, fuzz_target):
+    return uworker_msg_pb2.Output(
+        error_type=uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP)
   return None
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
@@ -424,11 +424,11 @@ def utask_main(uworker_input: uworker_msg_pb2.Input):  # pylint: disable=no-memb
   crash_revision = last_tested_crash_revision or testcase.crash_revision
   fuzz_target = testcase_manager.get_fuzz_target_from_input(uworker_input)
   fuzz_target = fuzz_target.binary if fuzz_target else None
-  build_manager.setup_build(crash_revision, fuzz_target)
+  build_setup_result = build_manager.setup_build(crash_revision, fuzz_target)
 
   # Check if we have an application path. If not, our build failed
   # to setup correctly.
-  if not build_manager.check_app_path():
+  if not build_setup_result or not build_manager.check_app_path():
     logs.error('Unable to setup build for minimization.')
     return uworker_msg_pb2.Output(
         error_type=uworker_msg_pb2.ErrorType.MINIMIZE_SETUP)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -251,14 +251,14 @@ def _check_fixed_for_custom_binary(testcase: data_types.Testcase,
                                    testcase_file_path: str,
                                    uworker_input: uworker_msg_pb2.Input):  # pylint: disable=no-member
   """Simplified fixed check for test cases using custom binaries."""
-  build_manager.setup_build()
+  build_setup_result = build_manager.setup_build()
   # 'APP_REVISION' is set during setup_build().
   revision = environment.get_value('APP_REVISION')
   if revision is None:
     logs.error('APP_REVISION is not set, setting revision to 0')
     revision = 0
 
-  if not build_manager.check_app_path():
+  if not build_setup_result or not build_manager.check_app_path():
     return uworker_msg_pb2.Output(
         error_message='Build setup failed for custom binary',
         error_type=uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR)
@@ -321,7 +321,8 @@ def _testcase_reproduces_in_revision(
   there was an error."""
   try:
     fuzz_target_binary = fuzz_target.binary if fuzz_target else None
-    build_manager.setup_build(revision, fuzz_target=fuzz_target_binary)
+    build_setup_result = build_manager.setup_build(
+        revision, fuzz_target=fuzz_target_binary)
   except errors.BuildNotFoundError as e:
     # Build no longer exists, so we need to mark this testcase as invalid.
     error_message = f'Build not found at r{e.revision}'
@@ -330,7 +331,7 @@ def _testcase_reproduces_in_revision(
         progression_task_output=progression_task_output,
         error_type=uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND)  # pylint: disable=no-member
 
-  if not build_manager.check_app_path():
+  if not build_setup_result or not build_manager.check_app_path():
     # Let postprocess handle the failure and reschedule the task if needed.
     error_message = f'Build setup failed at r{revision}'
     return None, uworker_msg_pb2.Output(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -120,8 +120,9 @@ def _testcase_reproduces_in_revision(
     logs.info(log_message)
 
   fuzz_target_binary = fuzz_target.binary if fuzz_target else None
-  build_manager.setup_build(revision, fuzz_target=fuzz_target_binary)
-  if not build_manager.check_app_path():
+  build_setup_result = build_manager.setup_build(
+      revision, fuzz_target=fuzz_target_binary)
+  if not build_setup_result or not build_manager.check_app_path():
     error_message = f'Build setup failed r{revision}'
     return None, uworker_msg_pb2.Output(
         regression_task_output=regression_task_output,

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
@@ -113,7 +113,7 @@ def utask_main(uworker_input):
   # Get crash revision used in setting up build.
   crash_revision = environment.get_value('APP_REVISION')
 
-  if not build_manager.check_app_path():
+  if not build or not build_manager.check_app_path():
     return uworker_msg_pb2.Output(
         error_message='Build setup failed',
         error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -121,7 +121,7 @@ def utask_main(uworker_input):
   # correctly.
   if not build_setup_result or not build_manager.check_app_path():
     return uworker_msg_pb2.Output(  # pylint: disable=no-member
-        error_type=uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP)
+        error_type=uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP)  # pylint: disable=no-member
 
   # Disable gestures if we're running on a different platform from that of
   # the original test case.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -111,7 +111,7 @@ def utask_main(uworker_input):
   try:
     fuzz_target = testcase_manager.get_fuzz_target_from_input(uworker_input)
     fuzz_target = fuzz_target.binary if fuzz_target else None
-    build_manager.setup_build(fuzz_target=fuzz_target)
+    build_setup_result = build_manager.setup_build(fuzz_target=fuzz_target)
   except errors.BuildNotFoundError:
     logs.warning('Matching build not found.')
     return uworker_msg_pb2.Output(  # pylint: disable=no-member
@@ -119,7 +119,7 @@ def utask_main(uworker_input):
 
   # Check if we have an application path. If not, our build failed to setup
   # correctly.
-  if not build_manager.check_app_path():
+  if not build_setup_result or not build_manager.check_app_path():
     return uworker_msg_pb2.Output(
         error_type=uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP)
 


### PR DESCRIPTION
We need to check the return value of `setup_build` to reliably check all cases of build setup failures.

This came from an exception in variant_task,
https://pantheon.corp.google.com/errors/detail/CIPKoND7o6Cudg;locations=global?e=-13802955&inv=1&invt=AbeQhw&mods=logs_tg_prod&organizationId=433637338589&project=google.com:cluster-fuzz

But this PR tries to fix things generally.