### PR TITLE
Allow configuring default corpora bucket location. (#4479)

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -977,7 +977,8 @@ def add_build_metadata(job_type,
 def create_data_bundle_bucket_and_iams(data_bundle_name, emails):
   """Creates a data bundle bucket and adds iams for access."""
   bucket_name = get_data_bundle_bucket_name(data_bundle_name)
-  if not storage.create_bucket_if_needed(bucket_name):
+  location = local_config.ProjectConfig().get('data_bundle_bucket_location')
+  if not storage.create_bucket_if_needed(bucket_name, location=location):
     return False
 
   client = storage.create_discovery_storage_client()

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -115,7 +115,7 @@ SignedUrlDownloadResult = collections.namedtuple('SignedUrlDownloadResult',
 class StorageProvider:
   """Core storage provider interface."""
 
-  def create_bucket(self, name, object_lifecycle, cors):
+  def create_bucket(self, name, object_lifecycle, cors, location):
     """Create a new bucket."""
     raise NotImplementedError
 
@@ -196,7 +196,7 @@ class GcsProvider(StorageProvider):
 
     return None
 
-  def create_bucket(self, name, object_lifecycle, cors):
+  def create_bucket(self, name, object_lifecycle, cors, location):
     """Create a new bucket."""
     project_id = utils.get_application_id()
     request_body = {'name': name}
@@ -205,6 +205,9 @@ class GcsProvider(StorageProvider):
 
     if cors:
       request_body['cors'] = cors
+
+    if location:
+      request_body['location'] = location
 
     client = create_discovery_storage_client()
     try:
@@ -535,7 +538,7 @@ class FileSystemProvider(StorageProvider):
 
     return fs_path
 
-  def create_bucket(self, name, object_lifecycle, cors):
+  def create_bucket(self, name, object_lifecycle, cors, location):
     """Create a new bucket."""
     bucket_path = self._fs_bucket_path(name)
     if os.path.exists(bucket_path):
@@ -906,13 +909,16 @@ def set_bucket_iam_policy(client, bucket_name, iam_policy):
   return None
 
 
-def create_bucket_if_needed(bucket_name, object_lifecycle=None, cors=None):
+def create_bucket_if_needed(bucket_name,
+                            object_lifecycle=None,
+                            cors=None,
+                            location=None):
   """Creates a GCS bucket."""
   provider = _provider()
   if provider.get_bucket(bucket_name):
     return True
 
-  if not provider.create_bucket(bucket_name, object_lifecycle, cors):
+  if not provider.create_bucket(bucket_name, object_lifecycle, cors, location):
     return False
 
   time.sleep(CREATE_BUCKET_DELAY)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
@@ -57,7 +57,7 @@ class BaseTest:
     self.local_gcs_buckets_path = tempfile.mkdtemp()
     os.environ['LOCAL_GCS_BUCKETS_PATH'] = self.local_gcs_buckets_path
     os.environ['TEST_BLOBS_BUCKET'] = 'blobs-bucket'
-    storage._provider().create_bucket('blobs-bucket', None, None)
+    storage._provider().create_bucket('blobs-bucket', None, None, None)
     helpers.patch(self, [
         'clusterfuzz._internal.bot.fuzzers.engine_common.unpack_seed_corpus_if_needed',
         'clusterfuzz._internal.bot.tasks.task_creation.create_tasks',

--- a/src/clusterfuzz/_internal/tests/core/google_cloud_utils/blobs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/google_cloud_utils/blobs_test.py
@@ -182,7 +182,7 @@ class BlobSignedURLTest(fake_filesystem_unittest.TestCase):
     test_utils.set_up_pyfakefs(self)
     os.environ['LOCAL_GCS_BUCKETS_PATH'] = '/local'
     os.environ['TEST_BLOBS_BUCKET'] = 'blobs-bucket'
-    self.provider.create_bucket('blobs-bucket', None, None)
+    self.provider.create_bucket('blobs-bucket', None, None, None)
 
   def test_get_blob_signed_upload_url_then_delete_blob(self):
     """Tests get_blob_signed_upload_url."""

--- a/src/clusterfuzz/_internal/tests/core/google_cloud_utils/storage_test.py
+++ b/src/clusterfuzz/_internal/tests/core/google_cloud_utils/storage_test.py
@@ -82,7 +82,7 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
 
   def test_create_bucket(self):
     """Test create_bucket."""
-    self.provider.create_bucket('test-bucket', None, None)
+    self.provider.create_bucket('test-bucket', None, None, None)
     self.assertTrue(os.path.isdir('/local/test-bucket'))
 
   def test_get_bucket(self):
@@ -281,7 +281,7 @@ class FileSystemProviderTests(fake_filesystem_unittest.TestCase):
   def test_upload_signed_url(self):
     """Tests upload_signed_url."""
     contents = b'aa'
-    self.provider.create_bucket('test-bucket', None, None)
+    self.provider.create_bucket('test-bucket', None, None, None)
     self.provider.upload_signed_url(contents, 'gs://test-bucket/a')
     with open('/local/test-bucket/objects/a', 'rb') as fp:
       return self.assertEqual(fp.read(), contents)


### PR DESCRIPTION
Allow instances to specify the GCS bucket location for data bundle buckets in `project.yaml` as a new key: `data_bundle_bucket_location`.

This will allow creating regional buckets instead of using the default `US` multi-region which results in high data transfer costs in Chrome's instance.

Cherry pick of: https://github.com/google/clusterfuzz/pull/4479