### PR TITLE
Check for upload permission based on google group

### DIFF
--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/external_testcase_reader_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/external_testcase_reader_test.py
@@ -32,108 +32,131 @@ BASIC_ATTACHMENT = {
 }
 
 
+@mock.patch.object(
+    external_testcase_reader,
+    'get_vrp_uploaders',
+    return_value=['test-reporter@gmail.com'],
+    autospec=True)
+@mock.patch.object(external_testcase_reader, 'submit_testcase', autospec=True)
+@mock.patch.object(
+    external_testcase_reader, 'close_issue_if_invalid', autospec=True)
 class ExternalTestcaseReaderTest(unittest.TestCase):
-  """external_testcase_reader tests."""
+  """external_testcase_reader handle main function tests."""
+
+  def test_handle_testcases(self, mock_close_issue_if_invalid,
+                            mock_submit_testcase, _):
+    """Test a basic handle_testcases where issue is fit for submission."""
+    mock_close_issue_if_invalid.return_value = False
+    mock_it = mock.create_autospec(issue_tracker.IssueTracker)
+    basic_issue = mock.MagicMock()
+    basic_issue.reporter.return_value = 'test-reporter@gmail.com'
+    mock_it.find_issues_with_filters.return_value = [basic_issue]
+
+    external_testcase_reader.handle_testcases(mock_it)
+
+    mock_close_issue_if_invalid.assert_called_once()
+    mock_it.get_attachment.assert_called_once()
+    mock_submit_testcase.assert_called_once()
+
+  def test_handle_testcases_invalid(self, mock_close_issue_if_invalid,
+                                    mock_submit_testcase, _):
+    """Test a basic handle_testcases where issue is invalid."""
+    mock_close_issue_if_invalid.return_value = True
+    mock_it = mock.create_autospec(issue_tracker.IssueTracker)
+    basic_issue = mock.MagicMock()
+    basic_issue.reporter.return_value = 'test-reporter@gmail.com'
+    mock_it.find_issues_with_filters.return_value = [basic_issue]
+
+    external_testcase_reader.handle_testcases(mock_it)
+
+    mock_close_issue_if_invalid.assert_called_once()
+    mock_it.get_attachment.assert_not_called()
+    mock_submit_testcase.assert_not_called()
+
+  @mock.patch.object(
+      external_testcase_reader,
+      'close_issue_if_not_reproducible',
+      autospec=True)
+  def test_handle_testcases_not_reproducible(
+      self, mock_repro, mock_close_issue_if_invalid, mock_submit_testcase, _):
+    """Test a basic handle_testcases where issue is not reproducible."""
+    mock_repro.return_value = True
+    mock_it = mock.create_autospec(issue_tracker.IssueTracker)
+    basic_issue = mock.MagicMock()
+    basic_issue.reporter.return_value = 'test-reporter@gmail.com'
+    mock_it.find_issues_with_filters.return_value = [basic_issue]
+
+    external_testcase_reader.handle_testcases(mock_it)
+
+    mock_close_issue_if_invalid.assert_not_called()
+    mock_it.get_attachment.assert_not_called()
+    mock_submit_testcase.assert_not_called()
+
+  def test_handle_testcases_no_issues(self, mock_close_issue_if_invalid,
+                                      mock_submit_testcase, _):
+    """Test a basic handle_testcases that returns no issues."""
+    mock_it = mock.create_autospec(issue_tracker.IssueTracker)
+    mock_it.find_issues_with_filters.return_value = []
+
+    external_testcase_reader.handle_testcases(mock_it)
+
+    mock_close_issue_if_invalid.assert_not_called()
+    mock_it.get_attachment.assert_not_called()
+    mock_submit_testcase.assert_not_called()
+
+
+class ExternalTestcaseReaderInvalidIssueTest(unittest.TestCase):
+  """external_testcase_reader close_issue_if_invalid tests."""
 
   def setUp(self):
     self.mock_basic_issue = mock.MagicMock()
     self.mock_basic_issue.created_time = '2024-06-25T01:29:30.021Z'
     self.mock_basic_issue.status = 'NEW'
