### PR TITLE
Add support for Chrome's new DCHECK message format

### DIFF
--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -1025,6 +1025,8 @@ class StackParser:
         self.update_state_on_check_failure(
             state, line, CHROME_CHECK_FAILURE_REGEX, 'CHECK failure')
         self.update_state_on_check_failure(
+            state, line, CHROME_DCHECK_FAILURE_REGEX, 'DCHECK failure')
+        self.update_state_on_check_failure(
             state, line, GOOGLE_CHECK_FAILURE_REGEX, 'CHECK failure')
 
         # V8 and Golang fatal errors.

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -86,6 +86,8 @@ CFI_NODEBUG_ERROR_MARKER_REGEX = re.compile(
     r'CFI: Most likely a control flow integrity violation;.*')
 CHROME_CHECK_FAILURE_REGEX = re.compile(
     r'\s*\[[^\]]*[:]([^\](]*).*\].*(?:Check failed:|NOTREACHED hit.)\s*(.*)')
+CHROME_DCHECK_FAILURE_REGEX = re.compile(
+    r'\s*\[[^\]]*[:]([^\](]*).*\].*(DCHECK failed:)\s*(.*)')
 CHROME_STACK_FRAME_REGEX = re.compile(
     r'[ ]*(#(?P<frame_id>[0-9]+)[ ]'  # frame id (2)
     r'([xX0-9a-fA-F]+)[ ])'  # addr (3)


### PR DESCRIPTION
Since we changed the output format of DCHECKs in Chrome, we need to handle that to prevent CF from considering the bugs fixed. In the meantime, we can add a 'DCHECK failure' error type to decouple checks and dchecks bugs.