### PR TITLE
[Monitoring] Partition uworker_output.ErrorType conditions into success, maybe_retry and failure outcomes

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -84,6 +84,52 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     self._subtask = subtask
     self._labels = None
     self.utask_main_failure = None
+    self._utask_success_conditions = [
+      uworker_msg_pb2.ErrorType.NO_ERROR,
+      uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH,
+      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX,
+      uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH,
+      uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE,
+      uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH,
+      uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY,
+      uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE,
+      uworker_msg_pb2.ErrorType.ANALYZE_CLOSE_INVALID_UPLOADED,
+    ]
+    self._utask_maybe_retry_conditions = [
+      uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP,
+      uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST,
+      uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
+      uworker_msg_pb2.ErrorType.MINIMIZE_SETUP,
+      uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE,
+      uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZ_TARGET_SELECTED,
+      uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH,
+      uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT,
+      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR,
+      uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR,
+      uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR,
+      uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR,
+      uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED,
+      uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE,
+
+
+    ]
+    self._utask_failure_conditions = [
+      uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISION_INDEX,
+      uworker_msg_pb2.ErrorType.UNHANDLED,
+      uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP,
+      uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE,
+      uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER,
+      uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR,
+      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND,
+      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD,
+      uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR,
+      uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND,
+      uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR,
+      uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED,
+      uworker_msg_pb2.ErrorType.CORPUS_PRUNING_FUZZER_SETUP_FAILED,
+      uworker_msg_pb2.ErrorType.CORPUS_PRUNING_ERROR,
+      uworker_msg_pb2.ErrorType.FUZZ_BAD_BUILD,
+    ]
 
     if subtask == _Subtask.PREPROCESS:
       self._preprocess_start_time_ns = self.start_time_ns

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -169,11 +169,11 @@ class _MetricRecorder(contextlib.AbstractContextManager):
       # Ensure we always have a value after this method returns.
       assert self._preprocess_start_time_ns is not None
 
-  def _infer_uworker_main_outcome(self, _exc_type, uworker_error):
+  def _infer_uworker_main_outcome(self, exc_type, uworker_error):
     '''Infers, on a best effort basis, whether an uworker output implies
       success or failure. If an unequivocal response is not possible,
       classifies as maybe_retry.'''
-    if _exc_type or uworker_error in self._utask_failure_conditions:
+    if exc_type or uworker_error in self._utask_failure_conditions:
       outcome = 'error'
     elif uworker_error in self._utask_maybe_retry_conditions:
       outcome = 'maybe_retry'

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -221,11 +221,6 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     monitoring_metrics.TASK_OUTCOME_COUNT_BY_ERROR_TYPE.increment(
         trimmed_labels)
 