-    external_testcase_reader.submit_testcase = mock.MagicMock()
-
-  def test_handle_testcases(self):
-    """Test a basic handle_testcases where issue is fit for submission."""
-    mock_it = mock.create_autospec(issue_tracker.IssueTracker)
-    mock_it.find_issues_with_filters.return_value = [self.mock_basic_issue]
-    external_testcase_reader.close_issue_if_invalid = mock.MagicMock()
-    external_testcase_reader.close_issue_if_invalid.return_value = False
-
-    external_testcase_reader.handle_testcases(mock_it)
-    external_testcase_reader.close_issue_if_invalid.assert_called_once()
-    mock_it.get_attachment.assert_called_once()
-    external_testcase_reader.submit_testcase.assert_called_once()
-
-  def test_handle_testcases_invalid(self):
-    """Test a basic handle_testcases where issue is invalid."""
-    mock_it = mock.create_autospec(issue_tracker.IssueTracker)
-    mock_it.find_issues_with_filters.return_value = [self.mock_basic_issue]
-    external_testcase_reader.close_issue_if_invalid = mock.MagicMock()
-    external_testcase_reader.close_issue_if_invalid.return_value = True
-
-    external_testcase_reader.handle_testcases(mock_it)
-    external_testcase_reader.close_issue_if_invalid.assert_called_once()
-    mock_it.get_attachment.assert_not_called()
-    external_testcase_reader.submit_testcase.assert_not_called()
-
-  def test_handle_testcases_not_reproducible(self):
-    """Test a basic handle_testcases where issue is not reprodiclbe."""
-    mock_it = mock.create_autospec(issue_tracker.IssueTracker)
-    mock_it.find_issues_with_filters.return_value = [self.mock_basic_issue]
-    external_testcase_reader.close_issue_if_not_reproducible = mock.MagicMock()
-    external_testcase_reader.close_issue_if_not_reproducible.return_value = True
-    external_testcase_reader.close_issue_if_invalid = mock.MagicMock()
-
-    external_testcase_reader.handle_testcases(mock_it)
-    external_testcase_reader.close_issue_if_invalid.assert_not_called()
-    mock_it.get_attachment.assert_not_called()
-    external_testcase_reader.submit_testcase.assert_not_called()
-
-  def test_handle_testcases_no_issues(self):
-    """Test a basic handle_testcases that returns no issues."""
-    mock_it = mock.create_autospec(issue_tracker.IssueTracker)
-    mock_it.find_issues_with_filters.return_value = []
-    external_testcase_reader.close_issue_if_invalid = mock.MagicMock()
-
-    external_testcase_reader.handle_testcases(mock_it)
-    external_testcase_reader.close_issue_if_invalid.assert_not_called()
-    mock_it.get_attachment.assert_not_called()
-    external_testcase_reader.submit_testcase.assert_not_called()
-
-  def test_close_issue_if_not_reproducible_true(self):
-    """Test a basic close_issue_if_invalid with valid flags."""
-    external_testcase_reader.filed_one_day_ago = mock.MagicMock()
-    external_testcase_reader.filed_one_day_ago.return_value = True
-    self.mock_basic_issue.status = 'ACCEPTED'
-    self.assertEqual(
-        True,
-        external_testcase_reader.close_issue_if_not_reproducible(
-            self.mock_basic_issue))
+    self.mock_basic_issue.reporter = 'test-reporter@gmail.com'
 
   def test_close_issue_if_invalid_basic(self):
     """Test a basic close_issue_if_invalid with valid flags."""
     attachment_info = [BASIC_ATTACHMENT]
     description = '--flag-one --flag_two'
-    self.assertEqual(
-        False,
-        external_testcase_reader.close_issue_if_invalid(
-            self.mock_basic_issue, attachment_info, description))
+
+    actual = external_testcase_reader.close_issue_if_invalid(
+        self.mock_basic_issue, attachment_info, description,
+        ['test-reporter@gmail.com'])
+
+    self.assertEqual(False, actual)
 
   def test_close_issue_if_invalid_no_flag(self):
     """Test a basic close_issue_if_invalid with no flags."""
     attachment_info = [BASIC_ATTACHMENT]
     description = ''
-    self.assertEqual(
-        False,
-        external_testcase_reader.close_issue_if_invalid(
-            self.mock_basic_issue, attachment_info, description))
+
+    actual = external_testcase_reader.close_issue_if_invalid(
+        self.mock_basic_issue, attachment_info, description,
+        ['test-reporter@gmail.com'])
+
+    self.assertEqual(False, actual)
 
   def test_close_issue_if_invalid_too_many_attachments(self):
     """Test close_issue_if_invalid with too many attachments."""
     attachment_info = [BASIC_ATTACHMENT, BASIC_ATTACHMENT]
     description = ''
