### PR TITLE
Handle null bot name correctly when trying to find region in monitoring

### DIFF
--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -493,8 +493,7 @@ def main():
       else:
         _set_testcase_stuck_state(testcase, False)
         logs.info(
-            f'Skipping testcase {testcase_id}, as the crash is not important.'
-        )
+            f'Skipping testcase {testcase_id}, as the crash is not important.')
         continue
 
     # Require that all tasks like minimizaton, regression testing, etc have

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -493,7 +493,7 @@ def main():
       else:
         _set_testcase_stuck_state(testcase, False)
         logs.info(
-            f'Skipping testcase {testcase_id}, since the crash is not important.'
+            f'Skipping testcase {testcase_id}, as the crash is not important.'
         )
         continue
 

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -313,9 +313,8 @@ class Metric:
     for key, value in labels.items():
       metric.labels[key] = str(value)
 
-    if not environment.is_running_on_k8s():
-      bot_name = environment.get_value('BOT_NAME', None)
-      metric.labels['region'] = _get_region(bot_name)
+    bot_name = environment.get_value('BOT_NAME', None)
+    metric.labels['region'] = _get_region(bot_name)
 
     return metric
 
@@ -625,6 +624,9 @@ def metrics_store():
 
 def _get_region(bot_name):
   """Get bot region."""
+  if not bot_name:
+    return 'unknown'
+
   try:
     regions = local_config.MonitoringRegionsConfig()
   except errors.BadConfigError:


### PR DESCRIPTION
This fixes the following error in app engine crons:

```
Failed to flush metrics: expected string or bytes-like object, got 'NoneType'
Traceback (most recent call last):
  File "/layers/google.python.runtime/python/lib/python3.11/threading.py", line 1002, in _bootstrap
    self._bootstrap_inner()
  File "/layers/google.python.runtime/python/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/layers/google.python.runtime/python/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/srv/clusterfuzz/_internal/metrics/monitor.py", line 171, in _flush_loop
    self._flush_function()
  File "/srv/clusterfuzz/_internal/metrics/monitor.py", line 134, in _flush_metrics
    logs.error(f'Failed to flush metrics: {e}')
LogError: Failed to flush metrics: expected string or bytes-like object, got 'NoneType'
Traceback (most recent call last):
  File "/srv/clusterfuzz/_internal/metrics/monitor.py", line 118, in _flush_metrics
    metric.monitoring_v3_time_series(series, labels, start_time, end_time,
  File "/srv/clusterfuzz/_internal/metrics/monitor.py", line 343, in monitoring_v3_time_series
    self.monitoring_v3_metric(time_series.metric, labels)
  File "/srv/clusterfuzz/_internal/metrics/monitor.py", line 321, in monitoring_v3_metric
    metric.labels['region'] = _get_region(bot_name)
                              ^^^^^^^^^^^^^^^^^^^^^
  File "/srv/clusterfuzz/_internal/metrics/monitor.py", line 637, in _get_region
    if re.match(pattern['pattern'], bot_name):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.runtime/python/lib/python3.11/re/__init__.py", line 166, in match
    return _compile(pattern, flags).match(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```