### PR TITLE
Remove incorrect assertion.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -749,8 +749,9 @@ def get_data_bundle_directory(fuzzer, setup_input):
   if not setup_input.data_bundle_corpuses:
     data_bundle = None
   else:
-    # There should only be one of these, get the first one.
-    assert len(setup_input.data_bundle_corpuses) == 1
+    # TODO(metzman): The old behavior was to call .get() on a query and get an
+    # arbitrary data bundle. What should we actually do when there's more than
+    # one?
     data_bundle = setup_input.data_bundle_corpuses[0].data_bundle
     data_bundle = uworker_io.entity_from_protobuf(data_bundle,
                                                   data_types.DataBundle)


### PR DESCRIPTION
I now understand what .get() does when a query returns more than one result, it gets an arbitrary one, it doesn't error. So don't error here.

Fixes: https://pantheon.corp.google.com/errors/detail/CKjxheXi1cOF-AE;filter=%5B%5D;time=PT1H;locations=global?e=-13802955&invt=AbfeBw&mods=logs_tg_prod&project=google.com:clusterfuzz