### PR TITLE
Stop running unit tests in package.py

### DIFF
--- a/src/local/butler/package.py
+++ b/src/local/butler/package.py
@@ -21,7 +21,6 @@ import zipfile
 from local.butler import appengine
 from local.butler import common
 from local.butler import constants
-from local.butler import py_unittest
 from src.clusterfuzz._internal.base import utils
 
 MIN_SUPPORTED_NODEJS_VERSION = 4

--- a/src/local/butler/package.py
+++ b/src/local/butler/package.py
@@ -84,8 +84,6 @@ def package(revision,
     print('You do not have nodejs, or your nodejs is not at least version 4.')
     sys.exit(1)
 
-  py_unittest.execute(args={})
-
   common.install_dependencies(platform_name=platform_name)
 
   # This needs to be done before packaging step to let src/appengine/config be


### PR DESCRIPTION
Unit tests were still being invoked in package after [reverting](https://github.com/google/clusterfuzz/pull/4616).

Properly reverting, to unblock deployments