### PR TITLE
Fix incorrect argument passed in google issue tracker.

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -1146,7 +1146,7 @@ class IssueTracker(issue_tracker.IssueTracker):
 
   def find_issues(self, keywords=None, only_open=None):
     """Finds issues."""
-    return self.find_issues_with_filters(keywords, only_open)
+    return self.find_issues_with_filters(keywords=keywords, only_open=only_open)
 
   def find_issues_with_filters(self,
                                keywords=None,


### PR DESCRIPTION
The positional arguments passed doesn't match with the actual signature of `find_issues_with_filters`. Use keyword arguments instead.

Fixes: b/388110772