### PR TITLE
Add actions/stale workflow.

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -1,0 +1,36 @@
+name: "Close stale issues and PRs"
+
+permissions: read-all
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          exempt-issue-labels: "good first issue,backlog"
+          exempt-all-assignees: true
+          ignore-updates: true
+          stale-issue-label: stale
+          stale-issue-message: |
+            This issue has not had any activity for 60 days and will be automatically closed in two weeks
+          stale-pr-label: stale
+          stale-pr-message: |
+            This pull request has not had any activity for 60 days and will be automatically closed in two weeks
+          close-issue-label: "autoclosed"
+          close-issue-message: |
+            Automatically closing stale issue
+          close-pr-label: "autoclosed"
+          close-pr-message: |
+            Automatically closing stale pull request


### PR DESCRIPTION
To help with cleaning up old/irrelevant issues and PRs.

Issues can be exempted from this by adding a "backlog" label, or by having an assignee.