### PR TITLE
[Monitoring] Adding a metric for task outcome

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -209,14 +209,6 @@ def get_command_object(task_name):
   return task_types.UTask(_COMMAND_MODULE_MAP[task_name])
 
 
-def _emit_task_outcome_metric(task, job, outcome):
-  monitoring_metrics.TASK_OUTCOME_COUNT.increment(labels={
-      'job': job,
-      'task': task,
-      'outcome': outcome,
-  })
-
-
 def run_command(task_name, task_argument, job_name, uworker_env):
   """Runs the command."""
   task = get_command_object(task_name)
@@ -257,17 +249,14 @@ def run_command(task_name, task_argument, job_name, uworker_env):
     # where a test case is reloaded from the datastore, just abort the task.
     logs.warning('Test case %s no longer exists.' % task_argument)
     rate_limiter.record_task(success=False)
-    _emit_task_outcome_metric(task_name, job_name, 'failure')
   except BaseException:
     # On any other exceptions, update state to reflect error and re-raise.
     rate_limiter.record_task(success=False)
-    _emit_task_outcome_metric(task_name, job_name, 'failure')
     if should_update_task_status(task_name):
       data_handler.update_task_status(task_state_name,
                                       data_types.TaskState.ERROR)
     raise
   else:
-    _emit_task_outcome_metric(task_name, job_name, 'success')
     rate_limiter.record_task(success=True)
 
   # Task completed successfully.

--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -208,12 +208,14 @@ def get_command_object(task_name):
   # Force remote execution.
   return task_types.UTask(_COMMAND_MODULE_MAP[task_name])
 
+
 def _emit_task_outcome_metric(task, job, outcome):
   monitoring_metrics.TASK_OUTCOME_COUNT.increment(labels={
-    'job': job,
-    'task': task,
-    'outcome': outcome,
+      'job': job,
+      'task': task,
+      'outcome': outcome,
   })
+
 
 def run_command(task_name, task_argument, job_name, uworker_env):
   """Runs the command."""

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -75,6 +75,7 @@ class _MetricRecorder(contextlib.AbstractContextManager):
   Members:
     start_time_ns (int): The time at which this recorder was constructed, in
       nanoseconds since the Unix epoch.
+    saw_failure: indicates if utask_main returned an error code as a value.
   """
 
   def __init__(self, subtask: _Subtask):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -75,14 +75,15 @@ class _MetricRecorder(contextlib.AbstractContextManager):
   Members:
     start_time_ns (int): The time at which this recorder was constructed, in
       nanoseconds since the Unix epoch.
-    saw_failure: indicates if utask_main returned an error code as a value.
+    utask_main_failure: this class stores the uworker_output.ErrorType object returned
+      by utask_main, and uses it to emmit a metric.
   """
 
   def __init__(self, subtask: _Subtask):
     self.start_time_ns = time.time_ns()
     self._subtask = subtask
     self._labels = None
-    self.saw_failure = False
+    self.utask_main_failure = None
 
     if subtask == _Subtask.PREPROCESS:
       self._preprocess_start_time_ns = self.start_time_ns
@@ -144,10 +145,25 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     # The only case where a task might fail without throwing, is in
     # utask_main, by returning an ErrorType proto which indicates
     # failure.
-    outcome = 'error' if _exc_type or self.saw_failure else 'success'
+    outcome = 'error' if _exc_type or self.utask_main_failure else 'success'
     monitoring_metrics.TASK_OUTCOME_COUNT.increment({
         **self._labels, 'outcome': outcome
     })
+    if outcome == "success":
+      error_condition = 'N/A'
+    elif _exc_type:
+      error_condition = 'UNHANDLED_EXCEPTION'
+    else:
+      error_condition = uworker_msg_pb2.ErrorType.Name(self.utask_main_failure)
+    # Get rid of job as a label, so we can have another metric to make 
+    # error conditions more explicit, respecting the 30k distinct
+    # labels limit recommended by gcp.
+    trimmed_labels = self._labels
+    del trimmed_labels['job']
+    trimmed_labels['outcome'] = outcome
+    trimmed_labels['error_condition'] = error_condition
+    monitoring_metrics.TASK_OUTCOME_COUNT_BY_ERROR_TYPE.increment(trimmed_labels)
+
 
 
 def ensure_uworker_env_type_safety(uworker_env):
@@ -238,7 +254,7 @@ def uworker_main_no_io(utask_module, serialized_uworker_input):
 
     # NOTE: Keep this in sync with `uworker_main()`.
     if uworker_output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
