### PR TITLE
[Monitoring] Adding a blackbox fuzzer testcase generation time metric

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1581,22 +1581,25 @@ class FuzzingSession:
 
     # Run the fuzzer to generate testcases. If error occurred while trying
     # to run the fuzzer, bail out.
-    testcase_generation_start_time = time.time()
+    testcase_generation_start = time.time()
     generate_result = self.generate_blackbox_testcases(
         fuzzer, job_type, fuzzer_directory, testcase_count)
     if not generate_result.success:
       return None, None, None, None
-    testcase_generation_finish_time = time.time()
-    elapsed_testcase_generation_time = testcase_generation_finish_time - testcase_generation_start_time
+    testcase_generation_finish = time.time()
+    elapsed_testcase_generation_time = testcase_generation_finish
+    elapsed_testcase_generation_time -= testcase_generation_start
     # Avoid division by zero
     if testcase_count:
-      average_time_per_testcase = elapsed_testcase_generation_time / testcase_count
+      average_time_per_testcase = elapsed_testcase_generation_time
+      average_time_per_testcase = average_time_per_testcase / testcase_count
       monitoring_metrics.TESTCASE_GENERATION_AVERAGE_TIME.add(
-        average_time_per_testcase, labels = {
-          'job': job_type,
-          'fuzzer': fuzzer,
-          'platform': environment.platform(),
-        })
+          average_time_per_testcase,
+          labels={
+              'job': job_type,
+              'fuzzer': fuzzer,
+              'platform': environment.platform(),
+          })
 
     environment.set_value('FUZZER_NAME', self.fully_qualified_fuzzer_name)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1605,7 +1605,7 @@ class FuzzingSession:
       return None, None, None, None
 
     self._emit_testcase_generation_time_metric(testcase_generation_start,
-                                               testcase_count, fuzzer, job_type)
+                                               testcase_count, fuzzer.name, job_type)
 
     environment.set_value('FUZZER_NAME', self.fully_qualified_fuzzer_name)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1604,8 +1604,8 @@ class FuzzingSession:
     if not generate_result.success:
       return None, None, None, None
 
-    self._emit_testcase_generation_time_metric(testcase_generation_start,
-                                               testcase_count, fuzzer.name, job_type)
+    self._emit_testcase_generation_time_metric(
+        testcase_generation_start, testcase_count, fuzzer.name, job_type)
 
     environment.set_value('FUZZER_NAME', self.fully_qualified_fuzzer_name)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1581,10 +1581,22 @@ class FuzzingSession:
 
     # Run the fuzzer to generate testcases. If error occurred while trying
     # to run the fuzzer, bail out.
+    testcase_generation_start_time = time.time()
     generate_result = self.generate_blackbox_testcases(
         fuzzer, job_type, fuzzer_directory, testcase_count)
     if not generate_result.success:
       return None, None, None, None
+    testcase_generation_finish_time = time.time()
+    elapsed_testcase_generation_time = testcase_generation_finish_time - testcase_generation_start_time
+    # Avoid division by zero
+    if testcase_count:
+      average_time_per_testcase = elapsed_testcase_generation_time / testcase_count
+      monitoring_metrics.TESTCASE_GENERATION_AVERAGE_TIME.add(
+        average_time_per_testcase, labels = {
+          'job': job_type,
+          'fuzzer': fuzzer,
+          'platform': environment.platform(),
+        })
 
     environment.set_value('FUZZER_NAME', self.fully_qualified_fuzzer_name)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1558,6 +1558,23 @@ class FuzzingSession:
 
     return crashes, fuzzer_metadata
 
+  def _emit_testcase_generation_time_metric(self, start_time, testcase_count,
+                                            fuzzer, job):
+    testcase_generation_finish = time.time()
+    elapsed_testcase_generation_time = testcase_generation_finish
+    elapsed_testcase_generation_time -= start_time
+    # Avoid division by zero.
+    if testcase_count:
+      average_time_per_testcase = elapsed_testcase_generation_time
+      average_time_per_testcase = average_time_per_testcase / testcase_count
+      monitoring_metrics.TESTCASE_GENERATION_AVERAGE_TIME.add(
+          average_time_per_testcase,
+          labels={
+              'job': job,
+              'fuzzer': fuzzer,
+              'platform': environment.platform(),
+          })
+
   def do_blackbox_fuzzing(self, fuzzer, fuzzer_directory, job_type):
     """Run blackbox fuzzing. Currently also used for engine fuzzing."""
     # Set the thread timeout values.
@@ -1586,20 +1603,9 @@ class FuzzingSession:
         fuzzer, job_type, fuzzer_directory, testcase_count)
     if not generate_result.success:
       return None, None, None, None
-    testcase_generation_finish = time.time()
-    elapsed_testcase_generation_time = testcase_generation_finish
-    elapsed_testcase_generation_time -= testcase_generation_start
-    # Avoid division by zero
-    if testcase_count:
-      average_time_per_testcase = elapsed_testcase_generation_time
-      average_time_per_testcase = average_time_per_testcase / testcase_count
-      monitoring_metrics.TESTCASE_GENERATION_AVERAGE_TIME.add(
-          average_time_per_testcase,
-          labels={
-              'job': job_type,
-              'fuzzer': fuzzer,
-              'platform': environment.platform(),
-          })
+
+    self._emit_testcase_generation_time_metric(testcase_generation_start,
+                                               testcase_count, fuzzer, job_type)
 
     environment.set_value('FUZZER_NAME', self.fully_qualified_fuzzer_name)
 

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -150,7 +150,7 @@ TESTCASE_GENERATION_AVERAGE_TIME = monitor.CumulativeDistributionMetric(
         monitor.StringField('platform'),
         monitor.StringField('job'),
         monitor.StringField('fuzzer'),
-    ],    
+    ],
 )
 
 FUZZER_TESTCASE_COUNT_RATIO = monitor.CumulativeDistributionMetric(

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -140,6 +140,19 @@ JOB_TOTAL_FUZZ_TIME = monitor.CounterMetric(
     ],
 )
 
+TESTCASE_GENERATION_AVERAGE_TIME = monitor.CumulativeDistributionMetric(
+    'task/fuzz/fuzzer/testcase_generation_duration',
+    bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),
+    description=('Distribution of blackbox fuzzer average testcase '
+                 ' generation time, in seconds '
+                 '(grouped by fuzzer, job and platform).'),
+    field_spec=[
+        monitor.StringField('platform'),
+        monitor.StringField('job'),
+        monitor.StringField('fuzzer'),
+    ],    
+)
+
 FUZZER_TESTCASE_COUNT_RATIO = monitor.CumulativeDistributionMetric(
     'task/fuzz/fuzzer/testcase_count_ratio',
     bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -142,7 +142,7 @@ JOB_TOTAL_FUZZ_TIME = monitor.CounterMetric(
 
 TESTCASE_GENERATION_AVERAGE_TIME = monitor.CumulativeDistributionMetric(
     'task/fuzz/fuzzer/testcase_generation_duration',
-    bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),
+    bucketer=monitor.GeometricBucketer(),
     description=('Distribution of blackbox fuzzer average testcase '
                  ' generation time, in seconds '
                  '(grouped by fuzzer, job and platform).'),


### PR DESCRIPTION
### Motivation

Chrome folks need to know how long on average a fuzzer takes to generate a testcase. This PR implements that.

Part of #4271 