### PR TITLE
Set a proper timeout for corpus minimization after a fuzzing session

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -188,7 +188,6 @@ class Engine(engine.Engine):
 
     return arguments
 
-  # pylint: disable=unused-argument
   def fuzz_additional_processing_timeout(self, options):
     """Return the maximum additional timeout in seconds for additional
     operations in fuzz() (e.g. merging back new items).
@@ -199,6 +198,7 @@ class Engine(engine.Engine):
     Returns:
       An int representing the number of seconds required.
     """
+    del options
     return engine_common.get_merge_timeout(engine_common.DEFAULT_MERGE_TIMEOUT)
 
   # pylint: disable=unused-argument

--- a/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/engine_common.py
@@ -74,6 +74,9 @@ RADAMSA_TIMEOUT = 3
 
 HEXDIGITS_SET = set(string.hexdigits)
 
+# Allow 30 minutes to merge the testcases back into the corpus.
+DEFAULT_MERGE_TIMEOUT = 30 * 60
+
 
 class Generator:
   """Generators we can use."""

--- a/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py
@@ -235,7 +235,7 @@ class Engine(engine.Engine):
           output_corpus_dir=merge_corpus,
           reproducers_dir=None,
           max_time=engine_common.get_merge_timeout(
-              libfuzzer.DEFAULT_MERGE_TIMEOUT))
+              engine_common.DEFAULT_MERGE_TIMEOUT))
 
       engine_common.move_mergeable_units(merge_corpus, corpus_dir)
       new_corpus_len = shell.get_directory_file_count(corpus_dir)

--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -39,9 +39,6 @@ from clusterfuzz._internal.system import shell
 # Maximum length of a random chosen length for `-max_len`.
 MAX_VALUE_FOR_MAX_LENGTH = 10000
 
-# Allow 30 minutes to merge the testcases back into the corpus.
-DEFAULT_MERGE_TIMEOUT = 30 * 60
-
 StrategyInfo = collections.namedtuple('StrategiesInfo', [
     'fuzzing_strategies',
     'arguments',
@@ -1296,7 +1293,7 @@ def get_fuzz_timeout(is_mutations_run, total_timeout=None):
   """Get the fuzz timeout."""
   fuzz_timeout = (
       engine_common.get_hard_timeout(total_timeout=total_timeout) -
-      engine_common.get_merge_timeout(DEFAULT_MERGE_TIMEOUT))
+      engine_common.get_merge_timeout(engine_common.DEFAULT_MERGE_TIMEOUT))
 
   if is_mutations_run:
     fuzz_timeout -= engine_common.get_new_testcase_mutations_timeout()

--- a/src/clusterfuzz/_internal/metrics/fuzzer_stats_schema.py
+++ b/src/clusterfuzz/_internal/metrics/fuzzer_stats_schema.py
@@ -855,6 +855,10 @@ _CENTIPEDE_SCHEMA = [{
     'mode': 'NULLABLE',
     'name': 'average_exec_per_sec',
     'type': 'FLOAT'
+}, {
+    'mode': 'NULLABLE',
+    'name': 'new_units_added',
+    'type': 'INTEGER'
 }] + _COMMON_COLUMNS
 
 _SCHEMA = {


### PR DESCRIPTION
This change also adds the collected new_units_added stat to the centipede schema.