-      recorder.saw_failure = True
+      recorder.utask_main_failure = uworker_output.error_type
     uworker_output.bot_name = environment.get_value('BOT_NAME', '')
     uworker_output.platform_id = environment.get_platform_id()
 
@@ -320,7 +336,7 @@ def uworker_main(input_download_url) -> None:
     uworker_output = utask_module.utask_main(uworker_input)
 
     if uworker_output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
-      recorder.saw_failure = True
+      recorder.utask_main_failure = uworker_output.error_type
 
     # NOTE: Keep this in sync with `uworker_main_no_io()`.
     uworker_output.bot_name = environment.get_value('BOT_NAME', '')

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -156,15 +156,15 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     else:
       error_condition = uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
           self.utask_main_failure)
-    # Get rid of job as a label, so we can have another metric to make 
+    # Get rid of job as a label, so we can have another metric to make
     # error conditions more explicit, respecting the 30k distinct
     # labels limit recommended by gcp.
     trimmed_labels = self._labels
     del trimmed_labels['job']
     trimmed_labels['outcome'] = outcome
     trimmed_labels['error_condition'] = error_condition
-    monitoring_metrics.TASK_OUTCOME_COUNT_BY_ERROR_TYPE.increment(trimmed_labels)
-
+    monitoring_metrics.TASK_OUTCOME_COUNT_BY_ERROR_TYPE.increment(
+        trimmed_labels)
 
 
 def ensure_uworker_env_type_safety(uworker_env):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -33,6 +33,14 @@ from clusterfuzz._internal.system import environment
 Timestamp = timestamp_pb2.Timestamp  # pylint: disable=no-member
 
 
+def _emit_task_outcome_metric(task, job, outcome):
+  monitoring_metrics.TASK_OUTCOME_COUNT.increment(labels={
+      'job': job,
+      'task': task,
+      'outcome': outcome,
+  })
+
+
 class Mode(enum.Enum):
   """The execution mode of `uworker_main` tasks in a bot process."""
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -75,8 +75,8 @@ class _MetricRecorder(contextlib.AbstractContextManager):
   Members:
     start_time_ns (int): The time at which this recorder was constructed, in
       nanoseconds since the Unix epoch.
-    utask_main_failure: this class stores the uworker_output.ErrorType object returned
-      by utask_main, and uses it to emmit a metric.
+    utask_main_failure: this class stores the uworker_output.ErrorType 
+      object returned by utask_main, and uses it to emmit a metric.
   """
 
   def __init__(self, subtask: _Subtask):
@@ -154,7 +154,8 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     elif _exc_type:
       error_condition = 'UNHANDLED_EXCEPTION'
     else:
-      error_condition = uworker_msg_pb2.ErrorType.Name(self.utask_main_failure)
+      error_condition = uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
+          self.utask_main_failure)
     # Get rid of job as a label, so we can have another metric to make 
     # error conditions more explicit, respecting the 30k distinct
     # labels limit recommended by gcp.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -146,6 +146,9 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     monitoring_metrics.UTASK_SUBTASK_E2E_DURATION_SECS.add(
         e2e_duration_secs, self._labels)
 
+    outcome = 'error' if _exc_type else 'success'
+    monitoring_metrics.TASK_OUTCOME_COUNT.increment({**self._labels, 'outcome': outcome})
+
 
 def ensure_uworker_env_type_safety(uworker_env):
   """Converts all values in |uworker_env| to str types.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -33,14 +33,6 @@ from clusterfuzz._internal.system import environment
 Timestamp = timestamp_pb2.Timestamp  # pylint: disable=no-member
 
 
-def _emit_task_outcome_metric(task, job, outcome):
-  monitoring_metrics.TASK_OUTCOME_COUNT.increment(labels={
-      'job': job,
-      'task': task,
-      'outcome': outcome,
-  })
-
-
 class Mode(enum.Enum):
   """The execution mode of `uworker_main` tasks in a bot process."""
 
@@ -147,7 +139,9 @@ class _MetricRecorder(contextlib.AbstractContextManager):
         e2e_duration_secs, self._labels)
 
     outcome = 'error' if _exc_type else 'success'
