### PR TITLE
Add a script to run tasks locally in butler

### DIFF
--- a/src/local/butler/scripts/run_task.py
+++ b/src/local/butler/scripts/run_task.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run a task locally."""
+
+from clusterfuzz._internal.bot.tasks import commands
+from clusterfuzz._internal.system import environment
+from clusterfuzz._internal.bot.fuzzers import init
+# from local.butler.run_bot
+
+def execute(args):
+  """Build keywords."""
+  environment.set_bot_environment()
+  init.run()
+  commands.process_command_impl('fuzz', 'libFuzzer', 'libfuzzer_asan_log4j2', True, True)
+  pass

--- a/src/local/butler/scripts/run_task.py
+++ b/src/local/butler/scripts/run_task.py
@@ -13,14 +13,17 @@
 # limitations under the License.
 """Run a task locally."""
 
+from clusterfuzz._internal.bot.fuzzers import init
 from clusterfuzz._internal.bot.tasks import commands
 from clusterfuzz._internal.system import environment
-from clusterfuzz._internal.bot.fuzzers import init
+
 # from local.butler.run_bot
+
 
 def execute(args):
   """Build keywords."""
   environment.set_bot_environment()
   init.run()
-  commands.process_command_impl('fuzz', 'libFuzzer', 'libfuzzer_asan_log4j2', True, True)
+  commands.process_command_impl('fuzz', 'libFuzzer', 'libfuzzer_asan_log4j2',
+                                True, True)
   pass


### PR DESCRIPTION
### Motivation

Running a task locally is tribal knowledge for now. This PR intends to ventilate that knowledge.

Suggested vscode debug target:

```
{
            "name": "Debug a forced run command",
            "type": "debugpy",
            "request": "launch",
            "program": "${workspaceFolder}/butler.py",
            "console": "integratedTerminal",
            "justMyCode": false,
            "args": "run run_task --config-dir=$HOME/projects/clusterfuzz-config/configs/external --non-dry-run",
            "env": {
                "CONFIG_DIR_OVERRIDE": "/usr/local/google/home/vitorguidi/projects/clusterfuzz-config/configs/external",
                "BATCH_TEST_CONFIG_PATH": "/usr/local/google/home/vitorguidi/projects/clusterfuzz-config/configs/external",
                "DEBUG_TASK": "TRUE",
            },
        },
```