### PR TITLE
Try to improve corpus pruning preprocess time.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -1097,12 +1097,12 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
       last_execution_metadata and
       last_execution_metadata.status == data_types.TaskState.FINISHED)
 
-  # # Make sure we're the only instance running for the given fuzzer and
-  # # job_type.
-  # if not data_handler.update_task_status(task_name,
-  #                                        data_types.TaskState.STARTED):
-  #   logs.info('A previous corpus pruning task is still running, exiting.')
-  #   return None
+  # Make sure we're the only instance running for the given fuzzer and
+  # job_type.
+  if not data_handler.update_task_status(task_name,
+                                         data_types.TaskState.STARTED):
+    logs.info('A previous corpus pruning task is still running, exiting.')
+    return None
 
   setup_input = (
       setup.preprocess_update_fuzzer_and_data_bundles(fuzz_target.engine))

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -160,7 +160,7 @@ async def _limit_corpus_size(corpus_url):
       assert deleting
       blobs_to_delete.append(blob)
       if len(blobs_to_delete) == GOOGLE_CLOUD_MAX_BATCH_SIZE:
-        delete_success = await fast_http.delete_batch(
+        delete_success = await fast_http.delete_gcs_blobs_batch(
             session, bucket, blobs_to_delete, creds.token)
         if delete_success:
           num_deleted += GOOGLE_CLOUD_MAX_BATCH_SIZE

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -1068,10 +1068,10 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
 
   # Make sure we're the only instance running for the given fuzzer and
   # job_type.
-  # if not data_handler.update_task_status(task_name,
-  #                                        data_types.TaskState.STARTED):
-  #   logs.info('A previous corpus pruning task is still running, exiting.')
-  #   return None
+  if not data_handler.update_task_status(task_name,
+                                         data_types.TaskState.STARTED):
+    logs.info('A previous corpus pruning task is still running, exiting.')
+    return None
 
   setup_input = (
       setup.preprocess_update_fuzzer_and_data_bundles(fuzz_target.engine))

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -171,8 +171,8 @@ async def _limit_corpus_size(corpus_url):
       else:
         assert len(blobs_to_delete) < GOOGLE_CLOUD_MAX_BATCH_SIZE
       if blobs_to_delete:
-        await fast_http.delete_batch(session, bucket, blobs_to_delete,
-                                     creds.token)
+        await fast_http.delete_gcs_blobs_batch(session, bucket, blobs_to_delete,
+                                               creds.token)
     if num_deleted:
       logs.info(f'Deleted over {num_deleted} corpus files.')
     else:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -133,8 +133,7 @@ def _limit_corpus_size(corpus_url, not_failed):
   for corpus_file in storage.get_blobs(corpus_url):
     corpus_count += 1
     corpus_size += corpus_file['size']
-    if (corpus_count > num_files_limit or
-        corpus_size > size_limit):
+    if (corpus_count > num_files_limit or corpus_size > size_limit):
       path_to_delete = storage.get_cloud_storage_file_path(
           bucket, corpus_file['name'])
       storage.delete(path_to_delete)
@@ -1063,8 +1062,9 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
   last_execution_not_successful = not bool(
       last_execution_metadata and
       last_execution_metadata.status == data_types.TaskState.FINISHED)
-  last_execution_failed = bool(last_execution_metadata and
-                               last_execution_metadata.status == data_types.TaskState.ERROR)
+  last_execution_failed = bool(
+      last_execution_metadata and
+      last_execution_metadata.status == data_types.TaskState.ERROR)
 
   # Make sure we're the only instance running for the given fuzzer and
   # job_type.

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -756,15 +756,17 @@ def get_corpuses_for_pruning(engine, project_qualified_name):
       project_qualified_name,
       include_regressions=True,
       include_delete_urls=True,
+      max_upload_urls=5000,
       max_download_urls=50000)
-  max_upload_urls = len(corpus.proto_corpus.corpus.corpus_urls)
   # We will never need to upload more than the number of testcases in the
-  # corpus to the quarantine.
+  # corpus to the quarantine. But add a max of 500 to avoid spending
+  # too much time on crazy edge cases.
+  max_upload_urls = min(len(corpus.proto_corpus.corpus.corpus_urls), 500)
   quarantine_corpus = get_fuzz_target_corpus(
       engine,
       project_qualified_name,
       quarantine=True,
       include_delete_urls=True,
       max_upload_urls=max_upload_urls,
-      max_download_urls=50000)
+      max_download_urls=5000)
   return corpus, quarantine_corpus

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -757,7 +757,7 @@ def get_corpuses_for_pruning(engine, project_qualified_name):
       include_regressions=True,
       include_delete_urls=True,
       max_upload_urls=5000,
-      max_download_urls=50000)
+      max_download_urls=40000)
   # We will never need to upload more than the number of testcases in the
   # corpus to the quarantine. But add a max of 500 to avoid spending
   # too much time on crazy edge cases.

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -755,7 +755,9 @@ def get_corpuses_for_pruning(engine, project_qualified_name):
       engine,
       project_qualified_name,
       include_regressions=True,
-      include_delete_urls=True)
+      include_delete_urls=True,
+      max_download_urls=50000
+  )
   max_upload_urls = len(corpus.proto_corpus.corpus.corpus_urls)
   # We will never need to upload more than the number of testcases in the
   # corpus to the quarantine.