-    monitoring_metrics.TASK_OUTCOME_COUNT.increment({**self._labels, 'outcome': outcome})
+    monitoring_metrics.TASK_OUTCOME_COUNT.increment({
+        **self._labels, 'outcome': outcome
+    })
 
 
 def ensure_uworker_env_type_safety(uworker_env):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -25,9 +25,9 @@ from clusterfuzz._internal import swarming
 from clusterfuzz._internal.base.tasks import task_utils
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.bot.webserver import http_server
-from clusterfuzz._internal.protos import uworker_msg_pb2
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.metrics import monitoring_metrics
+from clusterfuzz._internal.protos import uworker_msg_pb2
 from clusterfuzz._internal.system import environment
 
 # Define an alias to appease pylint.
@@ -236,7 +236,7 @@ def uworker_main_no_io(utask_module, serialized_uworker_input):
       return None
 
     # NOTE: Keep this in sync with `uworker_main()`.
-    if uworker_output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
+    if uworker_output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
       recorder.saw_failure = True
     uworker_output.bot_name = environment.get_value('BOT_NAME', '')
     uworker_output.platform_id = environment.get_platform_id()
@@ -318,7 +318,7 @@ def uworker_main(input_download_url) -> None:
     logs.info('Starting utask_main: %s.' % utask_module)
     uworker_output = utask_module.utask_main(uworker_input)
 
-    if uworker_output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:
+    if uworker_output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
       recorder.saw_failure = True
 
     # NOTE: Keep this in sync with `uworker_main_no_io()`.

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -228,6 +228,7 @@ TASK_TOTAL_RUN_TIME = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('task'),
         monitor.StringField('job'),
+        monitor.StringField('outcome'),
     ],
 )
 
@@ -241,6 +242,7 @@ TESTCASE_UPLOAD_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
         monitor.StringField('job'),
     ],
 )
+
 TASK_RATE_LIMIT_COUNT = monitor.CounterMetric(
     'task/rate_limit',
     description=('Counter for rate limit events.'),
@@ -249,6 +251,15 @@ TASK_RATE_LIMIT_COUNT = monitor.CounterMetric(
         monitor.StringField('job'),
         monitor.StringField('argument'),
     ])
+
+TASK_OUTCOME_COUNT = monitor.CounterMetric(
+    'task/outcome',
+    description=('Counter metric for task outcome (success/failure).'),
+    field_spec=[
+        monitor.StringField('task'),
+        monitor.StringField('job'),
+    ]
+)
 
 UTASK_SUBTASK_E2E_DURATION_SECS = monitor.CumulativeDistributionMetric(
     'utask/subtask_e2e_duration_secs',

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -228,7 +228,6 @@ TASK_TOTAL_RUN_TIME = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('task'),
         monitor.StringField('job'),
-        monitor.StringField('outcome'),
     ],
 )
 
@@ -258,6 +257,7 @@ TASK_OUTCOME_COUNT = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('task'),
         monitor.StringField('job'),
+        monitor.StringField('outcome'),
     ])
 
 UTASK_SUBTASK_E2E_DURATION_SECS = monitor.CumulativeDistributionMetric(

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -258,8 +258,7 @@ TASK_OUTCOME_COUNT = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('task'),
         monitor.StringField('job'),
-    ]
-)
+    ])
 
 UTASK_SUBTASK_E2E_DURATION_SECS = monitor.CumulativeDistributionMetric(
     'utask/subtask_e2e_duration_secs',

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -263,6 +263,18 @@ TASK_OUTCOME_COUNT = monitor.CounterMetric(
         monitor.StringField('outcome'),
     ])
 
+TASK_OUTCOME_COUNT_BY_ERROR_TYPE = monitor.CounterMetric(
+    'task/outcome_by_error_type',
+    description=('Counter metric for task outcome, with error type.'),
+    field_spec=[
+        monitor.StringField('task'),
+        monitor.StringField('subtask'),
+        monitor.StringField('mode'),
+        monitor.StringField('platform'),
+        monitor.StringField('outcome'),
+        monitor.StringField('error_condition'),
+    ])
+
 UTASK_SUBTASK_E2E_DURATION_SECS = monitor.CumulativeDistributionMetric(
     'utask/subtask_e2e_duration_secs',
     description=(

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -257,6 +257,9 @@ TASK_OUTCOME_COUNT = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('task'),
         monitor.StringField('job'),
+        monitor.StringField('subtask'),
+        monitor.StringField('mode'),
+        monitor.StringField('platform'),
         monitor.StringField('outcome'),
     ])
 


### PR DESCRIPTION
### Motivation

We currently have no metric that tracks the error rate for each task. This PR implements that, and the error rate can be obtained by summing up the metric with outcome=failure, divided by the overall sum.

This is useful for SLI alerting.

Part of #4271 