### PR TITLE
Speed up preprocessing significantly

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -80,6 +80,11 @@ class AlreadyRunningError(Error):
 def cleanup_task_state():
   """Cleans state before and after a task is executed."""
   # Cleanup stale processes.
+
+  if environment.is_tworker():
+    # Nothing to clean.
+    return
+
   process_handler.cleanup_stale_processes()
 
   # Clear build urls, temp and testcase directories.
@@ -468,7 +473,6 @@ def process_command_impl(task_name, task_argument, job_name, high_end,
     return run_command(task_name, task_argument, job_name, uworker_env)
   finally:
     # Final clean up.
-    if not environment.is_tworker():
-      cleanup_task_state()
+    cleanup_task_state()
     if 'CF_TASK_ID' in os.environ:
       del os.environ['CF_TASK_ID']

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -665,7 +665,7 @@ def get_proto_corpus(bucket_name,
     urls = itertools.islice(urls, max_download_urls)
   corpus_urls = dict(
       storage.sign_urls_for_existing_files(urls, include_delete_urls))
-
+  
   upload_urls = storage.get_arbitrary_signed_upload_urls(
       gcs_url, num_uploads=max_upload_urls)
   corpus = uworker_msg_pb2.Corpus(  # pylint: disable=no-member

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -476,7 +476,6 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
     # Convert this to a dict so proto's map doesn't return a default value for
     # missing keys (this hides errors).
     corpus_urls = dict(corpus.corpus_urls)
-
     for result in results:
       if not result.url:
         fails += 1
@@ -666,7 +665,7 @@ def get_proto_corpus(bucket_name,
     urls = itertools.islice(urls, max_download_urls)
   corpus_urls = dict(
       storage.sign_urls_for_existing_files(urls, include_delete_urls))
-  
+
   upload_urls = storage.get_arbitrary_signed_upload_urls(
       gcs_url, num_uploads=max_upload_urls)
   corpus = uworker_msg_pb2.Corpus(  # pylint: disable=no-member

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -476,6 +476,7 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
     # Convert this to a dict so proto's map doesn't return a default value for
     # missing keys (this hides errors).
     corpus_urls = dict(corpus.corpus_urls)
+
     for result in results:
       if not result.url:
         fails += 1

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -663,7 +663,8 @@ def get_proto_corpus(bucket_name,
   # again.
   if max_download_urls is not None:
     urls = itertools.islice(urls, max_download_urls)
-  corpus_urls = dict(storage.sign_urls_for_existing_files(urls, include_delete_urls))
+  corpus_urls = storage.sign_urls_for_existing_files(urls, include_delete_urls)
+  corpus_urls = dict(corpus_urls)
 
   upload_urls = storage.get_arbitrary_signed_upload_urls(
       gcs_url, num_uploads=max_upload_urls)

--- a/src/clusterfuzz/_internal/fuzzing/leak_blacklist.py
+++ b/src/clusterfuzz/_internal/fuzzing/leak_blacklist.py
@@ -17,6 +17,7 @@ import os
 import re
 
 from clusterfuzz._internal.base import errors
+from clusterfuzz._internal.base import memoize
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.datastore import ndb_utils
@@ -65,8 +66,9 @@ def cleanup_global_blacklist():
   ndb_utils.delete_multi(blacklists_to_delete)
 
 
+@memoize.wrap(memoize.Memcache(60 * 10))
 def get_global_blacklisted_functions():
-  # Copy global blacklist into local blacklist.
+  """Get global blacklisted functions."""
   global_blacklists = data_types.Blacklist.query(
       data_types.Blacklist.tool_name == LSAN_TOOL_NAME)
   blacklisted_functions = []

--- a/src/clusterfuzz/_internal/google_cloud_utils/credentials.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/credentials.py
@@ -19,6 +19,7 @@ from google.auth import credentials
 from google.auth.transport import requests
 from google.oauth2 import service_account
 
+from clusterfuzz._internal.base import memoize
 from clusterfuzz._internal.base import retry
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.google_cloud_utils import secret_manager
@@ -59,6 +60,7 @@ def _use_anonymous_credentials():
     retries=FAIL_RETRIES,
     delay=FAIL_WAIT,
     function='google_cloud_utils.credentials.get_default')
+@memoize.wrap(memoize.FifoInMemory(1))
 def get_default(scopes=None):
   """Get default Google Cloud credentials."""
   if _use_anonymous_credentials():

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -249,10 +249,11 @@ class GcsProvider(StorageProvider):
 
     if names_only:
       fields = 'items(name),nextPageToken'
-      iterator = bucket.list_blobs(
-        prefix=path, delimiter=delimiter, fields=fields)
     else:
-      iterator = bucket.list_blobs(prefix=path, delimiter=delimiter)
+      fields = None
+
+    iterator = bucket.list_blobs(
+        prefix=path, delimiter=delimiter, fields=fields)
 
     for blob in iterator:
       properties['bucket'] = bucket_name

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -1388,13 +1388,6 @@ def get_arbitrary_signed_upload_urls(remote_directory: str,
     remote_directory = remote_directory + '/'
   # The remote_directory ends with slash.
   base_path = f'{remote_directory}{base_name}'
-  base_search_path = f'{base_path}*'
-  if exists(base_search_path):
-    # Raise the error and let retry go again. There is a vanishingly small
-    # chance that we get more collisions. This is vulnerable to races, but is
-    # probably unneeded anyway.
-    raise ValueError(f'UUID collision found {str(unique_id)}')
-
   urls = (f'{base_path}-{idx}' for idx in range(num_uploads))
   logs.info('Signing URLs for arbitrary uploads.')
   with concurrency.make_pool(


### PR DESCRIPTION
1. Cache credentials. This should have been done long ago.
Not doing so causes a new process to be created each time credentials
are requested. This is probably the highest risk change.
2. Properly skip task cleanup. It's not needed in tworkers.
3. Cache leak sanitizer db queries in Redis.
4. Only request names when listing contents of GCS directory.
5. Don't check that there is no UUID collision when uploading corpus elements. This is basically impossible and wastes time. It is also benign and not a security risk if it happens within the same 24 hours (one fuzz task will overwrite the corpus for the same fuzzer).