### PR TITLE
[Centipede] Perform corpus minimization during a fuzzing session

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/constants.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/constants.py
@@ -40,7 +40,7 @@ EXTRA_BINARIES_FLAGNAME = 'extra_binaries'
 EXIT_ON_CRASH_FLAGNAME = 'exit_on_crash'
 
 MAX_LEN_FLAGNAME = 'max_len'
-RUNS_FLAGNAME = 'runs'
+NUM_RUNS_FLAGNAME = 'num_runs'
 BATCH_SIZE_FLAGNAME = 'batch_size'
 
 NUM_RUNS_PER_MINIMIZATION = 100000

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/constants.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/constants.py
@@ -39,6 +39,10 @@ BINARY_FLAGNAME = 'binary'
 EXTRA_BINARIES_FLAGNAME = 'extra_binaries'
 EXIT_ON_CRASH_FLAGNAME = 'exit_on_crash'
 
+MAX_LEN_FLAGNAME = 'max_len'
+RUNS_FLAGNAME = 'runs'
+BATCH_SIZE_FLAGNAME = 'batch_size'
+
 NUM_RUNS_PER_MINIMIZATION = 100000
 
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -216,7 +216,7 @@ class Engine(engine.Engine):
     # Directory to place new units. While fuzzing, the new corpus
     # elements are written to the first dir in the list of corpus directories.
     new_corpus_dir = engine_common.create_temp_fuzzing_dir('new')
-    corpus_dirs = [new_corpus_dir, corpus_dir]
+    corpus_dirs = [str(new_corpus_dir), str(corpus_dir)]
     arguments[constants.CORPUS_DIR_FLAGNAME] = ','.join(
         dir for dir in corpus_dirs)
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -72,6 +72,8 @@ RADAMSA_MUTATIONS = 2000
 # Maximum number of seconds to run radamsa for.
 RADAMSA_TIMEOUT = 3
 
+HEXDIGITS_SET = set(string.hexdigits)
+
 
 class Generator:
   """Generators we can use."""
@@ -664,8 +666,7 @@ def is_sha1_hash(possible_hash):
   if len(possible_hash) != 40:
     return False
 
-  hexdigits_set = set(string.hexdigits)
-  return all(char in hexdigits_set for char in possible_hash)
+  return all(char in HEXDIGITS_SET for char in possible_hash)
 
 
 def move_mergeable_units(merge_directory, corpus_directory):

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -21,6 +21,7 @@ import random
 import re
 import shlex
 import shutil
+import string
 import sys
 import time
 
@@ -656,3 +657,34 @@ def get_log_header(command, time_executed):
   """Get the log header."""
   quoted_command = get_command_quoted(command)
   return f'Command: {quoted_command}\nTime ran: {time_executed}\n'
+
+
+def is_sha1_hash(possible_hash):
+  """Returns True if |possible_hash| looks like a valid sha1 hash."""
+  if len(possible_hash) != 40:
+    return False
+
+  hexdigits_set = set(string.hexdigits)
+  return all(char in hexdigits_set for char in possible_hash)
+
+
+def move_mergeable_units(merge_directory, corpus_directory):
+  """Move new units in |merge_directory| into |corpus_directory|."""
+  initial_units = {
+      os.path.basename(filename)
+      for filename in shell.get_files_list(corpus_directory)
+  }
+
+  for unit_path in shell.get_files_list(merge_directory):
+    unit_name = os.path.basename(unit_path)
+    if unit_name in initial_units and is_sha1_hash(unit_name):
+      continue
+    dest_path = os.path.join(corpus_directory, unit_name)
+    shell.move(unit_path, dest_path)
+
+
+def create_temp_fuzzing_dir(name):
+  """Create a temporary directory for fuzzing."""
+  new_corpus_directory = os.path.join(fuzzer_utils.get_temp_dir(), name)
+  recreate_directory(new_corpus_directory)
+  return new_corpus_directory

