### PR TITLE
fix: update wrong get_libfuzzer_flags to get_fuzzer_flags

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -545,7 +545,7 @@ class CrossPollinator:
     environment.reset_current_memory_tool_options(redzone_size=DEFAULT_REDZONE)
     self.runner.process_sanitizer_options()
 
-    additional_args = self.runner.get_libfuzzer_flags()
+    additional_args = self.runner.get_fuzzer_flags()
 
     try:
       result = self.runner.minimize_corpus(additional_args,

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/corpus_pruning_task_test.py
@@ -434,9 +434,11 @@ class CorpusPruningTestCentipede(unittest.TestCase, BaseTest):
     # Mocking some inputs to simplify
     # We should recover the random directory name for
     # asserting here
-    self.mock.minimize_corpus.assert_called_once_with(
+    self.mock.minimize_corpus.assert_called_with(
         self.engine, os.path.join(TEST_DIR, 'build/clusterfuzz_format_target'),
         [], [self.default_path], self.default_path, self.default_path, 79200)
+    # It should be called again on the CrossPolinator
+    self.assertEqual(self.mock.minimize_corpus.call_count, 2)
 
 
 class GetProtoTimestampTest(unittest.TestCase):


### PR DESCRIPTION
the `get_libfuzzer_flags` was renamed to `get_fuzzer_flags` but was wrongly invocated with the old name.