### PR TITLE
[Monitoring] Collecting a metric for the age of untriaged testcases

### DIFF
--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -347,7 +347,6 @@ def main():
       continue
 
     critical_tasks_completed = data_handler.critical_tasks_completed(testcase)
-    _emmit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
 
     # Skip if testcase's job is removed.
     if testcase.job_type not in all_jobs:
@@ -356,6 +355,9 @@ def main():
     # Skip if testcase's job is in exclusions list.
     if testcase.job_type in excluded_jobs:
       continue
+
+    # Emmit the metric for testcases that should be triaged.
+    _emmit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
 
     # Skip if we are running progression task at this time.
     if testcase.get_metadata('progression_pending'):

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -305,11 +305,9 @@ def _emit_untriaged_testcase_age_metric(critical_tasks_completed: bool,
     return
   if not testcase.timestamp:
     return
-  current_time = datetime.datetime.utcnow()
-  testcase_age = current_time - testcase.get_created_time()
-  testcase_age = testcase_age.total_seconds()
+
   monitoring_metrics.UNTRIAGED_TESTCASE_AGE.add(
-      testcase_age,
+      testcase.get_age_in_seconds(),
       labels={
           'job': testcase.job_type,
           'platform': testcase.platform,

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -306,7 +306,13 @@ def _emmit_untriaged_testcase_age_metric(critical_tasks_completed: bool,
   if not testcase.timestamp:
     return
   current_time = datetime.datetime.utcnow()
-  testcase_age = current_time - testcase.timestamp
+  # testcase.timestamp is mutated in analyze task.
+  # taking the minimum between these two timestamps
+  # avoids the need to backfill creation_timestamp
+  testcase_creation_time = testcase.timestamp
+  if testcase.creation_timestamp:
+    testcase_creation_time = testcase.creation_timestamp
+  testcase_age = current_time - testcase_creation_time
   testcase_age = testcase_age.total_seconds()
   monitoring_metrics.UNTRIAGED_TESTCASE_AGE.add(
       testcase_age,

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -298,9 +298,8 @@ def _file_issue(testcase, issue_tracker, throttler):
   return filed
 
 
-def _emmit_untriaged_testcase_age_metric(
-    critical_tasks_completed: bool,
-    testcase: data_types.Testcase):
+def _emmit_untriaged_testcase_age_metric(critical_tasks_completed: bool,
+                                         testcase: data_types.Testcase):
   """Emmits a metric to track age of untriaged testcases."""
   if critical_tasks_completed:
     return
@@ -310,12 +309,11 @@ def _emmit_untriaged_testcase_age_metric(
   testcase_age = current_time - testcase.timestamp
   testcase_age = testcase_age.total_seconds()
   monitoring_metrics.UNTRIAGED_TESTCASE_AGE.add(
-    testcase_age,
-    labels = {
-      'job': testcase.job_type,
-      'platform': testcase.platform,
-    }
-  )
+      testcase_age,
+      labels={
+          'job': testcase.job_type,
+          'platform': testcase.platform,
+      })
 
 
 def main():

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -788,7 +788,7 @@ def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
   testcase.archive_filename = archive_filename
   testcase.http_flag = http_flag
   testcase.timestamp = datetime.datetime.utcnow()
-  testcase.creation_timestamp = testcase.timestamp
+  testcase.created = testcase.timestamp
   testcase.gestures = gestures
   testcase.redzone = redzone
   testcase.disable_ubsan = disable_ubsan
@@ -1378,7 +1378,7 @@ def create_user_uploaded_testcase(key,
       testcase.set_metadata(metadata_key, metadata_value, update_testcase=False)
 
   testcase.timestamp = utils.utcnow()
-  testcase.creation_timestamp = testcase.timestamp
+  testcase.created = testcase.timestamp
   testcase.uploader_email = uploader_email
   testcase.put()
 

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -788,6 +788,7 @@ def store_testcase(crash, fuzzed_keys, minimized_keys, regression, fixed,
   testcase.archive_filename = archive_filename
   testcase.http_flag = http_flag
   testcase.timestamp = datetime.datetime.utcnow()
+  testcase.creation_timestamp = testcase.timestamp
   testcase.gestures = gestures
   testcase.redzone = redzone
   testcase.disable_ubsan = disable_ubsan
@@ -1377,6 +1378,7 @@ def create_user_uploaded_testcase(key,
       testcase.set_metadata(metadata_key, metadata_value, update_testcase=False)
 
   testcase.timestamp = utils.utcnow()
+  testcase.creation_timestamp = testcase.timestamp
   testcase.uploader_email = uploader_email
   testcase.put()
 

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -684,6 +684,11 @@ class Testcase(Model):
   def get_created_time(self) -> ndb.DateTimeProperty:
     return self.created if self.created else self.timestamp
 
+  def get_age_in_seconds(self):
+    current_time = datetime.datetime.utcnow()
+    testcase_age = current_time - self.get_created_time()
+    return testcase_age.total_seconds()
+
   def get_metadata(self, key=None, default=None):
     """Get metadata for a test case. Slow on first access."""
     self._ensure_metadata_is_cached()

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -423,6 +423,9 @@ class Testcase(Model):
   # Timestamp.
   timestamp = ndb.DateTimeProperty()
 
+  # Original creation timestamp.
+  creation_timestamp = ndb.DateTimeProperty()
+
   # Does the testcase crash stack vary b/w crashes ?
   flaky_stack = ndb.BooleanProperty(default=False, indexed=False)
 

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -264,6 +264,17 @@ ISSUE_CLOSING = monitor.CounterMetric(
         monitor.StringField('status'),
     ])
 
+UNTRIAGED_TESTCASE_AGE = monitor.CumulativeDistributionMetric(
+    'issues/untriaged_testcase_age',
+    description='Age of testcases that were not yet triaged '
+    '(have not yet completed analyze, progression,'
+    ' minimization, impact task), in seconds.',
+    bucketer=monitor.GeometricBucketer(),
+    field_spec=[
+        monitor.StringField('job'),
+        monitor.StringField('platform'),
+    ])
+
 ANALYZE_TASK_REPRODUCIBILITY = monitor.CounterMetric(
     'task/analyze/reproducibility',
     description='Outcome count for analyze task.',

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -276,7 +276,7 @@ ISSUE_CLOSING = monitor.CounterMetric(
 UNTRIAGED_TESTCASE_AGE = monitor.CumulativeDistributionMetric(
     'issues/untriaged_testcase_age',
     description='Age of testcases that were not yet triaged '
-    '(have not yet completed analyze, progression,'
+    '(have not yet completed analyze, regression,'
     ' minimization, impact task), in seconds.',
     bucketer=monitor.GeometricBucketer(),
     field_spec=[


### PR DESCRIPTION
### Motivation


Once a testcase is generated (or manually uploaded), followup tasks (analyze/progression) are started. This happens by publishing to a pubsub queue, both for the manually uploaded case, and for the fuzzer generated case.

If for any reason the messages are not processed, the testcase gets stuck. To get better visibility into these stuck testcases, the UNTRIAGED_TESTCASE_AGE metric is introduced, to pinpoint how old these testcases that have not yet been triaged are(more precisely, gone through analyze/regression/impact/progression tasks).


### Attention points

Testcase.timestamp mutates in analyze task:

https://github.com/google/clusterfuzz/blob/6ed80851ad0f6f624c5b232b0460c405f0a018b5/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py#L589

 This makes it unreliable as a source of truth for testcase creation time. To circumvent that, a new ```created``` field is added to the Testcase entity, from which we can derive the correct creation time.

Since this new field will only apply for testcases created after this PR is merged, Testcase.timestamp will be used instead to calculate the testcase age when the new field is missing.

### Testing strategy

Ran the triage cron locally, and verified the codepath for the metric is hit and produces sane output (reference testcase: 4505741036158976).
![image](https://github.com/user-attachments/assets/6281b44f-768a-417e-8ec1-763f132c8181)


Part of #4271 
