### PR TITLE
Log time series that failed to upload

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -87,6 +87,7 @@ def _create_time_series(name: str, time_series: List[_TimeSeries]):
     _monitoring_v3_client.create_time_series(name=name, time_series=time_series)
   except Exception as e:
     logs.warning(f'Error uploading time series: {e}')
+    logs.warning(f'Time series - {name} - contents: {time_series}')
 
 
 class _MockMetric:


### PR DESCRIPTION
We are currently facing the following error:

```
Duplicate TimeSeries encountered. Only one point can be written per TimeSeries per request.
```

It probably happens because the custom metric store/upload stuff is missing this restriction in [create time series request](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/create).

In order to further troubleshoot the issue, logging is required, to figure out exactly what metric is being published with >1 point.