### PR TITLE
Fix regression in regression task.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -281,12 +281,16 @@ def find_min_revision(
   assert next_index < max_index, (next_index, max_index)
   assert max_index <= crash_index, (max_index, crash_index)
 
+  # Make sure we account for MIN_REVISION.
+  first_revision = revisions.get_first_revision_in_list(revision_list)
+  first_index = revisions.find_min_revision_index(revision_list, first_revision)
+
   while True:
     # If we fall off the end of the revision list, try the earliest revision.
     # Note that if the earliest revision is bad, we will skip it and try the
     # next one. This will go on until we find the first good revision, at which
     # point we will stop looping.
-    next_index = max(next_index, 0)
+    next_index = max(next_index, first_index)
     next_revision = revision_list[next_index]
 
     if next_index == max_index:


### PR DESCRIPTION
After https://github.com/google/clusterfuzz/pull/3934, we stopped taking into account MIN_REVISION.

MIN_REVISION is usually used by jobs to indicate the minimum revision to start bisecting (because all builds prior are known to be "bad").

All jobs with MIN_REVISION set are currently failing regression because this is not respected.