### PR TITLE
[rate limitng] Record errors properly.

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/task_rate_limiting.py
+++ b/src/clusterfuzz/_internal/base/tasks/task_rate_limiting.py
@@ -20,7 +20,6 @@ from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
-
 # TODO(metzman): This needs to be done better in utasks where main may return
 # an error rather than except. This needs to be handled in postprocess.
 

--- a/src/clusterfuzz/_internal/base/tasks/task_rate_limiting.py
+++ b/src/clusterfuzz/_internal/base/tasks/task_rate_limiting.py
@@ -21,6 +21,10 @@ from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
 
+# TODO(metzman): This needs to be done better in utasks where main may return
+# an error rather than except. This needs to be handled in postprocess.
+
+
 def _get_datetime_now():
   return datetime.datetime.now()
 

--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -203,8 +203,8 @@ def run_command(task_name, task_argument, job_name, uworker_env):
   if should_update_task_status(task_name):
     if not data_handler.update_task_status(task_state_name,
                                            data_types.TaskState.STARTED):
-      logs.info('Another instance of "{}" already '
-                'running, exiting.'.format(task_state_name))
+      logs.info(f'Another instance of "{task_state_name}" already running, '
+                'exiting.')
       raise AlreadyRunningError
 
   result = None
@@ -227,10 +227,10 @@ def run_command(task_name, task_argument, job_name, uworker_env):
     rate_limiter.record_task(success=False)
   except BaseException:
     # On any other exceptions, update state to reflect error and re-raise.
+    rate_limiter.record_task(success=False)
     if should_update_task_status(task_name):
       data_handler.update_task_status(task_state_name,
                                       data_types.TaskState.ERROR)
-      rate_limiter.record_task(success=False)
     raise
   else:
     rate_limiter.record_task(success=True)


### PR DESCRIPTION
We can't record an error after an exception is raised. Record it first.