### PR TITLE
Start to schedule fuzz tasks on batch in OSS-Fuzz

### DIFF
--- a/configs/test/batch/batch.yaml
+++ b/configs/test/batch/batch.yaml
@@ -70,4 +70,4 @@ project: 'test-clusterfuzz'
 # TODO(metzman): Come up with a better system than this. I think a system where
 # we have a list of zones and associated config (such as subnets) to pick where
 # to launch tasks is ideal.
-zone: 'us-central1-a'
+region: 'us-central1-a'

--- a/configs/test/batch/batch.yaml
+++ b/configs/test/batch/batch.yaml
@@ -67,3 +67,7 @@ mapping:
     preemptible: true
     machine_type: n1-standard-1
 project: 'test-clusterfuzz'
+# TODO(metzman): Come up with a better system than this. I think a system where
+# we have a list of zones and associated config (such as subnets) to pick where
+# to launch tasks is ideal.
+zone: 'us-central1-a'

--- a/configs/test/batch/batch.yaml
+++ b/configs/test/batch/batch.yaml
@@ -69,4 +69,4 @@ project: 'test-clusterfuzz'
 # TODO(metzman): Come up with a better system than this. I think a system where
 # we have a list of zones and associated config (such as subnets) to pick where
 # to launch tasks is ideal.
-region: 'us-central1-a'
+region: 'us-central1'

--- a/configs/test/batch/batch.yaml
+++ b/configs/test/batch/batch.yaml
@@ -20,7 +20,6 @@ mapping:
     disk_size_gb: 110
     disk_type: pd-standard
     service_account_email: test-clusterfuzz-service-account-email
-    subnetwork: null
     gce_region: 'gce-region'
     gce_zone: 'gce-zone'
     network: 'projects/google.com:clusterfuzz/global/networks/networkname'

--- a/infra/k8s/schedule-fuzz.yaml
+++ b/infra/k8s/schedule-fuzz.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup
+spec:
+  schedule: "*/20 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 1200  # 20 minutes.
+      template:
+        spec: 
+          containers:
+          - name: backup
+            image: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
+            imagePullPolicy: Always
+            env:
+            - name: CLUSTERFUZZ_RELEASE
+              value: "prod"
+            - name: RUN_CMD
+              value: "python3.11 $ROOT_DIR/src/python/bot/startup/run_cron.py schedule_fuzz"
+            - name: IS_K8S_ENV
+              value: "true"
+            - name: DISABLE_MOUNTS
+              value: "true"
+          restartPolicy: OnFailure
+      backoffLimit: 3

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -609,10 +609,8 @@ def add_utask_main(command, input_url, job_type, wait_time=None):
       extra_info={'initial_command': initial_command})
 
 
-def bulk_add_tasks(
-    tasks,
-    queue=None,
-    eta_now=False):
+def bulk_add_tasks(tasks, queue=None, eta_now=False):
+  """Adds |tasks| in bulk to |queue|."""
 
   # Old testcases may pass in queue=None explicitly, so we must check this here.
   if queue is None:
@@ -628,17 +626,17 @@ def bulk_add_tasks(
     for task in tasks:
       task.eta = now
 
-  pubsub.PubSubClient()
+  pubsub_client = pubsub.PubSubClient()
+  pubsub_messages = [task.to_pubsub_message() for task in tasks]
   pubsub_client.publish(
-      pubsub.topic_name(utils.get_application_id(), queue),
-      [task.to_pubsub_message() for task in tasks])
-
+      pubsub.topic_name(utils.get_application_id(), queue), pubsub_messages)
 
 
 def add_task(command,
              argument,
              job_type,
              queue=None,
+             wait_time=None,
              extra_info=None):
   """Add a new task to the job queue."""
   if wait_time is None:

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -28,13 +28,18 @@ from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
 
+
+def _get_quotas():
+  compute.regions().get(  # pylint: disable=no-member
+      region=region,
+      project=utils.get_application_id()).execute().quotas
+
+
 def get_available_cpus(region: str) -> int:
   """Gets the number of available CPUs in the current GCE region."""
   gcp_credentials = credentials.get_default()
   compute = discovery.build('compute', 'v1', credentials=gcp_credentials)
