### PR TITLE
Fix Datetime not being including in data_types.py

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Classes for objects stored in the datastore."""
 
+import datetime
 import re
 
 from google.cloud import ndb


### PR DESCRIPTION
https://crbug.com/380707237 is caused by this discrepency between master and chrome branches.