### PR TITLE
Gate async HTTP on a config

### DIFF
--- a/configs/test/project.yaml
+++ b/configs/test/project.yaml
@@ -42,6 +42,10 @@ monitoring:
   # Flag to indicate if Stackdriver monitoring is enabled or not (disabled by default).
   enabled: false
 
+async_http:
+  # WARNING: This can cause OOMs.
+  enabled: true
+
 firebase:
   # API key for Firebase (public).
   api_key: firebase-api-key

--- a/src/clusterfuzz/_internal/system/fast_http.py
+++ b/src/clusterfuzz/_internal/system/fast_http.py
@@ -19,10 +19,10 @@ import itertools
 import multiprocessing
 from typing import List
 from typing import Tuple
-from clusterfuzz._internal.base import utils
 
 import aiohttp
 
+from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 

--- a/src/clusterfuzz/_internal/system/fast_http.py
+++ b/src/clusterfuzz/_internal/system/fast_http.py
@@ -60,7 +60,7 @@ def download_urls(urls_and_filepaths: List[Tuple[str, str]]) -> List[bool]:
     batch = urls_and_filepaths[idx:idx + batch_size]
     batches.append(batch)
   with _pool() as pool:
-    return list(itertools.chain(*map(_download_files, batches)))
+    return list(itertools.chain(*pool.map(_download_files, batches)))
 
 
 def _download_files(urls_and_paths: List[Tuple[str, str]]) -> List[bool]:

--- a/src/clusterfuzz/_internal/system/fast_http.py
+++ b/src/clusterfuzz/_internal/system/fast_http.py
@@ -18,7 +18,6 @@ import contextlib
 import itertools
 import multiprocessing
 from typing import List
-from typing import Optional
 from typing import Tuple
 
 import aiohttp
@@ -41,36 +40,32 @@ def _pool(pool_size=_POOL_SIZE):
     yield futures.ProcessPoolExecutor(pool_size)
 
 
-def download_urls(urls: List[str], filepaths: List[str]) -> List[Optional[str]]:
-  """Downloads multiple |urls| to |filepaths| in parallel and
-  asynchronously. Tolerates errors. Returns a list of whether each
-  download was successful."""
-  assert len(urls) == len(filepaths)
-  if len(urls) == 0:
+def download_urls(urls_and_filepaths: List[Tuple[str, str]]) -> List[bool]:
+  """Downloads multiple urls to filepaths in parallel and asynchronously.
+  Tolerates errors. Returns a list of whether each download was successful."""
+  if len(urls_and_filepaths) == 0:
     # Do this to avoid issues with the range function.
     return []
-  url_batches = []
-  url_batch_size = len(urls) // _POOL_SIZE
+  batches = []
 
+  batch_size = len(urls_and_filepaths) // _POOL_SIZE
   # Avoid issues with range when urls is less than _POOL_SIZE.
-  url_batch_size = max(url_batch_size, len(urls))
+  batch_size = max(batch_size, len(urls_and_filepaths))
 
-  urls_and_filepaths = list(zip(urls, filepaths))
-  for idx in range(0, len(urls), url_batch_size):
-    url_batch = urls_and_filepaths[idx:idx + url_batch_size]
-    url_batches.append(url_batch)
+  for idx in range(0, len(urls_and_filepaths), batch_size):
+    batch = urls_and_filepaths[idx:idx + batch_size]
+    batches.append(batch)
   with _pool() as pool:
-    return list(itertools.chain(*pool.map(_download_files, url_batches)))
+    return list(itertools.chain(*pool.map(_download_files, batches)))
 
 
-def _download_files(
-    urls_and_paths: List[Tuple[str, str]]) -> List[Optional[str]]:
+def _download_files(urls_and_paths: List[Tuple[str, str]]) -> List[bool]:
   urls, paths = list(zip(*urls_and_paths))
   return asyncio.run(_async_download_files(list(urls), list(paths)))
 
 
 async def _async_download_files(urls: List[str],
-                                paths: List[str]) -> List[Optional[str]]:
+                                paths: List[str]) -> List[bool]:
   async with aiohttp.ClientSession() as session:
     tasks = [
         asyncio.create_task(_error_tolerant_download_file(session, url, path))
@@ -80,13 +75,13 @@ async def _async_download_files(urls: List[str],
 
 
 async def _error_tolerant_download_file(session: aiohttp.ClientSession,
-                                        url: str, path: str) -> Optional[str]:
+                                        url: str, path: str) -> bool:
   try:
     await _async_download_file(session, url, path)
-    return url
+    return True
   except:
     logs.warning(f'Failed to download {url}.')
-    return None
+    return False
 
 
 async def _async_download_file(session: aiohttp.ClientSession, url: str,
@@ -102,8 +97,5 @@ async def _async_download_file(session: aiohttp.ClientSession, url: str,
           status=response.status,
       )
     with open(path, 'wb') as fp:
-      while True:
-        chunk = await response.content.read(1024)
-        if not chunk:
-          return
+      async for chunk in response.content.iter_any(1024):
         fp.write(chunk)


### PR DESCRIPTION
The async HTTP usage has been shown to cause OOMs in OSS-Fuzz that cause significant problems,
in particular causing NTP to fail to sync.