### PR TITLE
Backport batch changes to master from oss-fuzz.

### DIFF
--- a/configs/test/batch/batch.yaml
+++ b/configs/test/batch/batch.yaml
@@ -20,10 +20,13 @@ mapping:
     disk_size_gb: 110
     disk_type: pd-standard
     service_account_email: test-clusterfuzz-service-account-email
-    gce_region: 'gce-region'
-    gce_zone: 'gce-zone'
-    network: 'projects/google.com:clusterfuzz/global/networks/networkname'
-    subnetwork: 'projects/google.com:clusterfuzz/regions/gce-region/subnetworks/subnetworkname'
+    subconfigs:
+      -
+        name: central1-network1
+        weight: .5
+      -
+        name: central1-network2
+        weight: .5
     preemptible: false
     machine_type: n1-standard-1
   LINUX-NONPREEMPTIBLE-UNPRIVILEGED:
@@ -33,13 +36,19 @@ mapping:
     disk_size_gb: 110
     disk_type: pd-standard
     service_account_email: test-unpriv-clusterfuzz-service-account-email
-    gce_region: 'gce-region'
-    gce_zone: 'gce-zone'
-    network: 'projects/google.com:clusterfuzz/global/networks/networkname'
-    subnetwork: 'projects/google.com:clusterfuzz/regions/gce-region/subnetworks/subnetworkname'
     preemptible: false
     machine_type: n1-standard-1
     retry: true
+    subconfigs:
+      -
+        name: central1-network1
+        weight: .2
+      -
+        name: central1-network2
+        weight: .3
+      -
+        name: east4-network2
+        weight: .5
   LINUX-PREEMPTIBLE:
     clusterfuzz_release: 'prod'
     docker_image: 'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
@@ -47,12 +56,12 @@ mapping:
     disk_size_gb: 75
     disk_type: pd-standard
     service_account_email: test-clusterfuzz-service-account-email
-    gce_region: 'gce-region'
-    gce_zone: 'gce-zone'
-    network: 'projects/google.com:clusterfuzz/global/networks/networkname'
-    subnetwork: 'projects/google.com:clusterfuzz/regions/gce-region/subnetworks/subnetworkname'
     preemptible: true
     machine_type: n1-standard-1
+    subconfigs:
+      -
+        name: east4-network2
+        weight: 1
   LINUX-PREEMPTIBLE-UNPRIVILEGED:
     clusterfuzz_release: 'prod'
     docker_image: 'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
@@ -60,10 +69,23 @@ mapping:
     disk_size_gb: 75
     disk_type: pd-standard
     service_account_email: test-unpriv-clusterfuzz-service-account-email
-    gce_region: 'gce-region'
-    gce_zone: 'gce-zone'
-    network: 'projects/google.com:clusterfuzz/global/networks/networkname'
-    subnetwork: 'projects/google.com:clusterfuzz/regions/gce-region/subnetworks/subnetworkname'
     preemptible: true
     machine_type: n1-standard-1
+    subconfigs:
+      -
+        name: east4-network2
+        weight: 1
 project: 'test-clusterfuzz'
+subconfigs:
+  central1-network1:
+    region: 'us-central1'
+    network: 'projects/project_name/global/networks/networkname'
+    subnetwork: 'projects/project_name/regions/us-central1/subnetworks/subnetworkname'
+  central1-network2:
+    region: 'us-central1'
+    network: 'projects/project_name/global/networks/networkname2'
+    subnetwork: 'projects/project_name/regions/us-central1/subnetworks/subnetworkname2'
+  east4-network2:
+    region: 'us-east4'
+    network: 'projects/project_name/global/networks/networkname2'
+    subnetwork: 'projects/project_name/regions/us-east4/subnetworks/subnetworkname2'

--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -14,7 +14,9 @@
 """Cloud Batch helpers."""
 import collections
 import threading
+from typing import Dict
 from typing import List
+from typing import Tuple
 import uuid
 
 from google.cloud import batch_v1 as batch
@@ -25,17 +27,15 @@ from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.base.tasks import task_utils
 from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.system import environment
 
-# TODO(metzman): Change to from . import credentials when we are done
-# developing.
 from . import credentials
 
 _local = threading.local()
 
 DEFAULT_RETRY_COUNT = 0
-
-TASK_BUNCH_SIZE = 20
 
 # Controls how many containers (ClusterFuzz tasks) can run on a single VM.
 # THIS SHOULD BE 1 OR THERE WILL BE SECURITY PROBLEMS.
