### PR TITLE
Add generic tworker.

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -27,6 +27,7 @@ IMAGES=(
   gcr.io/clusterfuzz-images/oss-fuzz/worker
   gcr.io/clusterfuzz-images/ci
   gcr.io/clusterfuzz-images/utask-main-scheduler
+  gcr.io/clusterfuzz-images/tworker
   gcr.io/clusterfuzz-images/fuchsia
 )
 

--- a/docker/tworker/Dockerfile
+++ b/docker/tworker/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM gcr.io/clusterfuzz-images/base
+
+# Worker that only reads from queues, preprocesses and postprocesses.
+ENV TWORKER=1

--- a/src/clusterfuzz/_internal/base/tasks/task_utils.py
+++ b/src/clusterfuzz/_internal/base/tasks/task_utils.py
@@ -15,7 +15,6 @@
 any other module in tasks to prevent circular imports and issues with
 appengine."""
 
-from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.system import environment
 
 
@@ -26,25 +25,12 @@ def get_command_from_module(full_module_name: str) -> str:
   return module_name[:-len('_task')]
 
 
-def is_remotely_executing_utasks(task=None) -> bool:
+def is_remotely_executing_utasks() -> bool:
   """Returns True if the utask_main portions of utasks are being remotely
   executed on Google cloud batch."""
-  if bool(environment.is_production() and
-          environment.get_value('REMOTE_UTASK_EXECUTION')):
-    return True
-  if task is None:
-    return False
-  return bool(is_task_opted_into_uworker_execution(task))
-
-
-def get_opted_in_tasks():
-  return local_config.ProjectConfig().get('uworker_tasks', [])
-
-
-def is_task_opted_into_uworker_execution(task: str) -> bool:
-  # TODO(metzman): Remove this after OSS-Fuzz and Chrome are at parity.
-  uworker_tasks = get_opted_in_tasks()
-  return task in uworker_tasks
+  # TODO(metzman): REMOTE_UTASK_EXECUTION should be a config not an env var.
+  return (environment.is_production() and
+          environment.get_value('REMOTE_UTASK_EXECUTION'))
 
 
 class UworkerMsgParseError(RuntimeError):

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -46,6 +46,7 @@ class TrustedTask(BaseTask):
   def execute(self, task_argument, job_type, uworker_env):
     # Simple tasks can just use the environment they don't need the uworker env.
     del uworker_env
+    assert not enviornment.is_tworker()
     self.module.execute_task(task_argument, job_type)
 
 
@@ -58,6 +59,7 @@ class BaseUTask(BaseTask):
     raise NotImplementedError('Child class must implement.')
 
   def execute_locally(self, task_argument, job_type, uworker_env):
+    assert not enviornment.is_tworker()
     uworker_input = utasks.tworker_preprocess_no_io(self.module, task_argument,
                                                     job_type, uworker_env)
     if uworker_input is None:

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -119,7 +119,7 @@ class UTask(BaseUTask):
 
   @staticmethod
   def is_execution_remote(command=None):
-    return task_utils.is_remotely_executing_utasks(command)
+    return task_utils.is_remotely_executing_utasks()
 
   def execute(self, task_argument, job_type, uworker_env):
     """Executes a utask."""
@@ -154,19 +154,6 @@ class UTask(BaseUTask):
       return None
     logs.info('Utask: done with preprocess.')
     return download_url
-
-
-# TODO(b/378684001): Remove this, it's needed for testing but is otherwise a bad
-# design.
-class UTaskMostlyLocalExecutor(UTask):
-
-  @staticmethod
-  def is_execution_remote(command=None):
-    del command
-    if environment.get_value('IS_FROM_QUEUE'):
-      logs.info('IS FROM QUEUE')
-      return True
-    return False
 
 
 class PostprocessTask(BaseTask):
@@ -211,7 +198,7 @@ COMMAND_TYPES = {
     'analyze': UTask,
     'blame': TrustedTask,
     'corpus_pruning': UTask,
-    'fuzz': UTaskMostlyLocalExecutor,
+    'fuzz': UTaskLocalExecutor,
     'impact': TrustedTask,
     'minimize': UTask,
     'progression': UTask,

--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -46,7 +46,7 @@ class TrustedTask(BaseTask):
   def execute(self, task_argument, job_type, uworker_env):
     # Simple tasks can just use the environment they don't need the uworker env.
     del uworker_env
-    assert not enviornment.is_tworker()
+    assert not environment.is_tworker()
     self.module.execute_task(task_argument, job_type)
 
 
@@ -59,7 +59,8 @@ class BaseUTask(BaseTask):
     raise NotImplementedError('Child class must implement.')
 
   def execute_locally(self, task_argument, job_type, uworker_env):
-    assert not enviornment.is_tworker()
+    """Executes the utask locally (on this machine, not on batch)."""
+    assert not environment.is_tworker()
     uworker_input = utasks.tworker_preprocess_no_io(self.module, task_argument,
                                                     job_type, uworker_env)
     if uworker_input is None:

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1177,3 +1177,7 @@ def can_testcase_run_on_platform(testcase_platform_id, current_platform_id):
                                                      current_platform_id)
 
   return False
+
+
+def is_tworker():
+  return get_value('TWORKER', False)

--- a/src/clusterfuzz/_internal/tests/appengine/common/tasks_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/common/tasks_test.py
@@ -52,13 +52,11 @@ class GetTaskTest(unittest.TestCase):
         'clusterfuzz._internal.base.persistent_cache.get_value',
         'clusterfuzz._internal.base.persistent_cache.set_value',
         'clusterfuzz._internal.base.utils.utcnow',
-        'clusterfuzz._internal.base.tasks.task_utils.get_opted_in_tasks',
         'time.sleep',
     ])
 
     self.mock.get_value.return_value = None
     self.mock.sleep.return_value = None
-    self.mock.get_opted_in_tasks.return_value = False
     data_types.Job(name='job').put()
 
     client = pubsub.PubSubClient()

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/schedule_fuzz_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/schedule_fuzz_test.py
@@ -69,16 +69,12 @@ class OssfuzzFuzzTaskScheduler(unittest.TestCase):
 
     num_cpus = 10
     scheduler = schedule_fuzz.OssfuzzFuzzTaskScheduler(num_cpus)
-    results = scheduler.get_fuzz_tasks()
+    tasks = scheduler.get_fuzz_tasks()
     comparable_results = []
-    for tasks in results.values():
-      comparable_tasks = []
-      for task in tasks:
-        comparable_tasks.append((task.command, task.argument, task.job))
-      comparable_results.append(comparable_tasks)
+    for task in tasks:
+      comparable_results.append((task.command, task.argument, task.job))
 
-    expected_results = [[('fuzz', 'libFuzzer', 'myjob')] * 5]
-    self.assertListEqual(list(results.keys()), ['jobs-linux'])
+    expected_results = [('fuzz', 'libFuzzer', 'myjob')] * 5
     self.assertListEqual(comparable_results, expected_results)
 
 

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/task_utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/task_utils_test.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for task_utils."""
-import os
 import unittest
 
 from clusterfuzz._internal.base.tasks import task_utils
 from clusterfuzz._internal.bot.tasks import commands
