### PR TITLE
Handle disfunctional issue handlers properly in triage

### DIFF
--- a/src/clusterfuzz/_internal/cron/grouper.py
+++ b/src/clusterfuzz/_internal/cron/grouper.py
@@ -426,9 +426,10 @@ def group_testcases():
         try:
           issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(
               testcase)
-          logs.info(
-              f'Running grouping with issue tracker {issue_tracker.project}, '
-              f' for testcase {testcase_id}')
+          if issue_tracker:
+            logs.info(
+                f'Running grouping with issue tracker {issue_tracker.project}, '
+                f' for testcase {testcase_id}')
         except ValueError:
           logs.error('Couldn\'t get issue tracker for issue.')
           del testcase_map[testcase_id]

--- a/src/clusterfuzz/_internal/cron/grouper.py
+++ b/src/clusterfuzz/_internal/cron/grouper.py
@@ -426,6 +426,9 @@ def group_testcases():
         try:
           issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(
               testcase)
+          logs.info(
+              f'Running grouping with issue tracker {issue_tracker.project()}, '
+              f' for testcase {testcase_id}')
         except ValueError:
           logs.error('Couldn\'t get issue tracker for issue.')
           del testcase_map[testcase_id]

--- a/src/clusterfuzz/_internal/cron/grouper.py
+++ b/src/clusterfuzz/_internal/cron/grouper.py
@@ -427,7 +427,7 @@ def group_testcases():
           issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(
               testcase)
           logs.info(
-              f'Running grouping with issue tracker {issue_tracker.project()}, '
+              f'Running grouping with issue tracker {issue_tracker.project}, '
               f' for testcase {testcase_id}')
         except ValueError:
           logs.error('Couldn\'t get issue tracker for issue.')

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -442,7 +442,7 @@ def main():
     # Clean up old triage messages that would be not applicable now.
     testcase.delete_metadata(TRIAGE_MESSAGE_KEY, update_testcase=False)
 
-    # # File the bug first and then create filed bug metadata.
+    # File the bug first and then create filed bug metadata.
     if not _file_issue(testcase, issue_tracker, throttler):
       logs.info(f'Issue filing failed for testcase id {testcase_id}')
       continue

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -421,7 +421,10 @@ def main():
 
     # If this project does not have an associated issue tracker, we cannot
     # file this crash anywhere.
