### PR TITLE
Try to bunch tasks on batch more efficiently

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -90,11 +90,11 @@ PREPROCESS_QUEUE = 'preprocess'
 # See https://github.com/google/clusterfuzz/issues/3347 for usage
 SUBQUEUE_IDENTIFIER = ':'
 
-UTASK_QUEUE_PULL_SECONDS = 60
+UTASK_QUEUE_PULL_SECONDS = 120
 
 # The maximum number of utasks we will collect from the utask queue before
 # scheduling on batch.
-MAX_UTASKS = 250
+MAX_UTASKS = 800
 
 UTASKS = {
     'analyze',


### PR DESCRIPTION
We're experiencing big delays in our batch scheduling (meaning batch is an hour behind). We may have too many jobs for batch.
Start trying to bunch the tasks more efficiently so we have fewer jobs.