### PR TITLE
Fix issue returning timeouts.

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -316,6 +316,8 @@ def get_hard_timeout(total_timeout=None):
   """Get the hard timeout for fuzzing."""
   if total_timeout is None:
     total_timeout = environment.get_value('FUZZ_TEST_TIMEOUT')
+    if total_timeout is not None:
+      total_timeout = float(total_timeout)
 
   return get_overridable_timeout(total_timeout, 'HARD_TIMEOUT_OVERRIDE')
 


### PR DESCRIPTION
This could result in the string "X - Y" being used as a timeout in the event that both `FUZZ_TEST_TIMEOUT` and `MERGE_TIMEOUT_OVERRIDE` were set in a given job.