### PR TITLE
Log exceptions in cron jobs.

### DIFF
--- a/src/python/bot/startup/run_cron.py
+++ b/src/python/bot/startup/run_cron.py
@@ -60,8 +60,12 @@ def main():
 
   task_module_name = f'clusterfuzz._internal.cron.{task}'
   with monitor.wrap_with_monitoring(), ndb_init.context():
-    task_module = importlib.import_module(task_module_name)
-    return 0 if task_module.main() else 1
+    try:
+      task_module = importlib.import_module(task_module_name)
+      return 0 if task_module.main() else 1
+    except Exception as e:
+      logs.error(f'Unhandled exception in cron: {e}')
+      return 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It was noticed in #4568 that exceptions in cron jobs aren't logged. This is very important.