### PR TITLE
[Monitoring] Adding metric to track time from testcase creation to bug filing

### DIFF
--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -254,6 +254,16 @@ def _check_and_update_similar_bug(testcase, issue_tracker):
   return False
 
 
+def _emit_bug_filing_from_testcase_elapsed_time_metric(testcase):
+  testcase_age = testcase.get_age_in_seconds()
+  monitoring_metrics.BUG_FILING_FROM_TESTCASE_ELAPSED_TIME.add(
+      testcase_age,
+      labels={
+          'job': testcase.job_type,
+          'platform': testcase.platform,
+      })
+
+
 def _file_issue(testcase, issue_tracker, throttler):
   """File an issue for the testcase."""
   logs.info(f'_file_issue for {testcase.key.id()}')
@@ -282,6 +292,7 @@ def _file_issue(testcase, issue_tracker, throttler):
         'fuzzer_name': testcase.fuzzer_name,
         'status': 'success',
     })
+    _emit_bug_filing_from_testcase_elapsed_time_metric(testcase)
   except Exception as e:
     file_exception = e
 

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -295,6 +295,14 @@ ISSUE_CLOSING = monitor.CounterMetric(
         monitor.StringField('status'),
     ])
 
+BUG_FILING_FROM_TESTCASE_ELAPSED_TIME = monitor.CumulativeDistributionMetric(
+    'fuzzed_testcase_analysis/triage_duration_secs',
+    description='Time elapsed between testcase and bug creation, in minutes.',
+    bucketer=monitor.GeometricBucketer(),
+    field_spec=[
+        monitor.StringField('job'),
+    ]),
+
 UNTRIAGED_TESTCASE_AGE = monitor.CumulativeDistributionMetric(
     'issues/untriaged_testcase_age',
     description='Age of testcases that were not yet triaged '

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -301,7 +301,8 @@ BUG_FILING_FROM_TESTCASE_ELAPSED_TIME = monitor.CumulativeDistributionMetric(
     bucketer=monitor.GeometricBucketer(),
     field_spec=[
         monitor.StringField('job'),
-    ]),
+        monitor.StringField('platform'),
+    ])
 
 UNTRIAGED_TESTCASE_AGE = monitor.CumulativeDistributionMetric(
     'issues/untriaged_testcase_age',


### PR DESCRIPTION
### Motivation

As per Chrome request, it is desirable to know how long it takes for an issue to be opened, from the moment a testcase is created.

Part of #4271 