### PR TITLE
Close old non reproducible bugs

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -426,6 +426,11 @@ class Issue(issue_tracker.Issue):
     self._data['issueState']['assignee'] = _make_user(new_assignee)
 
   @property
+  def created_time(self):
+    """The time at which this issue was created."""
+    return self._data['createdTime']
+
+  @property
   def ccs(self):
     """The issue CC list."""
     return self._ccs

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_management/google_issue_tracker/google_issue_tracker_test.py
@@ -120,6 +120,7 @@ class GoogleIssueTrackerTest(unittest.TestCase):
     self.assertCountEqual([], issue.components)
     self.assertCountEqual([], issue.ccs)
     self.assertEqual('test body', issue.body)
+    self.assertEqual('2019-06-25T01:29:30.021Z', issue.created_time)
 
   def test_closed(self):
     """Test a closed issue."""


### PR DESCRIPTION
Clusterfuzz will either confirm bugs are reproducible, mark them as non reproducible and close, or say nothing. In the last case, we want to auto close any bugs that have been open for long enough for it to have tried reproducing and failed