### PR TITLE
Updating deploy script for downloading internal_issue_tracker module from GCS

### DIFF
--- a/src/clusterfuzz/_internal/config/local_config.py
+++ b/src/clusterfuzz/_internal/config/local_config.py
@@ -161,7 +161,7 @@ class Config:
 
     return Config(root=new_root)
 
-  # it returns if the config is for internal, external or google
+  # it returns that the config is for internal, external or google
   # TODO: add and get this information from the project.yaml file
   def get_target(self):
     return self._config_dir.split("/")[-1]

--- a/src/clusterfuzz/_internal/config/local_config.py
+++ b/src/clusterfuzz/_internal/config/local_config.py
@@ -161,6 +161,14 @@ class Config:
 
     return Config(root=new_root)
 
+  # it returns if the config is for internal, external or google
+  # TODO: add and get this information from the project.yaml file
+  def get_target(self):
+    return self._config_dir.split("/")[-1]
+
+  def get_config_dir(self):
+    return self._config_dir
+
   def _get_helper(self, key_name='', default=None,
                   value_is_relative_path=False):
     """Helper for get and get_absolute_functions."""

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -236,11 +236,12 @@ def _deploy_zip(bucket_name, zip_path, test_deployment=False):
   else:
     common.execute('gsutil cp %s gs://%s/%s' % (zip_path, bucket_name,
                                                 os.path.basename(zip_path)))
-    
+
 
 def _download_zip(bucket_name, gcs_file_path, target_path):
   """Download zip from GCS."""
-  common.execute('gsutil cp gs://%s/%s %s' % (bucket_name, gcs_file_path, target_path))
+  common.execute(
+      'gsutil cp gs://%s/%s %s' % (bucket_name, gcs_file_path, target_path))
 
 
 def _deploy_manifest(bucket_name,
@@ -619,8 +620,8 @@ def execute(args):
     # and it's needed for loading the monitoring module
     config = local_config.ProjectConfig()
     config.set_environment()
-    # We are removing the internal_issue_tracker module from cluterfuzz-config code
-    # to be able to open the clusterfuzz-config code.
+    # We are removing the internal_issue_tracker module from cluterfuzz-config
+    # code to be able to open the clusterfuzz-config code.
     # This workaround manages to download the internal_issue_tracker module from
     # GCS during the deployment.
     if config.get_target() == "google":
@@ -628,7 +629,8 @@ def execute(args):
       config_path = os.path.join(config_dir, 'modules')
       bucket = config.get('deployment.bucket')
       _download_zip(bucket, "internal_issue_tracker.zip", config_path)
-      common.execute(f'unzip {config_path}/internal_issue_tracker.zip -d {config_path}')
+      common.execute(
+          f'unzip {config_path}/internal_issue_tracker.zip -d {config_path}')
       common.execute(f'rm {config_path}/internal_issue_tracker.zip')
     environment.set_value("BOT_NAME", os.uname().nodename)
     _prod_deployment_helper(


### PR DESCRIPTION
It is updating the butler deploy to download and unpack the internal_issue_tracker module from GCS for Google project deployments. 
It's being needed because there's some sensitive code into the internal_issue_tracker module and we want to open the clusterfuzz-config code.

It was tested by running the butler deploy locally with the internal_issue_tracker module deleted, and it managed to "recreate" the module properly.