### PR TITLE
Use python's implementations for random_weighted_choice 

### DIFF
--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -786,7 +786,7 @@ def timeout(duration):
       return func
 
     @functools.wraps(func)
-    def _wrapper(*args, **kwargs):
+    def _wrapper(*args, **kwargs):  # pylint: disable=inconsistent-return-statements
       """Wrapper."""
       # FIXME: Weird exceptions in imports, might be something relating to our
       # reload module. Needs further investigation, try this as a temporary fix.

--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -599,21 +599,10 @@ def random_number(start, end):
   return random.SystemRandom().randint(start, end)
 
 
-# pylint: disable=inconsistent-return-statements
 def random_weighted_choice(element_list, weight_attribute='weight'):
   """Returns a random element from list taking its weight into account."""
-  total = sum(getattr(e, weight_attribute) for e in element_list)
-  random_pick = random.SystemRandom().uniform(0, total)
-  temp = 0
-  for element in element_list:
-    element_weight = getattr(element, weight_attribute)
-    if element_weight == 0:
-      continue
-    if temp + element_weight >= random_pick:
-      return element
-    temp += element_weight
-
-  assert False, 'Failed to make a random weighted choice.'
+  weights = [getattr(element, weight_attribute) for element in element_list]
+  return random.SystemRandom().choices(element_list, weights, k=1)[0]
 
 
 def read_data_from_file(file_path, eval_data=True, default=None):

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1671,7 +1671,7 @@ def record_fuzz_targets(engine_name, binaries, job_type):
   jobs = get_or_create_multi_entities_from_keys(job_mapping)
 
   for job in jobs:
-    # TODO(metzman): Decide if we want to handle unused fuzzers differentlyo.
+    # TODO(metzman): Decide if we want to handle unused fuzzers differently.
     job.last_run = utils.utcnow()
 
   ndb_utils.put_multi(jobs)

--- a/src/clusterfuzz/_internal/tests/core/base/utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/utils_test.py
@@ -201,59 +201,6 @@ class NormalizeEmailTest(unittest.TestCase):
     self.assertTrue(utils.emails_equal('A@b.com', 'a@B.com'))
 
 
-class RandomWeightedChoiceTest(unittest.TestCase):
-  """Tests random_weighted_choice."""
-
-  def setUp(self):
-    helpers.patch(self, ['random.SystemRandom.uniform'])
-
-    class O:
-
-      def __init__(self, data, weight):
-        self.data = data
-        self.weight = weight
-
-    self.list = [O('A1', 0), O('A2', 1), O('A3', 3), O('A4', 0), O('A5', 5)]
-
-  def test_1(self):
-    self.mock.uniform.return_value = 0
-    self.assertNotEqual('A1', utils.random_weighted_choice(self.list).data)
-
-  def test_2(self):
-    self.mock.uniform.return_value = 0
-    self.assertEqual('A2', utils.random_weighted_choice(self.list).data)
-
-    self.mock.uniform.return_value = 0.4
-    self.assertEqual('A2', utils.random_weighted_choice(self.list).data)
-
-    self.mock.uniform.return_value = 1
-    self.assertEqual('A2', utils.random_weighted_choice(self.list).data)
-
-  def test_3(self):
-    self.mock.uniform.return_value = 1.1
-    self.assertEqual('A3', utils.random_weighted_choice(self.list).data)
-
-    self.mock.uniform.return_value = 2
-    self.assertEqual('A3', utils.random_weighted_choice(self.list).data)
-
-    self.mock.uniform.return_value = 4
-    self.assertEqual('A3', utils.random_weighted_choice(self.list).data)
-
-  def test_4(self):
-    self.mock.uniform.return_value = 4.1
-    self.assertNotEqual('A4', utils.random_weighted_choice(self.list).data)
-
-  def test_5(self):
-    self.mock.uniform.return_value = 4.1
-    self.assertEqual('A5', utils.random_weighted_choice(self.list).data)
-
-    self.mock.uniform.return_value = 7
-    self.assertEqual('A5', utils.random_weighted_choice(self.list).data)
-
-    self.mock.uniform.return_value = 9
-    self.assertEqual('A5', utils.random_weighted_choice(self.list).data)
-
-
 class GetCrashStacktraceOutputTest(unittest.TestCase):
   """Tests get_crash_stacktrace_output."""
 


### PR DESCRIPTION
The existing implementation looked buggy. It was fine but let's use
Python's stdlib implementation so we can be more sure and reduce complexity.