### PR TITLE
Allowing id token on oauth for appengine

### DIFF
--- a/src/appengine/libs/handler.py
+++ b/src/appengine/libs/handler.py
@@ -161,25 +161,26 @@ def unsupported_on_local_server(func):
   return wrapper
 
 
-def _validade_access_token(authorization):
+def _validate_access_token(authorization):
   access_token = authorization.split(' ')[1]
   response_access_token = requests.get(
       'https://www.googleapis.com/oauth2/v3/tokeninfo',
       params={'access_token': access_token},
       timeout=HTTP_GET_TIMEOUT_SECS)
+
+  if response_access_token.status_code == 200:
+    return response_access_token
+
   response_id_token = requests.get(
       'https://www.googleapis.com/oauth2/v3/tokeninfo',
       params={'id_token': access_token},
       timeout=HTTP_GET_TIMEOUT_SECS)
-  if response_access_token.status_code != 200 and response_id_token:
-    raise helpers.UnauthorizedError(
-        f'Failed to authorize. The Authorization header ({authorization}) '
-        'is neither a valid id or access token.')
-  
-  if response_access_token.status_code == 200:
-    return response_access_token
-  
-  return response_id_token
+  if response_id_token.status_code == 200:
+    return response_id_token
+
+  raise helpers.UnauthorizedError(
+      f'Failed to authorize. The Authorization header ({authorization}) '
+      'is neither a valid id or access token.')
 
 
 def get_email_and_access_token(authorization):
@@ -192,7 +193,7 @@ def get_email_and_access_token(authorization):
         'The Authorization header is invalid. It should have been started with'
         " '%s'." % BEARER_PREFIX)
 
-  response = _validade_access_token(authorization)
+  response = _validate_access_token(authorization)
 
   try:
     data = json.loads(response.text)

--- a/src/appengine/libs/handler.py
+++ b/src/appengine/libs/handler.py
@@ -162,6 +162,7 @@ def unsupported_on_local_server(func):
 
 
 def _validate_access_token(authorization):
+  """Validates a JWT as an access or id token, or raises."""
   access_token = authorization.split(' ')[1]
   response_access_token = requests.get(
       'https://www.googleapis.com/oauth2/v3/tokeninfo',


### PR DESCRIPTION
### Motivation

In order to get healthchecks on appengine handlers, we need to use GCP Uptimes. They authenticate through an [oauth id token](https://cloud.google.com/monitoring/uptime-checks#create). As things currently stand, oauth on appengine only supportes access tokens, so this PR solves that.


### Alternatives considered

It would be ideal if we only did one api call, either to validade an id or access token. However, the [specification](https://auth0.com/docs/secure/tokens/id-tokens/id-token-structure) for oauth2 does not present a standard way of, given a token, differentiating between the two. For that reason, two api calls to GCP are made.

Part of #4271 