### PR TITLE
Add ability to set HOST_JOB_SELECTION from instance metadata.

### DIFF
--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -18,9 +18,9 @@ if [ -z "$DEPLOYMENT_BUCKET" ]; then
   export DEPLOYMENT_BUCKET=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/attributes/deployment-bucket)
 fi
 
-if [ -z "$COMMAND_OVERRIDE" ]; then
-  # Get command override from instance metadata, if any.
-  export COMMAND_OVERRIDE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/command-override || true)
+if [ -z "$HOST_JOB_SELECTION" ]; then
+  # Get list of jobs to focus on from instance metadata, if any.
+  export HOST_JOB_SELECTION=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/host-job-selection || true)
 fi
 
 CLUSTERFUZZ_FILE=clusterfuzz_package.zip

--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -18,6 +18,11 @@ if [ -z "$DEPLOYMENT_BUCKET" ]; then
   export DEPLOYMENT_BUCKET=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/attributes/deployment-bucket)
 fi
 
+if [ -z "$COMMAND_OVERRIDE" ]; then
+  # Get command override from instance metadata, if any.
+  export COMMAND_OVERRIDE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/command-override || true)
+fi
+
 CLUSTERFUZZ_FILE=clusterfuzz_package.zip
 # When $LOCAL_SRC is set, use source zip on mounted volume for local testing.
 if [[ -z "$LOCAL_SRC" ]]; then


### PR DESCRIPTION
This allows spinning up instances dedicated to a subset of jobs without creating dedicated docker images.

Chrome would like to experiment with spending more compute on a relatively small number of fuzzers.