### PR TITLE
Emitting deployments number metric

### DIFF
--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -918,7 +918,6 @@ def current_project():
 
 def current_source_version():
   """Return the current source revision."""
-  # For test use.
   source_version_override = environment.get_value('SOURCE_VERSION_OVERRIDE')
   if source_version_override:
     return source_version_override

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -388,3 +388,14 @@ ANALYZE_TASK_REPRODUCIBILITY = monitor.CounterMetric(
         monitor.BooleanField('reproducible'),
         monitor.BooleanField('crashes'),
     ])
+
+PRODUCTION_DEPLOYMENT = monitor.CounterMetric(
+    'debug/deployment/count',
+    description='The number of deployments',
+    field_spec=[
+        monitor.BooleanField('success'),
+        monitor.StringField('release'),
+        monitor.BooleanField('deploy_zip'),
+        monitor.BooleanField('deploy_app_engine'),
+        monitor.BooleanField('deploy_kubernetes')
+    ])

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -397,5 +397,6 @@ PRODUCTION_DEPLOYMENT = monitor.CounterMetric(
         monitor.StringField('release'),
         monitor.BooleanField('deploy_zip'),
         monitor.BooleanField('deploy_app_engine'),
-        monitor.BooleanField('deploy_kubernetes')
+        monitor.BooleanField('deploy_kubernetes'),
+        monitor.StringField('clusterfuzz_version')
     ])

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -22,6 +22,7 @@ import re
 import sys
 import tempfile
 import time
+from typing import Any
 
 import pytz
 
@@ -31,9 +32,9 @@ from local.butler import constants
 from local.butler import package
 from src.clusterfuzz._internal.base import utils
 from src.clusterfuzz._internal.config import local_config
+from src.clusterfuzz._internal.metrics import monitoring_metrics
+from src.clusterfuzz._internal.metrics.monitor import wrap_with_monitoring
 from src.clusterfuzz._internal.system import environment
-from clusterfuzz._internal.metrics import monitoring_metrics
-from typing import Any, Dict
 
 EXPECTED_BOT_COUNT_PERCENT = 0.8
 
@@ -91,6 +92,7 @@ def _additional_app_env_vars(project):
       'REDIS_HOST': _get_redis_ip(project),
   }
 
+
 # TODO: Add structured log
 def _deploy_app_prod(project,
                      deployment_bucket,
@@ -113,19 +115,21 @@ def _deploy_app_prod(project,
 
     for service in services:
       _delete_old_versions(project, service, VERSION_DELETE_WINDOW_MINUTES)
-  releases = [release]
-  releases += constants.ADDITIONAL_RELEASES if release == 'prod' else []
+
   if package_zip_paths:
     for package_zip_path in package_zip_paths:
       _deploy_zip(
           deployment_bucket, package_zip_path, test_deployment=test_deployment)
 
+    releases = [release]
+    releases += constants.ADDITIONAL_RELEASES if release == 'prod' else []
     for rel in releases:
-        _deploy_manifest(
+      _deploy_manifest(
           deployment_bucket,
           constants.PACKAGE_TARGET_MANIFEST_PATH,
           test_deployment=test_deployment,
           release=rel)
+
 
 def _deploy_app_staging(project, yaml_paths):
   """Deploy app in staging."""
@@ -399,6 +403,11 @@ def _staging_deployment_helper():
   print('Staging deployment finished.')
 
 
+def _increment_production_deployment(labels):
+  with wrap_with_monitoring():
+    monitoring_metrics.PRODUCTION_DEPLOYMENT.increment(labels)
+
+
 def _prod_deployment_helper(config_dir,
                             package_zip_paths,
                             deploy_appengine=True,
@@ -431,11 +440,12 @@ def _prod_deployment_helper(config_dir,
       'deploy_app_engine': deploy_appengine,
       'deploy_kubernetes': deploy_k8s,
       'success': True,
-      'release': release
-    }
-  
+      'release': release,
+      'clusterfuzz_version': utils.current_source_version()
+  }
+
   try:
-    deployments_success = _deploy_app_prod(
+    _deploy_app_prod(
         project,
         deployment_bucket,
         yaml_paths,
@@ -451,14 +461,14 @@ def _prod_deployment_helper(config_dir,
     if deploy_k8s:
       _deploy_terraform(config_dir)
       _deploy_k8s(config_dir)
-    
-    print(f'Production deployment finished. {labels}, {deployments_success}')
-    labels.update({'success': True})
-    monitoring_metrics.PRODUCTION_DEPLOYMENT.increment(labels)
+
+    print(f'Production deployment finished. {labels}')
+    _increment_production_deployment(labels)
   except Exception as ex:
     labels.update({'success': False})
-    monitoring_metrics.PRODUCTION_DEPLOYMENT.increment(labels)
+    _increment_production_deployment(labels)
     raise ex
+
 
 def _deploy_terraform(config_dir):
   """Deploys GKE cluster via terraform."""


### PR DESCRIPTION
It adds a new metric regarding the number of deployments. Alongside with this, this metric has several labels that helps to identify smaller scopes.

Also, this metric will be used to create an alert for each deployment, providing visibility to our costumers. 


The metric was created correctly on metric explorer:
**
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/d83a49f5-3843-424c-b231-feb7fc32bf3b" />
**