### PR TITLE
Adding args and kwargs to oauth decorator in appengine

### DIFF
--- a/src/appengine/libs/handler.py
+++ b/src/appengine/libs/handler.py
@@ -248,20 +248,20 @@ def oauth(func):
   """
 
   @functools.wraps(func)
-  def wrapper(self):
+  def wrapper(self, *args, **kwargs):
     """Wrapper."""
     auth_header = request.headers.get('Authorization')
     if auth_header:
       email, returned_auth_header = get_email_and_access_token(auth_header)
       setattr(g, '_oauth_email', email)
 
-      response = make_response(func(self))
+      response = make_response(func(self, *args, **kwargs))
       response.headers[CLUSTERFUZZ_AUTHORIZATION_HEADER] = str(
           returned_auth_header)
       response.headers[CLUSTERFUZZ_AUTHORIZATION_IDENTITY] = str(email)
       return response
 
-    return func(self)
+    return func(self, *args, **kwargs)
 
   return wrapper
 


### PR DESCRIPTION
### Motivation 

#4312 added the oauth handler to several get endpoints, in order for GCP uptime to probe them. However, the decorator assumed that all handlers would be of the form func(self), not declaring args or kwargs.

This is not true, for the following signatures:
```
coverage_report.py
...
  def get(self, report_type=None, argument=None, date=None, extra=None):
  
fuzzer_stats.py
...
  def get(self, extra=None):
```

This PR adds *args and **kwargs to the wrapper, so it can work for these endpoints.

Part of #4271 

Error groups:
[coverage](https://pantheon.corp.google.com/errors/detail/CKrE1Jfd88vKIQ;service=;version=;filter=%5B%22handler%22%5D;time=P7D;locations=global?e=-13802955&inv=1&invt=AbfeYw&mods=logs_tg_prod&project=clusterfuzz-external)
[stats](https://pantheon.corp.google.com/errors/detail/CMiEwKaYs4DfEA;service=;version=;filter=%5B%22handler%22%5D;time=P7D;locations=global?e=-13802955&inv=1&invt=AbfeYw&mods=logs_tg_prod&project=clusterfuzz-external)