### PR TITLE
Logging successful task executions in utask _MetricRecorder

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -169,8 +169,7 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     if error_condition != 'UNHANDLED_EXCEPTION':
       task = self._labels['task']
       subtask = self._labels['subtask']
-      logs.info(f'Task {task}, at subtask {subtask}, '
-                'finished successfully.')
+      logs.info(f'Task {task}, at subtask {subtask}, finished successfully.')
 
 
 def ensure_uworker_env_type_safety(uworker_env):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -166,6 +166,12 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     monitoring_metrics.TASK_OUTCOME_COUNT_BY_ERROR_TYPE.increment(
         trimmed_labels)
 
+    if error_condition != 'UNHANDLED_EXCEPTION':
+      task = self._labels['task']
+      subtask = self._labels['subtask']
+      logs.info(f'Task {task}, at subtask {subtask}, '
+                'finished successfully.')
+
 
 def ensure_uworker_env_type_safety(uworker_env):
   """Converts all values in |uworker_env| to str types.

--- a/src/clusterfuzz/_internal/common/testcase_utils.py
+++ b/src/clusterfuzz/_internal/common/testcase_utils.py
@@ -47,7 +47,7 @@ def emit_testcase_triage_duration_metric(testcase_id: int, step: str):
   ]
   elapsed_time_since_upload = datetime.datetime.utcnow()
   elapsed_time_since_upload -= testcase_upload_metadata.timestamp
-  elapsed_time_since_upload = elapsed_time_since_upload.total_seconds()
+  elapsed_time_since_upload = elapsed_time_since_upload.total_seconds() / 3600
 
   testcase = data_handler.get_testcase_by_id(testcase_id)
 

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -320,7 +320,7 @@ def _emit_untriaged_testcase_age_metric(critical_tasks_completed: bool,
   logs.info(f'Emiting UNTRIAGED_TESTCASE_AGE for testcase {testcase.key.id()} '
             f'(age = {testcase.get_age_in_seconds()})')
   monitoring_metrics.UNTRIAGED_TESTCASE_AGE.add(
-      testcase.get_age_in_seconds(),
+      testcase.get_age_in_seconds() / 3600,
       labels={
           'job': testcase.job_type,
           'platform': testcase.platform,

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -234,7 +234,8 @@ TASK_TOTAL_RUN_TIME = monitor.CounterMetric(
 TESTCASE_UPLOAD_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
     'uploaded_testcase_analysis/triage_duration_secs',
     description=('Time elapsed between testcase upload and completion'
-                 ' of relevant tasks in the testcase upload lifecycle.'),
+                 ' of relevant tasks in the testcase upload lifecycle, '
+                 'in hours.'),
     bucketer=monitor.GeometricBucketer(),
     field_spec=[
         monitor.StringField('step'),
@@ -357,7 +358,7 @@ UNTRIAGED_TESTCASE_AGE = monitor.CumulativeDistributionMetric(
     'issues/untriaged_testcase_age',
     description='Age of testcases that were not yet triaged '
     '(have not yet completed analyze, regression,'
-    ' minimization, impact task), in seconds.',
+    ' minimization, impact task), in hours.',
     bucketer=monitor.GeometricBucketer(),
     field_spec=[
         monitor.StringField('job'),


### PR DESCRIPTION
### Motivation

Progression task was failing 100% of the time due to an unhandled exception. This PR adds further logging so we can confirm if this is the case.

This also makes UNTRIAGED_TESTCASE_AGE and TESTCASE_UPLOAD_TRIAGE_DURATION in hours, instead of seconds, for better readability