### PR TITLE
[Monitoring] Add logging to understand stuck testcases

### DIFF
--- a/src/clusterfuzz/_internal/common/testcase_utils.py
+++ b/src/clusterfuzz/_internal/common/testcase_utils.py
@@ -61,6 +61,10 @@ def emit_testcase_triage_duration_metric(testcase_id: int, step: str):
                  ' failed to emit TESTCASE_UPLOAD_TRIAGE_DURATION metric.')
     return
 
+  logs.info('Emiting TESTCASE_UPLOAD_TRIAGE_DURATION metric for testcase '
+            f'{testcase_id} (age = {elapsed_time_since_upload}) '
+            'in step {step}.')
+
   monitoring_metrics.TESTCASE_UPLOAD_TRIAGE_DURATION.add(
       elapsed_time_since_upload,
       labels={

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -317,6 +317,8 @@ def _emit_untriaged_testcase_age_metric(critical_tasks_completed: bool,
   if not testcase.timestamp:
     return
 
+  logs.info(f'Emiting UNTRIAGED_TESTCASE_AGE for testcase {testcase.key.id()} '
+            f'(age = {testcase.get_age_in_seconds()})')
   monitoring_metrics.UNTRIAGED_TESTCASE_AGE.add(
       testcase.get_age_in_seconds(),
       labels={


### PR DESCRIPTION
### Motivation

#4364and #4381 have introduced metrics for how long it took between a testcase creation and some event of interest (cleanup considering to close a bug, analyze finishing, et al).

These percentile metrics allowed us to notice that there are several testcases that did not make progress for more than a year. This PR introduces logging so we can pinpoint them, and discuss if a purge of some sort is required