### PR TITLE
FIX Prevent None values in GCP log labels

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -357,9 +357,10 @@ def configure_cloud_logging():
   #   the service account's project and the logging project.
   client = google.cloud.logging.Client(
       project=os.getenv('LOGGING_CLOUD_PROJECT_ID'))
+  # client.project
   labels = {
       'compute.googleapis.com/resource_name': socket.getfqdn().lower(),
-      'bot_name': os.getenv('BOT_NAME'),
+      'bot_name': os.getenv('BOT_NAME', 'null'),
   }
   handler = client.get_default_handler(labels=labels)
 

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -357,7 +357,6 @@ def configure_cloud_logging():
   #   the service account's project and the logging project.
   client = google.cloud.logging.Client(
       project=os.getenv('LOGGING_CLOUD_PROJECT_ID'))
-  # client.project
   labels = {
       'compute.googleapis.com/resource_name': socket.getfqdn().lower(),
       'bot_name': os.getenv('BOT_NAME', 'null'),


### PR DESCRIPTION
While locally debugging on my machine for b/403539825, I noticed `BOT_NAME` was not set. This prevented me from sending logs to GCP, but the error message wasn't obvious.

To prevent this issue for other developers working with logs in the future, I suggest we add a default string value (e.g., "null") when `BOT_NAME` is not available. This should not interfere with production.