@@ -764,5 +766,7 @@ def get_corpuses_for_pruning(engine, project_qualified_name):
       project_qualified_name,
       quarantine=True,
       include_delete_urls=True,
-      max_upload_urls=max_upload_urls)
+      max_upload_urls=max_upload_urls,
+      max_download_urls=50000
+  )
   return corpus, quarantine_corpus

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -756,8 +756,7 @@ def get_corpuses_for_pruning(engine, project_qualified_name):
       project_qualified_name,
       include_regressions=True,
       include_delete_urls=True,
-      max_download_urls=50000
-  )
+      max_download_urls=50000)
   max_upload_urls = len(corpus.proto_corpus.corpus.corpus_urls)
   # We will never need to upload more than the number of testcases in the
   # corpus to the quarantine.
@@ -767,6 +766,5 @@ def get_corpuses_for_pruning(engine, project_qualified_name):
       quarantine=True,
       include_delete_urls=True,
       max_upload_urls=max_upload_urls,
-      max_download_urls=50000
-  )
+      max_download_urls=50000)
   return corpus, quarantine_corpus

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -1080,7 +1080,8 @@ def get_blobs(cloud_storage_path, recursive=True):
     exception_types=_TRANSIENT_ERRORS)
 def list_blobs(cloud_storage_path, recursive=True):
   """Return blob names under the given cloud storage path."""
-  for blob in _provider().list_blobs(cloud_storage_path, recursive=recursive):
+  for blob in _provider().list_blobs(
+      cloud_storage_path, recursive=recursive, names_only=True):
     yield blob['name']
 
 

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -1068,7 +1068,11 @@ def write_stream(stream, cloud_storage_file_path, metadata=None):
     delay=DEFAULT_FAIL_WAIT,
     function='google_cloud_utils.storage.get_blobs',
     exception_types=_TRANSIENT_ERRORS)
-def get_blobs(cloud_storage_path, recursive=True):
+def get_blobs(*args, **kwargs):
+  yield from get_blobs(*args, **kwargs)
+
+
+def get_blobs_no_retry(cloud_storage_path, recursive=True):
   """Return blobs under the given cloud storage path."""
   yield from _provider().list_blobs(cloud_storage_path, recursive=recursive)
 
@@ -1389,9 +1393,8 @@ def _mappable_sign_urls_for_existing_file(url_and_include_delete_urls):
 def sign_urls_for_existing_files(urls, include_delete_urls):
   logs.info('Signing URLs for existing files.')
   args = ((url, include_delete_urls) for url in urls)
-  result = parallel_map(_sign_urls_for_existing_file, args)
+  yield from parallel_map(_sign_urls_for_existing_file, args)
   logs.info('Done signing URLs for existing files.')
-  return result
 
 
 def get_arbitrary_signed_upload_url(remote_directory):
@@ -1426,6 +1429,9 @@ def get_arbitrary_signed_upload_urls(remote_directory: str, num_uploads: int):
   # unlikely, takes time, and it's basically benign if it happens (it
   # won't) since we will just clobber some other corpus uploads from
   # the same day.
+  if not num_uploads:
+    return
+
   unique_id = uuid.uuid4()
   base_name = unique_id.hex
   if not remote_directory.endswith('/'):
@@ -1435,6 +1441,5 @@ def get_arbitrary_signed_upload_urls(remote_directory: str, num_uploads: int):
 
   urls = (f'{base_path}-{idx}' for idx in range(num_uploads))
   logs.info('Signing URLs for arbitrary uploads.')
-  result = parallel_map(get_signed_upload_url, urls)
+  yield from parallel_map(get_signed_upload_url, urls)
   logs.info('Done signing URLs for arbitrary uploads.')
-  return result

--- a/src/clusterfuzz/_internal/system/fast_http.py
+++ b/src/clusterfuzz/_internal/system/fast_http.py
@@ -91,9 +91,10 @@ async def _async_download_file(session: aiohttp.ClientSession, url: str,
         fp.write(chunk)
 
 
-async def delete_batch(session, bucket, blobs, token):
+async def delete_gcs_blobs_batch(session, bucket, blobs, auth_token):
+  """Batch deletes |blobs| asynchronously."""
   headers = {
-      'Authorization': f'Bearer {token}',
+      'Authorization': f'Bearer {auth_token}',
       'Content-Type': f'multipart/mixed; boundary={MULTIPART_BOUNDARY}'
   }
   # Build multipart body
@@ -114,11 +115,6 @@ async def delete_batch(session, bucket, blobs, token):
     async with session.post(
         BATCH_DELETE_URL, headers=headers, data=body, timeout=20) as response:
       response.raise_for_status()
-
-      print('response', response.text, response, dir(response))
-      content_type = response.headers['Content-Type']
-      if 'multipart/mixed' not in content_type:
-        raise ValueError('Unexpected response format')
       return True
 
   except Exception as e:


### PR DESCRIPTION
1. Limit corpus signing to 50,000 URLs.
2. Treat a lack of successful corpus pruning as a semi-failure and force removal of corpus files in this case.
3. Only fetch the names of files when only the names are used, to improve speed.