### PR TITLE
Update launch_cvd command to increase fd limit via SSH

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -418,9 +418,9 @@ def start_cuttlefish_device():
   device_memory_mb = environment.get_value('DEVICE_MEMORY_MB',
                                            DEFAULT_DEVICE_MEMORY_MB)
   # TODO(https://github.com/google/clusterfuzz/issues/3777): Enable sandboxing
-  launch_cvd_command_line = (
-      f'{launch_cvd_path} -daemon -memory_mb {device_memory_mb} '
-      '-report_anonymous_usage_stats Y')
+  launch_cvd_command_line = (f'ulimit -n 1048576 && {launch_cvd_path} -daemon'
+                             f'-memory_mb {device_memory_mb}'
+                             '-report_anonymous_usage_stats Y')
   execute_command(launch_cvd_command_line, on_cuttlefish_host=True)
 
 

--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -418,9 +418,9 @@ def start_cuttlefish_device():
   device_memory_mb = environment.get_value('DEVICE_MEMORY_MB',
                                            DEFAULT_DEVICE_MEMORY_MB)
   # TODO(https://github.com/google/clusterfuzz/issues/3777): Enable sandboxing
-  launch_cvd_command_line = (f'ulimit -n 1048576 && {launch_cvd_path} -daemon'
-                             f'-memory_mb {device_memory_mb}'
-                             '-report_anonymous_usage_stats Y')
+  launch_cvd_command_line = (f'ulimit -n 1048576 && {launch_cvd_path} -daemon '
+                             f'-memory_mb {device_memory_mb} '
+                             f'-report_anonymous_usage_stats Y')
   execute_command(launch_cvd_command_line, on_cuttlefish_host=True)
 
 


### PR DESCRIPTION
Resolves following error faced while booting up cuttlefish.

ERROR devices::virtio::rng] rng worker thread failed: failed creating
WaitContext: Too many open files (os error 24)

ERROR crosvm::crosvm::sys::linux] failed to recv VmIrqRequest: failed to serialize/deserialize json from packet: attempt to deserialize out of bounds descriptor at line 1 column 28

This error was observed since executing "launch_cvd" via SSH limits number of FDs that user can create to 1024. This PR increases this limit to "1048576" resolving the error observed and boots up cuttlefish successfully.