-from clusterfuzz._internal.tests.test_libs import helpers
 
 
 class GetCommandFromModuleTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/task_utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/task_utils_test.py
@@ -35,19 +35,3 @@ class GetCommandFromModuleTest(unittest.TestCase):
       task_utils.get_command_from_module('postprocess')
     with self.assertRaises(ValueError):
       task_utils.get_command_from_module('uworker_main')
-
-
-class IsTaskOptedIntoUworkerExecution(unittest.TestCase):
-  """Tests that is_task_opted_into_uworker_execution only returns True for the
-  tasks we are testing in oss-fuzz."""
-
-  def setUp(self):
-    helpers.patch_environ(self)
-
-  def test_opt_in(self):
-    os.environ['JOB_NAME'] = 'libfuzzer_asan_skia'
-    self.assertTrue(task_utils.is_task_opted_into_uworker_execution('analyze'))
-
-  def test_no_opt_in(self):
-    os.environ['JOB_NAME'] = 'libfuzzer_asan_skia'
-    self.assertFalse(task_utils.is_task_opted_into_uworker_execution('fuzz'))

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -136,9 +136,9 @@ def task_loop():
         continue
 
       if environment.is_tworker():
-        task = tasks.get_task()
-      else:
         task = tasks.tworker_get_task()
+      else:
+        task = tasks.get_task()
 
       if not task:
         continue

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -29,7 +29,7 @@ import traceback
 
 from clusterfuzz._internal.base import dates
 from clusterfuzz._internal.base import errors
-from clusterfuzz._internal.base import tasks as taskslib
+from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import untrusted
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.base.tasks import task_utils
@@ -89,7 +89,7 @@ def schedule_utask_mains():
   from clusterfuzz._internal.google_cloud_utils import batch
 
   logs.info('Attempting to combine batch tasks.')
-  utask_mains = taskslib.get_utask_mains()
+  utask_mains = tasks.get_utask_mains()
   if not utask_mains:
     logs.info('No utask mains.')
     return
@@ -135,7 +135,11 @@ def task_loop():
         schedule_utask_mains()
         continue
 
-      task = taskslib.get_task()
+      if environment.is_tworker():
+        task = tasks.get_task()
+      else:
+        task = tasks.tworker_get_task()
+
       if not task:
         continue
 


### PR DESCRIPTION
This tworker will only run preprocess and postprocess. 
By generic, I mean it can do this regardless of the platform of the task.

Also, get rid of some kludges used to test utasks in oss-fuzz.
b/380104573