### PR TITLE
[Monitoring] Make monitoring reference the secondary project

### DIFF
--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+provider "google" {
+  alias = "monitoring"
+  project = var.secondary_project_id
+  region  = var.region
+}
+
 resource "google_monitoring_dashboard" "clusterfuzz_sli_dashboard" {
+  provider = google.monitoring
   dashboard_json = <<JSON
 {
   "displayName": "Clusterfuzz Relability Metrics",

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -15,6 +15,10 @@ variable "project_id" {
   description = "The project id"
 }
 
+variable "secondary_project_id" {
+  description = "Alternative project id, to accomodate the old chrome deployment"
+}
+
 variable "region" {
   description = "The region"
 }


### PR DESCRIPTION
Chrome is split in two projects internally, and the current way terraform is organized will create the dashboard in the wrong project.

This PR makes the dashboard reference the secondary project id, thus solving the problem.

Part of #4271 