### PR TITLE
Adding build revision metric

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1226,6 +1226,16 @@ def _emit_build_age_metric(gcs_path):
   except Exception as e:
     logs.error(f'Failed to emit build age metric for {gcs_path}: {e}')
 
+def _emit_build_revision_metric(revision):
+  """Emits a gauge metric to track the build revision."""
+  monitoring_metrics.JOB_BUILD_REVISION.set(
+    revision,
+    labels = {
+        'job': os.getenv('JOB_NAME'),
+        'platform': environment.platform(),
+        'task': os.getenv('TASK_NAME'), 
+    }
+  )
 
 def _get_build_url(bucket_path: Optional[str], revision: int,
                    job_type: Optional[str]):
@@ -1297,6 +1307,8 @@ def setup_regular_build(revision,
 
   if revision == latest_revision:
     _emit_build_age_metric(build_url)
+
+  _emit_build_revision_metric(revision)
 
   # build_url points to a GCP bucket, and we're only converting it to its HTTP
   # endpoint so that we can use remote unzipping.

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -44,6 +44,17 @@ JOB_BUILD_AGE = monitor.CumulativeDistributionMetric(
     ],
 )
 
+JOB_BUILD_REVISION = monitor.GaugeMetric(
+    'job/build_age',
+    description=('Gauge for revision of trunk build '
+                 '(grouped by job/platform/task).'),
+    field_spec=[
+        monitor.StringField('job'),
+        monitor.StringField('platform'),
+        monitor.StringField('task'),
+    ],
+)
+
 JOB_BUILD_RETRIEVAL_TIME = monitor.CumulativeDistributionMetric(
     'task/build_retrieval_time',
     bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),


### PR DESCRIPTION
### Motivation

Chrome folks want to know what build revision is being used in fuzz task for every job in fuzz_task. This PR implements that.