### PR TITLE
Add Fuzzilli cases to the test-input archive

### DIFF
--- a/src/python/other-bots/chromium-tests-syncer/run.py
+++ b/src/python/other-bots/chromium-tests-syncer/run.py
@@ -23,6 +23,7 @@ modules.fix_module_search_paths()
 import os
 import re
 import subprocess
+import tarfile
 import time
 
 from clusterfuzz._internal.base import utils
@@ -208,6 +209,38 @@ def create_gecko_tests_directory(tests_directory, gecko_checkout_subdirectory,
                            target_subdirectory)
 
 
+def create_fuzzilli_tests_directory(tests_directory):
+  logs.info('Syncing fuzzilli tests.')
+  fuzzilli_tests_directory = os.path.join(tests_directory, 'fuzzilli')
+  remote_archive_tmpl = 'gs://autozilli/autozilli-%d.tgz'
+
+  # Ensure we have an empty directory with no leftovers from a previous run.
+  shell.remove_directory(fuzzilli_tests_directory, recreate=True)
+
+  def filter(member, path):
+    # We only need JS files and the settings.json from the archive.
+    if member.name.endswith('fzil') or member.name.startswith('fuzzdir/stats'):
+      return None
+    return tarfile.data_filter(member, path)
+
+  for i in range(1, 10):
+    # Download archives number 1-9.
+    remote_archive = remote_archive_tmpl % i
+    logs.info(f'Processing {remote_archive}')
+    local_archive = os.path.join(fuzzilli_tests_directory, 'tmp.tgz')
+    subprocess.check_call(['gsutil', 'cp', remote_archive, local_archive])
+
+    # Extract relevant files.
+    with tarfile.open(local_archive) as tar:
+      tar.extractall(path=fuzzilli_tests_directory, filter=filter)
+
+    # Clean up.
+    os.rename(
+        os.path.join(fuzzilli_tests_directory, 'fuzzdir'),
+        os.path.join(fuzzilli_tests_directory, f'fuzzdir-{i}'))
+    shell.remove_file(local_archive)
+
+
 def sync_tests(tests_archive_bucket: str, tests_archive_name: str,
                tests_directory: str):
   """Main sync routine."""
@@ -264,6 +297,7 @@ def sync_tests(tests_archive_bucket: str, tests_archive_name: str,
           'WebKit/JSTests/es6',
           'WebKit/JSTests/stress',
           'WebKit/LayoutTests',
+          'fuzzilli',
           'gecko-tests',
           'v8/test/mjsunit',
           'spidermonkey',

--- a/src/python/other-bots/chromium-tests-syncer/run.py
+++ b/src/python/other-bots/chromium-tests-syncer/run.py
@@ -210,6 +210,7 @@ def create_gecko_tests_directory(tests_directory, gecko_checkout_subdirectory,
 
 
 def create_fuzzilli_tests_directory(tests_directory):
+  """Create Fuzzilli tests directory from the autozilli GCS archives."""
   logs.info('Syncing fuzzilli tests.')
   fuzzilli_tests_directory = os.path.join(tests_directory, 'fuzzilli')
   remote_archive_tmpl = 'gs://autozilli/autozilli-%d.tgz'
@@ -217,7 +218,7 @@ def create_fuzzilli_tests_directory(tests_directory):
   # Ensure we have an empty directory with no leftovers from a previous run.
   shell.remove_directory(fuzzilli_tests_directory, recreate=True)
 
-  def filter(member, path):
+  def filter_members(member, path):
     # We only need JS files and the settings.json from the archive.
     if member.name.endswith('fzil') or member.name.startswith('fuzzdir/stats'):
       return None
@@ -232,7 +233,7 @@ def create_fuzzilli_tests_directory(tests_directory):
 
     # Extract relevant files.
     with tarfile.open(local_archive) as tar:
-      tar.extractall(path=fuzzilli_tests_directory, filter=filter)
+      tar.extractall(path=fuzzilli_tests_directory, filter=filter_members)
 
     # Clean up.
     os.rename(


### PR DESCRIPTION
This adds 9 archives from Fuzzilli to the general test-input archives used by fuzzers on Clusterfuzz. The Fuzzilli-side archives are refreshed every few days. We'll add a freshness metric in a follow up.

This was tested locally with butler.

See bug: https://crbug.com/362963886