### PR TITLE
Dont quit preprocess early on tworkers

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -304,6 +304,7 @@ def process_command_impl(task_name, task_argument, job_name, high_end,
     # TODO(ochang): Remove the first part of this check once we migrate off the
     # old untrusted worker architecture.
     if (not environment.get_value('DEBUG_TASK') and
+        not environment.is_tworker() and
         not environment.is_trusted_host(ensure_connected=False) and
         job_base_queue_suffix != bot_base_queue_suffix):
       # This happens rarely, store this as a hard exception.


### PR DESCRIPTION
Fixes this error: 
```
Wrong platform for job libfuzzer_asan_frr: job queue [-frr-linux], bot queue [-linux].
```


https://pantheon.corp.google.com/logs/query;query=SEARCH%2528%22%60oss-fuzz-tworker%60%22%2529%0A-protoPayload.@type%3D%22type.googleapis.com%2Fgoogle.cloud.audit.AuditLog%22;cursorTimestamp=2024-11-21T20:28:38.660447475Z;startTime=2024-11-20T18:39:44.260279Z;endTime=2024-11-22T18:39:44.260Z?e=-13802955&mods=logs_tg_prod&project=clusterfuzz-external