### PR TITLE
Enriching bot count metric

### DIFF
--- a/configs/test/batch/batch.yaml
+++ b/configs/test/batch/batch.yaml
@@ -45,4 +45,15 @@ mapping:
     gce_zone: 'gce-zone'
     preemptible: true
     machine_type: n1-standard-1
+  LINUX-PREEMPTIBLE-UNPRIVILEGED:
+    clusterfuzz_release: 'candidate'
+    docker_image: 'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
+    user_data: 'file://linux-init.yaml'
+    disk_size_gb: 75
+    disk_type: pd-standard
+    service_account_email: test-clusterfuzz-service-account-email
+    subnetwork: null
+    gce_zone: 'gce-zone'
+    preemptible: true
+    machine_type: n1-standard-1
 project: 'test-clusterfuzz'

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -104,11 +104,16 @@ def clear_pyc_files(directory):
       shell.remove_file(file_path)
 
 
+def _get_os_version():
+  """Returns the version for the current OS."""
+  return platform.release()
+
 def track_revision():
   """Get the local revision and report as a metric."""
   revision = get_local_source_revision() or ''
   os_type = environment.platform()
   labels = {
+      'os_version': _get_os_version(),
       'revision': revision,
       'os_type': os_type,
       'release': utils.get_clusterfuzz_release(),

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -104,16 +104,12 @@ def clear_pyc_files(directory):
       shell.remove_file(file_path)
 
 
-def _get_os_version():
-  """Returns the version for the current OS."""
-  return platform.release()
-
 def track_revision():
   """Get the local revision and report as a metric."""
   revision = get_local_source_revision() or ''
   os_type = environment.platform()
   labels = {
-      'os_version': _get_os_version(),
+      'os_version': platform.release(),
       'revision': revision,
       'os_type': os_type,
       'release': utils.get_clusterfuzz_release(),

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -107,7 +107,14 @@ def clear_pyc_files(directory):
 def track_revision():
   """Get the local revision and report as a metric."""
   revision = get_local_source_revision() or ''
-  monitoring_metrics.BOT_COUNT.set(1, {'revision': revision})
+  os_type = environment.platform()
+  labels = {
+    'revision': revision,
+    'os_type': os_type,
+    'release': utils.get_clusterfuzz_release(),
+
+  }
+  monitoring_metrics.BOT_COUNT.set(1, labels)
 
 
 def get_local_source_revision():

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -109,10 +109,9 @@ def track_revision():
   revision = get_local_source_revision() or ''
   os_type = environment.platform()
   labels = {
-    'revision': revision,
-    'os_type': os_type,
-    'release': utils.get_clusterfuzz_release(),
-
+      'revision': revision,
+      'os_type': os_type,
+      'release': utils.get_clusterfuzz_release(),
   }
   monitoring_metrics.BOT_COUNT.set(1, labels)
 

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -140,7 +140,8 @@ BOT_COUNT = monitor.GaugeMetric(
     field_spec=[
         monitor.StringField('revision'),
         monitor.StringField('os_type'),
-        monitor.StringField('release')
+        monitor.StringField('release'),
+        monitor.StringField('os_version')
     ])
 
 TASK_COUNT = monitor.CounterMetric(

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -137,7 +137,10 @@ TRY_COUNT = monitor.CounterMetric(
 BOT_COUNT = monitor.GaugeMetric(
     'bot_count',
     description='Bot count',
-    field_spec=[monitor.StringField('revision')])
+    field_spec=[
+        monitor.StringField('revision'),
+        monitor.StringField('os_type'),
+        monitor.StringField('release')])
 
 TASK_COUNT = monitor.CounterMetric(
     'task/count',

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -140,7 +140,8 @@ BOT_COUNT = monitor.GaugeMetric(
     field_spec=[
         monitor.StringField('revision'),
         monitor.StringField('os_type'),
-        monitor.StringField('release')])
+        monitor.StringField('release')
+    ])
 
 TASK_COUNT = monitor.CounterMetric(
     'task/count',

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -59,12 +59,12 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
         'clusterfuzz._internal.system.environment.platform',
-        'clusterfuzz._internal.bot.tasks.update_task._get_os_version',
+        'platform.release',
     ])
 
     self.mock.platform.return_value = 'unix'
     self.mock.get_clusterfuzz_release.return_value = 'prod'
-    self.mock._get_os_version.return_value = 'v5'
+    self.mock.release.return_value = 'v5'
 
     os.environ['ROOT_DIR'] = '/root'
     os.environ['FAIL_RETRIES'] = '1'

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -57,8 +57,8 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     test_utils.set_up_pyfakefs(self)
     helpers.patch_environ(self)
     helpers.patch(self, [
-      'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
-      'clusterfuzz._internal.system.environment.platform',
+        'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
+        'clusterfuzz._internal.system.environment.platform',
     ])
 
     self.mock.platform.return_value = 'unix'
@@ -72,12 +72,13 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
   def test_no_revision(self):
     """Test when there's no revision."""
     update_task.track_revision()
-    self.assertEqual(0,
-                     monitoring_metrics.BOT_COUNT.get({
-                         'revision': 'revision',
-                         'os_type': 'unix',
-                         'release': 'prod',
-                     }))
+    self.assertEqual(
+        0,
+        monitoring_metrics.BOT_COUNT.get({
+            'revision': 'revision',
+            'os_type': 'unix',
+            'release': 'prod',
+        }))
 
   def test_has_revision(self):
     """Test when there's a revision."""
@@ -85,12 +86,13 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     self.fs.create_file(
         os.path.join('/root', utils.LOCAL_SOURCE_MANIFEST), contents='revision')
     update_task.track_revision()
-    self.assertEqual(1,
-                     monitoring_metrics.BOT_COUNT.get({
-                         'revision': 'revision',
-                         'os_type': 'unix',
-                         'release': 'prod',
-                     }))
+    self.assertEqual(
+        1,
+        monitoring_metrics.BOT_COUNT.get({
+            'revision': 'revision',
+            'os_type': 'unix',
+            'release': 'prod',
+        }))
 
 
 class GetNewerSourceRevisionTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -56,6 +56,13 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
   def setUp(self):
     test_utils.set_up_pyfakefs(self)
     helpers.patch_environ(self)
+    helpers.patch(self, [
+      'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
+      'clusterfuzz._internal.system.environment.platform',
+    ])
+
+    self.mock.platform.return_value = 'unix'
+    self.mock.get_clusterfuzz_release.return_value = 'prod'
 
     os.environ['ROOT_DIR'] = '/root'
     os.environ['FAIL_RETRIES'] = '1'
@@ -67,7 +74,9 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     update_task.track_revision()
     self.assertEqual(0,
                      monitoring_metrics.BOT_COUNT.get({
-                         'revision': 'revision'
+                         'revision': 'revision',
+                         'os_type': 'unix',
+                         'release': 'prod',
                      }))
 
   def test_has_revision(self):
@@ -78,7 +87,9 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     update_task.track_revision()
     self.assertEqual(1,
                      monitoring_metrics.BOT_COUNT.get({
-                         'revision': 'revision'
+                         'revision': 'revision',
+                         'os_type': 'unix',
+                         'release': 'prod',
                      }))
 
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -59,10 +59,12 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
         'clusterfuzz._internal.system.environment.platform',
+        'clusterfuzz._internal.bot.tasks.update_task._get_os_version',
     ])
 
     self.mock.platform.return_value = 'unix'
     self.mock.get_clusterfuzz_release.return_value = 'prod'
