### PR TITLE
Add a task id for easy tracking of tasks. 

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -14,6 +14,7 @@
 """Run command based on the current task."""
 
 import functools
+import os
 import sys
 import time
 import uuid

--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -92,6 +92,8 @@ def cleanup_task_state():
 
   # Call python's garbage collector.
   utils.python_gc()
+  if 'CF_TASK_ID' in os.environ:
+    del os.environ['CF_TASK_ID']
 
 
 def is_supported_cpu_arch_for_job():

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -375,7 +375,7 @@ def configure_cloud_logging():
   # Note that CLOUD_PROJECT_ID is not used here, as it might differ from both
   #   the service account's project and the logging project.
   client = google.cloud.logging.Client(
-      project=os.getenv("LOGGING_CLOUD_PROJECT_ID"))
+      project=os.getenv('LOGGING_CLOUD_PROJECT_ID'))
   labels = {
       'compute.googleapis.com/resource_name': socket.getfqdn().lower(),
       'bot_name': os.getenv('BOT_NAME'),
@@ -403,6 +403,8 @@ def configure_cloud_logging():
             json.dumps(
                 getattr(record, 'location', {'Error': True}),
                 default=_handle_unserializable)
+        'task_id':
+            os.getenv('CF_TASK_ID', 'null'),
     })
     return True
 

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -402,7 +402,7 @@ def configure_cloud_logging():
         'location':
             json.dumps(
                 getattr(record, 'location', {'Error': True}),
-                default=_handle_unserializable)
+                default=_handle_unserializable),
         'task_id':
             os.getenv('CF_TASK_ID', 'null'),
     })


### PR DESCRIPTION
This should make it easy to get the logs for the
preprocess, postprocess, and main parts of a task.