### PR TITLE
Ensure we don't rerun utaks on expired signed URLs for uworker_input.

### DIFF
--- a/src/clusterfuzz/_internal/base/errors.py
+++ b/src/clusterfuzz/_internal/base/errors.py
@@ -27,6 +27,7 @@ BOT_ERROR_TERMINATION_LIST = [
     'interrupted function call',
     'out of memory',
     'systemexit:',
+    'Failed to download uworker_input, expired signed url',
 ]
 
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -25,6 +25,7 @@ from clusterfuzz._internal import swarming
 from clusterfuzz._internal.base.tasks import task_utils
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.bot.webserver import http_server
+from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.protos import uworker_msg_pb2
@@ -375,7 +376,12 @@ def uworker_bot_main():
   """The entrypoint for a uworker."""
   logs.info('Starting utask_main on untrusted worker.')
   input_download_url = environment.get_value('UWORKER_INPUT_DOWNLOAD_URL')
-  uworker_main(input_download_url)
+  try:
+    uworker_main(input_download_url)
+  except storage.ExpiredSignedUrlError as e:
+    raise storage.ExpiredSignedUrlError(
+        f'Failed to download uworker_input: {e.url}. {e.response_text}', e.url,
+        e.response_text)
   return 0
 
 


### PR DESCRIPTION
If the URL is expired, we can't possibly complete the task. Doing this though requries a few steps:
1. Note that we fail to download a signed URL because of an expired token.
2. Note that the utask failed because of failing to download input due to signed URL expiration.
3. Ensure bots don't retry when encountering this error.