### PR TITLE
Fix battery level reading

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/battery.py
+++ b/src/clusterfuzz/_internal/platforms/android/battery.py
@@ -40,7 +40,7 @@ def get_battery_level_and_temperature():
   output = adb.run_shell_command(['dumpsys', 'battery'])
 
   # Get battery level.
-  m_battery_level = re.match(r'.*level: (\d+).*', output, re.DOTALL)
+  m_battery_level = re.match(r'.*  level: (\d+).*', output, re.DOTALL)
   if not m_battery_level:
     logs.error('Error occurred while getting battery status.')
     return None


### PR DESCRIPTION
dumpsys battery output probably changed, adding Capacity level (see below). This messes with the battery level parsing and thus the battery management i.e. no fuzzing is done, as [this](https://github.com/google/clusterfuzz/blob/1b799280abbaaf19c9325a69072d1f0fdbde8104/src/clusterfuzz/_internal/platforms/android/battery.py#L94) continuously waits for the battery to be above a threshold.

```
Current Battery Service state:
  AC powered: true
  USB powered: false
  Wireless powered: false
  Dock powered: false
  Max charging current: 1500000
  Max charging voltage: 5000000
  Charge counter: 3376000
  status: 4
  health: 3
  present: true
  level: 80
  scale: 100
  voltage: 4200
  temperature: 180
  technology: Li-ion
  Charging state: 4
  Charging policy: 1
  Capacity level: 3
```