--- a/src/clusterfuzz/_internal/bot/fuzzers/honggfuzz/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/honggfuzz/engine.py
@@ -21,7 +21,6 @@ import shutil
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot.fuzzers import dictionary_manager
 from clusterfuzz._internal.bot.fuzzers import engine_common
-from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.system import new_process
@@ -219,12 +218,6 @@ class Engine(engine.Engine):
     return engine.ReproduceResult(result.command, result.return_code,
                                   result.time_executed, result.output)
 
-  def _create_temp_corpus_dir(self, name):
-    """Creates temporary corpus directory."""
-    new_corpus_directory = os.path.join(fuzzer_utils.get_temp_dir(), name)
-    engine_common.recreate_directory(new_corpus_directory)
-    return new_corpus_directory
-
   def minimize_corpus(self, target_path, arguments, input_dirs, output_dir,
                       reproducers_dir, max_time):
     """Optional (but recommended): run corpus minimization.
@@ -244,7 +237,8 @@ class Engine(engine.Engine):
     del reproducers_dir
 
     runner = _get_runner()
-    combined_corpus_dir = self._create_temp_corpus_dir('minimize-workdir')
+    combined_corpus_dir = engine_common.create_temp_fuzzing_dir(
+        'minimize-workdir')
 
     # Copy all of the seeds into corpus.
     idx = 0

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -148,7 +148,7 @@ class Engine(engine.Engine):
     if (strategy_pool.do_strategy(strategy.CORPUS_SUBSET_STRATEGY) and
         shell.get_directory_file_count(corpus_dir) > subset_size):
       # Copy |subset_size| testcases into 'subset' directory.
-      corpus_subset_dir = self._create_temp_corpus_dir('subset')
+      corpus_subset_dir = engine_common.create_temp_fuzzing_dir('subset')
       libfuzzer.copy_from_corpus(corpus_subset_dir, corpus_dir, subset_size)
       strategy_info.fuzzing_strategies.append(
           strategy.CORPUS_SUBSET_STRATEGY.name + '_' + str(subset_size))
@@ -187,12 +187,6 @@ class Engine(engine.Engine):
     _, path = tempfile.mkstemp(dir=reproducers_dir)
     return path
 
-  def _create_temp_corpus_dir(self, name):
-    """Create temporary corpus directory."""
-    new_corpus_directory = os.path.join(fuzzer_utils.get_temp_dir(), name)
-    engine_common.recreate_directory(new_corpus_directory)
-    return new_corpus_directory
-
   def _create_temp_dir(self, name):
     """Create a temporary directory suitable for putting into the TMPDIR
     environment variable, which practically speaking sometimes needs to be
@@ -204,7 +198,7 @@ class Engine(engine.Engine):
 
   def _create_merge_corpus_dir(self):
     """Create merge corpus directory."""
-    return self._create_temp_corpus_dir('merge-corpus')
+    return engine_common.create_temp_fuzzing_dir('merge-corpus')
 
   def _merge_new_units(self, target_path, corpus_dir, new_corpus_dir,
                        fuzz_corpus_dirs, arguments, stat_overrides):
@@ -243,7 +237,7 @@ class Engine(engine.Engine):
           max_time=engine_common.get_merge_timeout(
               libfuzzer.DEFAULT_MERGE_TIMEOUT))
 
-      libfuzzer.move_mergeable_units(merge_corpus, corpus_dir)
+      engine_common.move_mergeable_units(merge_corpus, corpus_dir)
       new_corpus_len = shell.get_directory_file_count(corpus_dir)
       new_units_added = new_corpus_len - old_corpus_len
 
@@ -284,7 +278,7 @@ class Engine(engine.Engine):
 
     # Directory to place new units.
     if options.merge_back_new_testcases:
-      new_corpus_dir = self._create_temp_corpus_dir('new')
+      new_corpus_dir = engine_common.create_temp_fuzzing_dir('new')
       corpus_directories = [new_corpus_dir] + options.fuzz_corpus_dirs
     else:
       corpus_directories = options.fuzz_corpus_dirs
