### PR TITLE
[Monitoring] Enrich UNTRIAGED_TESTCASE_AGE metric to track testcases stuck in analyze

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/analyze_task.py
@@ -552,6 +552,8 @@ def _update_testcase(output):
   if analyze_task_output.platform_id:
     testcase.platform_id = analyze_task_output.platform_id
 
+  testcase.analyze_pending = False
+
   testcase.put()
 
 

--- a/src/clusterfuzz/_internal/common/testcase_utils.py
+++ b/src/clusterfuzz/_internal/common/testcase_utils.py
@@ -50,7 +50,7 @@ def emit_testcase_triage_duration_metric(testcase_id: int, step: str):
   if not testcase.get_age_in_seconds():
     logs.warning(f'No timestamp associated to testcase {testcase_id},'
                  ' failed to emit TESTCASE_TRIAGE_DURATION metric.')
-    return    
+    return
 
   testcase_age_in_hours = testcase.get_age_in_seconds() / (60 * 60)
 

--- a/src/clusterfuzz/_internal/common/testcase_utils.py
+++ b/src/clusterfuzz/_internal/common/testcase_utils.py
@@ -46,7 +46,7 @@ def emit_testcase_triage_duration_metric(testcase_id: int, step: str):
     return
 
   from_fuzzer = not get_testcase_upload_metadata(testcase_id)
-  testcase_age_in_hours = testcase.get_age_in_seconds() / (60*60)
+  testcase_age_in_hours = testcase.get_age_in_seconds() / (60 * 60)
 
   logs.info('Emiting TESTCASE_TRIAGE_DURATION metric for testcase '
             f'{testcase_id} (age = {testcase_age_in_hours} hours.) '

--- a/src/clusterfuzz/_internal/common/testcase_utils.py
+++ b/src/clusterfuzz/_internal/common/testcase_utils.py
@@ -46,6 +46,12 @@ def emit_testcase_triage_duration_metric(testcase_id: int, step: str):
     return
 
   from_fuzzer = not get_testcase_upload_metadata(testcase_id)
+
+  if not testcase.get_age_in_seconds():
+    logs.warning(f'No timestamp associated to testcase {testcase_id},'
+                 ' failed to emit TESTCASE_TRIAGE_DURATION metric.')
+    return    
+
   testcase_age_in_hours = testcase.get_age_in_seconds() / (60 * 60)
 
   logs.info('Emiting TESTCASE_TRIAGE_DURATION metric for testcase '

--- a/src/clusterfuzz/_internal/common/testcase_utils.py
+++ b/src/clusterfuzz/_internal/common/testcase_utils.py
@@ -31,59 +31,33 @@ TESTCASE_TRIAGE_DURATION_ISSUE_UPDATED_STEP = 'issue_updated'
 
 
 def emit_testcase_triage_duration_metric(testcase_id: int, step: str):
-  '''Finds out if a testcase is fuzzer generated or manually uploaded,
-      and emits the TESTCASE_UPLOAD_TRIAGE_DURATION metric.'''
-  testcase_upload_metadata = get_testcase_upload_metadata(testcase_id)
-  if not testcase_upload_metadata:
-    logs.warning(f'No upload metadata found for testcase {testcase_id},'
-                 ' failed to emit TESTCASE_UPLOAD_TRIAGE_DURATION metric.')
-    return
-  if not testcase_upload_metadata.timestamp:
-    logs.warning(
-        f'No timestamp for testcase {testcase_upload_metadata.testcase_id},'
-        ' failed to emit TESTCASE_UPLOAD_TRIAGE_DURATION metric.')
-    return
-  assert step in [
-      'analyze_launched', 'analyze_completed', 'minimize_completed',
-      'regression_completed', 'impact_completed', 'issue_updated'
-  ]
-
+  """Finds out if a testcase is fuzzer generated or manually uploaded,
+      and emits the TESTCASE_TRIAGE_DURATION metric."""
   testcase = data_handler.get_testcase_by_id(testcase_id)
 
   if not testcase:
     logs.warning(f'No testcase found with id {testcase_id},'
-                 ' failed to emit TESTCASE_UPLOAD_TRIAGE_DURATION metric.')
+                 ' failed to emit TESTCASE_TRIAGE_DURATION metric.')
     return
 
   if not testcase.job_type:
     logs.warning(f'No job_type associated to testcase {testcase_id},'
-                 ' failed to emit TESTCASE_UPLOAD_TRIAGE_DURATION metric.')
+                 ' failed to emit TESTCASE_TRIAGE_DURATION metric.')
     return
 
   from_fuzzer = not get_testcase_upload_metadata(testcase_id)
