### PR TITLE
Fixing typo in py_unittest breaking deployments

### DIFF
--- a/src/local/butler/package.py
+++ b/src/local/butler/package.py
@@ -21,7 +21,6 @@ import zipfile
 from local.butler import appengine
 from local.butler import common
 from local.butler import constants
-from local.butler import py_unittest
 from src.clusterfuzz._internal.base import utils
 
 MIN_SUPPORTED_NODEJS_VERSION = 4
@@ -83,8 +82,6 @@ def package(revision,
   if not _is_nodejs_up_to_date():
     print('You do not have nodejs, or your nodejs is not at least version 4.')
     sys.exit(1)
-
-  py_unittest.execute(args={})
 
   common.install_dependencies(platform_name=platform_name)
 

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -292,3 +292,13 @@ def run_tests(target=None,
   else:
     run_tests_single_core(pattern, unsuppress_output, test_directory,
                           top_level_dir)
+
+
+def execute(args):
+  run_tests(
+      target=args.target,
+      config_dir=args.config_dir,
+      verbose=args.verbose,
+      pattern=args.pattern,
+      unsuppress_output=args.unsuppress_output,
+      parallel=args.parallel)

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -292,13 +292,3 @@ def run_tests(target=None,
   else:
     run_tests_single_core(pattern, unsuppress_output, test_directory,
                           top_level_dir)
-
-
-def execute(args):
-  run_tests(
-      target=args.targets,
-      config_dir=args.config_dir,
-      verbose=args.verbose,
-      pattern=args.pattern,
-      unsuppress_output=args.unsuppress_output,
-      parallel=args.parallel)

--- a/src/local/butler/py_unittest.py
+++ b/src/local/butler/py_unittest.py
@@ -296,7 +296,7 @@ def run_tests(target=None,
 
 def execute(args):
   run_tests(
-      target=args.target,
+      target=args.targets,
       config_dir=args.config_dir,
       verbose=args.verbose,
       pattern=args.pattern,


### PR DESCRIPTION
This fixes the following error:

```
  File "/usr/local/google/home/metzman/clusterfuzz-311/butler.py", line 421, in <module>                                                                                                                           
    sys.exit(main())                                                                                                                                                                                               
             ^^^^^^                                                                                                                                                                                                
  File "/usr/local/google/home/metzman/clusterfuzz-311/butler.py", line 407, in main                                                                                                                               
    return command.execute(args)                                                                                                                                                                                   
           ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                   
  File "/usr/local/google/home/metzman/clusterfuzz-311/src/local/butler/deploy.py", line 576, in execute                                                                                                           
    package.package(                                                                                                                                                                                               
  File "/usr/local/google/home/metzman/clusterfuzz-311/src/local/butler/package.py", line 87, in package
    py_unittest.execute(args={})                                                                                                                                                                                   
  File "/usr/local/google/home/metzman/clusterfuzz-311/src/local/butler/py_unittest.py", line 299, in execute                                 
    target=args.target,                                                                                                                                                                                            
           ^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'target'
```