### PR TITLE
doc: Remove html b-tags from oss_fuzz_build_status.py (#4409)

### DIFF
--- a/src/clusterfuzz/_internal/cron/oss_fuzz_build_status.py
+++ b/src/clusterfuzz/_internal/cron/oss_fuzz_build_status.py
@@ -63,12 +63,12 @@ class OssFuzzBuildStatusError(Exception):
 def _get_issue_body(project_name, build_id, build_type):
   """Return the issue body for filing new bugs."""
   template = ('The last {num_builds} builds for {project} have been failing.\n'
-              '<b>Build log:</b> {log_link}\n'
+              'Build log: {log_link}\n'
               'Build type: {build_type}\n\n'
               'To reproduce locally, please see: '
               'https://google.github.io/oss-fuzz/advanced-topics/reproducing'
               '#reproducing-build-failures\n\n'
-              '<b>This bug tracker is not being monitored by OSS-Fuzz team.</b>'
+              '**This bug tracker is not being monitored by OSS-Fuzz team.**'
               ' If you have any questions, please create an issue at '
               'https://github.com/google/oss-fuzz/issues/new.\n\n'
               '**This bug will be automatically closed within a '

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
@@ -373,14 +373,14 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
     self.assertEqual('proj2: Fuzzing build failure', issue.summary)
     self.assertEqual(
         'The last 3 builds for proj2 have been failing.\n'
-        '<b>Build log:</b> '
+        'Build log: '
         'https://oss-fuzz-build-logs.storage.googleapis.com/'
         'log-proj2-id-f.txt\n'
         'Build type: fuzzing\n\n'
         'To reproduce locally, please see: '
         'https://google.github.io/oss-fuzz/advanced-topics/reproducing'
         '#reproducing-build-failures\n\n'
-        '<b>This bug tracker is not being monitored by OSS-Fuzz team.</b> '
+        '**This bug tracker is not being monitored by OSS-Fuzz team.** '
         'If you have any questions, please create an issue at '
         'https://github.com/google/oss-fuzz/issues/new.\n\n'
         '**This bug will be automatically closed within a '
@@ -394,14 +394,14 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
     self.assertEqual('proj6: Coverage build failure', issue.summary)
     self.assertEqual(
         'The last 3 builds for proj6 have been failing.\n'
-        '<b>Build log:</b> '
+        'Build log: '
         'https://oss-fuzz-build-logs.storage.googleapis.com/'
         'log-proj6-id-c.txt\n'
         'Build type: coverage\n\n'
         'To reproduce locally, please see: '
         'https://google.github.io/oss-fuzz/advanced-topics/reproducing'
         '#reproducing-build-failures\n\n'
-        '<b>This bug tracker is not being monitored by OSS-Fuzz team.</b> '
+        '**This bug tracker is not being monitored by OSS-Fuzz team.** '
         'If you have any questions, please create an issue at '
         'https://github.com/google/oss-fuzz/issues/new.\n\n'
         '**This bug will be automatically closed within a '


### PR DESCRIPTION
They are unsupported on the new tracker and aren't needed anyway. Example: https://issues.oss-fuzz.com/issues/379066972#comment1
Cherrypick of #4409