### PR TITLE
Update device check in download_trusty_symbols_if_needed

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -180,10 +180,10 @@ def download_trusty_symbols_if_needed(symbols_directory, app_name, bid):
   """Downloads and extracts Trusted App ELF files"""
   ab_target = ''
   device = settings.get_build_parameters().get('target')
-  if "cheetah" in device or "panther" in device:
-    ab_target = "cloudripper-fuzz-test-debug"
-  elif "oriole" in device or "raven" in device or "bluejay" in device:
-    ab_target = "slider-fuzz-test-debug"
+  if 'cheetah' in device or 'panther' in device:
+    ab_target = 'cloudripper-fuzz-test-debug'
+  elif 'oriole' in device or 'raven' in device or 'bluejay' in device:
+    ab_target = 'slider-fuzz-test-debug'
   else:
     logs.error(f'Unsupported device {device}.')
 

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -180,10 +180,12 @@ def download_trusty_symbols_if_needed(symbols_directory, app_name, bid):
   """Downloads and extracts Trusted App ELF files"""
   ab_target = ''
   device = settings.get_build_parameters().get('target')
-  if device in ['cheetah', 'panther']:
-    ab_target = 'cloudripper-fuzz-test-debug'
-  if device in ['oriole', 'raven', 'bluejay']:
-    ab_target = 'slider-fuzz-test-debug'
+  if "cheetah" in device or "panther" in device:
+    ab_target = "cloudripper-fuzz-test-debug"
+  elif "oriole" in device or "raven" in device or "bluejay" in device:
+    ab_target = "slider-fuzz-test-debug"
+  else:
+    logs.error(f'Unsupported device {device}.')
 
   branch = 'polygon-trusty-whitechapel-master'
   if not bid:


### PR DESCRIPTION
The device check is updated to use find instead of a literal match so that sanitized version of the devices (e.g: cheetah_hwasan) can also be used