@@ -54,7 +54,6 @@ BatchWorkloadSpec = collections.namedtuple('BatchWorkloadSpec', [
     'subnetwork',
     'preemptible',
     'project',
-    'gce_zone',
     'machine_type',
     'network',
     'gce_region',
@@ -66,10 +65,7 @@ BatchWorkloadSpec = collections.namedtuple('BatchWorkloadSpec', [
 
 def _create_batch_client_new():
   """Creates a batch client."""
-  creds, project = credentials.get_default()
-  if not project:
-    project = utils.get_application_id()
-
+  creds, _ = credentials.get_default()
   return batch.BatchServiceClient(credentials=creds)
 
 
@@ -108,9 +104,10 @@ def create_uworker_main_batch_job(module, job_type, input_download_url):
 def create_uworker_main_batch_jobs(batch_tasks: List[BatchTask]):
   """Creates batch jobs."""
   job_specs = collections.defaultdict(list)
+  specs = _get_specs_from_config(batch_tasks)
   for batch_task in batch_tasks:
     logs.info(f'Scheduling {batch_task.command}, {batch_task.job_type}.')
-    spec = _get_spec_from_config(batch_task.command, batch_task.job_type)
+    spec = specs[(batch_task.command, batch_task.job_type)]
     job_specs[spec].append(batch_task.input_download_url)
 
   logs.info('Creating batch jobs.')
@@ -119,7 +116,7 @@ def create_uworker_main_batch_jobs(batch_tasks: List[BatchTask]):
   logs.info('Batching utask_mains.')
   for spec, input_urls in job_specs.items():
     for input_urls_portion in utils.batched(input_urls,
-                                            MAX_CONCURRENT_VMS_PER_JOB):
+                                            MAX_CONCURRENT_VMS_PER_JOB - 1):
       jobs.append(_create_job(spec, input_urls_portion))
 
   return jobs
@@ -209,7 +206,6 @@ def _create_job(spec, input_urls):
   job = batch.Job()
   job.task_groups = [task_group]
   job.allocation_policy = _get_allocation_policy(spec)
-  job.labels = {'env': 'testing', 'type': 'container'}
   job.logs_policy = batch.LogsPolicy()
   job.logs_policy.destination = batch.LogsPolicy.Destination.CLOUD_LOGGING
   job.priority = spec.priority
@@ -239,39 +235,44 @@ def _get_batch_config():
   return local_config.BatchConfig()
 
 
-def _get_job(job_name):
-  """Returns the Job entity named by |job_name|. This function was made to make
-  mocking easier."""
-  return data_types.Job.query(data_types.Job.name == job_name).get()
-
-
 def is_no_privilege_workload(command, job_name):
   return is_remote_task(command, job_name)
 
 
 def is_remote_task(command, job_name):
   try:
-    _get_spec_from_config(command, job_name)
+    _get_specs_from_config([BatchTask(command, job_name, None)])
     return True
   except ValueError:
     return False
 
 
-def _get_config_name(command, job_name):
-  """Returns the name of the config for |command| and |job_name|."""
-  job = _get_job(job_name)
-  # As of this writing, batch only supports LINUX.
-  if utils.is_oss_fuzz():
-    # TODO(b/377885331): In OSS-Fuzz, the platform can't be used because, as of
-    # it includes the project name.
-    config_name = 'LINUX'
-  else:
-    config_name = job.platform
-  if command == 'fuzz':
-    config_name += '-PREEMPTIBLE-UNPRIVILEGED'
-  else:
-    config_name += '-NONPREEMPTIBLE-UNPRIVILEGED'
-  return config_name
+def _get_config_names(
+    batch_tasks: List[BatchTask]) -> Dict[Tuple[str, str], str]:
+  """"Gets the name of the configs for each batch_task. Returns a dict
+  that is indexed by command and job_type for efficient lookup."""
+  job_names = {task.job_type for task in batch_tasks}
+  query = data_types.Job.query(data_types.Job.name.IN(list(job_names)))
+  jobs = ndb_utils.get_all_from_query(query)
+  job_map = {job.name: job for job in jobs}
+  config_map = {}
+  for task in batch_tasks:
+    if task.job_type not in job_map:
+      logs.error(f'{task.job_type} doesn\'t exist.')
+      continue
+    if task.command == 'fuzz':
+      suffix = '-PREEMPTIBLE-UNPRIVILEGED'
+    else:
+      suffix = '-NONPREEMPTIBLE-UNPRIVILEGED'
+    job = job_map[task.job_type]
+    platform = job.platform if not utils.is_oss_fuzz() else 'LINUX'
+    disk_size_gb = environment.get_value(
+        'DISK_SIZE_GB', env=job.get_environment())
+    config_map[(task.command, task.job_type)] = (f'{platform}{suffix}',
+                                                 disk_size_gb)
+  # TODO(metzman): Come up with a more systematic way for configs to
+  # be overridden by jobs.
+  return config_map
 
 
 def _get_task_duration(command):
@@ -279,46 +280,89 @@ def _get_task_duration(command):
                                                  tasks.TASK_LEASE_SECONDS)
 
 
-def _get_spec_from_config(command, job_name):
+WeightedSubconfig = collections.namedtuple('WeightedSubconfig',
+                                           ['name', 'weight'])
+
+
+def _get_subconfig(batch_config, instance_spec):
+  # TODO(metzman): Make this pick one at random or based on conditions.
+  all_subconfigs = batch_config.get('subconfigs', {})
+  instance_subconfigs = instance_spec['subconfigs']
+  weighted_subconfigs = [
+      WeightedSubconfig(subconfig['name'], subconfig['weight'])
+      for subconfig in instance_subconfigs
+  ]
+  weighted_subconfig = utils.random_weighted_choice(weighted_subconfigs)
+  return all_subconfigs[weighted_subconfig.name]
+
+
+def _get_specs_from_config(batch_tasks) -> Dict:
   """Gets the configured specifications for a batch workload."""
-  config_name = _get_config_name(command, job_name)
+  if not batch_tasks:
+    return {}
   batch_config = _get_batch_config()
-  instance_spec = batch_config.get('mapping').get(config_name, None)
-  if instance_spec is None:
-    raise ValueError(f'No mapping for {config_name}')
-  project_name = batch_config.get('project')
-  docker_image = instance_spec['docker_image']
-  user_data = instance_spec['user_data']
-  should_retry = instance_spec.get('retry', False)
-  clusterfuzz_release = instance_spec.get('clusterfuzz_release', 'prod')
+  config_map = _get_config_names(batch_tasks)
+  specs = {}
+  subconfig_map = {}
+  for task in batch_tasks:
+    if (task.command, task.job_type) in specs:
+      # Don't repeat work for no reason.
+      continue
+    config_name, disk_size_gb = config_map[(task.command, task.job_type)]
 
-  # Lower numbers are lower priority. From:
-  # https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs
-  low_priority = command == 'fuzz'
-  priority = 0 if low_priority else 1
+    instance_spec = batch_config.get('mapping').get(config_name)
+    if instance_spec is None:
+      raise ValueError(f'No mapping for {config_name}')
+    project_name = batch_config.get('project')
+    clusterfuzz_release = instance_spec.get('clusterfuzz_release', 'prod')
+    # Lower numbers are a lower priority, meaning less likely to run From:
+    # https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs
+    priority = 0 if task.command == 'fuzz' else 1
+    max_run_duration = f'{_get_task_duration(task.command)}s'
+    # This saves us time and reduces fragementation, e.g. every linux fuzz task
+    # run in this call will run in the same zone.
+    if config_name not in subconfig_map:
+      subconfig = _get_subconfig(batch_config, instance_spec)
+      subconfig_map[config_name] = subconfig
 
-  max_run_duration = f'{_get_task_duration(command)}s'
-  if command == 'corpus_pruning':
-    should_retry = False  # It is naturally retried the next day.
+    should_retry = instance_spec.get('retry', False)
+    if should_retry and task.command == 'corpus_pruning':
+      should_retry = False  # It is naturally retried the next day.
 
-  spec = BatchWorkloadSpec(
-      clusterfuzz_release=clusterfuzz_release,
-      docker_image=docker_image,
-      user_data=user_data,
-      disk_size_gb=instance_spec['disk_size_gb'],
-      disk_type=instance_spec['disk_type'],
-      service_account_email=instance_spec['service_account_email'],
-      # TODO(metzman): Get rid of zone so that we can more easily run in
-      # multiple regions.
-      gce_zone=instance_spec['gce_zone'],
-      gce_region=instance_spec['gce_region'],
-      project=project_name,
-      network=instance_spec['network'],
-      subnetwork=instance_spec['subnetwork'],
-      preemptible=instance_spec['preemptible'],
-      machine_type=instance_spec['machine_type'],
-      priority=priority,
-      max_run_duration=max_run_duration,
-      retry=should_retry,
-  )
-  return spec
+    disk_size_gb = (disk_size_gb or instance_spec['disk_size_gb'])
+    subconfig = subconfig_map[config_name]
+    spec = BatchWorkloadSpec(
+        docker_image=instance_spec['docker_image'],
+        disk_size_gb=disk_size_gb,
+        disk_type=instance_spec['disk_type'],
+        user_data=instance_spec['user_data'],
+        service_account_email=instance_spec['service_account_email'],
+        preemptible=instance_spec['preemptible'],
+        machine_type=instance_spec['machine_type'],
+        gce_region=subconfig['region'],
+        network=subconfig['network'],
+        subnetwork=subconfig['subnetwork'],
+        project=project_name,
+        clusterfuzz_release=clusterfuzz_release,
+        priority=priority,
+        max_run_duration=max_run_duration,
+        retry=should_retry,
+    )
+    specs[(task.command, task.job_type)] = spec
+  return specs
+
+
+def count_queued_or_scheduled_tasks(project: str,
+                                    region: str) -> Tuple[int, int]:
+  """Counts the number of queued and scheduled tasks."""
+  region = f'projects/{project}/locations/{region}'
+  jobs_filter = 'Status.State="SCHEDULED" OR Status.State="QUEUED"'
+  req = batch.types.ListJobsRequest(parent=region, filter=jobs_filter)
+  queued = 0
+  scheduled = 0
+  for job in _batch_client().list_jobs(request=req):
+    if job.status.state == batch.JobStatus.State.SCHEDULED:
+      scheduled += job.task_groups[0].task_count
+    elif job.status.state == batch.JobStatus.State.QUEUED:
+      queued += job.task_groups[0].task_count
+  return (queued, scheduled)

--- a/src/clusterfuzz/_internal/tests/core/google_cloud_utils/batch_test.py
+++ b/src/clusterfuzz/_internal/tests/core/google_cloud_utils/batch_test.py
@@ -17,24 +17,32 @@ import unittest
 
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.google_cloud_utils import batch
+from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 
 # pylint: disable=protected-access
 
 
 @test_utils.with_cloud_emulators('datastore')
-class GetSpecFromConfigTest(unittest.TestCase):
-  """Tests for get_spec_from_config."""
+class GetSpecsFromConfigTest(unittest.TestCase):
+  """Tests for _get_specs_from_config."""
 
   def setUp(self):
     self.maxDiff = None
     self.job = data_types.Job(name='libfuzzer_chrome_asan', platform='LINUX')
     self.job.put()
+    helpers.patch(self, [
+        'clusterfuzz._internal.base.utils.random_weighted_choice',
+    ])
+    self.mock.random_weighted_choice.return_value = batch.WeightedSubconfig(
+        name='east4-network2',
+        weight=1,
+    )
 
   def test_nonpreemptible(self):
-    """Tests that get_spec_from_config works for non-preemptibles as
-    expected."""
-    spec = batch._get_spec_from_config('analyze', self.job.name)
+    """Tests that _get_specs_from_config works for non-preemptibles as
+        expected."""
+    spec = _get_spec_from_config('analyze', self.job.name)
     expected_spec = batch.BatchWorkloadSpec(
         clusterfuzz_release='prod',
         docker_image='gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654',
@@ -43,10 +51,9 @@ class GetSpecFromConfigTest(unittest.TestCase):
         disk_type='pd-standard',
         service_account_email='test-unpriv-clusterfuzz-service-account-email',
         subnetwork=
-        'projects/google.com:clusterfuzz/regions/gce-region/subnetworks/subnetworkname',
-        network='projects/google.com:clusterfuzz/global/networks/networkname',
-        gce_region='gce-region',
-        gce_zone='gce-zone',
+        'projects/project_name/regions/us-east4/subnetworks/subnetworkname2',
+        network='projects/project_name/global/networks/networkname2',
+        gce_region='us-east4',
         project='test-clusterfuzz',
         preemptible=False,
         machine_type='n1-standard-1',
@@ -57,11 +64,11 @@ class GetSpecFromConfigTest(unittest.TestCase):
 
     self.assertCountEqual(spec, expected_spec)
 
-  def test_fuzz_get_spec_from_config(self):
-    """Tests that get_spec_from_config works for fuzz tasks as expected."""
+  def test_fuzz_get_specs_from_config(self):
+    """Tests that _get_specs_from_config works for fuzz tasks as expected."""
     job = data_types.Job(name='libfuzzer_chrome_asan', platform='LINUX')
     job.put()
-    spec = batch._get_spec_from_config('fuzz', job.name)  # pylint: disable=protected-access
+    spec = _get_spec_from_config('fuzz', job.name)
     expected_spec = batch.BatchWorkloadSpec(
         clusterfuzz_release='prod',
         docker_image='gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654',
@@ -70,10 +77,9 @@ class GetSpecFromConfigTest(unittest.TestCase):
         disk_type='pd-standard',
         service_account_email='test-unpriv-clusterfuzz-service-account-email',
         subnetwork=
-        'projects/google.com:clusterfuzz/regions/gce-region/subnetworks/subnetworkname',
-        network='projects/google.com:clusterfuzz/global/networks/networkname',
-        gce_zone='gce-zone',
-        gce_region='gce-region',
+        'projects/project_name/regions/us-east4/subnetworks/subnetworkname2',
+        network='projects/project_name/global/networks/networkname2',
+        gce_region='us-east4',
         project='test-clusterfuzz',
         preemptible=True,
         machine_type='n1-standard-1',
@@ -86,14 +92,64 @@ class GetSpecFromConfigTest(unittest.TestCase):
 
   def test_corpus_pruning(self):
     """Tests that corpus pruning uses a spec of 24 hours and a different one
-    than normal."""
-    pruning_spec = batch._get_spec_from_config('corpus_pruning', self.job.name)
+        than normal."""
+    pruning_spec = _get_spec_from_config('corpus_pruning', self.job.name)
     self.assertEqual(pruning_spec.max_run_duration, f'{24 * 60 * 60}s')
-    normal_spec = batch._get_spec_from_config('analyze', self.job.name)
+    normal_spec = _get_spec_from_config('analyze', self.job.name)
     self.assertNotEqual(pruning_spec, normal_spec)
     job = data_types.Job(name='libfuzzer_chrome_msan', platform='LINUX')
     job.put()
     # This behavior is important for grouping batch alike tasks into a single
     # batch job.
-    pruning_spec2 = batch._get_spec_from_config('corpus_pruning', job.name)
+    pruning_spec2 = _get_spec_from_config('corpus_pruning', job.name)
     self.assertEqual(pruning_spec, pruning_spec2)
+
+  def test_get_specs_from_config_disk_size(self):
+    """Tests that DISK_SIZE_GB is respected."""
+    size = 500
+    data_types.Job(
+        environment_string=f'DISK_SIZE_GB = {size}\n',
+        platform='LINUX',
+        name='libfuzzer_asan_test').put()
+
+    spec = batch._get_specs_from_config(
+        [batch.BatchTask('fuzz', 'libfuzzer_asan_test', None)])
+    self.assertEqual(spec['fuzz', 'libfuzzer_asan_test'].disk_size_gb, size)
+
+  def test_get_specs_from_config_no_disk_size(self):
+    """Test that disk_size_gb isn't mandatory."""
+    data_types.Job(platform='LINUX', name='libfuzzer_asan_test').put()
+    spec = batch._get_specs_from_config(
+        [batch.BatchTask('fuzz', 'libfuzzer_asan_test', None)])
+    conf = batch._get_batch_config()
+    expected_size = (
+        conf.get('mapping')['LINUX-PREEMPTIBLE-UNPRIVILEGED']['disk_size_gb'])
+    self.assertEqual(spec['fuzz', 'libfuzzer_asan_test'].disk_size_gb,
+                     expected_size)
+
+  def test_get_specs_from_config_with_disk_size_override(self):
+    """Tests that disk_size_gb can be overridden by the job environment."""
+    job_name = 'libfuzzer_asan_test'
+    original_size = 75
+    overridden_size = 200
+    # First, create a job with the original disk size
+    data_types.Job(
+        environment_string=f'DISK_SIZE_GB = {original_size}\n',
+        platform='LINUX',
+        name=job_name).put()
+
+    # Then override it by creating a new job with a larger disk size
+    data_types.Job(
+        environment_string=f'DISK_SIZE_GB = {overridden_size}\n',
+        platform='LINUX',
+        name=job_name).put()
+
+    spec = batch._get_specs_from_config(
+        [batch.BatchTask('fuzz', job_name, None)])
+    self.assertEqual(spec['fuzz', job_name].disk_size_gb, overridden_size)
+
+
+def _get_spec_from_config(command, job_name):
+  return list(
+      batch._get_specs_from_config([batch.BatchTask(command, job_name,
+                                                    None)]).values())[0]


### PR DESCRIPTION
The current version of batch on master is non-functional. We need to get it working to start using master in Chrome.