### PR TITLE
Fix archiving Fuzzilli test cases

### DIFF
--- a/src/python/other-bots/chromium-tests-syncer/run.py
+++ b/src/python/other-bots/chromium-tests-syncer/run.py
@@ -273,6 +273,8 @@ def sync_tests(tests_archive_bucket: str, tests_archive_name: str,
 
   create_gecko_tests_directory(tests_directory, 'gecko-dev', 'gecko-tests')
 
+  create_fuzzilli_tests_directory(tests_directory)
+
   # Upload tests archive to google cloud storage.
   logs.info('Uploading tests archive to cloud.')
   tests_archive_local = os.path.join(tests_directory, tests_archive_name)


### PR DESCRIPTION
Calling the function was missing in https://github.com/google/clusterfuzz/pull/4515

Bug: https://crbug.com/362963886