### PR TITLE
Adding fuzzing session duration metric

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1852,13 +1852,12 @@ class FuzzingSession:
     self.fuzz_task_output.crash_groups.extend(crash_groups)
 
     fuzzing_session_duration = time.time() - start_time
-    labels = {
-      'fuzzer': self.fuzzer_name,
-      'job': self.job_type,
-      'platform': environment.platform()
-    }
     monitoring_metrics.FUZZING_SESSION_DURATION.add(
-      fuzzing_session_duration, labels)
+        fuzzing_session_duration, {
+            'fuzzer': self.fuzzer_name,
+            'job': self.job_type,
+            'platform': environment.platform()
+        })
 
     return uworker_msg_pb2.Output(fuzz_task_output=self.fuzz_task_output)  # pylint: disable=no-member
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1698,6 +1698,7 @@ class FuzzingSession:
 
   def run(self):
     """Run the fuzzing session."""
+    start_time = time.time()
     # Update LSAN local blacklist with global blacklist.
     global_blacklisted_functions = (
         self.uworker_input.fuzz_task_input.global_blacklisted_functions)
@@ -1849,6 +1850,15 @@ class FuzzingSession:
     self.fuzz_task_output.testcases_executed = testcases_executed
     self.fuzz_task_output.fuzzer_revision = self.fuzzer.revision
     self.fuzz_task_output.crash_groups.extend(crash_groups)
+
+    fuzzing_session_duration = time.time() - start_time
+    labels = {
+      'fuzzer': self.fuzzer_name,
+      'job': self.job_type,
+      'platform': environment.platform()
+    }
+    monitoring_metrics.FUZZING_SESSION_DURATION.add(
+      fuzzing_session_duration, labels)
 
     return uworker_msg_pb2.Output(fuzz_task_output=self.fuzz_task_output)  # pylint: disable=no-member
 

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -418,7 +418,6 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
       A bool indicating whether or not the command succeeded.
     """
     filenames_to_delete_dict = self._filenames_to_delete_urls_mapping.copy()
-    len_corpus = len(self._filenames_to_delete_urls_mapping)
     filepaths_to_upload = []
     logs.info('Rsyncing corpus from disk.')
     for filepath in shell.get_files_list(directory):

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -84,6 +84,17 @@ FUZZER_TOTAL_FUZZ_TIME = monitor.CounterMetric(
     ],
 )
 
+FUZZING_SESSION_DURATION = monitor.CumulativeDistributionMetric(
+    'task/fuzz/session/duration',
+    bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),
+    description=('Total duration of fuzzing session.'),
+    field_spec=[
+        monitor.StringField('fuzzer'),
+        monitor.StringField('job'),
+        monitor.StringField('platform'),
+    ],
+)
+
 JOB_TOTAL_FUZZ_TIME = monitor.CounterMetric(
     'task/fuzz/job/total_time',
     description=('The total fuzz time in seconds '

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -84,6 +84,8 @@ FUZZER_TOTAL_FUZZ_TIME = monitor.CounterMetric(
     ],
 )
 
+# This metric tracks fuzzer setup and data bundle update,
+# fuzzing time and the time to upload results to datastore
 FUZZING_SESSION_DURATION = monitor.CumulativeDistributionMetric(
     'task/fuzz/session/duration',
     bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),


### PR DESCRIPTION
### Motivation

We currently lack metrics for fuzzing session duration. This PR adds that as a histogram metric, with granularity by fuzzer, job and platform.

Part of #4271