### PR TITLE
[Monitoring] Fix untriaged testcase age oversampling, add untriaged testcase count

### DIFF
--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -314,7 +314,7 @@ untriaged_testcase_count = {}
 
 def _increment_untriaged_testcase_count(testcase: data_types.Testcase):
   identifier = (testcase.job_type, testcase.platform)
-  if not identifier in untriaged_testcase_count:
+  if identifier not in untriaged_testcase_count:
     untriaged_testcase_count[identifier] = 0
   untriaged_testcase_count[identifier] += 1
 
@@ -338,12 +338,11 @@ def _emit_untriaged_testcase_age_metric(testcase: data_types.Testcase):
 def _emit_untriaged_testcase_count_metric():
   for (job, platform) in untriaged_testcase_count:
     monitoring_metrics.UNTRIAGED_TESTCASE_COUNT.set(
-      untriaged_testcase_count[(job, platform)],
-      labels = {
-        'job': job,
-        'platform': platform,
-      }
-    )
+        untriaged_testcase_count[(job, platform)],
+        labels={
+            'job': job,
+            'platform': platform,
+        })
 
 
 def main():

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -349,6 +349,8 @@ def main():
 
   throttler = Throttler()
 
+  untriaged_testcases = 0
+
   for testcase_id in data_handler.get_open_testcase_id_iterator():
     logs.info(f'Triaging {testcase_id}')
     try:
@@ -373,12 +375,11 @@ def main():
                 f' exclusion list ({testcase.job_type})')
       continue
 
-    # Emmit the metric for testcases that should be triaged.
-    _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
-
     # Skip if we are running progression task at this time.
     if testcase.get_metadata('progression_pending'):
       logs.info(f'Skipping testcase {testcase_id}, progression pending')
+      _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
+      untriaged_testcases += 1
       continue
 
     # If the testcase has a bug filed already, no triage is needed.
@@ -397,6 +398,8 @@ def main():
     # Require that all tasks like minimizaton, regression testing, etc have
     # finished.
     if not critical_tasks_completed:
+      _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
+      untriaged_testcases += 1
       logs.info(
           f'Skipping testcase {testcase_id}, critical tasks still pending.')
       continue
@@ -413,11 +416,15 @@ def main():
     # metadata works well.
     if not testcase.group_id and not dates.time_has_expired(
         testcase.timestamp, hours=data_types.MIN_ELAPSED_TIME_SINCE_REPORT):
+      _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
+      untriaged_testcases += 1
       logs.info(f'Skipping testcase {testcase_id}, pending grouping.')
       continue
 
     if not testcase.get_metadata('ran_grouper'):
       # Testcase should be considered by the grouper first before filing.
+      _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
+      untriaged_testcases += 1
       logs.info(f'Skipping testcase {testcase_id}, pending grouping.')
       continue
 
@@ -447,6 +454,8 @@ def main():
     # File the bug first and then create filed bug metadata.
     if not _file_issue(testcase, issue_tracker, throttler):
       logs.info(f'Issue filing failed for testcase id {testcase_id}')
+      _emit_untriaged_testcase_age_metric(critical_tasks_completed, testcase)
+      untriaged_testcases += 1
       continue
 
     _create_filed_bug_metadata(testcase)

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -365,6 +365,16 @@ UNTRIAGED_TESTCASE_AGE = monitor.CumulativeDistributionMetric(
         monitor.StringField('platform'),
     ])
 
+UNTRIAGED_TESTCASE_COUNT = monitor.GaugeMetric(
+    'issues/untriaged_testcase_count',
+    description='Number of testcases that were not yet triaged '
+    '(have not yet completed analyze, regression,'
+    ' minimization, impact task), in hours.',
+    field_spec=[
+        monitor.StringField('job'),
+        monitor.StringField('platform'),
+    ])
+
 ANALYZE_TASK_REPRODUCIBILITY = monitor.CounterMetric(
     'task/analyze/reproducibility',
     description='Outcome count for analyze task.',


### PR DESCRIPTION
### Motivation

#4364 implemented a metric to track the percentile distributions of untriaged testcase age. It was overcounting testcases:
* Testcases for which a bug was already filed
* Testcases for which the crash was unimportant

This PR solves this issue, and adds the UNTRIAGED_TESTCASE_COUNT metric, drilled down by job and platform, so we can also know how many testcases are stuck, and not only their age distribution.