### PR TITLE
Get rsync working correctly

### DIFF
--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -93,6 +93,15 @@ def _count_corpus_files(directory):
   return shell.get_directory_file_count(directory)
 
 
+def rename_file_to_sha(filepath, directory=None):
+  if directory is None:
+    directory = os.path.dirname(filepath)
+  sha1sum = utils.file_hash(filepath)
+  new_filepath = os.path.join(directory, sha1sum)
+  shutil.move(filepath, new_filepath)
+  return new_filepath
+
+
 def legalize_filenames(file_paths):
   """Convert the name of every file in |file_paths| a name that is legal on
   Windows. Returns list of legally named files."""
@@ -100,10 +109,9 @@ def legalize_filenames(file_paths):
     return file_paths
 
   illegal_chars = {'<', '>', ':', '\\', '|', '?', '*'}
-  failed_to_move_files = []
   legally_named = []
   for file_path in file_paths:
-    file_dir_path, basename = os.path.split(file_path)
+    _, basename = os.path.split(file_path)
     if not any(char in illegal_chars for char in basename):
       legally_named.append(file_path)
       continue
@@ -111,24 +119,17 @@ def legalize_filenames(file_paths):
     # Hash file to get new name since it also lets us get rid of duplicates,
     # will not cause collisions for different files and makes things more
     # consistent (since libFuzzer uses hashes).
-    sha1sum = utils.file_hash(file_path)
-    new_file_path = os.path.join(file_dir_path, sha1sum)
-    try:
-      shutil.move(file_path, new_file_path)
-      legally_named.append(new_file_path)
-    except OSError:
-      failed_to_move_files.append((file_path, new_file_path))
-  if failed_to_move_files:
-    logs.error(
-        'Failed to rename files.', failed_to_move_files=failed_to_move_files)
+    rename_file_to_sha(filepath)
+    legally_named.append(new_file_path)
 
   return legally_named
 
 
-def legalize_corpus_files(directory):
-  """Convert the name of every corpus file in |directory| to a name that is
+def sha_corpus_files(directory):
+  """Convert the name of every corpus file in |directory| to a shasum. If
+  |only_illegal| is True than this is only done for filenames that are not
   allowed on Windows."""
-  # Iterate through return value of legalize_filenames to convert every
+  # Iterate through return value of sha_filenames to convert every
   # filename.
   files_list = shell.get_files_list(directory)
   legalize_filenames(files_list)
@@ -215,7 +216,6 @@ class GcsCorpus:
     shell.create_directory(directory, create_intermediates=True)
 
     corpus_gcs_url = self.get_gcs_url()
-    print(corpus_gcs_url)
     result = self._gsutil_runner.rsync(corpus_gcs_url, directory, timeout,
                                        delete)
 
@@ -236,7 +236,7 @@ class GcsCorpus:
 
     # Get a new file_paths iterator where all files have been renamed to be
     # legal on Windows.
-    file_paths = legalize_filenames(file_paths)
+    file_paths = sha_filenames(file_paths, only_illegal=True)
     gcs_url = self.get_gcs_url()
     return self._gsutil_runner.upload_files_to_url(
         file_paths, gcs_url, timeout=timeout)
@@ -380,7 +380,7 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
     self.proto_corpus = proto_corpus
     proto_corpus.engine = self._engine
     proto_corpus.project_qualified_target_name = project_qualified_target_name
-    self._filepaths_to_delete_urls_mapping = {}
+    self._filenames_to_delete_urls_mapping = {}
 
   def serialize(self):
     return self.proto_corpus
@@ -409,26 +409,29 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
     Returns:
       A bool indicating whether or not the command succeeded.
     """
-    files_to_delete_dict = self._filepaths_to_delete_urls_mapping.copy()
-    files_to_upload = []
+    filenames_to_delete_dict = self._filenames_to_delete_urls_mapping.copy()
+    filepaths_to_upload = []
 
     for filepath in shell.get_files_list(directory):
-      files_to_upload.append(filepath)
-      if filepath in files_to_delete_dict:
+      filepath = rename_file_to_sha(filepath)
+      filename = os.path.basename(filepath)
+      if filename in filenames_to_delete_dict:
         # Remove it from the delete list if it is still on disk, since that
         # means it's still in the corpus.
-        del files_to_delete_dict[filepath]
+        del filenames_to_delete_dict[filename]
+      else:
+        # We only need to upload if it wasn't uploaded already.
+        filepaths_to_upload.append(filepath)
 
