### PR TITLE
Add CF_TIP_BOOT_FAILED_COUNT metric for cuttlefish boot failures

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -23,6 +23,14 @@ BIG_QUERY_WRITE_COUNT = monitor.CounterMetric(
         monitor.BooleanField('success'),
     ])
 
+CF_TIP_BOOT_FAILED_COUNT = monitor.CounterMetric(
+    'tip_boot_failure',
+    description=
+    'Count of failure in booting up cuttlefish with tip-of-the-tree build ',
+    field_spec=[
+        monitor.StringField('build_id'),
+    ])
+
 JOB_BAD_BUILD_COUNT = monitor.CounterMetric(
     'task/fuzz/job/bad_build_count',
     description=("Count of fuzz task's bad build count "

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -29,6 +29,7 @@ CF_TIP_BOOT_FAILED_COUNT = monitor.CounterMetric(
     'Count of failure in booting up cuttlefish with tip-of-the-tree build ',
     field_spec=[
         monitor.StringField('build_id'),
+        monitor.BooleanField('is_succeeded'),
     ])
 
 JOB_BAD_BUILD_COUNT = monitor.CounterMetric(

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -21,6 +21,7 @@ from clusterfuzz._internal.base import dates
 from clusterfuzz._internal.base import persistent_cache
 from clusterfuzz._internal.datastore import locks
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.system import archive
 from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.system import shell
@@ -206,6 +207,9 @@ def flash_to_latest_build_if_needed():
     locks.release_lock(flash_lock_key_name, by_zone=True)
 
   if adb.get_device_state() != 'device':
+    monitoring_metrics.CF_TIP_BOOT_FAILED_COUNT.increment({
+        'build_id': build_info['bid']
+    })
     logs.error('Unable to find device. Reimaging failed.')
     adb.bad_state_reached()
 

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -208,11 +208,16 @@ def flash_to_latest_build_if_needed():
 
   if adb.get_device_state() != 'device':
     monitoring_metrics.CF_TIP_BOOT_FAILED_COUNT.increment({
-        'build_id': build_info['bid']
+        'build_id': build_info['bid'],
+        'is_succeeded': False
     })
     logs.error('Unable to find device. Reimaging failed.')
     adb.bad_state_reached()
 
+  monitoring_metrics.CF_TIP_BOOT_FAILED_COUNT.increment({
+      'build_id': build_info['bid'],
+      'is_succeeded': True
+  })
   logs.info('Reimaging finished.')
 
   # Reset all of our persistent keys after wipe.


### PR DESCRIPTION
This commit introduces the `CF_TIP_BOOT_FAILED_COUNT` metric to track failures when booting Cuttlefish with a tip-of-tree build. This metric is intended to be used as the basis for an alerting mechanism. By setting up an alerting policy on this metric, we can be notified when the number of tip-of-tree boot failures exceeds a defined threshold.