### PR TITLE
Dont do untrusted worker stuff on batch

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -287,7 +287,7 @@ def setup_testcase(testcase: data_types.Testcase, job_type: str,
     _copy_testcase_to_device_and_setup_environment(testcase, testcase_file_path)
 
   # Push testcases to worker.
-  if environment.is_trusted_host():
+  if take_trusted_host_path():
     from clusterfuzz._internal.bot.untrusted_runner import file_host
     file_host.push_testcases_to_worker()
 
@@ -467,6 +467,11 @@ def _prepare_update_data_bundle(fuzzer, data_bundle):
   return data_bundle_directory
 
 
+def take_trusted_host_path():
+  if environment.is_uworker():
+    return False
+  return environment.is_trusted_host()
+
 def update_data_bundle(
     fuzzer: data_types.Fuzzer,
     data_bundle_corpus: uworker_msg_pb2.DataBundleCorpus) -> bool:  # pylint: disable=no-member
@@ -486,8 +491,7 @@ def update_data_bundle(
   # case, the fuzzer will generate testcases from a gcs bucket periodically.
   if not _is_search_index_data_bundle(data_bundle.name):
 
-    if environment.is_uworker() or not (environment.is_trusted_host() and
-                                        data_bundle.sync_to_worker):
+    if not (take_trusted_host_path() and data_bundle.sync_to_worker):
       logs.info('Data bundles: normal path.')
       result = corpus_manager.sync_data_bundle_corpus_to_disk(
           data_bundle_corpus, data_bundle_directory)
@@ -518,7 +522,7 @@ def update_data_bundle(
   #  Write last synced time in the sync file.
   sync_file_path = _get_data_bundle_sync_file_path(data_bundle_directory)
   utils.write_data_to_file(time_before_sync_start, sync_file_path)
-  if environment.is_trusted_host() and data_bundle.sync_to_worker:
+  if take_trusted_host_path() and data_bundle.sync_to_worker:
     from clusterfuzz._internal.bot.untrusted_runner import file_host
     worker_sync_file_path = file_host.rebase_to_worker_root(sync_file_path)
     file_host.copy_file_to_worker(sync_file_path, worker_sync_file_path)
@@ -693,7 +697,7 @@ def update_fuzzer_and_data_bundles(
 
     # For launcher script usecase, we need the entire fuzzer directory on the
     # worker.
-    if environment.is_trusted_host():
+    if take_trusted_host_path():
       from clusterfuzz._internal.bot.untrusted_runner import file_host
       worker_fuzzer_directory = file_host.rebase_to_worker_root(
           fuzzer_directory)
@@ -713,8 +717,7 @@ def _is_data_bundle_up_to_date(data_bundle, data_bundle_directory):
   """Return true if the data bundle is up to date, false otherwise."""
   sync_file_path = _get_data_bundle_sync_file_path(data_bundle_directory)
 
-  if not environment.is_uworker() and (environment.is_trusted_host() and
-                                       data_bundle.sync_to_worker):
+  if not (take_trusted_host_path() and data_bundle.sync_to_worker):
     from clusterfuzz._internal.bot.untrusted_runner import file_host
     worker_sync_file_path = file_host.rebase_to_worker_root(sync_file_path)
     shell.remove_file(sync_file_path)

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -486,11 +486,13 @@ def update_data_bundle(
   # case, the fuzzer will generate testcases from a gcs bucket periodically.
   if not _is_search_index_data_bundle(data_bundle.name):
 
-    if not (environment.is_uworker() and environment.is_trusted_host() and
-            data_bundle.sync_to_worker):
+    if environment.is_uworker() or (and environment.is_trusted_host() and
+                                    data_bundle.sync_to_worker):
+      logs.info('Data bundles: normal path.')
       result = corpus_manager.sync_data_bundle_corpus_to_disk(
           data_bundle_corpus, data_bundle_directory)
     else:
+      logs.info('Data bundles: untrusted runner path.')
       from clusterfuzz._internal.bot.untrusted_runner import \
           corpus_manager as untrusted_corpus_manager
       from clusterfuzz._internal.bot.untrusted_runner import file_host

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -713,8 +713,8 @@ def _is_data_bundle_up_to_date(data_bundle, data_bundle_directory):
   """Return true if the data bundle is up to date, false otherwise."""
   sync_file_path = _get_data_bundle_sync_file_path(data_bundle_directory)
 
-  if not environment.is_uworker() and not (environment.is_trusted_host() and
-                                           data_bundle.sync_to_worker):
+  if not environment.is_uworker() and (environment.is_trusted_host() and
+                                       data_bundle.sync_to_worker):
     from clusterfuzz._internal.bot.untrusted_runner import file_host
     worker_sync_file_path = file_host.rebase_to_worker_root(sync_file_path)
     shell.remove_file(sync_file_path)

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -713,8 +713,8 @@ def _is_data_bundle_up_to_date(data_bundle, data_bundle_directory):
   """Return true if the data bundle is up to date, false otherwise."""
   sync_file_path = _get_data_bundle_sync_file_path(data_bundle_directory)
 
-  if (not environment.is_uworker() and environment.is_trusted_host() and
-      data_bundle.sync_to_worker):
+  if not environment.is_uworker() and not (environment.is_trusted_host() and
+                                           data_bundle.sync_to_worker):
     from clusterfuzz._internal.bot.untrusted_runner import file_host
     worker_sync_file_path = file_host.rebase_to_worker_root(sync_file_path)
     shell.remove_file(sync_file_path)

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -486,8 +486,8 @@ def update_data_bundle(
   # case, the fuzzer will generate testcases from a gcs bucket periodically.
   if not _is_search_index_data_bundle(data_bundle.name):
 
-    if environment.is_uworker() or (and environment.is_trusted_host() and
-                                    data_bundle.sync_to_worker):
+    if environment.is_uworker() or not (environment.is_trusted_host() and
+                                        data_bundle.sync_to_worker):
       logs.info('Data bundles: normal path.')
       result = corpus_manager.sync_data_bundle_corpus_to_disk(
           data_bundle_corpus, data_bundle_directory)

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -710,7 +710,8 @@ def _is_data_bundle_up_to_date(data_bundle, data_bundle_directory):
   """Return true if the data bundle is up to date, false otherwise."""
   sync_file_path = _get_data_bundle_sync_file_path(data_bundle_directory)
 
-  if environment.is_trusted_host() and data_bundle.sync_to_worker:
+  if (not environment.is_uworker()
+      and environment.is_trusted_host() and data_bundle.sync_to_worker):
     from clusterfuzz._internal.bot.untrusted_runner import file_host
     worker_sync_file_path = file_host.rebase_to_worker_root(sync_file_path)
     shell.remove_file(sync_file_path)

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -486,7 +486,8 @@ def update_data_bundle(
   # case, the fuzzer will generate testcases from a gcs bucket periodically.
   if not _is_search_index_data_bundle(data_bundle.name):
 
-    if not (environment.is_trusted_host() and data_bundle.sync_to_worker):
+    if not (environment.is_uworker() and environment.is_trusted_host() and
+            data_bundle.sync_to_worker):
       result = corpus_manager.sync_data_bundle_corpus_to_disk(
           data_bundle_corpus, data_bundle_directory)
     else:
@@ -710,8 +711,8 @@ def _is_data_bundle_up_to_date(data_bundle, data_bundle_directory):
   """Return true if the data bundle is up to date, false otherwise."""
   sync_file_path = _get_data_bundle_sync_file_path(data_bundle_directory)
 
-  if (not environment.is_uworker()
-      and environment.is_trusted_host() and data_bundle.sync_to_worker):
+  if (not environment.is_uworker() and environment.is_trusted_host() and
+      data_bundle.sync_to_worker):
     from clusterfuzz._internal.bot.untrusted_runner import file_host
     worker_sync_file_path = file_host.rebase_to_worker_root(sync_file_path)
     shell.remove_file(sync_file_path)

--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -472,6 +472,7 @@ def take_trusted_host_path():
     return False
   return environment.is_trusted_host()
 
+
 def update_data_bundle(
     fuzzer: data_types.Fuzzer,
     data_bundle_corpus: uworker_msg_pb2.DataBundleCorpus) -> bool:  # pylint: disable=no-member

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -611,9 +611,9 @@ def get_proto_data_bundle_corpus(
   data_bundle_corpus.data_bundle.CopyFrom(
       uworker_io.entity_to_protobuf(data_bundle))
   if task_types.task_main_runs_on_uworker():
-    # Slow path for when we need an untrusted worker to run a task.
-    # Note that the security of the system (only the correctness) depends on
-    # this path being taken. If it is not taken when we need to, utask_main will
+    # Slow path for when we need an untrusted worker to run a task. Note that
+    # the security of the system (only the correctness) does not depend on this
+    # path being taken. If it is not taken when we need to, utask_main will
     # simply fail as it tries to do privileged operation it does not have
     # permissions for.
     urls = (f'{data_bundle_corpus.gcs_url}/{url}'
@@ -627,7 +627,8 @@ def get_proto_data_bundle_corpus(
 
 
 def sync_data_bundle_corpus_to_disk(data_bundle_corpus, directory):
-  if not task_types.task_main_runs_on_uworker():
+  if (not task_types.task_main_runs_on_uworker() and
+      not environment.is_uworker()):
     # Fast path for when we don't need an untrusted worker to run a task.
     return gsutil.GSUtilRunner().rsync(
         data_bundle_corpus.gcs_url, directory, delete=False).return_code == 0


### PR DESCRIPTION
This is breaking fuzzing on batch in oss-fuzz.
Looking forward to the day when we can get rid of untrusted worker. Living side by side with uworker is unpleasant.