### PR TITLE
Make task rate limiting opt in

### DIFF
--- a/configs/test/project.yaml
+++ b/configs/test/project.yaml
@@ -33,6 +33,10 @@ coverage:
     # Bucket to load code coverage information from.
     bucket: test-coverage-bucket
 
+
+rate_limit_tasks:
+  enabled: true
+
 logs:
   fuzzer:
     # Bucket to store logs for fuzzer runs.

--- a/configs/test/project.yaml
+++ b/configs/test/project.yaml
@@ -33,7 +33,6 @@ coverage:
     # Bucket to load code coverage information from.
     bucket: test-coverage-bucket
 
-
 rate_limit_tasks:
   enabled: true
 


### PR DESCRIPTION
Make the rate limiting added in https://github.com/google/clusterfuzz/commit/c26e353f230793f148860718fad866cbc04b82f3 opt-in temporarily so we can deploy to other instances without worrying if this damages their fuzzing.