-  quotas = compute.regions().get(  # pylint: disable=no-member
-      region=region,
-      project=utils.get_application_id()).execute().quotas
+  quotas = _get_quotas()
 
   # If preemptible quota is not defined, we need to use CPU quota instead.
   cpu_quota = None

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -1,0 +1,167 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cron job to schedule fuzz tasks in ClusterFuzz."""
+
+import os
+import sys
+import time
+
+from googleapiclient import discovery
+
+from clusterfuzz._internal.base import utils
+from clusterfuzz._internal.base import tasks
+from clusterfuzz._internal.google_cloud_utils import credentials
+from clusterfuzz._internal.bot.tasks import task_creation
+from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.system import environment
+from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.datastore import ndb_utils
+
+
+def get_available_cpus(region: str) -> int:
+  """Gets the number of available CPUs in the current GCE region."""
+  gcp_credentials = credentials.get_default()
+  compute = discovery.build('compute', 'v1', credentials=gcp_credentials)
+  quotas = compute.regions().get(region=region,
+      project=project=utils.get_application_id()).execute().quotas
+
+  # If preemptible quota is not defined, we need to use CPU quota instead.
+  cpu_quota = None
+  preemptible_cpu = None
+
+  # Get preemptible_quota and cpu_quota from the list of quotas.
+  for quota in quotas:
+    if preemptible_quota and cpu_quota:
+      break
+    if quota['metric'] == 'CPUS':
+      cpu_quota = quota
+      continue
+    if quota['metric'] == 'PREEMPTIBLE_CPUS':
+      preemptible_quota = quota
+      continue
+    assert preemptible_quota and cpu_quota
+
+  if not preemptible_quota['limit']:
+    quota = cpu_quota
+  else:
+    quota = preemptible_quota
+  assert quota['limit'], quota
+
+  return quota['limit'] - quota['usage']
+
+
+def _get_job_to_oss_fuzz_project_mapping():
+  """Returns a mapping of jobs to OSS-Fuzz project."""
+  mapping = {}
+  for job in ndb_utils.get_all_from_query(data_types.Job.query()):
+    project_name = job.get_environment().get('PROJECT_NAME')
+    assert project_name
+    mappping[job.name] = project_name
+  return mapping
+
+
+class FuzzTaskSchedulerBase:
+  def __init__(self, num_cpus):
+    self.num_cpus = num_cpus
+
+  def get_fuzz_tasks(self):
+    raise NotImplemented
+
+  def _get_cpus_per_fuzz_job(self, job_name):
+    del job_name
+    # TODO(metzman): Actually implement this.
+    return 2
+
+  def get_fuzz_tasks(self, job_distributions):
+    pass
+
+
+class OssfuzzFuzzTaskScheduler(FuzzTaskSchedulerBase):
+
+  def get_fuzz_tasks(self) -> [tasks.Task]:
+    # TODO(metzman): Handle high end.
+    projects = list(ndb_utils.get_all_from_query(
+        data_types.OssFuzzProject.query()))
+
+    total_cpu_weight = sum(project.cpu_weight for project in projects)
+    project_weights = {}
+    for project in projects:
+      # Don't accidentally save this.
+      project_weight = project.cpu_weight / total_cpu_weight
+      project_weights[name] = project_weight
+
+    platform = environment.platform()
+    fuzzer_jobs = list(ndb_utils.get_all_from_query(
+        query.filter(data_types.FuzzerJobs.platform == platform)))
+    fuzzer_jobs = {job.name for job in fuzzer_jobs}
+
+    job_to_project = _get_job_to_oss_fuzz_project_mapping()
+    fuzzer_job_weights = {}
+    for fuzzer_job in fuzzer_jobs.values():
+      project_name = job_to_project[fuzzer_job.name]
+      fuzzer_job_weight = (
+          fuzzer_job.actual_weight * project_weights[project_name])
+      fuzzer_job_weights[fuzzer_job.name] = fuzzer_job_weight
+
+    # TODO(metzman): Handle different number of CPUs correctly.
+    fuzzer_job_names = list(fuzzer_job_weights.keys())
+    fuzzer_job_weights = [fuzzer_job_weight[name] for name in fuzzer_job_names]
+    num_instances = self.num_cpus
+
+    choices = random.choices(
+        fuzzer_job_names, weights=fuzzer_job_weights, k=num_instances)
+    fuzz_tasks = [
+        Task('fuzz',
+             fuzzer_jobs[fuzzer_job_name].fuzzer,
+             fuzzer_jobs[fuzzer_job_name].job)
+        for fuzzer_job_name in choices
+    ]
+    return fuzz_tasks
+
+
+def get_fuzz_tasks() -> [tasks.Task]:
+  assert utils.is_oss_fuzz()
+  scheduler = OssfuzzFuzzTaskScheduler(available_cpus)
+  fuzz_tasks = scheduler.get_fuzz_tasks()
+  return fuzz_tasks
+
+
+def schedule_fuzz_tasks() -> bool:
+  """Schedules fuzz tasks."""
+  # TODO(metzman): Remove this when we are ready to run on Chrome.
+  start = time.time()
+
+  available_cpus = get_available_cpus()
+  # TODO(metzman): Remove this as we move from experimental code to production.
+  available_cpus = max(num_cpus, 50)
+  fuzz_tasks = get_fuzz_tasks(available_cpus)
+  if not fuzz_tasks:
+    logs.error('No fuzz tasks found to schedule.')
+    return False
+  bulk_add_tasks(fuzz_tasks)
+  logs.log_info('Scheduled %d fuzz tasks.', tasks_scheduled)
+
+  end = time.time()
+  total = end - start
+  logs.info(f'Task scheduling took {total} seconds.')
+  return True
+
+
+def main():
+  return return 0 if schedule_fuzz_tasks() else 1
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -125,7 +125,7 @@ def update_platform_for_job(job_name, new_platform):
   ndb_utils.put_multi(new_mappings)
 
 
-def get_fuzz_task_payload(platform=None):
+def get_fuzz_task_payloads(platform=None):
   """Select a fuzzer that can run on this platform."""
   if not platform:
     queue_override = environment.get_value('QUEUE_OVERRIDE')

--- a/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
+++ b/src/clusterfuzz/_internal/fuzzing/fuzzer_selection.py
@@ -125,7 +125,7 @@ def update_platform_for_job(job_name, new_platform):
   ndb_utils.put_multi(new_mappings)
 
 
-def get_fuzz_task_payloads(platform=None):
+def get_fuzz_task_payload(platform=None):
   """Select a fuzzer that can run on this platform."""
   if not platform:
     queue_override = environment.get_value('QUEUE_OVERRIDE')

--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -46,9 +46,20 @@ TASK_COUNT_PER_NODE = 1
 MAX_CONCURRENT_VMS_PER_JOB = 1000
 
 BatchWorkloadSpec = collections.namedtuple('BatchWorkloadSpec', [
-    'clusterfuzz_release', 'disk_size_gb', 'disk_type', 'docker_image',
-    'user_data', 'service_account_email', 'subnetwork', 'preemptible',
-    'project', 'gce_zone', 'machine_type', 'network', 'gce_region', 'priority',
+    'clusterfuzz_release',
+    'disk_size_gb',
+    'disk_type',
+    'docker_image',
+    'user_data',
+    'service_account_email',
+    'subnetwork',
+    'preemptible',
+    'project',
+    'gce_zone',
+    'machine_type',
+    'network',
+    'gce_region',
+    'priority',
 ])
 
 
@@ -192,7 +203,7 @@ def _get_allocation_policy(spec):
   return allocation_policy
 
 
-def _create_job(spec, input_urls, priority):
+def _create_job(spec, input_urls):
   """Creates and starts a batch job from |spec| that executes all tasks."""
   task_group = batch.TaskGroup()
   task_group.task_count = len(input_urls)
@@ -220,8 +231,7 @@ def _create_job(spec, input_urls, priority):
   create_request.job_id = job_name
   # The job's parent is the region in which the job will run
   project_id = spec.project
-  create_request.parent = (
-      f'projects/{project_id}/locations/{spec.gce_region}')
+  create_request.parent = f'projects/{project_id}/locations/{spec.gce_region}'
   job_result = _send_create_job_request(create_request)
   logs.info(f'Created batch job id={job_name}.', spec=spec)
   return job_result
@@ -287,8 +297,8 @@ def _get_spec_from_config(command, job_name):
   user_data = instance_spec['user_data']
   clusterfuzz_release = instance_spec.get('clusterfuzz_release', 'prod')
 
-  # Lower numbers are lower priority
-  # From https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs
+  # Lower numbers are lower priority. From:
+  # https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs
   low_priority = command == 'fuzz'
   priority = 0 if low_priority else 1
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/schedule_fuzz_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/schedule_fuzz_test.py
@@ -1,0 +1,89 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for schedule_fuzz.py"""
+
+import unittest
+
+from clusterfuzz._internal.cron import schedule_fuzz
+from clusterfuzz._internal.tests.test_libs.helpers as test_helpers
+from clusterfuzz._internal.tests.test_libs import test_utils
+from clusterfuzz._internal.datastore import data_types
+
+# pylint: disable=protected-access
+
+@test_utils.with_cloud_emulators('datastore')
+class OssfuzzFuzzTaskScheduler(unittest.TestCase):
+  def setUp(self):
+    self.job_name = 'myjob'
+    project_name = 'myproject'
+    dead_job = data_types.Job(name='dead_job', environment_string=f'PROJECT_NAME = {self.project_name}', 
+                         )
+    dead_job.put()
+    job = data_types.Job(name=self.job_name, environment_string=f'PROJECT_NAME = {self.project_name}', 
+)
+    job.put()
+
+    dead_project_job = data_types.Job(name='dead_project_job', environment_string=f'PROJECT_NAME = dead_project', 
+                         )
+    dead_project_job.put()
+  
+    dead_job = data_types.FuzzerJob(name='dead_job', weight=0.0, platform='LINUX')
+    dead_job.put()
+    job = data_types.FuzzerJob(self.job_name, platform='LINUX')
+    job.put()
+    dead_project_job = data_types.FuzzerJob('dead_project_job', platform='LINUX')
+    dead_project_job.put()
+    data_types.OssFuzzProject(name=self.project_name).put()
+    data_types.OssFuzzProject(name='dead_project', cpu_weight=0.0).put()
+
+    self.num_cpus = 10
+    self.scheduler = schedule_fuzz.OssfuzzFuzzTaskScheduler(self.num_cpus)
+    
+
+  def test_get_fuzz_tasks(self):
+    self.assertEqual(self.scheduler.get_fuzz_tasks(), [])
+
+
+@test_utils.with_cloud_emulators('datastore')
+class TestGetJobToOssfuzzProjectMapping(unittest.TestCase):
+  def test_get_job_to_oss_fuzz_project_mapping(self):
+    job = data_types.Job(name='job', environment_string='PROJECT_NAME = myproject')
+    job.put()
+    mapping = schedule_fuzz._get_job_to_oss_fuzz_project_mapping()
+    self.assertDictEqual(mapping, {'job': 'myproject'})
+
+      
+  
+class TestGetAvailableCpus(unittest.TestCase):
+  """Tests for get_available_cpus."""
+
+  def setUp(self):
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.cron.schedule_fuzz._get_quotas'
+    ])
+
+  def test_usage(self):
+    """Tests that get_available_cpus handles usage properly."""
+    self.mock._get_quotas.return_value = [
+      {'metric': 'PREEMPTIBLE_CPUS', 'limit': 5, 'usage': 2}
+    ]
+    self.assertEqual(schedule_fuzz.get_available_cpus('project', 'region'), 3)
+
+  def test_cpus_and_preemptible_cpus(self):
+    """Tests that get_available_cpus handles usage properly."""
+    self.mock._get_quotas.return_value = [
+      {'metric': 'PREEMPTIBLE_CPUS', 'limit': 5, 'usage': 0},
+      {'metric': 'CPUS', 'limit': 5, 'usage': 5}
+    ]
+    self.assertEqual(schedule_fuzz.get_available_cpus('region', 'project'), 5)


### PR DESCRIPTION
Start to schedule fuzz tasks on batch in OSS-Fuzz

The scheduler will work differenly in OSS-Fuzz and Chrome. This only implements and OSS-Fuzz version.
This version will use job and project weights to decide which fuzzing jobs to schedule. It then adds these tasks
to the queue for other bots to preprocess and then for the utask_main_scheduler to actually schedule on batch.
For now, we will only do this for 100 CPUs.
1. Add a cron job to run the scheduler every 15 minutes.
2. Improve region handling in batch (still far from complete).
3. Add function for bulk adding of tasks to queue for use by scheduler.
4. Make fuzz tasks less of a priority on batch than others.