### PR TITLE
FIX Correct error handling for setting `HOST_JOB_SELECTION`

### DIFF
--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -22,7 +22,6 @@ if [ -z "$HOST_JOB_SELECTION" ]; then
   if HOST_JOB_SELECTION=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/host-job-selection); then
     export HOST_JOB_SELECTION
   else
-    echo "Failed to retrieve HOST_JOB_SELECTION from metadata."
     unset HOST_JOB_SELECTION
   fi
 fi

--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -24,7 +24,8 @@ if [ -z "$HOST_JOB_SELECTION" ]; then
   if [ $? -eq 0 ]; then
     export HOST_JOB_SELECTION
   else
-    unset HOST_JOB_SELECTION
+    HOST_JOB_SELECTION=""
+    export HOST_JOB_SELECTION
   fi
 fi
 

--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -19,13 +19,11 @@ if [ -z "$DEPLOYMENT_BUCKET" ]; then
 fi
 
 if [ -z "$HOST_JOB_SELECTION" ]; then
-  HOST_JOB_SELECTION=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/host-job-selection)
-  # Don't set the env var to a 404 error page.
-  if [ $? -eq 0 ]; then
+  if HOST_JOB_SELECTION=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/host-job-selection); then
     export HOST_JOB_SELECTION
   else
-    HOST_JOB_SELECTION=""
-    export HOST_JOB_SELECTION
+    echo "Failed to retrieve HOST_JOB_SELECTION from metadata."
+    unset HOST_JOB_SELECTION
   fi
 fi
 


### PR DESCRIPTION
After pull request #4663, the bots were having trouble finding a task to select for fuzzing because `HOST_JOB_SELECTION` was not properly set.

After the attempted fix in pull request #4690, the machine was not initializing properly. This was because [we run the init script with -e]((https://github.com/google/clusterfuzz/blob/750dfd2c7896b7f8db528436b4e6d100655c0581/docker/base/start.sh#L25) ), which caused the `curl` call to terminate the script execution prematurely during the bash run.

This pull request handles `HOST_JOB_SELECTION` in a way that doesn't exit the script.

___

Minimal examples ran during tests:

Previous logic:

```bash
$ sudo cat script.sh
#!/bin/bash -ex

if [ -z "$HOST_JOB_SELECTION" ]; then
  HOST_JOB_SELECTION=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/host-job-selection)
  # Don't set the env var to a 404 error page.
  if [ $? -eq 0 ]; then
    export HOST_JOB_SELECTION
  else
    unset HOST_JOB_SELECTION
  fi
fi
echo $HOST_JOB_SELECTION

$ sudo bash -ex script.sh
+ '[' -z '' ']'
++ curl -sf -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/attributes/host-job-selection
+ HOST_JOB_SELECTION=
```

This PR logic:

```bash
$ sudo cat script.sh
#!/bin/bash -ex

if [ -z "$HOST_JOB_SELECTION" ]; then
  if HOST_JOB_SELECTION=$(curl -sf -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/host-job-selection); then
    export HOST_JOB_SELECTION
  else
    echo "Failed to retrieve HOST_JOB_SELECTION from metadata."
    unset HOST_JOB_SELECTION
  fi
fi
echo "$HOST_JOB_SELECTION"

$ sudo bash -ex script.sh
+ '[' -z '' ']'
++ curl -sf -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/attributes/host-job-selection
+ HOST_JOB_SELECTION=
+ echo 'Failed to retrieve HOST_JOB_SELECTION from metadata.'
Failed to retrieve HOST_JOB_SELECTION from metadata.
+ unset HOST_JOB_SELECTION
+ echo ''
```