### PR TITLE
Fix metrics on GAE cron

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -569,6 +569,8 @@ def _initialize_monitored_resource():
   # Use bot name here instance as that's more useful to us.
   if environment.is_running_on_k8s():
     instance_name = environment.get_value('HOSTNAME')
+  elif environment.is_running_on_app_engine():
+    instance_name = environment.get_value('GAE_INSTANCE')
   else:
     instance_name = environment.get_value('BOT_NAME')
   _monitored_resource.labels['instance_id'] = instance_name


### PR DESCRIPTION
This solves the following error:

```
bad argument type for built-in operation\nTraceback (most recent call last):\n  File \"/srv/handlers/base_handler.py\", line 278, in dispatch_request\n    return super().dispatch_request(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/layers/google.python.pip/pip/lib/python3.11/site-packages/flask/views.py\", line 188, in dispatch_request\n    return current_app.ensure_sync(meth)(**kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/srv/libs/handler.py\", line 100, in wrapper\n    with monitor.wrap_with_monitoring():\n  File \"/layers/google.python.runtime/python/lib/python3.11/contextlib.py\", line 137, in __enter__\n    return next(self.gen)\n           ^^^^^^^^^^^^^^\n  File \"/srv/clusterfuzz/_internal/metrics/monitor.py\", line 147, in wrap_with_monitoring\n    initialize()\n  File \"/srv/clusterfuzz/_internal/metrics/monitor.py\", line 605, in initialize\n    _initialize_monitored_resource()\n  File \"/srv/clusterfuzz/_internal/metrics/monitor.py\", line 574, in _initialize_monitored_resource\n    _monitored_resource.labels['instance_id'] = instance_name\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^\nTypeError: bad argument type for built-in operation",
```

The instance ID was being improperly fetched.

Docs for env var can be found in https://cloud.google.com/appengine/docs/standard/python3/runtime