-    issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(testcase)
+    try:
+      issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(testcase)
+    except ValueError:
+      issue_tracker = None
     if not issue_tracker:
       logs.info(f'No issue tracker detected for testcase {testcase_id}, '
                 'publishing message.')

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -327,25 +327,25 @@ def _emit_untriaged_testcase_age_metric(critical_tasks_completed: bool,
 
 def main():
   """Files bugs."""
-  # try:
-  #   logs.info('Grouping testcases.')
-  #   grouper.group_testcases()
-  #   logs.info('Grouping done.')
-  # except:
-  #   logs.error('Error occurred while grouping test cases.')
-  #   return False
+  try:
+    logs.info('Grouping testcases.')
+    grouper.group_testcases()
+    logs.info('Grouping done.')
+  except:
+    logs.error('Error occurred while grouping test cases.')
+    return False
 
-  # # Free up memory after group task run.
-  # utils.python_gc()
+  # Free up memory after group task run.
+  utils.python_gc()
 
-  # # Get a list of jobs excluded from bug filing.
-  # excluded_jobs = _get_excluded_jobs()
+  # Get a list of jobs excluded from bug filing.
+  excluded_jobs = _get_excluded_jobs()
 
-  # # Get a list of all jobs. This is used to filter testcases whose jobs have
-  # # been removed.
-  # all_jobs = data_handler.get_all_job_type_names()
+  # Get a list of all jobs. This is used to filter testcases whose jobs have
+  # been removed.
+  all_jobs = data_handler.get_all_job_type_names()
 
-  # throttler = Throttler()
+  throttler = Throttler()
 
   for testcase_id in data_handler.get_open_testcase_id_iterator():
     logs.info(f'Triaging {testcase_id}')
@@ -355,57 +355,57 @@ def main():
       # Already deleted.
       continue
 
-    # critical_tasks_completed = data_handler.critical_tasks_completed(testcase)
+    critical_tasks_completed = data_handler.critical_tasks_completed(testcase)
 
-    # # # Skip if testcase's job is removed.
-    # # if testcase.job_type not in all_jobs:
-    # #   continue
+    # Skip if testcase's job is removed.
+    if testcase.job_type not in all_jobs:
+      continue
 
-    # # # Skip if testcase's job is in exclusions list.
-    # # if testcase.job_type in excluded_jobs:
-    # #   continue
+    # Skip if testcase's job is in exclusions list.
+    if testcase.job_type in excluded_jobs:
+      continue
 
-    # # Emmit the metric for testcases that should be triaged.
-    # # _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
+    # Emmit the metric for testcases that should be triaged.
+    _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
 
-    # # Skip if we are running progression task at this time.
-    # if testcase.get_metadata('progression_pending'):
-    #   continue
+    # Skip if we are running progression task at this time.
+    if testcase.get_metadata('progression_pending'):
+      continue
 
-    # # If the testcase has a bug filed already, no triage is needed.
-    # if _is_bug_filed(testcase):
-    #   continue
+    # If the testcase has a bug filed already, no triage is needed.
+    if _is_bug_filed(testcase):
+      continue
 
-    # # Check if the crash is important, i.e. it is either a reproducible crash
-    # # or an unreproducible crash happening frequently.
-    # if not _is_crash_important(testcase):
-    #   continue
+    # Check if the crash is important, i.e. it is either a reproducible crash
+    # or an unreproducible crash happening frequently.
+    if not _is_crash_important(testcase):
+      continue
 
-    # # Require that all tasks like minimizaton, regression testing, etc have
-    # # finished.
-    # if not critical_tasks_completed:
-    #   continue
+    # Require that all tasks like minimizaton, regression testing, etc have
+    # finished.
+    if not critical_tasks_completed:
+      continue
 
-    # # For testcases that are not part of a group, wait an additional time to
-    # # make sure it is grouped.
-    # # The grouper runs prior to this step in the same cron, but there is a
-    # # window of time where new testcases can come in after the grouper starts.
-    # # This delay needs to be longer than the maximum time the grouper can take
-    # # to account for that.
-    # # FIXME: In future, grouping might be dependent on regression range, so we
-    # # would have to add an additional wait time.
-    # # TODO(ochang): Remove this after verifying that the `ran_grouper`
-    # # metadata works well.
-    # if not testcase.group_id and not dates.time_has_expired(
-    #     testcase.timestamp, hours=data_types.MIN_ELAPSED_TIME_SINCE_REPORT):
-    #   continue
+    # For testcases that are not part of a group, wait an additional time to
+    # make sure it is grouped.
+    # The grouper runs prior to this step in the same cron, but there is a
+    # window of time where new testcases can come in after the grouper starts.
+    # This delay needs to be longer than the maximum time the grouper can take
+    # to account for that.
+    # FIXME: In future, grouping might be dependent on regression range, so we
+    # would have to add an additional wait time.
+    # TODO(ochang): Remove this after verifying that the `ran_grouper`
+    # metadata works well.
+    if not testcase.group_id and not dates.time_has_expired(
+        testcase.timestamp, hours=data_types.MIN_ELAPSED_TIME_SINCE_REPORT):
+      continue
 
-    # if not testcase.get_metadata('ran_grouper'):
-    #   # Testcase should be considered by the grouper first before filing.
-    #   continue
+    if not testcase.get_metadata('ran_grouper'):
+      # Testcase should be considered by the grouper first before filing.
+      continue
 
-    # # If this project does not have an associated issue tracker, we cannot
-    # # file this crash anywhere.
+    # If this project does not have an associated issue tracker, we cannot
+    # file this crash anywhere.
     issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(testcase)
     if not issue_tracker:
       issue_filer.notify_issue_update(testcase, 'new')
@@ -420,8 +420,8 @@ def main():
     testcase.delete_metadata(TRIAGE_MESSAGE_KEY, update_testcase=False)
 
     # # File the bug first and then create filed bug metadata.
-    # if not _file_issue(testcase, issue_tracker, throttler):
-    #   continue
+    if not _file_issue(testcase, issue_tracker, throttler):
+      continue
 
     _create_filed_bug_metadata(testcase)
     issue_filer.notify_issue_update(testcase, 'new')

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -353,19 +353,22 @@ def main():
       testcase = data_handler.get_testcase_by_id(testcase_id)
     except errors.InvalidTestcaseError:
       # Already deleted.
-      logs.info(f'Skipping testcase {testcase_id}, since it was already deleted.')
+      logs.info(
+          f'Skipping testcase {testcase_id}, since it was already deleted.')
       continue
 
     critical_tasks_completed = data_handler.critical_tasks_completed(testcase)
 
     # Skip if testcase's job is removed.
     if testcase.job_type not in all_jobs:
-      logs.info(f'Skipping testcase {testcase_id}, since its job was removed ({testcase.job_type})')
+      logs.info(f'Skipping testcase {testcase_id}, since its job was removed '
+                f' ({testcase.job_type})')
       continue
 
     # Skip if testcase's job is in exclusions list.
     if testcase.job_type in excluded_jobs:
-      logs.info(f'Skipping testcase {testcase_id}, since its job is in the exclusion list ({testcase.job_type})')
+      logs.info(f'Skipping testcase {testcase_id}, since its job is in the'
+                f' exclusion list ({testcase.job_type})')
       continue
 
     # Emmit the metric for testcases that should be triaged.
@@ -378,19 +381,22 @@ def main():
 
     # If the testcase has a bug filed already, no triage is needed.
     if _is_bug_filed(testcase):
-      logs.info(f'Skipping testcase {testcase_id}, since a bug was already filed.')
+      logs.info(
+          f'Skipping testcase {testcase_id}, since a bug was already filed.')
       continue
 
     # Check if the crash is important, i.e. it is either a reproducible crash
     # or an unreproducible crash happening frequently.
     if not _is_crash_important(testcase):
-      logs.info(f'Skipping testcase {testcase_id}, since the crash is not important.')
+      logs.info(
+          f'Skipping testcase {testcase_id}, since the crash is not important.')
       continue
 
     # Require that all tasks like minimizaton, regression testing, etc have
     # finished.
     if not critical_tasks_completed:
-      logs.info(f'Skipping testcase {testcase_id}, critical tasks still pending.')
+      logs.info(
+          f'Skipping testcase {testcase_id}, critical tasks still pending.')
       continue
 
     # For testcases that are not part of a group, wait an additional time to
@@ -417,14 +423,16 @@ def main():
     # file this crash anywhere.
     issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(testcase)
     if not issue_tracker:
-      logs.info(f'No issue tracker detected for testcase {testcase_id}, publishing message.')
+      logs.info(f'No issue tracker detected for testcase {testcase_id}, '
+                'publishing message.')
       issue_filer.notify_issue_update(testcase, 'new')
       continue
 
     # If there are similar issues to this test case already filed or recently
     # closed, skip filing a duplicate bug.
     if _check_and_update_similar_bug(testcase, issue_tracker):
-      logs.info(f'Skipping testcase {testcase_id}, since a similar bug was already filed.')
+      logs.info(f'Skipping testcase {testcase_id}, since a similar bug'
+                ' was already filed.')
       continue
 
     # Clean up old triage messages that would be not applicable now.

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -347,8 +347,6 @@ def main():
 
   throttler = Throttler()
 
-  return_code = True
-
   for testcase_id in data_handler.get_open_testcase_id_iterator():
     logs.info(f'Triaging {testcase_id}')
     try:
@@ -430,31 +428,19 @@ def main():
       issue_filer.notify_issue_update(testcase, 'new')
       continue
 
-    try:
-      # If there are similar issues to this test case already filed or recently
-      # closed, skip filing a duplicate bug.
-      if _check_and_update_similar_bug(testcase, issue_tracker):
-        logs.info(f'Skipping testcase {testcase_id}, since a similar bug'
-                  ' was already filed.')
-        continue
-    except Exception as e:
-      logs.error(f'Failed to check testcase {testcase.id.key()}'
-                 f' for similar bugs: {e}')
-      return_code = False
+    # If there are similar issues to this test case already filed or recently
+    # closed, skip filing a duplicate bug.
+    if _check_and_update_similar_bug(testcase, issue_tracker):
+      logs.info(f'Skipping testcase {testcase_id}, since a similar bug'
+                ' was already filed.')
       continue
 
     # Clean up old triage messages that would be not applicable now.
     testcase.delete_metadata(TRIAGE_MESSAGE_KEY, update_testcase=False)
 
-    try:
-      # # File the bug first and then create filed bug metadata.
-      if not _file_issue(testcase, issue_tracker, throttler):
-        logs.info(f'Issue filing failed for testcase id {testcase_id}')
-        continue
-    except Exception as e:
-      logs.error('Failed to file issue for testcase '
-                 f'{testcase.id.key()}: {e}')
-      return_code = False
+    # # File the bug first and then create filed bug metadata.
+    if not _file_issue(testcase, issue_tracker, throttler):
+      logs.info(f'Issue filing failed for testcase id {testcase_id}')
       continue
 
     _create_filed_bug_metadata(testcase)
@@ -463,12 +449,8 @@ def main():
     logs.info('Filed new issue %s for testcase %d.' % (testcase.bug_information,
                                                        testcase_id))
 
-  if return_code:
-    logs.info('Triage testcases succeeded.')
-  else:
-    logs.error('Triage testcases failed.')
-
-  return return_code
+  logs.info('Triage testcases succeeded.')
+  return True
 
 
 class Throttler:

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -422,7 +422,8 @@ def main():
     # If this project does not have an associated issue tracker, we cannot
     # file this crash anywhere.
     try:
-      issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(testcase)
+      issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(
+          testcase)
     except ValueError:
       issue_tracker = None
     if not issue_tracker:

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -327,25 +327,25 @@ def _emit_untriaged_testcase_age_metric(critical_tasks_completed: bool,
 
 def main():
   """Files bugs."""
-  try:
-    logs.info('Grouping testcases.')
-    grouper.group_testcases()
-    logs.info('Grouping done.')
-  except:
-    logs.error('Error occurred while grouping test cases.')
-    return False
+  # try:
+  #   logs.info('Grouping testcases.')
+  #   grouper.group_testcases()
+  #   logs.info('Grouping done.')
+  # except:
+  #   logs.error('Error occurred while grouping test cases.')
+  #   return False
 
-  # Free up memory after group task run.
-  utils.python_gc()
+  # # Free up memory after group task run.
+  # utils.python_gc()
 
-  # Get a list of jobs excluded from bug filing.
-  excluded_jobs = _get_excluded_jobs()
+  # # Get a list of jobs excluded from bug filing.
+  # excluded_jobs = _get_excluded_jobs()
 
-  # Get a list of all jobs. This is used to filter testcases whose jobs have
-  # been removed.
-  all_jobs = data_handler.get_all_job_type_names()
+  # # Get a list of all jobs. This is used to filter testcases whose jobs have
+  # # been removed.
+  # all_jobs = data_handler.get_all_job_type_names()
 
-  throttler = Throttler()
+  # throttler = Throttler()
 
   for testcase_id in data_handler.get_open_testcase_id_iterator():
     logs.info(f'Triaging {testcase_id}')
@@ -355,57 +355,57 @@ def main():
       # Already deleted.
       continue
 
-    critical_tasks_completed = data_handler.critical_tasks_completed(testcase)
+    # critical_tasks_completed = data_handler.critical_tasks_completed(testcase)
 
-    # Skip if testcase's job is removed.
-    if testcase.job_type not in all_jobs:
-      continue
+    # # # Skip if testcase's job is removed.
+    # # if testcase.job_type not in all_jobs:
+    # #   continue
 
-    # Skip if testcase's job is in exclusions list.
-    if testcase.job_type in excluded_jobs:
-      continue
+    # # # Skip if testcase's job is in exclusions list.
+    # # if testcase.job_type in excluded_jobs:
+    # #   continue
 
-    # Emmit the metric for testcases that should be triaged.
-    _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
+    # # Emmit the metric for testcases that should be triaged.
+    # # _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
 
-    # Skip if we are running progression task at this time.
-    if testcase.get_metadata('progression_pending'):
-      continue
+    # # Skip if we are running progression task at this time.
+    # if testcase.get_metadata('progression_pending'):
+    #   continue
 
-    # If the testcase has a bug filed already, no triage is needed.
-    if _is_bug_filed(testcase):
-      continue
+    # # If the testcase has a bug filed already, no triage is needed.
+    # if _is_bug_filed(testcase):
+    #   continue
 
-    # Check if the crash is important, i.e. it is either a reproducible crash
-    # or an unreproducible crash happening frequently.
-    if not _is_crash_important(testcase):
-      continue
+    # # Check if the crash is important, i.e. it is either a reproducible crash
+    # # or an unreproducible crash happening frequently.
+    # if not _is_crash_important(testcase):
+    #   continue
 
-    # Require that all tasks like minimizaton, regression testing, etc have
-    # finished.
-    if not critical_tasks_completed:
-      continue
+    # # Require that all tasks like minimizaton, regression testing, etc have
+    # # finished.
+    # if not critical_tasks_completed:
+    #   continue
 
-    # For testcases that are not part of a group, wait an additional time to
-    # make sure it is grouped.
-    # The grouper runs prior to this step in the same cron, but there is a
-    # window of time where new testcases can come in after the grouper starts.
-    # This delay needs to be longer than the maximum time the grouper can take
-    # to account for that.
-    # FIXME: In future, grouping might be dependent on regression range, so we
-    # would have to add an additional wait time.
-    # TODO(ochang): Remove this after verifying that the `ran_grouper`
-    # metadata works well.
-    if not testcase.group_id and not dates.time_has_expired(
-        testcase.timestamp, hours=data_types.MIN_ELAPSED_TIME_SINCE_REPORT):
-      continue
+    # # For testcases that are not part of a group, wait an additional time to
+    # # make sure it is grouped.
+    # # The grouper runs prior to this step in the same cron, but there is a
+    # # window of time where new testcases can come in after the grouper starts.
+    # # This delay needs to be longer than the maximum time the grouper can take
+    # # to account for that.
+    # # FIXME: In future, grouping might be dependent on regression range, so we
+    # # would have to add an additional wait time.
+    # # TODO(ochang): Remove this after verifying that the `ran_grouper`
+    # # metadata works well.
+    # if not testcase.group_id and not dates.time_has_expired(
+    #     testcase.timestamp, hours=data_types.MIN_ELAPSED_TIME_SINCE_REPORT):
+    #   continue
 
-    if not testcase.get_metadata('ran_grouper'):
-      # Testcase should be considered by the grouper first before filing.
-      continue
+    # if not testcase.get_metadata('ran_grouper'):
+    #   # Testcase should be considered by the grouper first before filing.
+    #   continue
 
-    # If this project does not have an associated issue tracker, we cannot
-    # file this crash anywhere.
+    # # If this project does not have an associated issue tracker, we cannot
+    # # file this crash anywhere.
     issue_tracker = issue_tracker_utils.get_issue_tracker_for_testcase(testcase)
     if not issue_tracker:
       issue_filer.notify_issue_update(testcase, 'new')
@@ -419,9 +419,9 @@ def main():
     # Clean up old triage messages that would be not applicable now.
     testcase.delete_metadata(TRIAGE_MESSAGE_KEY, update_testcase=False)
 
-    # File the bug first and then create filed bug metadata.
-    if not _file_issue(testcase, issue_tracker, throttler):
-      continue
+    # # File the bug first and then create filed bug metadata.
+    # if not _file_issue(testcase, issue_tracker, throttler):
+    #   continue
 
     _create_filed_bug_metadata(testcase)
     issue_filer.notify_issue_update(testcase, 'new')

--- a/src/clusterfuzz/_internal/issue_management/issue_tracker_utils.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_tracker_utils.py
@@ -45,7 +45,7 @@ def _get_issue_tracker_project_name(testcase=None):
   from clusterfuzz._internal.datastore import data_handler
   job_type = testcase.job_type if testcase else None
   issue_tracker_name = data_handler.get_issue_tracker_name(job_type)
-  logs.info(f'For testcase {testcase}, using issue tracker {issue_tracker_name}')
+  logs.info(f'For testcase {testcase.key}, using issue tracker {issue_tracker_name}')
   return issue_tracker_name
 
 

--- a/src/clusterfuzz/_internal/issue_management/issue_tracker_utils.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_tracker_utils.py
@@ -45,7 +45,8 @@ def _get_issue_tracker_project_name(testcase=None):
   from clusterfuzz._internal.datastore import data_handler
   job_type = testcase.job_type if testcase else None
   issue_tracker_name = data_handler.get_issue_tracker_name(job_type)
-  logs.info(f'For testcase {testcase.key}, using issue tracker {issue_tracker_name}')
+  logs.info(
+      f'For testcase {testcase.key}, using issue tracker {issue_tracker_name}')
   return issue_tracker_name
 
 
@@ -69,7 +70,8 @@ def get_issue_tracker(project_name=None):
   issue_project_config = issue_tracker_config.get(project_name)
   if not issue_project_config:
     raise ValueError('Issue tracker for {} does not exist'.format(project_name))
-  logs.info(f'Issue tracker = {project_name}, issue tracker config = {issue_project_config}')
+  logs.info(f'Issue tracker = {project_name}, issue tracker config = '
+            f'{issue_project_config}')
 
   issue_tracker_type = issue_project_config['type']
   constructor = _ISSUE_TRACKER_CONSTRUCTORS.get(issue_tracker_type)

--- a/src/clusterfuzz/_internal/issue_management/issue_tracker_utils.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_tracker_utils.py
@@ -21,6 +21,7 @@ from clusterfuzz._internal.issue_management import google_issue_tracker
 from clusterfuzz._internal.issue_management import issue_tracker_policy
 from clusterfuzz._internal.issue_management import jira
 from clusterfuzz._internal.issue_management import monorail
+from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
 _ISSUE_TRACKER_CACHE_CAPACITY = 8
@@ -43,7 +44,9 @@ def _get_issue_tracker_project_name(testcase=None):
   """Return issue tracker project name given a testcase or default."""
   from clusterfuzz._internal.datastore import data_handler
   job_type = testcase.job_type if testcase else None
-  return data_handler.get_issue_tracker_name(job_type)
+  issue_tracker_name = data_handler.get_issue_tracker_name(job_type)
+  logs.info(f'For testcase {testcase}, using issue tracker {issue_tracker_name}')
+  return issue_tracker_name
 
 
 def request_or_task_cache(func):
@@ -66,8 +69,11 @@ def get_issue_tracker(project_name=None):
   issue_project_config = issue_tracker_config.get(project_name)
   if not issue_project_config:
     raise ValueError('Issue tracker for {} does not exist'.format(project_name))
+  logs.info(f'Issue tracker = {project_name}, issue tracker config = {issue_project_config}')
 
-  constructor = _ISSUE_TRACKER_CONSTRUCTORS.get(issue_project_config['type'])
+  issue_tracker_type = issue_project_config['type']
+  constructor = _ISSUE_TRACKER_CONSTRUCTORS.get(issue_tracker_type)
+  logs.info(f'Using the issue tracker constructor for {issue_tracker_type}')
   if not constructor:
     raise ValueError('Invalid issue tracker type: ' +
                      issue_project_config['type'])

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Executes update task locally, so we can run it through a debugger."""
 
-from clusterfuzz._internal.cron import triage
+from clusterfuzz._internal.cron import oss_fuzz_apply_ccs
 from clusterfuzz._internal.system import environment
 
 
 def execute(args):  #pylint: disable=unused-argument
   """Build keywords."""
   environment.set_bot_environment()
-  triage.main()
+  oss_fuzz_apply_ccs.main()

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Executes update task locally, so we can run it through a debugger."""
 
-from clusterfuzz._internal.cron import oss_fuzz_apply_ccs
+from clusterfuzz._internal.cron import triage
 from clusterfuzz._internal.system import environment
 
 
 def execute(args):  #pylint: disable=unused-argument
   """Build keywords."""
   environment.set_bot_environment()
-  oss_fuzz_apply_ccs.main()
+  triage.main()


### PR DESCRIPTION
### Motivation

Fuchsia testcases were referencing monorail, for which the API was deprecated. This implied on the cronjob failing prematurely, and no issues being filed on google3.

This PR adds extra logging, so we can troubleshoot this sort of issue more easily.

Also, under the triage cronjob, the ValueError exception is handled, to handle gracefully the case where some testcase references an issue finder that is not present under the issue tracker config.