### PR TITLE
Update android_trunk_stable_versions to contain lowercase versions

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/util.py
+++ b/src/clusterfuzz/_internal/platforms/android/util.py
@@ -84,8 +84,9 @@ def can_testcase_run_on_platform(testcase_platform_id, current_platform_id):
   # Check for the trunk stable versions - Z, A, B.
   # Source: go/release-version_trunk-stable#examples
   # If the current version is 'Z', 'A' or 'B', run the test case
-  android_trunk_stable_versions = ['Z', 'A', 'B']
-  if current_platform_id_fields[2] in android_trunk_stable_versions:
+  # Note: Use lowercase as platform_id is in lowercase
+  android_trunk_stable_versions = ['z', 'a', 'b']
+  if current_platform_id_fields[2].lower() in android_trunk_stable_versions:
     return True
 
   return False


### PR DESCRIPTION
platform_id string is in lowercase. Hence update the trunk stable versions to lowercase.