### PR TITLE
Debug revision URL and pattern logs removed

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -522,7 +522,6 @@ def find_fixed_range(uworker_input):
 
   logs.info(
       f'min_revision is {min_revision} and max_revision is {max_revision}.')
-  logs.info(f'revision_list is {revision_list}.')
 
   min_index = revisions.find_min_revision_index(revision_list, min_revision)
   if min_index is None:

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -1081,9 +1081,6 @@ def get_revisions_list(bucket_path, bad_revisions, testcase=None):
   if not revision_urls:
     return None
 
-  logs.info(f'revision_urls is {revision_urls} and revision_pattern '
-            f'is {revision_pattern}.')
-
   # Parse the revisions out of the build urls.
   revision_list = []
   for url in revision_urls:


### PR DESCRIPTION
Couple of debug logs which print the entire revision_urls and revision_list array have been removed