### PR TITLE
Extend TESTCASE_UPLOAD_TRIAGE_DURATION to account for fuzzer generated test cases

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -234,11 +234,14 @@ TASK_TOTAL_RUN_TIME = monitor.CounterMetric(
 TESTCASE_UPLOAD_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
     'uploaded_testcase_analysis/triage_duration_secs',
     description=('Time elapsed between testcase upload and completion'
-                 ' of relevant tasks in the testcase upload lifecycle.'),
+                 ' of relevant tasks in the testcase upload lifecycle.'
+                 ' Origin can be either from a fuzzer, or a manual'
+                 ' upload.'),
     bucketer=monitor.GeometricBucketer(),
     field_spec=[
         monitor.StringField('step'),
         monitor.StringField('job'),
+        monitor.StringField('origin'),
     ],
 )
 TASK_RATE_LIMIT_COUNT = monitor.CounterMetric(


### PR DESCRIPTION
### Motivation

[#4364](https://github.com/google/clusterfuzz/pull/4364) implemented the tracking for the time it takes clusterfuzz to complete several steps of the manually uploaded testcase lifecycle.

As per Chrome's request, the metric will now contain an 'origin' label, which indicates if the testcase was 'manually_uploaded'  or generated by a 'fuzzer'