### PR TITLE
Instrumenting the test syncer script

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -206,6 +206,12 @@ ANDROID_UPTIME = monitor.CounterMetric(
     ],
 )
 
+CHROME_TEST_SYNCER_SUCCESS = monitor.CounterMetric(
+    'chrome_test_syncer_success',
+    description='Counter for successful test syncer exits.',
+    field_spec=[],
+)
+
 # Metrics related to issue lifecycle
 
 ISSUE_FILING = monitor.CounterMetric(

--- a/src/python/other-bots/chromium-tests-syncer/run.py
+++ b/src/python/other-bots/chromium-tests-syncer/run.py
@@ -32,6 +32,8 @@ from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.datastore import ndb_init
 from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.metrics import monitor
+from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.system import archive
 from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.system import shell
@@ -293,6 +295,7 @@ def main():
       ['gsutil', 'cp', tests_archive_local, tests_archive_remote])
 
   logs.info('Completed cycle, sleeping for %s seconds.' % sync_interval)
+  monitoring_metrics.CHROME_TEST_SYNCER_SUCCESS.increment(1)
   time.sleep(sync_interval)
 
 
@@ -306,7 +309,7 @@ if __name__ == '__main__':
   # Continue this forever.
   while True:
     try:
-      with ndb_init.context():
+      with monitor.wrap_with_monitoring(), ndb_init.context():
         main()
     except Exception:
       logs.error('Failed to sync tests.')


### PR DESCRIPTION
### Motivation

We currently have no way to tell if the chrome test syncer is running successfully. This PR implements a counter metric, that can be used to alert on if missing for 12h (or some arbitrary treshold).

The monitor wrapper must be done in main for this script, since it is the entrypoint 
Reference: https://github.com/google/clusterfuzz/blob/master/docker/chromium/tests-syncer/Dockerfile#L17

Part of #4271 