### PR TITLE
Bring back parallel signing for tworkers.

### DIFF
--- a/src/clusterfuzz/_internal/base/concurrency.py
+++ b/src/clusterfuzz/_internal/base/concurrency.py
@@ -36,7 +36,7 @@ class SingleThreadPool:
 def make_pool(pool_size=POOL_SIZE, cpu_bound=False, max_pool_size=None):
   """Returns a pool that can (usually) execute tasks concurrently."""
   if max_pool_size is not None:
-    pool_size = max(pool_size, max_pool_size)
+    pool_size = min(pool_size, max_pool_size)
 
   # Don't use processes on Windows and unittests to avoid hangs.
   if (environment.get_value('PY_UNITTESTS') or


### PR DESCRIPTION
It's important for speed, probably safe on tworkers, and it will be very easy to notice if things go wrong since the preprocess queue will pile up.
This PR also fixes a bad bug where the max_pool_size was not obeyed, but in practice since this code never runs on machines with more than 2 cores, it's unlikely to matter.
Partial undoes https://github.com/google/clusterfuzz/pull/4430