### PR TITLE
Increasing number of retries for buganizer

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -32,7 +32,7 @@ from clusterfuzz._internal.issue_management import issue_tracker
 from clusterfuzz._internal.issue_management.google_issue_tracker import client
 from clusterfuzz._internal.metrics import logs
 
-_NUM_RETRIES = 3
+_NUM_RETRIES = 5
 
 # TODO: Make these configuration settings instead of hardcoded values in code.
 # These custom fields use repeated enums.


### PR DESCRIPTION
### Motivation

oss-fuzz-apply-ccs is failing. A possible cause is request rate limiting on the buganizer API. This PR increases the number of retries for buganizer requests, in order to fix this particular issue.