+  testcase_age_in_hours = testcase.get_age_in_seconds() / (60*60)
 
-  assert step in [
-      'analyze_launched', 'analyze_completed', 'minimize_completed',
-      'regression_completed', 'impact_completed', 'issue_updated'
-  ]
-
-  if not testcase.get_age_in_seconds():
-    logs.warning(f'No timestamp associated to testcase {testcase_id},'
-                 ' failed to emit TESTCASE_UPLOAD_TRIAGE_DURATION metric.')
-    return
-
-  testcase_age_in_hours = testcase.get_age_in_seconds() / 3600
-
-  logs.info('Emiting TESTCASE_UPLOAD_TRIAGE_DURATION metric for testcase '
+  logs.info('Emiting TESTCASE_TRIAGE_DURATION metric for testcase '
             f'{testcase_id} (age = {testcase_age_in_hours} hours.) '
-            'in step {step}.')
+            f'in step {step}, from_fuzzer: {from_fuzzer}.')
 
-  monitoring_metrics.TESTCASE_UPLOAD_TRIAGE_DURATION.add(
+  monitoring_metrics.TESTCASE_TRIAGE_DURATION.add(
       testcase_age_in_hours,
       labels={
           'job': testcase.job_type,
           'step': step,
-          'origin': 'fuzzer' if from_fuzzer else 'manually_uploaded'
+          'from_fuzzer': from_fuzzer
       })
 
 

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -352,7 +352,7 @@ def _emit_untriaged_testcase_age_metric(testcase: data_types.Testcase,
     return
 
   logs.info(f'Emiting UNTRIAGED_TESTCASE_AGE for testcase {testcase.key.id()} '
-            f'(age = {testcase.get_age_in_seconds()})')
+            f'(age = {testcase.get_age_in_seconds()}), step = {step}')
   monitoring_metrics.UNTRIAGED_TESTCASE_AGE.add(
       testcase.get_age_in_seconds() / 3600,
       labels={

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -343,7 +343,8 @@ PENDING_GROUPING = 'pending_grouping'
 PENDING_FILING = 'pending_filing'
 
 
-def _emit_untriaged_testcase_age_metric(testcase: data_types.Testcase, step: str):
+def _emit_untriaged_testcase_age_metric(testcase: data_types.Testcase,
+                                        step: str):
   """Emmits a metric to track age of untriaged testcases."""
   if not testcase.timestamp:
     return
@@ -355,6 +356,7 @@ def _emit_untriaged_testcase_age_metric(testcase: data_types.Testcase, step: str
       labels={
           'job': testcase.job_type,
           'platform': testcase.platform,
+          'step': step,
       })
 
 
@@ -436,7 +438,7 @@ def main():
       status = PENDING_ANALYZE if testcase.analyze_pending else PENDING_CRITICAL_TASKS
       _emit_untriaged_testcase_age_metric(testcase, status)
       _set_testcase_stuck_state(testcase, True)
-      _increment_untriaged_testcase_count(testcase.job_type,
+      _increment_untriaged_testcase_count(testcase.job_type, 
                                           status)
       logs.info(
           f'Skipping testcase {testcase_id}, critical tasks still pending.')

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -921,7 +921,7 @@ def critical_tasks_completed(testcase):
     return testcase.minimized_keys and testcase.regression
 
   return bool(testcase.minimized_keys and testcase.regression and
-              testcase.is_impact_set_flag)
+              testcase.is_impact_set_flag and not testcase.analyze_pending)
 
 
 # ------------------------------------------------------------------------------

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1380,6 +1380,7 @@ def create_user_uploaded_testcase(key,
 
   testcase.timestamp = utils.utcnow()
   testcase.created = testcase.timestamp
+  testcase.analyze_pending = True
   testcase.uploader_email = uploader_email
   testcase.put()
 

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -693,6 +693,8 @@ class Testcase(Model):
 
   def get_age_in_seconds(self):
     current_time = datetime.datetime.utcnow()
+    if not self.get_created_time():
+      return None
     testcase_age = current_time - self.get_created_time()
     return testcase_age.total_seconds()
 

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -689,8 +689,6 @@ class Testcase(Model):
 
   def get_age_in_seconds(self):
     current_time = datetime.datetime.utcnow()
-    if not self.get_created_time():
-      return None
     testcase_age = current_time - self.get_created_time()
     return testcase_age.total_seconds()
 

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -583,6 +583,10 @@ class Testcase(Model):
   # Tracks if a testcase is stuck during triage.
   stuck_in_triage = ndb.BooleanProperty(default=False)
 
+  # Tracks if analyze task is pending.
+  # Defaults to false, since most testcases are fuzzer produced.
+  analyze_pending = ndb.BooleanProperty(default=False)
+
   def is_chromium(self):
     return self.project_name in ('chromium', 'chromium-testing')
 

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -231,7 +231,7 @@ TASK_TOTAL_RUN_TIME = monitor.CounterMetric(
     ],
 )
 
-TESTCASE_UPLOAD_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
+TESTCASE_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
     'uploaded_testcase_analysis/triage_duration_secs',
     description=('Time elapsed between testcase upload and completion'
                  ' of relevant tasks in the testcase upload lifecycle.'
@@ -241,7 +241,7 @@ TESTCASE_UPLOAD_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
     field_spec=[
         monitor.StringField('step'),
         monitor.StringField('job'),
-        monitor.StringField('origin'),
+        monitor.BooleanField('from_fuzzer'),
     ],
 )
 

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -232,9 +232,9 @@ TASK_TOTAL_RUN_TIME = monitor.CounterMetric(
 )
 
 TESTCASE_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
-    'uploaded_testcase_analysis/triage_duration_secs',
+    'testcase_analysis/triage_duration_secs',
     description=('Time elapsed between testcase upload and completion'
-                 ' of relevant tasks in the testcase upload lifecycle.'
+                 ' of relevant tasks in the testcase lifecycle.'
                  ' Origin can be either from a fuzzer, or a manual'
                  ' upload. Measured in hours.'),
     bucketer=monitor.GeometricBucketer(),
@@ -244,6 +244,7 @@ TESTCASE_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
         monitor.BooleanField('from_fuzzer'),
     ],
 )
+
 
 TASK_RATE_LIMIT_COUNT = monitor.CounterMetric(
     'task/rate_limit',

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -245,7 +245,6 @@ TESTCASE_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
     ],
 )
 