-    if error_condition != 'UNHANDLED_EXCEPTION':
-      task = self._labels['task']
-      subtask = self._labels['subtask']
-      logs.info(f'Task {task}, at subtask {subtask}, finished successfully.')
-
 
 def ensure_uworker_env_type_safety(uworker_env):
   """Converts all values in |uworker_env| to str types.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -85,48 +85,48 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     self._labels = None
     self.utask_main_failure = None
     self._utask_success_conditions = [
-      uworker_msg_pb2.ErrorType.NO_ERROR,
-      uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX,
-      uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH,
-      uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE,
-      uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH,
-      uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY,
-      uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE,
-      uworker_msg_pb2.ErrorType.ANALYZE_CLOSE_INVALID_UPLOADED,
+        uworker_msg_pb2.ErrorType.NO_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.ANALYZE_NO_CRASH,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.PROGRESSION_BAD_STATE_MIN_MAX,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.REGRESSION_NO_CRASH,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.REGRESSION_LOW_CONFIDENCE_IN_REGRESSION_RANGE,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.MINIMIZE_UNREPRODUCIBLE_CRASH,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.MINIMIZE_CRASH_TOO_FLAKY,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_UNREPRODUCIBLE,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.ANALYZE_CLOSE_INVALID_UPLOADED,  # pylint: disable=no-member
     ]
     self._utask_maybe_retry_conditions = [
-      uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP,
-      uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST,
-      uworker_msg_pb2.ErrorType.TESTCASE_SETUP,
-      uworker_msg_pb2.ErrorType.MINIMIZE_SETUP,
-      uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE,
-      uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZ_TARGET_SELECTED,
-      uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH,
-      uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR,
-      uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR,
-      uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR,
-      uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR,
-      uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED,
-      uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE,
+        uworker_msg_pb2.ErrorType.ANALYZE_BUILD_SETUP,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISIONS_LIST,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.TESTCASE_SETUP,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.MINIMIZE_SETUP,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.FUZZ_DATA_BUNDLE_SETUP_FAILURE,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZ_TARGET_SELECTED,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.PROGRESSION_NO_CRASH,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.PROGRESSION_TIMEOUT,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_SETUP_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_SETUP_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.REGRESSION_TIMEOUT_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.MINIMIZE_DEADLINE_EXCEEDED_IN_MAIN_FILE_PHASE,  # pylint: disable=no-member
     ]
     self._utask_failure_conditions = [
-      uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISION_INDEX,
-      uworker_msg_pb2.ErrorType.UNHANDLED,
-      uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP,
-      uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE,
-      uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER,
-      uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND,
-      uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD,
-      uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR,
-      uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND,
-      uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR,
-      uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED,
-      uworker_msg_pb2.ErrorType.CORPUS_PRUNING_FUZZER_SETUP_FAILED,
-      uworker_msg_pb2.ErrorType.CORPUS_PRUNING_ERROR,
-      uworker_msg_pb2.ErrorType.FUZZ_BAD_BUILD,
+        uworker_msg_pb2.ErrorType.ANALYZE_NO_REVISION_INDEX,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.UNHANDLED,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.VARIANT_BUILD_SETUP,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.FUZZ_NO_FUZZER,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.PROGRESSION_REVISION_LIST_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.PROGRESSION_BAD_BUILD,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.REGRESSION_REVISION_LIST_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.REGRESSION_BUILD_NOT_FOUND,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.REGRESSION_BAD_BUILD_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.LIBFUZZER_MINIMIZATION_FAILED,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.CORPUS_PRUNING_FUZZER_SETUP_FAILED,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.CORPUS_PRUNING_ERROR,  # pylint: disable=no-member
+        uworker_msg_pb2.ErrorType.FUZZ_BAD_BUILD,  # pylint: disable=no-member
     ]
 
     if subtask == _Subtask.PREPROCESS:
@@ -170,14 +170,15 @@ class _MetricRecorder(contextlib.AbstractContextManager):
       assert self._preprocess_start_time_ns is not None
 
   def _infer_uworker_main_outcome(self, _exc_type, uworker_error):
-    '''Infers, on a best effort basis, whether an uworker output implies success or
-      failure. If an unequivocal response is not possible, classifies as maybe_retry.'''
+    '''Infers, on a best effort basis, whether an uworker output implies
+      success or failure. If an unequivocal response is not possible,
+      classifies as maybe_retry.'''
     if _exc_type or uworker_error in self._utask_failure_conditions:
       outcome = 'error'
     elif uworker_error in self._utask_maybe_retry_conditions:
       outcome = 'maybe_retry'
     else:
-      outcome='success'
+      outcome = 'success'
     return outcome
 
   def __exit__(self, _exc_type, _exc_value, _traceback):
@@ -200,7 +201,8 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     # The only case where a task might fail without throwing, is in
     # utask_main, by returning an ErrorType proto which indicates
     # failure.
-    outcome = self._infer_uworker_main_outcome(_exc_type, self.utask_main_failure)
+    outcome = self._infer_uworker_main_outcome(_exc_type,
+                                               self.utask_main_failure)
     monitoring_metrics.TASK_OUTCOME_COUNT.increment({
         **self._labels, 'outcome': outcome
     })


### PR DESCRIPTION
### Motivation

#4458 implemented a task outcome metric, so we can track error rates in utasks, by job/task/subtask.

As failures are expected for ClusterFuzz, initially only unhandled exceptions would be considered as actual errors. Chrome folks asked for a better partitioning of error codes, which is implemented here as the following outcomes:

* success: the task has unequivocally succeeded, producing a sane result
* maybe_retry: some transient error happened, and the task is potentially being retried. This might capture some unretriable failure condition, but it is a compromise we are willing to make in order to decrease false positives.
* failure: the task has unequivocally failed.

Part of #4271 