### PR TITLE
add logs at the end of unpacking

### DIFF
--- a/src/clusterfuzz/_internal/system/archive.py
+++ b/src/clusterfuzz/_internal/system/archive.py
@@ -181,6 +181,8 @@ class ArchiveReader(abc.ABC):
       if archive_file_unpack_count % 1000 == 0:
         logs.info('Unpacked %d/%d.' % (archive_file_unpack_count,
                                        archive_file_total_count))
+    logs.info('Unpacked %d/%d. Done.' % (archive_file_unpack_count,
+                                         archive_file_total_count))
 
     return not error_occurred
 


### PR DESCRIPTION
We are currently logging progression when unpacking, but we're missing the last log. This can be useful to monitor what's going on in CF.