### PR TITLE
builds: consider missing APP_PATH blackbox builds as bad builds

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1796,7 +1796,7 @@ class FuzzingSession:
 
     # Check if we have an application path. If not, our build failed
     # to setup correctly.
-    if not build_setup_result or not build_manager.check_app_path():
+    if not build_setup_result:
       return uworker_msg_pb2.Output(  # pylint: disable=no-member
           error_type=uworker_msg_pb2.ErrorType.FUZZ_BUILD_SETUP_FAILURE)  # pylint: disable=no-member
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -331,7 +331,7 @@ def _testcase_reproduces_in_revision(
         progression_task_output=progression_task_output,
         error_type=uworker_msg_pb2.ErrorType.PROGRESSION_BUILD_NOT_FOUND)  # pylint: disable=no-member
 
-  if not build_setup_result or not build_manager.check_app_path():
+  if not build_setup_result:
     # Let postprocess handle the failure and reschedule the task if needed.
     error_message = f'Build setup failed at r{revision}'
     return None, uworker_msg_pb2.Output(  # pylint: disable=no-member

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -127,7 +127,7 @@ def _testcase_reproduces_in_revision(
   fuzz_target_binary = fuzz_target.binary if fuzz_target else None
   build_setup_result = build_manager.setup_build(
       revision, fuzz_target=fuzz_target_binary)
-  if not build_setup_result or not build_manager.check_app_path():
+  if not build_setup_result:
     error_message = f'Build setup failed r{revision}'
     return None, uworker_msg_pb2.Output(  # pylint: disable=no-member
         regression_task_output=regression_task_output,

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1152,6 +1152,15 @@ def check_for_bad_build(job_type: str,
         should_ignore_crash_result=True,
         build_run_console_output='')
 
+  if environment.get_value(
+      'APP_NAME', None) and not bool(environment.get_value('APP_PATH')):
+    # This is a bad build, because we couldn't find the APP_NAME in the build.
+    return uworker_msg_pb2.BuildData(  # pylint: disable=no-member
+        revision=crash_revision,
+        is_bad_build=True,
+        should_ignore_crash_result=True,
+        build_run_console_output='')
+
   # Create a blank command line with no file to run and no http.
   command = get_command_line_for_application(file_to_run='', needs_http=False)
 


### PR DESCRIPTION
In cases where we have an APP_NAME and no APP_PATH set, it means we failed at finding the APP_NAME in the build. In such cases, it means we'll never be able to use them. For that reason, just mark those builds as bad.