### PR TITLE
Fix dealing with invalid GCS messages

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -560,6 +560,8 @@ def get_task_from_message(message, can_defer=True,
     return None
   try:
     task = initialize_task(message, task_cls=task_cls)
+    if task is None:
+      return None
   except KeyError:
     logs.error('Received an invalid task, discarding...')
     message.ack()


### PR DESCRIPTION
Fixes: https://pantheon.corp.google.com/errors/detail/CMScmPbnk9jdvAE;time=PT6H;locations=global?project=clusterfuzz-external&e=-13802955&mods=dm_deploy_from_gcs

AttributeError: 'NoneType' object has no attribute 'defer'

at .get_task_from_message ( /mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/base/tasks/__init__.py:570 )
at .get_postprocess_task ( /mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/base/tasks/__init__.py:310 )
at .tworker_get_task ( /mnt/scratch0/clusterfuzz/src/clusterfuzz/_internal/base/tasks/__init__.py:339 )
at .task_loop ( /mnt/scratch0/clusterfuzz/src/python/bot/startup/run_bot.py:139 )