### PR TITLE
[centipede] add support for gathering stats for centipede runs

### DIFF
--- a/src/clusterfuzz/_internal/metrics/fuzzer_stats_schema.py
+++ b/src/clusterfuzz/_internal/metrics/fuzzer_stats_schema.py
@@ -403,10 +403,461 @@ _HONGGFUZZ_SCHEMA = [{
     'type': 'INTEGER'
 }] + _COMMON_COLUMNS
 
+_CENTIPEDE_SCHEMA = [{
+    'mode': 'NULLABLE',
+    'name': 'NumCoveredPcs_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumCoveredPcs_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumCoveredPcs_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumExecs_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumExecs_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumExecs_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'ActiveCorpusSize_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'ActiveCorpusSize_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'ActiveCorpusSize_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'MaxEltSize_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'MaxEltSize_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'MaxEltSize_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'AvgEltSize_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'AvgEltSize_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'AvgEltSize_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'UnixMicros_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'UnixMicros_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'FuzzTimeSec_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'FuzzTimeSec_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'FuzzTimeSec_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumProxyCrashes_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumProxyCrashes_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumProxyCrashes_Sum',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'TotalCorpusSize_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'TotalCorpusSize_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'TotalCorpusSize_Sum',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'Num8BitCounterFts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'Num8BitCounterFts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'Num8BitCounterFts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumDataFlowFts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumDataFlowFts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumDataFlowFts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumCmpFts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumCmpFts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumCmpFts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumCallStackFts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumCallStackFts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumCallStackFts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumBoundedPathFts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumBoundedPathFts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumBoundedPathFts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumPcPairFts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumPcPairFts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumPcPairFts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUserFts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUserFts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUserFts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUnknownFts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUnknownFts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUnknownFts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumFuncsInFrontier_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumFuncsInFrontier_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumFuncsInFrontier_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'EngineRusageAvgCores_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'EngineRusageCpuPct_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'EngineRusageRssMb_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'EngineRusageVSizeMb_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser0Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser0Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser0Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser1Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser1Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser1Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser2Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser2Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser2Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser3Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser3Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser3Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser4Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser4Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser4Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser5Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser5Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser5Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser6Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser6Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser6Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser7Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser7Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser7Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser8Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser8Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser8Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser9Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser9Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser9Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser10Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser10Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser10Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser11Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser11Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser11Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser12Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser12Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser12Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser13Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser13Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser13Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser14Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser14Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser14Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser15Fts_Min',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser15Fts_Max',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'NumUser15Fts_Avg',
+    'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'crash_count',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'oom_count',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'timeout_count',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'leak_count',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'expected_duration',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'actual_duration',
+    'type': 'INTEGER'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'fuzzing_time_percent',
+    'type': 'FLOAT'
+}] + _COMMON_COLUMNS
+
 _SCHEMA = {
     'afl': _AFL_SCHEMA,
     'honggfuzz': _HONGGFUZZ_SCHEMA,
     'libFuzzer': _LIBFUZZER_SCHEMA,
+    'centipede': _CENTIPEDE_SCHEMA,
 }
 
 

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
@@ -328,6 +328,15 @@ class IntegrationTest(unittest.TestCase):
     # Check the prefix was trimmed.
     self.assertNotRegex(results.logs, 'CRASH LOG:.*')
 
+    self.assertIsNotNone(results.stats)
+
+    if content == 'oom':
+      self.assertEqual(results.stats['oom_count'], 1)
+    elif content == 'slo':
+      self.assertEqual(results.stats['timeout_count'], 1)
+    else:
+      self.assertEqual(results.stats['crash_count'], 1)
+
     # Check the correct input was saved.
     with open(crash.input_path) as f:
       self.assertEqual(content, f.read())

--- a/src/local/butler/scripts/setup.py
+++ b/src/local/butler/scripts/setup.py
@@ -282,6 +282,38 @@ class CentipedeDefaults(BaseBuiltinFuzzerDefaults):
     super().__init__()
     self.name = 'centipede'
     self.key_id = 1342
+    # Use single quotes since the string ends in a double quote.
+    # pylint: disable=line-too-long
+    self.stats_column_descriptions = '''fuzzer: "Fuzz target"
+tests_executed: "Number of testcases executed during this time period"
+new_crashes: "Number of new unique crashes observed during this time period"
+edge_coverage: "Coverage for this fuzz target (number of edges/total)"
+cov_report: "Link to coverage report"
+corpus_size: "Size of the minimized corpus generated based on code coverage (number of testcases and total size on disk)"
+avg_exec_per_sec: "Average number of testcases executed per second"
+fuzzing_time_percent: "Percent of expected fuzzing time that is actually spent fuzzing."
+regular_crash_percent: "Percent of fuzzing runs that had regular crashes (other than ooms, leaks, timeouts, startup and bad instrumentation crashes)"
+oom_percent: "Percent of fuzzing runs that crashed on OOMs (should be 0)"
+leak_percent: "Percent of fuzzing runs that crashed on memory leaks (should be 0)"
+timeout_percent: "Percent of fuzzing runs that had testcases timeout (should be 0)"
+total_fuzzing_time_hrs: "Total time in hours for which the fuzzer(s) ran. Will be lower if fuzzer hits a crash frequently."
+logs: "Link to fuzzing logs"
+corpus_backup: "Backup copy of the minimized corpus generated based on code coverage"'''
+
+    self.stats_columns = """sum(t.number_of_executed_units) as tests_executed,
+custom(j.new_crashes) as new_crashes,
+_EDGE_COV as edge_coverage,
+_COV_REPORT as cov_report,
+_CORPUS_SIZE as corpus_size,
+avg(t.FuzzTimeSec_Avg / t.NumExecs_Avg) as avg_exec_per_sec,
+avg(t.fuzzing_time_percent) as fuzzing_time_percent,
+avg(t.crash_count*100) as regular_crash_percent,
+avg(t.oom_count*100) as oom_percent,
+avg(t.leak_count*100) as leak_percent,
+avg(t.timeout_count*100) as timeout_percent,
+sum(t.actual_duration/3600.0) as total_fuzzing_time_hrs,
+_FUZZER_RUN_LOGS as logs,
+_CORPUS_BACKUP as corpus_backup,"""
 
 
 def setup_config(non_dry_run):


### PR DESCRIPTION
This PR adds supports so that CF supports Centipede stats. This will help understand better how centipede fuzzers are performing on ClusterFuzz.