### PR TITLE
[merge from master]build_manager: allow remote unpacking when unpacking everything

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -485,12 +485,11 @@ class Build(BaseBuild):
     # if the HTTP URL is compatible with remote unzipping.
     allow_unpack_over_http = environment.get_value(
         'ALLOW_UNPACK_OVER_HTTP', default_value=False)
-    can_unzip_over_http = (
-        allow_unpack_over_http and not self._unpack_everything and
-        http_build_url and
+    can_unpack_over_http = (
+        allow_unpack_over_http and http_build_url and
         build_archive.unzip_over_http_compatible(http_build_url))
 
-    if not can_unzip_over_http:
+    if not can_unpack_over_http:
       return self._download_and_open_build_archive(base_build_dir, build_dir,
                                                    build_url)
     # We do not emmit a metric for build download time, if using http


### PR DESCRIPTION
Now that we are lazily checking for fuzzing targets, it makes sense to allow remote unpacking even when unpacking the full archive. Furthermore, it seems that remote unpacking performances are much higher than local unpacking on CF bots, so this might improve overall performances of the build_manager.