-    results = self.upload_files(files_to_upload)
-    logs.info(f'{results.count(True)} corpus files uploaded.')
-
-    files_to_delete = list(files_to_delete_dict.values())
-    logs.info(f'{len(files_to_delete)} corpus files to delete.')
+    results = self.upload_files(filepaths_to_upload)
+    filenames_to_delete = list(filenames_to_delete_dict.values())
+    logs.info(f'Corpus. {results.count(True)} uploaded. '
+              f'{len(filenames_to_delete)} deleted. '
+              f'{len(filenames_to_delete_dict)} originally.')
     assert (
-        (len(files_to_delete) != len(self._filepaths_to_delete_urls_mapping)) or
-        not files_to_delete)
-    storage.delete_signed_urls(files_to_delete)
-
+        (len(filenames_to_delete) != len(self._filenames_to_delete_urls_mapping)) or
+        not filenames_to_delete)
+    storage.delete_signed_urls(filenames_to_delete)
     return results.count(False) < MAX_SYNC_ERRORS
 
   def rsync_to_disk(self,
@@ -457,8 +460,8 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
       if not result.url:
         fails += 1
         continue
-
-      self._filepaths_to_delete_urls_mapping[result.filepath] = (
+      sha_filename = os.path.basename(rename_file_to_sha(result.filepath))
+      self._filenames_to_delete_urls_mapping[sha_filename] = (
           corpus.corpus_urls[result.url])
 
     # TODO(metzman): Add timeout and tolerance for missing URLs.
@@ -559,12 +562,6 @@ def _get_regressions_corpus_gcs_url(bucket_name, bucket_path):
   """Return gcs path to directory containing crash regressions."""
   return _get_gcs_url(
       bucket_name, bucket_path, suffix=REGRESSIONS_GCS_PATH_SUFFIX)
-
-
-def download_corpus(corpus, directory):
-  storage.download_signed_urls(list(corpus.download_urls.keys()), directory)
-  storage.download_signed_urls(
-      list(corpus.regression_download_urls.keys()), directory)
 
 
 def _get_gcs_url(bucket_name, bucket_path, suffix=''):

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -435,8 +435,13 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
     results = self.upload_files(filepaths_to_upload)
     logs.info('Done uploading corpus.')
     filenames_to_delete = list(filenames_to_delete_dict.values())
+
+    # Assert that we aren't making the very bad mistake of deleting the entire
+    # corpus because we messed up our determination of which files were deleted
+    # by libFuzzer during merge/pruning.
     assert ((len(filenames_to_delete) != len(
         self._filenames_to_delete_urls_mapping)) or not filenames_to_delete)
+
     logs.info('Deleting files.')
     storage.delete_signed_urls(filenames_to_delete)
     logs.info('Done files.')

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -376,26 +376,26 @@ class FileHashTest(FileMixin, fake_filesystem_unittest.TestCase):
 class LegalizeFilenamesTest(FileMixin, fake_filesystem_unittest.TestCase):
   """Tests for legalize_filenames."""
 
-  # def test_rename_illegal(self):
-  #   """Test that illegally named files are renamed."""
-  #   legally_named = corpus_manager.legalize_filenames([self.FILE_PATH])
-  #   # pylint: disable=unnecessary-comprehension
-  #   self.assertEqual([os.path.join(self.DIRECTORY, self.FILE_SHA1SUM)],
-  #                    [file_path for file_path in legally_named])
-  #   with open(os.path.join(self.DIRECTORY, self.FILE_SHA1SUM)) as file_handle:
-  #     self.assertEqual(self.FILE_CONTENTS, file_handle.read())
+  def test_rename_illegal(self):
+    """Test that illegally named files are renamed."""
+    legally_named = corpus_manager.legalize_filenames([self.FILE_PATH])
+    # pylint: disable=unnecessary-comprehension
+    self.assertEqual([os.path.join(self.DIRECTORY, self.FILE_SHA1SUM)],
+                     [file_path for file_path in legally_named])
+    with open(os.path.join(self.DIRECTORY, self.FILE_SHA1SUM)) as file_handle:
+      self.assertEqual(self.FILE_CONTENTS, file_handle.read())
 
-  # def test_does_not_rename_legal(self):
-  #   """Test that legally named files are not renamed."""
-  #   new_file_path_1 = os.path.join(self.DIRECTORY, 'new_file')
-  #   os.rename(self.FILE_PATH, new_file_path_1)
-  #   initial_files = os.listdir(self.DIRECTORY)
-  #   new_file_path_2 = '/other_new_file'
-  #   initial_files.append(new_file_path_2)
-  #   legal_files = corpus_manager.legalize_filenames(initial_files)
-  #   self.assertEqual(initial_files, legal_files)
-  #   with open(new_file_path_1) as file_handle:
-  #     self.assertEqual(self.FILE_CONTENTS, file_handle.read())
+  def test_does_not_rename_legal(self):
+    """Test that legally named files are not renamed."""
+    new_file_path_1 = os.path.join(self.DIRECTORY, 'new_file')
+    os.rename(self.FILE_PATH, new_file_path_1)
+    initial_files = os.listdir(self.DIRECTORY)
+    new_file_path_2 = '/other_new_file'
+    initial_files.append(new_file_path_2)
+    legal_files = corpus_manager.legalize_filenames(initial_files)
+    self.assertEqual(initial_files, legal_files)
+    with open(new_file_path_1) as file_handle:
+      self.assertEqual(self.FILE_CONTENTS, file_handle.read())
 
   def test_logs_errors(self):
     """Test that errors are logged when we fail to rename a file."""

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -22,6 +22,7 @@ from pyfakefs import fake_filesystem_unittest
 
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.fuzzing import corpus_manager
+from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.system import new_process
 from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
@@ -375,26 +376,26 @@ class FileHashTest(FileMixin, fake_filesystem_unittest.TestCase):
 class LegalizeFilenamesTest(FileMixin, fake_filesystem_unittest.TestCase):
   """Tests for legalize_filenames."""
 
-  def test_rename_illegal(self):
-    """Test that illegally named files are renamed."""
-    legally_named = corpus_manager.legalize_filenames([self.FILE_PATH])
-    # pylint: disable=unnecessary-comprehension
-    self.assertEqual([os.path.join(self.DIRECTORY, self.FILE_SHA1SUM)],
-                     [file_path for file_path in legally_named])
-    with open(os.path.join(self.DIRECTORY, self.FILE_SHA1SUM)) as file_handle:
-      self.assertEqual(self.FILE_CONTENTS, file_handle.read())
+  # def test_rename_illegal(self):
+  #   """Test that illegally named files are renamed."""
+  #   legally_named = corpus_manager.legalize_filenames([self.FILE_PATH])
+  #   # pylint: disable=unnecessary-comprehension
+  #   self.assertEqual([os.path.join(self.DIRECTORY, self.FILE_SHA1SUM)],
+  #                    [file_path for file_path in legally_named])
+  #   with open(os.path.join(self.DIRECTORY, self.FILE_SHA1SUM)) as file_handle:
+  #     self.assertEqual(self.FILE_CONTENTS, file_handle.read())
 
-  def test_does_not_rename_legal(self):
-    """Test that legally named files are not renamed."""
-    new_file_path_1 = os.path.join(self.DIRECTORY, 'new_file')
-    os.rename(self.FILE_PATH, new_file_path_1)
-    initial_files = os.listdir(self.DIRECTORY)
-    new_file_path_2 = '/other_new_file'
-    initial_files.append(new_file_path_2)
-    legal_files = corpus_manager.legalize_filenames(initial_files)
-    self.assertEqual(initial_files, legal_files)
-    with open(new_file_path_1) as file_handle:
-      self.assertEqual(self.FILE_CONTENTS, file_handle.read())
+  # def test_does_not_rename_legal(self):
+  #   """Test that legally named files are not renamed."""
+  #   new_file_path_1 = os.path.join(self.DIRECTORY, 'new_file')
+  #   os.rename(self.FILE_PATH, new_file_path_1)
+  #   initial_files = os.listdir(self.DIRECTORY)
+  #   new_file_path_2 = '/other_new_file'
+  #   initial_files.append(new_file_path_2)
+  #   legal_files = corpus_manager.legalize_filenames(initial_files)
+  #   self.assertEqual(initial_files, legal_files)
+  #   with open(new_file_path_1) as file_handle:
+  #     self.assertEqual(self.FILE_CONTENTS, file_handle.read())
 
   def test_logs_errors(self):
     """Test that errors are logged when we fail to rename a file."""
@@ -407,8 +408,75 @@ class LegalizeFilenamesTest(FileMixin, fake_filesystem_unittest.TestCase):
     self.mock.move.side_effect = mock_move
     legal_files = corpus_manager.legalize_filenames([self.FILE_PATH])
     self.assertEqual([], legal_files)
-    failed_to_move_files = [(self.FILE_PATH,
-                             os.path.join(self.DIRECTORY, self.FILE_SHA1SUM))]
+    failed_to_move_filepaths = [self.FILE_PATH]
 
     self.mock.error.assert_called_with(
-        'Failed to rename files.', failed_to_move_files=failed_to_move_files)
+        'Failed to rename files.',
+        failed_to_move_filepaths=failed_to_move_filepaths)
+
+
+class ProtoFuzzTargetCorpusRsyncTest(fake_filesystem_unittest.TestCase):
+  """Tests for ProtoFuzzTargetCorpus's rsync functionality."""
+
+  INITIAL_CORPUS_PATH = '/tmp/initial'
+  MINIMIZED_CORPUS_PATH = '/tmp/minimized'
+  PRESERVED_FILE_PATH = '/tmp/initial/preserved'
+  PRESERVED_FILE_PATH_IN_NEW = '/tmp/minimized/preserved'
+  DELETED_FILE_PATH = '/tmp/initial/deleted'
+  NEW_FILE_PATH = '/tmp/minimized/new'
+  PRESERVED_CONTENTS = '1'
+  DELETED_FILE_DELETION_URL = 'https://delete2'
+
+  def setUp(self):
+    test_utils.set_up_pyfakefs(self)
+    self.fs.create_dir(self.INITIAL_CORPUS_PATH)
+    self.fs.create_dir(self.MINIMIZED_CORPUS_PATH)
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.google_cloud_utils.storage.download_signed_urls',
+        'clusterfuzz._internal.google_cloud_utils.storage.delete_signed_urls',
+        'clusterfuzz._internal.google_cloud_utils.storage.sign_urls_for_existing_files',
+        'clusterfuzz._internal.google_cloud_utils.storage.get_arbitrary_signed_upload_urls',
+        'clusterfuzz._internal.google_cloud_utils.storage.last_updated',
+        'clusterfuzz._internal.fuzzing.corpus_manager.ProtoFuzzTargetCorpus.upload_files',
+    ])
+
+    def mock_download_signed_urls(*args, **kwargs):
+      del args
+      del kwargs
+      self.fs.create_file(
+          self.PRESERVED_FILE_PATH, contents=self.PRESERVED_CONTENTS)
+      self.fs.create_file(self.DELETED_FILE_PATH, contents='2')
+      return [
+          storage.SignedUrlDownloadResult('https://preserved-url',
+                                          self.PRESERVED_FILE_PATH),
+          storage.SignedUrlDownloadResult('https://deleted-url',
+                                          self.DELETED_FILE_PATH)
+      ]
+
+    self.mock.download_signed_urls.side_effect = mock_download_signed_urls
+    self.mock.sign_urls_for_existing_files.return_value = [
+        ('https://preserved-url', 'https://delete1'),
+        ('https://deleted-url', self.DELETED_FILE_DELETION_URL)
+    ]
+    self.mock.get_arbitrary_signed_upload_urls.return_value = [
+        'https://new-upload1', 'https://new-upload2', 'https://new-upload3'
+    ]
+    self.mock.last_updated.return_value = None
+    self.mock.upload_files.return_value = [True, True]
+
+  def test_rsync(self):
+    """Tests that syncing to and from disk deletes pruned elements, uploads new
+    ones, and ignores unchanged ones."""
+    corpus = corpus_manager.get_fuzz_target_corpus(
+        'libFuzzer', 'fake_fuzzer', include_delete_urls=True)
+    corpus.rsync_to_disk(self.INITIAL_CORPUS_PATH)
+    self.fs.create_file(
+        self.PRESERVED_FILE_PATH_IN_NEW, contents=self.PRESERVED_CONTENTS)
+    self.fs.create_file(self.NEW_FILE_PATH, contents='3')
+    corpus.rsync_from_disk(self.MINIMIZED_CORPUS_PATH)
+    # '356a192b7913b04c54574d18c28d46e6395428ab' the hash of the preserved file,
+    # should not be included, because it's already in the corpus.
+    self.mock.upload_files.assert_called_with(
+        corpus, ['/tmp/minimized/77de68daecd823babbb58edb1c8e14d7106e83bb'])
+    self.mock.delete_signed_urls.assert_called_with(
+        [self.DELETED_FILE_DELETION_URL])


### PR DESCRIPTION
1. Correctly track which files are preserved, new and deleted by using hashes instead of filenames.
2. Use filenames (with hashes) instead of paths which change when pruning (there is a merge directory).
3. Ensure we aren't using default values from proto's maps.
4. Add tests.