### PR TITLE
google_issue_tracker: Set default priority.

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -44,6 +44,7 @@ _OSS_FUZZ_PROJECT_CUSTOM_FIELD_ID = '1349507'
 _SEVERITY_LABEL_PREFIX = 'Security_Severity-'
 
 _DEFAULT_SEVERITY = 'S4'
+_DEFAULT_PRIORITY = 'P4'
 
 
 class IssueAccessLevel(str, enum.Enum):
@@ -722,11 +723,10 @@ class Issue(issue_tracker.Issue):
     """Saves the issue."""
     if self._is_new:
       logs.info('google_issue_tracker: Creating new issue..')
-      priority = _extract_label(self.labels, 'Pri-')
+      priority = _extract_label(self.labels, 'Pri-') or _DEFAULT_PRIORITY
       issue_type = _extract_label(self.labels, 'Type-') or 'BUG'
       self._data['issueState']['type'] = issue_type
-      if priority:
-        self._data['issueState']['priority'] = priority
+      self._data['issueState']['priority'] = priority
 
       custom_field_entries = []
       oses = _sanitize_oses(_extract_all_labels(self.labels, 'OS-'))

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -258,6 +258,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'hotlistIds': [12345],
                     'type': 'BUG',
                     'severity': 'S4',
+                    'priority': 'P4',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -300,7 +301,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'status': 'ASSIGNED',
                     'title': 'issue title',
                     'type': 'BUG',
-                    'severity': 'S4'
+                    'severity': 'S4',
+                    'priority': 'P4',
                 },
                 'issueComment': {
                     'comment': 'issue body'
@@ -371,6 +373,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'foundInVersions': ['123', '789'],
                     'severity':
                         'S4',
+                    'priority':
+                        'P4',
                 },
                 'issueComment': {
                     'comment': 'issue body'
@@ -403,6 +407,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'title': 'issue title',
                     'type': 'BUG',
                     'severity': 'S4',
+                    'priority': 'P4',
                 },
             },
             templateOptions_applyTemplate=True,
@@ -471,6 +476,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                     'foundInVersions': ['123', '789'],
                     'severity':
                         'S4',
+                    'priority':
+                        'P4',
                 },
                 'issueComment': {
                     'comment': 'issue body'
@@ -535,6 +542,8 @@ class GoogleIssueTrackerTest(unittest.TestCase):
                         'Bug-Security',
                     'severity':
                         'S4',
+                    'priority':
+                        'P4',
                 },
                 'issueComment': {
                     'comment': 'issue body'


### PR DESCRIPTION
Otherwise new issues may error out because it's a required field.