### PR TITLE
Enriching BOT_COUNT metric

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -108,7 +108,7 @@ def track_revision():
   """Get the local revision and report as a metric."""
   revision = get_local_source_revision() or ''
   os_type = environment.platform()
-  os_version = environment.release()
+  os_version = environment.platform_version()
   release = utils.get_clusterfuzz_release()
   labels = {
       'revision': revision,

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -111,10 +111,10 @@ def track_revision():
   os_version = environment.release()
   release = utils.get_clusterfuzz_release()
   labels = {
-    'revision': revision,
-    'os_type': os_type,
-    'os_version': os_version,
-    'release': release,
+      'revision': revision,
+      'os_type': os_type,
+      'os_version': os_version,
+      'release': release,
   }
   monitoring_metrics.BOT_COUNT.set(1, labels)
 

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -107,7 +107,16 @@ def clear_pyc_files(directory):
 def track_revision():
   """Get the local revision and report as a metric."""
   revision = get_local_source_revision() or ''
-  monitoring_metrics.BOT_COUNT.set(1, {'revision': revision})
+  os_type = environment.platform()
+  os_version = environment.release()
+  release = utils.get_clusterfuzz_release()
+  labels = {
+    'revision': revision,
+    'os_type': os_type,
+    'os_version': os_version,
+    'release': release,
+  }
+  monitoring_metrics.BOT_COUNT.set(1, labels)
 
 
 def get_local_source_revision():

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -137,7 +137,12 @@ TRY_COUNT = monitor.CounterMetric(
 BOT_COUNT = monitor.GaugeMetric(
     'bot_count',
     description='Bot count',
-    field_spec=[monitor.StringField('revision')])
+    field_spec=[
+        monitor.StringField('revision'),
+        monitor.StringField('os_type'),
+        monitor.StringField('os_version'),
+        monitor.StringField('release'),
+    ])
 
 TASK_COUNT = monitor.CounterMetric(
     'task/count',

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -787,7 +787,7 @@ def platform():
   raise ValueError('Unsupported platform "%s".' % sys.platform)
 
 
-def platform_vesion():
+def platform_version():
   """Return the operating system type, unless an override is provided."""
   environment_override = get_value('OS_OVERRIDE')
   if environment_override:

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -16,6 +16,7 @@
 import ast
 import functools
 import os
+from platform import release
 import re
 import socket
 import subprocess
@@ -784,6 +785,14 @@ def platform():
     return 'MAC'
 
   raise ValueError('Unsupported platform "%s".' % sys.platform)
+
+
+def platform_vesion():
+  """Return the operating system type, unless an override is provided."""
+  environment_override = get_value('OS_OVERRIDE')
+  if environment_override:
+    return ''
+  return release()
 
 
 def remove_key(key_name):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -55,35 +55,35 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
 
   def setUp(self):
     test_utils.set_up_pyfakefs(self)
-    helpers.patch(
-      self,
-      [
+    helpers.patch(self, [
         'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
         'clusterfuzz._internal.system.environment.platform',
-        'clusterfuzz._internal.system.environment.release'])
+        'clusterfuzz._internal.system.environment.release'
+    ])
 
     os.environ['ROOT_DIR'] = '/root'
     os.environ['FAIL_RETRIES'] = '1'
 
-    self.OS_TYPE = 'unix'
-    self.OS_VERSION = 'v5'
-    self.CLUSTERFUZZ_RELEASE = 'prod'
-    self.mock.release.return_value = self.OS_VERSION
-    self.mock.platform.return_value = self.OS_TYPE
-    self.mock.get_clusterfuzz_release.return_value = self.CLUSTERFUZZ_RELEASE
+    self.os_type = 'unix'
+    self.os_version = 'v5'
+    self.clusterfuzz_release = 'prod'
+    self.mock.release.return_value = self.os_version
+    self.mock.platform.return_value = self.os_type
+    self.mock.get_clusterfuzz_release.return_value = self.clusterfuzz_release
 
     monitor.metrics_store().reset_for_testing()
 
   def test_no_revision(self):
     """Test when there's no revision."""
     update_task.track_revision()
-    self.assertEqual(0,
-                     monitoring_metrics.BOT_COUNT.get({
-                         'revision': 'revision',
-                         'os_type': self.OS_TYPE,
-                         'os_version': self.OS_VERSION,
-                         'release': self.CLUSTERFUZZ_RELEASE,
-                     }))
+    self.assertEqual(
+        0,
+        monitoring_metrics.BOT_COUNT.get({
+            'revision': 'revision',
+            'os_type': self.os_type,
+            'os_version': self.os_version,
+            'release': self.clusterfuzz_release,
+        }))
 
   def test_has_revision(self):
     """Test when there's a revision."""
@@ -91,13 +91,14 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     self.fs.create_file(
         os.path.join('/root', utils.LOCAL_SOURCE_MANIFEST), contents='revision')
     update_task.track_revision()
-    self.assertEqual(1,
-                     monitoring_metrics.BOT_COUNT.get({
-                         'revision': 'revision',
-                         'os_type': self.OS_TYPE,
-                         'os_version': self.OS_VERSION,
-                         'release': self.CLUSTERFUZZ_RELEASE,
-                     }))
+    self.assertEqual(
+        1,
+        monitoring_metrics.BOT_COUNT.get({
+            'revision': 'revision',
+            'os_type': self.os_type,
+            'os_version': self.os_version,
+            'release': self.clusterfuzz_release,
+        }))
 
 
 class GetNewerSourceRevisionTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -55,6 +55,7 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
 
   def setUp(self):
     test_utils.set_up_pyfakefs(self)
+    helpers.patch_environ(self)
     helpers.patch(self, [
         'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
         'clusterfuzz._internal.system.environment.platform',

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -55,10 +55,22 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
 
   def setUp(self):
     test_utils.set_up_pyfakefs(self)
-    helpers.patch_environ(self)
+    helpers.patch(
+      self,
+      [
+        'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
+        'clusterfuzz._internal.system.environment.platform',
+        'clusterfuzz._internal.system.environment.release'])
 
     os.environ['ROOT_DIR'] = '/root'
     os.environ['FAIL_RETRIES'] = '1'
+
+    self.OS_TYPE = 'unix'
+    self.OS_VERSION = 'v5'
+    self.CLUSTERFUZZ_RELEASE = 'prod'
+    self.mock.release.return_value = self.OS_VERSION
+    self.mock.platform.return_value = self.OS_TYPE
+    self.mock.get_clusterfuzz_release.return_value = self.CLUSTERFUZZ_RELEASE
 
     monitor.metrics_store().reset_for_testing()
 
@@ -67,7 +79,10 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     update_task.track_revision()
     self.assertEqual(0,
                      monitoring_metrics.BOT_COUNT.get({
-                         'revision': 'revision'
+                         'revision': 'revision',
+                         'os_type': self.OS_TYPE,
+                         'os_version': self.OS_VERSION,
+                         'release': self.CLUSTERFUZZ_RELEASE,
                      }))
 
   def test_has_revision(self):
@@ -78,7 +93,10 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     update_task.track_revision()
     self.assertEqual(1,
                      monitoring_metrics.BOT_COUNT.get({
-                         'revision': 'revision'
+                         'revision': 'revision',
+                         'os_type': self.OS_TYPE,
+                         'os_version': self.OS_VERSION,
+                         'release': self.CLUSTERFUZZ_RELEASE,
                      }))
 
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -58,7 +58,7 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
         'clusterfuzz._internal.system.environment.platform',
-        'clusterfuzz._internal.system.environment.release'
+        'clusterfuzz._internal.system.environment.platform_version'
     ])
 
     os.environ['ROOT_DIR'] = '/root'
@@ -67,7 +67,7 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     self.os_type = 'unix'
     self.os_version = 'v5'
     self.clusterfuzz_release = 'prod'
-    self.mock.release.return_value = self.os_version
+    self.mock.platform_version.return_value = self.os_version
     self.mock.platform.return_value = self.os_type
     self.mock.get_clusterfuzz_release.return_value = self.clusterfuzz_release
 

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -222,7 +222,13 @@ class JonathanDebugTest(unittest.TestCase):
     monitor.FLUSH_INTERVAL_SECONDS = 1
     monitor._monitoring_daemon = monitor._MonitoringDaemon(
         monitor._flush_metrics, monitor.FLUSH_INTERVAL_SECONDS)
-    monitoring_metrics.BOT_COUNT.set(1, {'revision': '1'})
+    labels = {
+      'revision': '1',
+      'os_type': 'unix',
+      'os_version': 'v5',
+      'release': 'prod'  
+    }
+    monitoring_metrics.BOT_COUNT.set(1, labels)
     monitor.utils.get_application_id = lambda: 'google.com:clusterfuzz'
     os.environ['BOT_NAME'] = 'bot-1'
     monitor._initialize_monitored_resource()

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -223,10 +223,10 @@ class JonathanDebugTest(unittest.TestCase):
     monitor._monitoring_daemon = monitor._MonitoringDaemon(
         monitor._flush_metrics, monitor.FLUSH_INTERVAL_SECONDS)
     labels = {
-      'revision': '1',
-      'os_type': 'unix',
-      'os_version': 'v5',
-      'release': 'prod'  
+        'revision': '1',
+        'os_type': 'unix',
+        'os_version': 'v5',
+        'release': 'prod'
     }
     monitoring_metrics.BOT_COUNT.set(1, labels)
     monitor.utils.get_application_id = lambda: 'google.com:clusterfuzz'


### PR DESCRIPTION
### Motivation

As a request from the Chrome team, it would be nice to know what:
* OS type
* OS version
* Release (prod/candidate)

a bot corresponds to. This PR implements that.

Part of #4271 