### PR TITLE
[Monitoring] Move histogram metrics to GeometricBucketer

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1887,15 +1887,12 @@ class FuzzingSession:
     self.fuzz_task_output.crash_groups.extend(crash_groups)
 
     fuzzing_session_duration = time.time() - start_time
-    labels = {
-        'fuzzer': self.fuzzer_name,
-        'job': self.job_type,
-        'platform': environment.platform()
-    }
-    logs.info(f'FUZZING_SESSION_DURATION: add {fuzzing_session_duration} '
-              'for {labels}.')
-    monitoring_metrics.FUZZING_SESSION_DURATION.add(fuzzing_session_duration,
-                                                    labels)
+    monitoring_metrics.FUZZING_SESSION_DURATION.add(
+        fuzzing_session_duration, {
+            'fuzzer': self.fuzzer_name,
+            'job': self.job_type,
+            'platform': environment.platform()
+        })
 
     return uworker_msg_pb2.Output(fuzz_task_output=self.fuzz_task_output)  # pylint: disable=no-member
 

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -300,17 +300,14 @@ def set_environment_vars(search_directories, app_path='APP_PATH',
 
 
 def _emit_job_build_retrieval_metric(start_time, step, build_type):
-  """Emits a metrick to track the distribution of build retrieval times."""
   elapsed_minutes = (time.time() - start_time) / 60
-  labels = {
-      'job': os.getenv('JOB_NAME'),
-      'platform': environment.platform(),
-      'step': step,
-      'build_type': build_type,
-  }
-  logs.info(f'JOB_BUILD_RETRIEVAL_TIME: adding {elapsed_minutes} '
-            f'for labels {labels}.')
-  monitoring_metrics.JOB_BUILD_RETRIEVAL_TIME.add(elapsed_minutes, labels)
+  monitoring_metrics.JOB_BUILD_RETRIEVAL_TIME.add(
+      elapsed_minutes, {
+          'job': os.getenv('JOB_NAME'),
+          'platform': environment.platform(),
+          'step': step,
+          'build_type': build_type,
+      })
 
 
 class BaseBuild:
@@ -1223,7 +1220,6 @@ def _emit_build_age_metric(gcs_path):
         'platform': environment.platform(),
         'task': os.getenv('TASK_NAME'),
     }
-    logs.info(f'JOB_BUILD_AGE: adding {elapsed_time_in_hours} for {labels}')
     monitoring_metrics.JOB_BUILD_AGE.add(elapsed_time_in_hours, labels)
     # This field is expected as a datetime object
     # https://cloud.google.com/storage/docs/json_api/v1/objects#resource

--- a/src/clusterfuzz/_internal/common/testcase_utils.py
+++ b/src/clusterfuzz/_internal/common/testcase_utils.py
@@ -61,17 +61,12 @@ def emit_testcase_triage_duration_metric(testcase_id: int, step: str):
                  ' failed to emit TESTCASE_UPLOAD_TRIAGE_DURATION metric.')
     return
 
-  labels = {
-      'job': testcase.job_type,
-      'step': step,
-  }
-
-  logs.info(
-      f'TESTCASE_UPLOAD_TRIAGE_DURATION: adding {elapsed_time_since_upload} for {labels}.'
-  )
-
   monitoring_metrics.TESTCASE_UPLOAD_TRIAGE_DURATION.add(
-      elapsed_time_since_upload, labels=labels)
+      elapsed_time_since_upload,
+      labels={
+          'job': testcase.job_type,
+          'step': step,
+      })
 
 
 def get_testcase_upload_metadata(

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -306,16 +306,12 @@ def _emit_untriaged_testcase_age_metric(critical_tasks_completed: bool,
   if not testcase.timestamp:
     return
 
-  labels = {
-      'job': testcase.job_type,
-      'platform': testcase.platform,
-  }
-
-  logs.info(f'UNTRIAGED_TESTCASE_AGE: adding {testcase.get_age_in_seconds()}'
-            ' for {labels}')
-
   monitoring_metrics.UNTRIAGED_TESTCASE_AGE.add(
-      testcase.get_age_in_seconds(), labels=labels)
+      testcase.get_age_in_seconds(),
+      labels={
+          'job': testcase.job_type,
+          'platform': testcase.platform,
+      })
 
 
 def main():

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -34,7 +34,7 @@ JOB_BAD_BUILD_COUNT = monitor.CounterMetric(
 
 JOB_BUILD_AGE = monitor.CumulativeDistributionMetric(
     'job/build_age',
-    bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),
+    bucketer=monitor.GeometricBucketer(),
     description=('Distribution of latest build\'s age in hours. '
                  '(grouped by fuzzer/job)'),
     field_spec=[
@@ -46,7 +46,7 @@ JOB_BUILD_AGE = monitor.CumulativeDistributionMetric(
 
 JOB_BUILD_RETRIEVAL_TIME = monitor.CumulativeDistributionMetric(
     'task/build_retrieval_time',
-    bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),
+    bucketer=monitor.GeometricBucketer(),
     description=('Distribution of fuzz task\'s build retrieval times. '
                  '(grouped by fuzzer/job, in minutes).'),
     field_spec=[
@@ -120,7 +120,7 @@ FUZZER_TOTAL_FUZZ_TIME = monitor.CounterMetric(
 # fuzzing time and the time to upload results to datastore
 FUZZING_SESSION_DURATION = monitor.CumulativeDistributionMetric(
     'task/fuzz/session/duration',
-    bucketer=monitor.FixedWidthBucketer(width=0.05, num_finite_buckets=20),
+    bucketer=monitor.GeometricBucketer(),
     description=('Total duration of fuzzing session.'),
     field_spec=[
         monitor.StringField('fuzzer'),


### PR DESCRIPTION
### Motivation

Cumulative distribution metrics from the monitoring initiative were incorrectly set to use the fixed width bucketer, and/or width=0.05 and max_buckets=20. This caused percentile metrics to cap at 1, which was wrong behavior.

This PR attempts to fix that by moving them all to Geometric Bucketer, without the aforementioned limits. It also reverts #4429 , since it apparently broke triage.py in chrome.

Part of #4271 