### PR TITLE
Add the option to force the detection of OOMS and hangs, ignoring the redzone

### DIFF
--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_analyzer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_analyzer.py
@@ -93,8 +93,9 @@ def get_crash_data(crash_data,
   fuzz_target = fuzz_target or environment.get_value('FUZZ_TARGET')
   redzone_size = environment.get_value('REDZONE')
   if detect_ooms_and_hangs is None:
+    report_value = environment.get_value('REPORT_OOMS_AND_HANGS')
     detect_ooms_and_hangs = (
-        environment.get_value('REPORT_OOMS_AND_HANGS') and
+        report_value == 'FORCE' or report_value and
         (not redzone_size or
          redzone_size <= MAX_REDZONE_SIZE_FOR_OOMS_AND_HANGS))
 

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2606,8 +2606,9 @@ class StackAnalyzerTestcase(unittest.TestCase):
 
     See https://crbug.com/396148611.
     """
-    os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
+    os.environ['REPORT_OOMS_AND_HANGS'] = 'FORCE'
     os.environ['FUZZ_TARGET'] = 'foo'
+    os.environ['REDZONE'] = '256'
 
     data = self._read_test_data('centipede_timeout_abrt.txt')
     expected_type = 'Timeout'


### PR DESCRIPTION
the redzone prevents the detection of centipede timeouts, resulting in a lot of wrongly classified testcases https://crbug.com/396148611.

I wasn't able to find the reasons of the redzone limitation, so I went for a third value forcing.  Alternatively we might want to split ooms and hangs if only one is limited due to redzones? 