### PR TITLE
Restore logging for android commands with proper truncation

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -545,12 +545,15 @@ def emit(level, message, exc_info=None, **extras):
 
     _add_appengine_trace(all_extras)
 
+  log_limit = STACKDRIVER_LOG_MESSAGE_LIMIT if _cloud_logging_enabled(
+  ) else LOCAL_LOG_MESSAGE_LIMIT
+
   # We need to make a dict out of it because member of the dict becomes the
   # first class attributes of LogEntry. It is very tricky to identify the extra
   # attributes. Therefore, we wrap extra fields under the attribute 'extras'.
   logger.log(
       level,
-      truncate(message, LOCAL_LOG_MESSAGE_LIMIT),
+      truncate(message, log_limit),
       exc_info=exc_info,
       extra={
           'extras': all_extras,

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -697,6 +697,9 @@ def run_command(cmd, log_output=False, timeout=None, recover=True):
     wait_until_fully_booted()
     output = execute_command(get_adb_command_line(cmd), timeout)
 
+  if log_output:
+    logs.info('Output: (%s)' % output)
+
   return output
 
 


### PR DESCRIPTION
When logging directly to GCP we were not using the specific stackdriver log limit, that might've been the issue causing log-too long errors? 
In that case this should fix this + reenable those logs

This is somewhat reverting /pull/4021