@@ -446,7 +440,8 @@ class Engine(engine.Engine):
 
     # The dir where merge control file is located must persist for both merge
     # steps. The second step re-uses the MCF produced during the first step.
-    merge_control_file_dir = self._create_temp_corpus_dir('mcf_tmp_dir')
+    merge_control_file_dir = engine_common.create_temp_fuzzing_dir(
+        'mcf_tmp_dir')
     self._merge_control_file = os.path.join(merge_control_file_dir, 'MCF')
 
     # Two step merge process to obtain accurate stats for the new corpus units.
@@ -572,7 +567,7 @@ class Engine(engine.Engine):
     runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path)
 
-    minimize_tmp_dir = self._create_temp_corpus_dir('minimize-workdir')
+    minimize_tmp_dir = engine_common.create_temp_fuzzing_dir('minimize-workdir')
     result = runner.minimize_crash(
         input_path,
         output_path,
@@ -606,7 +601,7 @@ class Engine(engine.Engine):
     runner = libfuzzer.get_runner(target_path)
     libfuzzer.set_sanitizer_options(target_path)
 
-    cleanse_tmp_dir = self._create_temp_corpus_dir('cleanse-workdir')
+    cleanse_tmp_dir = engine_common.create_temp_fuzzing_dir('cleanse-workdir')
     result = runner.cleanse_crash(
         input_path,
         output_path,

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -20,7 +20,6 @@ import os
 import random
 import re
 import shutil
-import string
 
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot import testcase_manager
@@ -1194,14 +1193,6 @@ def get_runner(fuzzer_path, temp_dir=None, use_minijail=None):
   return runner
 
 
-def create_corpus_directory(name):
-  """Create a corpus directory with a give name in temp directory and return its
-  full path."""
-  new_corpus_directory = os.path.join(fuzzer_utils.get_temp_dir(), name)
-  engine_common.recreate_directory(new_corpus_directory)
-  return new_corpus_directory
-
-
 def copy_from_corpus(dest_corpus_path, src_corpus_path, num_testcases):
   """Choose |num_testcases| testcases from the src corpus directory (and its
   subdirectories) and copy it into the dest directory."""
@@ -1313,30 +1304,6 @@ def get_fuzz_timeout(is_mutations_run, total_timeout=None):
   return fuzz_timeout
 
 
-def is_sha1_hash(possible_hash):
-  """Returns True if |possible_hash| looks like a valid sha1 hash."""
-  if len(possible_hash) != 40:
-    return False
-
-  hexdigits_set = set(string.hexdigits)
-  return all(char in hexdigits_set for char in possible_hash)
-
-
-def move_mergeable_units(merge_directory, corpus_directory):
-  """Move new units in |merge_directory| into |corpus_directory|."""
-  initial_units = {
-      os.path.basename(filename)
-      for filename in shell.get_files_list(corpus_directory)
-  }
-
-  for unit_path in shell.get_files_list(merge_directory):
-    unit_name = os.path.basename(unit_path)
-    if unit_name in initial_units and is_sha1_hash(unit_name):
-      continue
-    dest_path = os.path.join(corpus_directory, unit_name)
-    shell.move(unit_path, dest_path)
-
-
 def pick_strategies(strategy_pool, fuzzer_path, corpus_directory,
                     existing_arguments):
   """Pick strategies."""
@@ -1352,7 +1319,8 @@ def pick_strategies(strategy_pool, fuzzer_path, corpus_directory,
 
   # Generate new testcase mutations using radamsa, etc.
   if is_mutations_run:
-    new_testcase_mutations_directory = create_corpus_directory('mutations')
+    new_testcase_mutations_directory = engine_common.create_temp_fuzzing_dir(
+        'mutations')
     generator_used = engine_common.generate_new_testcase_mutations(
         corpus_directory, new_testcase_mutations_directory, candidate_generator)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
@@ -237,10 +237,12 @@ class IntegrationTest(unittest.TestCase):
         self.test_paths,
         centipede_bin,
         sanitized_target_dir=sanitized_target_dir)
-    work_dir = '/tmp/temp-1337/workdir'
 
     options = engine_impl.prepare(self.test_paths.corpus, target_path,
                                   self.test_paths.data)
+
+    work_dir = options.workdir
+    self.assertTrue(work_dir)
 
     arguments = fuzzer_options.FuzzerArguments.from_list(options.arguments)
     self.assertListEqual(arguments.list(), options.arguments)
@@ -263,8 +265,9 @@ class IntegrationTest(unittest.TestCase):
     if dictionary:
       expected_args[centipede_constants.DICTIONARY_FLAGNAME] = str(dictionary)
     expected_args[centipede_constants.WORKDIR_FLAGNAME] = str(work_dir)
-    expected_args[centipede_constants.CORPUS_DIR_FLAGNAME] = str(
-        self.test_paths.corpus)
+    expected_args[
+        centipede_constants.
+        CORPUS_DIR_FLAGNAME] = f'{options.new_corpus_dir},{self.test_paths.corpus}'
     expected_args[centipede_constants.BINARY_FLAGNAME] = str(target_path)
     if str(target_path) != str(sanitized_target_path):
       expected_args[centipede_constants.EXTRA_BINARIES_FLAGNAME] = str(

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/engine_common_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/engine_common_test.py
@@ -25,6 +25,10 @@ from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 
 
+# An arbirtrary SHA1 sum.
+ARBITRARY_SHA1_HASH = 'dd122581c8cd44d0227f9c305581ffcb4b6f1b46'
+
+
 class GetIssueOwnersTest(fake_filesystem_unittest.TestCase):
   """get_issue_owners tests."""
 
@@ -531,3 +535,58 @@ class ProcessSanitizerOptionsOverridesTest(fake_filesystem_unittest.TestCase):
     environment.set_value(options_name, 'a=1:b=2:c=1')
     engine_common.process_sanitizer_options_overrides(self.fuzz_target)
     self.assertEqual('a=1:b=2:c=1', environment.get_value(options_name))
+
+
+class IsSha1HashTest(unittest.TestCase):
+  """Tests for is_sha1_hash."""
+
+  def test_non_hashes(self):
+    """Tests that False is returned for non hashes."""
+    self.assertFalse(engine_common.is_sha1_hash(''))
+    self.assertFalse(engine_common.is_sha1_hash('z' * 40))
+    self.assertFalse(engine_common.is_sha1_hash('a' * 50))
+    fake_hash = str('z' + ARBITRARY_SHA1_HASH[1:])
+    self.assertFalse(engine_common.is_sha1_hash(fake_hash))
+
+  def test_hash(self):
+    """Tests that False is returned for a real hash."""
+    self.assertTrue(engine_common.is_sha1_hash(ARBITRARY_SHA1_HASH))
+
+
+class MoveMergeableUnitsTest(fake_filesystem_unittest.TestCase):
+  """Tests for move_mergeable_units."""
+  CORPUS_DIRECTORY = '/corpus'
+  MERGE_DIRECTORY = '/corpus-merge'
+
+  def setUp(self):
+    test_utils.set_up_pyfakefs(self)
+
+  def move_mergeable_units(self):
+    """Helper function for move_mergeable_units."""
+    engine_common.move_mergeable_units(self.MERGE_DIRECTORY, self.CORPUS_DIRECTORY)
+
+  def test_duplicate_not_moved(self):
+    """Tests that a duplicated file is not moved into the corpus directory."""
+    self.fs.create_file(
+        os.path.join(self.CORPUS_DIRECTORY, ARBITRARY_SHA1_HASH))
+    merge_corpus_file = os.path.join(self.MERGE_DIRECTORY, ARBITRARY_SHA1_HASH)
+    self.fs.create_file(merge_corpus_file)
+    self.move_mergeable_units()
+    # File will be deleted from merge directory if it isn't a duplicate.
+    self.assertTrue(os.path.exists(merge_corpus_file))
+
+  def test_new_file_moved(self):
+    """Tests that a new file is moved into the corpus directory."""
+    # Make a file that looks like a sha1 hash but is different from
+    # ARBITRARY_SHA1_HASH.
+    filename = ARBITRARY_SHA1_HASH.replace('d', 'a')
+    self.fs.create_file(os.path.join(self.CORPUS_DIRECTORY, filename))
+    # Create an arbitrary file with a hash name that is different from this
+    # filename.
+    merge_corpus_file = os.path.join(self.MERGE_DIRECTORY, ARBITRARY_SHA1_HASH)
+    self.fs.create_file(merge_corpus_file)
+    self.move_mergeable_units()
+    # File will be deleted from merge directory if it isn't a duplicate.
+    self.assertFalse(os.path.exists(merge_corpus_file))
+    self.assertTrue(
+        os.path.exists(os.path.join(self.CORPUS_DIRECTORY, filename)))

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/engine_common_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/engine_common_test.py
@@ -24,7 +24,6 @@ from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 
-
 # An arbirtrary SHA1 sum.
 ARBITRARY_SHA1_HASH = 'dd122581c8cd44d0227f9c305581ffcb4b6f1b46'
 
@@ -563,7 +562,8 @@ class MoveMergeableUnitsTest(fake_filesystem_unittest.TestCase):
 
   def move_mergeable_units(self):
     """Helper function for move_mergeable_units."""
-    engine_common.move_mergeable_units(self.MERGE_DIRECTORY, self.CORPUS_DIRECTORY)
+    engine_common.move_mergeable_units(self.MERGE_DIRECTORY,
+                                       self.CORPUS_DIRECTORY)
 
   def test_duplicate_not_moved(self):
     """Tests that a duplicated file is not moved into the corpus directory."""

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/engine_test.py
@@ -667,10 +667,11 @@ class IntegrationTests(BaseIntegrationTest):
     def mocked_create_merge_directory(_):
       """A mocked version of create_merge_directory that adds some interesting
       files to the merge corpus and initial corpus."""
-      merge_directory_path = libfuzzer.create_corpus_directory('merge-corpus')
+      merge_directory_path = engine_common.create_temp_fuzzing_dir(
+          'merge-corpus')
 
       # Write the minimal unit to the new corpus directory.
-      new_corpus_directory_path = libfuzzer.create_corpus_directory('new')
+      new_corpus_directory_path = engine_common.create_temp_fuzzing_dir('new')
       minimal_unit_path = os.path.join(new_corpus_directory_path,
                                        minimal_unit_hash)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/libfuzzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/libfuzzer_test.py
@@ -18,15 +18,12 @@ import os
 import shutil
 import unittest
 
-import pyfakefs.fake_filesystem_unittest as fake_fs_unittest
-
 from clusterfuzz._internal.bot.fuzzers import engine_common
 from clusterfuzz._internal.bot.fuzzers import libfuzzer
 from clusterfuzz._internal.bot.fuzzers import strategy_selection
 from clusterfuzz._internal.bot.fuzzers.libFuzzer import fuzzer
 from clusterfuzz._internal.fuzzing import strategy
 from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
-from clusterfuzz._internal.tests.test_libs import test_utils
 
 TESTDATA_PATH = os.path.join(os.path.dirname(__file__), 'libfuzzer_test_data')
 
@@ -134,6 +131,7 @@ def set_strategy_pool(strategies=None):
     for strategy_tuple in strategies:
       strategy_pool.add_strategy(strategy_tuple)
   return strategy_pool
+
 
 class SelectGeneratorTest(unittest.TestCase):
   """Tests for _select_generator."""


### PR DESCRIPTION
This change call's centipede's minimize_corpus method on each fuzzing round. 
This allows us to distill the corpus and only add useful units.
On a local run, this allowed to decrease the number of units added from 2000+ to 5 with the same coverage.
The cl also extracts some common functionality into engine_common.