-
 TASK_RATE_LIMIT_COUNT = monitor.CounterMetric(
     'task/rate_limit',
     description=('Counter for rate limit events.'),
@@ -366,6 +365,7 @@ UNTRIAGED_TESTCASE_AGE = monitor.CumulativeDistributionMetric(
     field_spec=[
         monitor.StringField('job'),
         monitor.StringField('platform'),
+        monitor.StringField('step'),
     ])
 
 UNTRIAGED_TESTCASE_COUNT = monitor.GaugeMetric(

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -232,7 +232,7 @@ TASK_TOTAL_RUN_TIME = monitor.CounterMetric(
 )
 
 TESTCASE_TRIAGE_DURATION = monitor.CumulativeDistributionMetric(
-    'testcase_analysis/triage_duration_secs',
+    'testcase_analysis/triage_duration_hours',
     description=('Time elapsed between testcase upload and completion'
                  ' of relevant tasks in the testcase lifecycle.'
                  ' Origin can be either from a fuzzer, or a manual'


### PR DESCRIPTION
### Motivation

We currently have no way to tell if analyze task was successfully executed. The TESTCASE_UPLOAD_TRIAGE_DURATION metric from #4364 would only track duration for tasks that did finish.

An analyze_pending field is added to the Testcase entity in datastore, which is set to False by default, to True for manually uploaded testcases, and to False once analyze task postprocess runs.

It also increments the UNTRIAGED_TESTCASE_AGE metric from #4381 with a status label, so we can know at what step the testcase is stuck, thus allowing us to alert if analyze is taking longer to finish than expected.

The alert itself could be, for instance, P50 age of untriaged testcase (status=analyze_pending) > 3h.

Also, this retroactively addresses comments from #4481:

* Fixes docstring for emit_testcase_triage_duration_metric
* Removes assertions
* Renames TESTCASE_UPLOAD_TRIAGE_DURATION to TESTCASE_TRIAGE_DURATION, since it now accounts for fuzzer generated testcases
* Use a boolean "from_fuzzer" field, instead of "origin" string, in TESTCASE_TRIAGE_DURATION
