### PR TITLE
Modify get_fastboot_path() to allow for custom binaries

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -242,6 +242,10 @@ def get_fastboot_command_line(fastboot_cmd):
 
 def get_fastboot_path():
   """Return path to fastboot binary."""
+  fastboot_path = environment.get_value('FASTBOOT')
+  if fastboot_path:
+    return fastboot_path
+
   return os.path.join(environment.get_platform_resources_directory(),
                       'fastboot')
 


### PR DESCRIPTION
Custom binaries are often used emulators (i.e. the binary being used by the host).

This code follows the same strategy used for the ADB binary above in `get_adb_path()`.