-    self.assertEqual(
-        True,
-        external_testcase_reader.close_issue_if_invalid(
-            self.mock_basic_issue, attachment_info, description))
+
+    actual = external_testcase_reader.close_issue_if_invalid(
+        self.mock_basic_issue, attachment_info, description,
+        ['test-reporter@gmail.com'])
+
+    self.assertEqual(True, actual)
 
   def test_close_issue_if_invalid_no_attachments(self):
     """Test close_issue_if_invalid with no attachments."""
     attachment_info = []
     description = ''
-    self.assertEqual(
-        True,
-        external_testcase_reader.close_issue_if_invalid(
-            self.mock_basic_issue, attachment_info, description))
+
+    actual = external_testcase_reader.close_issue_if_invalid(
+        self.mock_basic_issue, attachment_info, description,
+        ['test-reporter@gmail.com'])
+
+    self.assertEqual(True, actual)
 
   def test_close_issue_if_invalid_invalid_upload(self):
     """Test close_issue_if_invalid with an invalid upload."""
@@ -146,10 +169,12 @@ class ExternalTestcaseReaderTest(unittest.TestCase):
         'etag': 'TXpjek9Ea3pNekV4TFRZd01USTNOalk0TFRjNE9URTROVFl4TlE9PQ=='
     }]
     description = ''
-    self.assertEqual(
-        True,
-        external_testcase_reader.close_issue_if_invalid(
-            self.mock_basic_issue, attachment_info, description))
+
+    actual = external_testcase_reader.close_issue_if_invalid(
+        self.mock_basic_issue, attachment_info, description,
+        ['test-reporter@gmail.com'])
+
+    self.assertEqual(True, actual)
 
   def test_close_issue_if_invalid_invalid_content_type(self):
     """Test close_issue_if_invalid with an invalid content type."""
@@ -164,7 +189,41 @@ class ExternalTestcaseReaderTest(unittest.TestCase):
         'etag': 'TXpjek9Ea3pNekV4TFRZd01USTNOalk0TFRjNE9URTROVFl4TlE9PQ=='
     }]
     description = ''
-    self.assertEqual(
-        True,
-        external_testcase_reader.close_issue_if_invalid(
-            self.mock_basic_issue, attachment_info, description))
+    actual = external_testcase_reader.close_issue_if_invalid(
+        self.mock_basic_issue, attachment_info, description,
+        ['test-reporter@gmail.com'])
+
+    self.assertEqual(True, actual)
+
+  def test_close_issue_if_invalid_no_permission(self):
+    """Test close_issue_if_invalid with an no upload permission."""
+    attachment_info = [BASIC_ATTACHMENT]
+    description = ''
+    actual = external_testcase_reader.close_issue_if_invalid(
+        self.mock_basic_issue, attachment_info, description, [])
+
+    self.assertEqual(True, actual)
+
+
+class ExternalTestcaseReaderPermissionTest(unittest.TestCase):
+  """external_testcase_reader get_vrp_uploaders tests."""
+
+  def test_get_vrp_uploaders(self):
+    """Test get_vrp_uploaders."""
+    with mock.patch(
+        'src.clusterfuzz._internal.cron.external_testcase_reader.storage.Client'
+    ) as mock_storage:
+      mock_storage.return_value = mock.MagicMock()
+      mock_bucket = mock.MagicMock()
+      mock_storage.return_value.bucket.return_value = mock_bucket
+      mock_blob = mock.MagicMock()
+      mock_bucket.blob.return_value = mock_blob
+      mock_blob.download_as_string.return_value = "test-user@google.com,test-user2@chromium.org".encode(
+          'utf-8')
+
+      actual = external_testcase_reader.get_vrp_uploaders()
+      mock_storage.return_value.bucket.assert_called_once_with(
+          'clusterfuzz-vrp-uploaders')
+      mock_bucket.blob.assert_called_once_with('vrp-uploaders')
+      self.assertEqual(actual,
+                       ['test-user@google.com', 'test-user2@chromium.org'])


### PR DESCRIPTION
Although the IssueTracker component create controls are locked down to this group, its possible for folks to accidentally migrate bugs into this component. To prevent that from happening, check for the reporter's membership before proceeding with the upload. It is a bit hacky i admit.