### PR TITLE
Fixing oauth annotation order

### DIFF
--- a/src/appengine/handlers/corpora.py
+++ b/src/appengine/handlers/corpora.py
@@ -29,9 +29,9 @@ class Handler(base_handler.Handler):
 
   @handler.unsupported_on_local_server
   @handler.get(handler.HTML)
+  @handler.oauth
   @handler.check_admin_access_if_oss_fuzz
   @handler.check_user_access(need_privileged_access=False)
-  @handler.oauth
   def get(self):
     """Handle a get request."""
     data_bundles = list(data_types.DataBundle.query().order(

--- a/src/appengine/handlers/fuzzers.py
+++ b/src/appengine/handlers/fuzzers.py
@@ -40,9 +40,9 @@ class Handler(base_handler.Handler):
   """Manages fuzzers."""
 
   @handler.get(handler.HTML)
+  @handler.oauth
   @handler.check_admin_access_if_oss_fuzz
   @handler.check_user_access(need_privileged_access=False)
-  @handler.oauth
   def get(self):
     """Handle a get request."""
     fuzzer_logs_bucket = fuzzer_logs.get_bucket()

--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -95,8 +95,8 @@ class Handler(base_handler.Handler):
   """View job handler."""
 
   @handler.get(handler.HTML)
-  @handler.check_user_access(need_privileged_access=True)
   @handler.oauth
+  @handler.check_user_access(need_privileged_access=True)
   def get(self):
     """Handle a get request."""
     templates = list(data_types.JobTemplate.query().order(


### PR DESCRIPTION
### Motivation

Uptime healthchecks are breaking for fuzzer/jobs/corpora. This happens because the check_user_access annotation is placed BEFORE the oauth one, which leads to the verification being [asserted](https://github.com/google/clusterfuzz/blob/master/src/appengine/libs/access.py#L89) before credentials are fetched.

This PR fixes the annotation order, making authentication happen before authorization.

Part of #4271 