### PR TITLE
Allowing service accounts to become admins in appengine

### DIFF
--- a/src/clusterfuzz/_internal/cron/sync_admins.py
+++ b/src/clusterfuzz/_internal/cron/sync_admins.py
@@ -13,16 +13,18 @@
 # limitations under the License.
 """Cron to sync admin users."""
 
+from typing import List
+
 from googleapiclient import discovery
 
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.metrics import logs
-from typing import List
 
-def get_emails_from_bindings(
-    iam_policy, principal_type, allowed_roles) -> List[str]:
+
+def get_emails_from_bindings(iam_policy, principal_type,
+                             allowed_roles) -> List[str]:
   """Returns emails that should be admins, given constraints."""
   admins = []
 
@@ -39,6 +41,7 @@ def get_emails_from_bindings(
 
   return admins
 
+
 def admins_from_iam_policy(iam_policy):
   """Gets a list of admins from the IAM policy."""
   # Per
@@ -52,15 +55,11 @@ def admins_from_iam_policy(iam_policy):
       'roles/appengine.appAdmin',
   ]
 
-  service_account_roles = [
-    'roles/viewer'
-  ]
+  service_account_roles = ['roles/viewer']
 
-  user_admins = get_emails_from_bindings(
-    iam_policy, 'user', user_roles)
+  user_admins = get_emails_from_bindings(iam_policy, 'user', user_roles)
   service_account_admins = get_emails_from_bindings(
-    iam_policy, 'serviceAccount', service_account_roles)
-
+      iam_policy, 'serviceAccount', service_account_roles)
 
   user_admins.extend(service_account_admins)
   return user_admins

--- a/src/clusterfuzz/_internal/cron/sync_admins.py
+++ b/src/clusterfuzz/_internal/cron/sync_admins.py
@@ -58,7 +58,8 @@ def admins_from_iam_policy(iam_policy):
   service_account_admins = get_emails_from_bindings(iam_policy, 'serviceAccount', service_account_roles)
 
 
-  return user_admins.extend(service_account_admins)
+  user_admins.extend(service_account_admins)
+  return user_admins
 
 
 def update_admins(new_admins):

--- a/src/clusterfuzz/_internal/cron/sync_admins.py
+++ b/src/clusterfuzz/_internal/cron/sync_admins.py
@@ -21,7 +21,9 @@ from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.metrics import logs
 from typing import List
 
-def get_emails_from_bindings(iam_policy, principal_type, allowed_roles) -> List[str]:
+def get_emails_from_bindings(
+    iam_policy, principal_type, allowed_roles) -> List[str]:
+  """Returns emails that should be admins, given constraints."""
   admins = []
 
   assert principal_type in ['user', 'serviceAccount']
@@ -54,8 +56,10 @@ def admins_from_iam_policy(iam_policy):
     'roles/viewer'
   ]
 
-  user_admins = get_emails_from_bindings(iam_policy, 'user', user_roles)
-  service_account_admins = get_emails_from_bindings(iam_policy, 'serviceAccount', service_account_roles)
+  user_admins = get_emails_from_bindings(
+    iam_policy, 'user', user_roles)
+  service_account_admins = get_emails_from_bindings(
+    iam_policy, 'serviceAccount', service_account_roles)
 
 
   user_admins.extend(service_account_admins)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/sync_admins_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/sync_admins_test.py
@@ -72,7 +72,10 @@ class SyncAdminsTest(unittest.TestCase):
                 },
                 {
                     'role': 'roles/viewer',
-                    'members': ['user:user5@email.com',]
+                    'members': [
+                      'user:user5@email.com',
+                      'serviceAccount:another_sa@sa.com'
+                    ]
                 },
             ]
         }
@@ -87,4 +90,5 @@ class SyncAdminsTest(unittest.TestCase):
         'user3@email.com',
         'user4@email.com',
         'user5@email.com',
+        'another_sa@sa.com',
     ], [admin.email for admin in admins])

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/sync_admins_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/sync_admins_test.py
@@ -71,10 +71,11 @@ class SyncAdminsTest(unittest.TestCase):
                     'members': ['user:user4@email.com',]
                 },
                 {
-                    'role': 'roles/viewer',
+                    'role':
+                        'roles/viewer',
                     'members': [
-                      'user:user5@email.com',
-                      'serviceAccount:another_sa@sa.com'
+                        'user:user5@email.com',
+                        'serviceAccount:another_sa@sa.com'
                     ]
                 },
             ]


### PR DESCRIPTION
### Motivation

Sync admins only replicates admins to datastore if they conform to 'user:{email}', but it is interesting to allow service accounts for monitoring purposes (uptime) of the form 'serviceAccount:{email}'.

This PR fixes that.

Part of #4271 