### PR TITLE
Disable SIGINT handling on GAE crons for metric collection

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -145,7 +145,10 @@ def wrap_with_monitoring():
   """Wraps execution so we flush metrics on exit"""
   try:
     initialize()
-    signal.signal(signal.SIGTERM, handle_sigterm)
+    # Signals can only be handled in the main thread/interpreter
+    # GAE crons do not satisfy this condition
+    if not environment.is_running_on_app_engine():
+      signal.signal(signal.SIGTERM, handle_sigterm)
     yield
   finally:
     stop()


### PR DESCRIPTION
This solves the following error:

```
signal only works in main thread of the main interpreter
Traceback (most recent call last):
  File "/srv/handlers/base_handler.py", line 278, in dispatch_request
    return super().dispatch_request(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/flask/views.py", line 188, in dispatch_request
    return current_app.ensure_sync(meth)(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/libs/handler.py", line 100, in wrapper
    with monitor.wrap_with_monitoring():
  File "/layers/google.python.runtime/python/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/srv/clusterfuzz/_internal/metrics/monitor.py", line 148, in wrap_with_monitoring
    signal.signal(signal.SIGTERM, handle_sigterm)
  File "/layers/google.python.runtime/python/lib/python3.11/signal.py", line 58, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: signal only works in main thread of the main interpreter
```