### PR TITLE
Adding test case reproducibility metric

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -414,7 +414,8 @@ def utask_main(uworker_input):
         labels={
             'fuzzer_name': uworker_input.fuzzer_name,
             'job': uworker_input.job_type,
-            'outcome': 'does_not_reproduce',
+            'crashes': False,
+            'reproducible': False,
             'platform': environment.platform(),
         })
     return uworker_msg_pb2.Output(  # pylint: disable=no-member
@@ -436,13 +437,13 @@ def utask_main(uworker_input):
   one_time_flag = testcase.one_time_crasher_flag
 
   analyze_task_output.one_time_crasher_flag = one_time_flag
-  analyze_outcome = 'one_timer' if one_time_flag else 'reproduces'
 
   monitoring_metrics.ANALYZE_TASK_REPRODUCIBILITY.increment(
       labels={
           'fuzzer_name': uworker_input.fuzzer_name,
           'job': uworker_input.job_type,
-          'outcome': analyze_outcome,
+          'crashes': True,
+          'reproducible': not one_time_flag,
           'platform': environment.platform(),
       })
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -2045,8 +2045,7 @@ def _to_engine_output(output: str, return_code: int,
 def _upload_engine_output_log(engine_output):
   timestamp = uworker_io.proto_timestamp_to_timestamp(engine_output.timestamp)
   testcase_manager.upload_log(engine_output.output.decode(),
-                              engine_output.return_code,
-                              timestamp)
+                              engine_output.return_code, timestamp)
 
 
 def utask_postprocess(output):

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -230,11 +230,13 @@ ISSUE_CLOSING = monitor.CounterMetric(
         monitor.StringField('status'),
     ])
 
+
 ANALYZE_TASK_REPRODUCIBILITY = monitor.CounterMetric(
     'task/analyze/reproducibility',
     description='Outcome count for analyze task.',
     field_spec=[
         monitor.StringField('job'),
         monitor.StringField('fuzzer_name'),
-        monitor.StringField('outcome'),
+        monitor.BooleanField('reproducible'),
+        monitor.BooleanField('crashes'),
     ])

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -229,3 +229,12 @@ ISSUE_CLOSING = monitor.CounterMetric(
         monitor.StringField('fuzzer_name'),
         monitor.StringField('status'),
     ])
+
+ANALYZE_TASK_REPRODUCIBILITY = monitor.CounterMetric(
+    'task/analyze/reproducibility',
+    description='Outcome count for analyze task.',
+    field_spec=[
+        monitor.StringField('job'),
+        monitor.StringField('fuzzer_name'),
+        monitor.StringField('outcome'),
+    ])

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -230,7 +230,6 @@ ISSUE_CLOSING = monitor.CounterMetric(
         monitor.StringField('status'),
     ])
 
-
 ANALYZE_TASK_REPRODUCIBILITY = monitor.CounterMetric(
     'task/analyze/reproducibility',
     description='Outcome count for analyze task.',


### PR DESCRIPTION
### Motivation

The Chrome team has no easy visibility into how many manually uploaded test cases flake or successfully reproduce. This PR implements a counter metric to track that.

There are three possible outcomes, each represented by a string label: 'reproduces', 'one_timer' and 'does_not_reproduce'

Part of #4271 