### PR TITLE
Upgrade VMs type and number of nodes for GKE cluster

### DIFF
--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -36,12 +36,12 @@ variable "ip_cidr_range" {
 }
 
 variable "gke_num_nodes" {
-  default     = 2
+  default     = 5
   description = "The number of gke nodes"
 }
 
 variable "machine_type" {
-  default     = "e2-standard-2"
+  default     = "e2-standard-4"
   description = "The machine type"
 }
 


### PR DESCRIPTION
Following the work being done to migrate chrome-tests-syncer to k8s, it was noticed that the current spec of GKE clusters is not enough for scheduling the tests-syncer as a k8s cronjob. During the tests done, the cronjob never gets schedule due to insufficient resources (memory/cpu). 
Thus, this PR aims at upgrading the machine types and the number of nodes available.

Related bug: b/389048599