### PR TITLE
[NFC] Use an absolute path for configs when running butler scripts.

### DIFF
--- a/src/local/butler/run.py
+++ b/src/local/butler/run.py
@@ -30,7 +30,7 @@ def execute(args):
   sys.path.insert(0, os.path.abspath(os.path.join('src', 'appengine')))
   sys.path.insert(
       0, os.path.abspath(os.path.join('src', 'appengine', 'third_party')))
-  os.environ['CONFIG_DIR_OVERRIDE'] = args.config_dir
+  os.environ['CONFIG_DIR_OVERRIDE'] = os.path.abspath(args.config_dir)
   local_config.ProjectConfig().set_environment()
 
   if args.local:


### PR DESCRIPTION
Some parts of CF will chdir, breaking relative paths.