### PR TITLE
Optimize corpus signing by 6-8%

### DIFF
--- a/src/clusterfuzz/_internal/base/concurrency.py
+++ b/src/clusterfuzz/_internal/base/concurrency.py
@@ -31,6 +31,9 @@ class SingleThreadPool:
   def map(self, f, l):
     return list(map(f, l))
 
+  def imap_unordered(self, f, l):
+    return list(map(f, l))
+
 
 @contextlib.contextmanager
 def make_pool(pool_size=POOL_SIZE, cpu_bound=False, max_pool_size=None):
@@ -46,7 +49,7 @@ def make_pool(pool_size=POOL_SIZE, cpu_bound=False, max_pool_size=None):
     else:
       yield futures.ThreadPoolExecutor(pool_size)
   else:
-    yield futures.ProcessPoolExecutor(pool_size)
+    yield multiprocessing.Pool(pool_size)
 
 
 # TODO(metzman): Find out if batching makes things even faster.

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -663,21 +663,21 @@ def get_proto_corpus(bucket_name,
   # again.
   if max_download_urls is not None:
     urls = itertools.islice(urls, max_download_urls)
-  corpus_urls = dict(
-      storage.sign_urls_for_existing_files(urls, include_delete_urls))
-
+  corpus_urls = storage.sign_urls_for_existing_files(urls, include_delete_urls)
   upload_urls = storage.get_arbitrary_signed_upload_urls(
       gcs_url, num_uploads=max_upload_urls)
   corpus = uworker_msg_pb2.Corpus(  # pylint: disable=no-member
-      corpus_urls=corpus_urls,
-      upload_urls=upload_urls,
-      gcs_url=gcs_url,
-  )
+      gcs_url=gcs_url,)
   last_updated = _last_updated(_get_gcs_url(bucket_name, bucket_path))
   if last_updated:
     timestamp = timestamp_pb2.Timestamp()  # pylint: disable=no-member
     timestamp.FromDatetime(last_updated)
     corpus.last_updated_time.CopyFrom(timestamp)
+  # Iterate over imap_unordered results.
+  for upload_url in upload_urls:
+    corpus.upload_urls.append(upload_url)
+  for download_url, delete_url in corpus_urls:
+    corpus.corpus_urls[download_url] = delete_url
 
   return corpus
 

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -1234,7 +1234,6 @@ def str_to_bytes(data):
 
 
 def download_signed_url_to_file(url, filepath):
-  # print('filepath', filepath)
   contents = download_signed_url(url)
   os.makedirs(os.path.dirname(filepath), exist_ok=True)
   with open(filepath, 'wb') as fp:
@@ -1365,8 +1364,7 @@ def _mappable_sign_urls_for_existing_file(url_and_include_delete_urls):
   return _sign_urls_for_existing_file(url, include_delete_urls)
 
 
-def sign_urls_for_existing_files(urls,
-                                 include_delete_urls) -> List[Tuple[str, str]]:
+def sign_urls_for_existing_files(urls, include_delete_urls):
   logs.info('Signing URLs for existing files.')
   args = ((url, include_delete_urls) for url in urls)
   result = maybe_parallel_map(_sign_urls_for_existing_file, args)
@@ -1385,15 +1383,14 @@ def maybe_parallel_map(func, arguments):
   if not environment.is_tworker():
     # TODO(b/metzman): When the rearch is done, internal google CF won't have
     # tworkers, but maybe should be using parallel.
-    return list(map(func, arguments))
+    return map(func, arguments)
 
   max_size = 2
   with concurrency.make_pool(cpu_bound=True, max_pool_size=max_size) as pool:
-    return list(pool.map(func, arguments))
+    return pool.imap_unordered(func, arguments)
 
 
-def get_arbitrary_signed_upload_urls(remote_directory: str,
-                                     num_uploads: int) -> List[str]:
+def get_arbitrary_signed_upload_urls(remote_directory: str, num_uploads: int):
   """Returns |num_uploads| number of signed upload URLs to upload files with
   unique arbitrary names to remote_directory."""
   # We verify there are no collisions for uuid4s in CF because it would be bad


### PR DESCRIPTION
Use imap_unordered for these two improvements.
1. Async signing, we can start signing the arbitrary URLs before we are done listing and signing the existing URLs.
2. Ignoring the order means we can sign/list even faster.
3. Use of iterables means we don't need to use unnecessary memory.