### PR TITLE
Fix AFL++ in ClusterFuzz.

### DIFF
--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -394,7 +394,7 @@ class UploadHandlerCommon:
 
     # Chrome is the only ClusterFuzz deployment where there are trusted bots running utasks.
     # This check also fails on oss-fuzz because of the way it abuses platform.
-    if (not trusted_agreement_signed and utils.is_chromium() and        
+    if (not trusted_agreement_signed and utils.is_chromium() and
         task_utils.is_remotely_executing_utasks() and
         ((platform_id and platform_id != 'Linux') or
          job.platform.lower() != 'linux')):

--- a/src/appengine/handlers/upload_testcase.py
+++ b/src/appengine/handlers/upload_testcase.py
@@ -392,8 +392,9 @@ class UploadHandlerCommon:
     trusted_agreement_signed = request.get(
         'trustedAgreement') == TRUSTED_AGREEMENT_TEXT.strip()
 
-    # Chrome is the only ClusterFuzz deployment where there are trusted bots running utasks.
-    # This check also fails on oss-fuzz because of the way it abuses platform.
+    # Chrome is the only ClusterFuzz deployment where there are trusted bots
+    # running utasks. This check also fails on oss-fuzz because of the way it
+    # abuses platform.
     if (not trusted_agreement_signed and utils.is_chromium() and
         task_utils.is_remotely_executing_utasks() and
         ((platform_id and platform_id != 'Linux') or

--- a/src/clusterfuzz/_internal/base/tasks/task_rate_limiting.py
+++ b/src/clusterfuzz/_internal/base/tasks/task_rate_limiting.py
@@ -38,7 +38,6 @@ _UTASK_PSEUDO_TASKS = {'uworker_main', 'postprocess', 'preprocess'}
 @memoize.wrap(memoize.FifoInMemory(1))
 def optin_to_task_rate_limiting():
   enabled = local_config.ProjectConfig().get('rate_limit_tasks.enabled', False)
-  logs.info(f'Using async HTTP: {enabled}.')
   return enabled
 
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/afl/launcher.py
@@ -1609,6 +1609,7 @@ def prepare_runner(fuzzer_path,
 
   # Add *SAN_OPTIONS overrides from .options file.
   engine_common.process_sanitizer_options_overrides(fuzzer_path)
+  environment.set_value('LSAN_OPTIONS', 'detect_leaks=0:symbolize=0')
 
   return runner
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -1107,13 +1107,12 @@ def utask_preprocess(fuzzer_name, job_type, uworker_env):
       last_execution_metadata and
       last_execution_metadata.status == data_types.TaskState.FINISHED)
 
-  # TODO: Revert me.
   # Make sure we're the only instance running for the given fuzzer and
   # job_type.
-  #if not data_handler.update_task_status(task_name,
-  #                                       data_types.TaskState.STARTED):
-  #  logs.info('A previous corpus pruning task is still running, exiting.')
-  #  return None
+  if not data_handler.update_task_status(task_name,
+                                         data_types.TaskState.STARTED):
+    logs.info('A previous corpus pruning task is still running, exiting.')
+    return None
 
   setup_input = (
       setup.preprocess_update_fuzzer_and_data_bundles(fuzz_target.engine))

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -1,4 +1,3 @@
-
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -286,9 +285,9 @@ def get_available_cpus(project: str, regions: List[str]) -> int:
   occupied_cpus = waiting_tasks * CPUS_PER_FUZZ_JOB + usage
   logs.info(f'Soon or currently occupied CPUs: {occupied_cpus}')
 
-  logs.info('Actually free CPUs (before subtracting soon '
-            f'occupied): {target}')
+  logs.info(f'Target number CPUs: {target}')
   available_cpus = max(target - occupied_cpus, 0)
+  logs.info(f'Available CPUs: {available_cpus}')
 
   # Don't schedule more than 50K tasks at once. So we don't overload batch.
   # This number is arbitrary, but we aren't at full capacity at lower numbers.

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/schedule_fuzz_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/schedule_fuzz_test.py
@@ -79,7 +79,7 @@ class OssfuzzFuzzTaskScheduler(unittest.TestCase):
     self.assertListEqual(comparable_results, expected_results)
 
 
-class TestGetCpuLimitForRegions(unittest.TestCase):
+class TestGetCpuUsage(unittest.TestCase):
   """Tests for get_cpu_limit_for_regions."""
 
   def setUp(self):
@@ -95,8 +95,7 @@ class TestGetCpuLimitForRegions(unittest.TestCase):
         'usage': 2
     }]
     self.assertEqual(
-        schedule_fuzz.get_cpu_limit_for_regions(self.creds, 'project',
-                                                'region'), 3)
+        schedule_fuzz.get_cpu_usage(self.creds, 'project', 'region'), 3)
 
   def test_cpus_and_preemptible_cpus(self):
     """Tests that get_cpu_limit_for_regions handles usage properly."""
@@ -110,5 +109,4 @@ class TestGetCpuLimitForRegions(unittest.TestCase):
         'usage': 5
     }]
     self.assertEqual(
-        schedule_fuzz.get_cpu_limit_for_regions(self.creds, 'region',
-                                                'project'), 5)
+        schedule_fuzz.get_cpu_usage(self.creds, 'region', 'project'), 5)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/schedule_fuzz_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/schedule_fuzz_test.py
@@ -95,7 +95,7 @@ class TestGetCpuUsage(unittest.TestCase):
         'usage': 2
     }]
     self.assertEqual(
-        schedule_fuzz.get_cpu_usage(self.creds, 'project', 'region'), 3)
+        schedule_fuzz.get_cpu_usage(self.creds, 'project', 'region'), (5, 2))
 
   def test_cpus_and_preemptible_cpus(self):
     """Tests that get_cpu_limit_for_regions handles usage properly."""
@@ -109,4 +109,4 @@ class TestGetCpuUsage(unittest.TestCase):
         'usage': 5
     }]
     self.assertEqual(
-        schedule_fuzz.get_cpu_usage(self.creds, 'region', 'project'), 5)
+        schedule_fuzz.get_cpu_usage(self.creds, 'region', 'project'), (5, 0))


### PR DESCRIPTION
AFL++ is broken because LSAN_OPTIONS are being set, but not in a way that AFL++ likes. Change things so that we always use the right options for AFL++.