+    self.mock._get_os_version.return_value = 'v5'
 
     os.environ['ROOT_DIR'] = '/root'
     os.environ['FAIL_RETRIES'] = '1'
@@ -77,6 +79,7 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
         monitoring_metrics.BOT_COUNT.get({
             'revision': 'revision',
             'os_type': 'unix',
+            'os_version': 'v5',
             'release': 'prod',
         }))
 
@@ -91,6 +94,7 @@ class TrackRevisionTest(fake_filesystem_unittest.TestCase):
         monitoring_metrics.BOT_COUNT.get({
             'revision': 'revision',
             'os_type': 'unix',
+            'os_version': 'v5',
             'release': 'prod',
         }))
 

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -222,11 +222,7 @@ class JonathanDebugTest(unittest.TestCase):
     monitor.FLUSH_INTERVAL_SECONDS = 1
     monitor._monitoring_daemon = monitor._MonitoringDaemon(
         monitor._flush_metrics, monitor.FLUSH_INTERVAL_SECONDS)
-    labels = {
-      'revision': '1',
-      'os_type': 'linux',
-      'release': 'candidate'
-    }
+    labels = {'revision': '1', 'os_type': 'linux', 'release': 'candidate'}
     monitoring_metrics.BOT_COUNT.set(1, labels)
     monitor.utils.get_application_id = lambda: 'google.com:clusterfuzz'
     os.environ['BOT_NAME'] = 'bot-1'

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -222,7 +222,12 @@ class JonathanDebugTest(unittest.TestCase):
     monitor.FLUSH_INTERVAL_SECONDS = 1
     monitor._monitoring_daemon = monitor._MonitoringDaemon(
         monitor._flush_metrics, monitor.FLUSH_INTERVAL_SECONDS)
-    labels = {'revision': '1', 'os_type': 'linux', 'release': 'candidate'}
+    labels = {
+      'revision': '1',
+      'os_type': 'linux',
+      'release': 'candidate',
+      'os_version': 'v5'
+    }
     monitoring_metrics.BOT_COUNT.set(1, labels)
     monitor.utils.get_application_id = lambda: 'google.com:clusterfuzz'
     os.environ['BOT_NAME'] = 'bot-1'

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -222,7 +222,12 @@ class JonathanDebugTest(unittest.TestCase):
     monitor.FLUSH_INTERVAL_SECONDS = 1
     monitor._monitoring_daemon = monitor._MonitoringDaemon(
         monitor._flush_metrics, monitor.FLUSH_INTERVAL_SECONDS)
-    monitoring_metrics.BOT_COUNT.set(1, {'revision': '1'})
+    labels = {
+      'revision': '1',
+      'os_type': 'linux',
+      'release': 'candidate'
+    }
+    monitoring_metrics.BOT_COUNT.set(1, labels)
     monitor.utils.get_application_id = lambda: 'google.com:clusterfuzz'
     os.environ['BOT_NAME'] = 'bot-1'
     monitor._initialize_monitored_resource()

--- a/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/monitor_test.py
@@ -223,10 +223,10 @@ class JonathanDebugTest(unittest.TestCase):
     monitor._monitoring_daemon = monitor._MonitoringDaemon(
         monitor._flush_metrics, monitor.FLUSH_INTERVAL_SECONDS)
     labels = {
-      'revision': '1',
-      'os_type': 'linux',
-      'release': 'candidate',
-      'os_version': 'v5'
+        'revision': '1',
+        'os_type': 'linux',
+        'release': 'candidate',
+        'os_version': 'v5'
     }
     monitoring_metrics.BOT_COUNT.set(1, labels)
     monitor.utils.get_application_id = lambda: 'google.com:clusterfuzz'


### PR DESCRIPTION
### Motivation

As a request from the Chrome team, it would be nice to know what:
* OS type
* OS version
* Release (prod/candidate)

a bot corresponds to. This PR implements that.

Part of #4271 