### PR TITLE
Make all batch tasks unprivileged

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -283,8 +283,7 @@ def _get_spec_from_config(command, job_name):
     config_name += '-NONPREEMPTIBLE'
   # TODO(metzman): Get rid of this when we stop doing privileged operations in
   # utasks.
-  if command in _UNPRIVILEGED_TASKS:
-    config_name += '-UNPRIVILEGED'
+  config_name += '-UNPRIVILEGED'
   batch_config = _get_batch_config()
   instance_spec = batch_config.get('mapping').get(config_name, None)
   if instance_spec is None:


### PR DESCRIPTION
We can deal with other needs less far in advance.