### PR TITLE
Merge #4626 into chrome branch

### DIFF
--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -672,10 +672,10 @@ class TestcaseRunner:
     return state
 
   def reproduce_with_retries(self,
-                             retries,
-                             expected_state=None,
-                             expected_security_flag=None,
-                             flaky_stacktrace=False):
+                             retries: int,
+                             expected_state: CrashInfo | None = None,
+                             expected_security_flag: bool | None = None,
+                             flaky_stacktrace: bool = False) -> CrashResult:
     """Try reproducing a crash with retries."""
     self._pre_run_cleanup()
     crash_result = None
@@ -774,7 +774,7 @@ def test_for_crash_with_retries(fuzz_target,
                                 http_flag=False,
                                 use_gestures=True,
                                 compare_crash=True,
-                                crash_retries=None):
+                                crash_retries=None) -> CrashResult:
   """Test for a crash and return crash parameters like crash type, crash state,
   crash stacktrace, etc."""
   logs.info('Testing for crash.')


### PR DESCRIPTION
Previous logic would overwrite `minimized_keys` if say round 5 of libfuzzer minimization failed, even if round 4 succeeded. This resulted in tasks completing minimization successfully, but not storing `minimized_keys` to reflect that in the database.

Instead, we should take the result of the last successful minimization round. This both aligns with the logic around crash results and testcase file names, and prevents another side effect of this bug: we were previously deleting blobs on GCS that had been uploaded during successful minimization rounds :/

Note: it seems a similar bug affects the cleanse step, but I did not change logic there as it is OSS-Fuzz specific and I was not sure whether or not it could be intentional. See [`minimize_task.py` line 1686](https://github.com/google/clusterfuzz/pull/4626/files#diff-e8255271eeeadc2bda46b215fbc7b0bb160ef1116f6e27ff895990d88caafa5fR1686).

There are exceedingly few tests for minimize task, so I did not write a test for this either - the effort required seemed too high.

Bug: https://crbug.com/389589679