### PR TITLE
Dont enforce a 25 second timeout. (#4607)

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py
@@ -42,7 +42,7 @@ def get_arguments(fuzzer_path) -> options.FuzzerArguments:
     rss_limit_mb = arguments.get('rss_limit_mb', constructor=int)
     timeout = arguments.get('timeout', constructor=int)
 
-  if timeout is None or timeout > constants.DEFAULT_TIMEOUT_LIMIT:
+  if timeout is None:
     arguments[constants.TIMEOUT_FLAGNAME] = constants.DEFAULT_TIMEOUT_LIMIT
 
   if not rss_limit_mb and (utils.is_chromium() or


### PR DESCRIPTION
This was requested by chrome. I can't really think of a strong justification for this paternalistic behavior, and I can think of some against it, mainly that it causes CF to behave unlike the user expects.

Cherry-picked from 01239a0137e4b4405c611dd89a8e61312a59c3fd in master.

Fixes: b/382207330