### PR TITLE
Allow remote unpacking for projects that fill the disk.

### DIFF
--- a/src/clusterfuzz/_internal/cron/project_setup.py
+++ b/src/clusterfuzz/_internal/cron/project_setup.py
@@ -817,6 +817,8 @@ class ProjectSetup:
           engine=template.engine,
           project_name=base_project_name,
           disk_size_gb=oss_fuzz_gb)
+      if oss_fuzz_gb is not None:
+        job.envrionment_string += 'ALLOW_UNPACK_OVER_HTTP = True\n'
 
       # Centipede requires a separate build of the sanitized binary.
       if template.engine == 'centipede':


### PR DESCRIPTION
https://github.com/google/clusterfuzz/commit/a76b922f0b8f6edd33cff8e0e4e0e5563ec68aac Didn't completely work. These projects need a lot more disk. Let's try another solution.