### PR TITLE
Bunch more aggressively, but schedule less tasks

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -90,11 +90,11 @@ PREPROCESS_QUEUE = 'preprocess'
 # See https://github.com/google/clusterfuzz/issues/3347 for usage
 SUBQUEUE_IDENTIFIER = ':'
 
-UTASK_QUEUE_PULL_SECONDS = 60
+UTASK_QUEUE_PULL_SECONDS = 120
 
 # The maximum number of utasks we will collect from the utask queue before
 # scheduling on batch.
-MAX_UTASKS = 250
+MAX_UTASKS = 800
 
 UTASKS = {
     'analyze',

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -90,11 +90,11 @@ PREPROCESS_QUEUE = 'preprocess'
 # See https://github.com/google/clusterfuzz/issues/3347 for usage
 SUBQUEUE_IDENTIFIER = ':'
 
-UTASK_QUEUE_PULL_SECONDS = 120
+UTASK_QUEUE_PULL_SECONDS = 150
 
 # The maximum number of utasks we will collect from the utask queue before
 # scheduling on batch.
-MAX_UTASKS = 800
+MAX_UTASKS = 3000
 
 UTASKS = {
     'analyze',

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -191,7 +191,7 @@ def schedule_fuzz_tasks() -> bool:
   # TODO(metzman): Put the CPU-based scheduling in tworkers.
   available_cpus = get_available_cpus(project, 'us-east4')
   # TODO(metzman): Remove this as we move from experimental code to production.
-  available_cpus = min(available_cpus, 12000)
+  available_cpus = min(available_cpus, 3000)
   fuzz_tasks = get_fuzz_tasks(available_cpus)
   if not fuzz_tasks:
     logs.error('No fuzz tasks found to schedule.')


### PR DESCRIPTION
The experiment failed because batch is throttling job creation for some reason.
Lower the amount of tasks we schedule so we don't create a backlog that prevents non-fuzz tasks from being run.