### PR TITLE
Increase fuzz tasks scheduled to deal with reduced capacity

### DIFF
--- a/infra/k8s/schedule-fuzz.yaml
+++ b/infra/k8s/schedule-fuzz.yaml
@@ -18,10 +18,10 @@ metadata:
   name: schedule-fuzz
 spec:
   schedule: "*/10 * * * *"
-  concurrencyPolicy: Forbid
+  concurrencyPolicy: Allow
   jobTemplate:
     spec:
-      activeDeadlineSeconds: 900  # 15 minutes.
+      activeDeadlineSeconds: 1800  # 30 minutes.
       template:
         spec:
           containers:

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -253,7 +253,7 @@ def get_available_cpus(project: str, regions: List[str]) -> int:
   # Add up all queued and scheduled.
   region_counts = [sum(tup) for tup in region_counts]
   logs.info(f'Region counts: {region_counts}')
-  if region_counts[0] > 20000:
+  if region_counts[0] > 10000:
     # Check queued tasks.
     logs.info('Too many jobs queued, not scheduling more fuzzing.')
     return 0

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -253,7 +253,7 @@ def get_available_cpus(project: str, regions: List[str]) -> int:
   # Add up all queued and scheduled.
   region_counts = [sum(tup) for tup in region_counts]
   logs.info(f'Region counts: {region_counts}')
-  if region_counts[0] > 5000:
+  if region_counts[0] > 20000:
     # Check queued tasks.
     logs.info('Too many jobs queued, not scheduling more fuzzing.')
     return 0


### PR DESCRIPTION
The execution of tasks is more jagged under batch.
1. By having a buffer of tasks, we might be able to smooth this out by having fewer temporary declines in tasks.
2. The fuzz task scheduling takes very long (>20minutes) because of how long batch task querying takes. This can leave gaps that we are slow to react to.