### PR TITLE
MNT Introduces a flush interval for GCP logs

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -370,7 +370,7 @@ def configure_cloud_logging():
 
   # Rate for the BackgroundThreadTransport to flush the logs.
   handler.transport.worker._max_latency = int(
-      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60'))  # disable=protected-access
+      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60'))  # pylint: disable=protected-access
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -353,6 +353,7 @@ def configure_cloud_logging():
   """ Configure Google cloud logging, for bots not running on appengine nor k8s.
   """
   import google.cloud.logging
+  from google.cloud.logging.handlers.transports import BackgroundThreadTransport
 
   # project will default to the service account's project (likely from
   #   GOOGLE_APPLICATION_CREDENTIALS).
@@ -366,7 +367,8 @@ def configure_cloud_logging():
       'compute.googleapis.com/resource_name': socket.getfqdn().lower(),
       'bot_name': os.getenv('BOT_NAME', 'null'),
   }
-  handler = client.get_default_handler(labels=labels)
+  handler = client.get_default_handler(labels=labels)#, transport=BackgroundThreadTransport)
+  handler.transport.worker._max_latency = 60
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -353,7 +353,6 @@ def configure_cloud_logging():
   """ Configure Google cloud logging, for bots not running on appengine nor k8s.
   """
   import google.cloud.logging
-  from google.cloud.logging.handlers.transports import BackgroundThreadTransport
 
   # project will default to the service account's project (likely from
   #   GOOGLE_APPLICATION_CREDENTIALS).

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -367,7 +367,9 @@ def configure_cloud_logging():
       'compute.googleapis.com/resource_name': socket.getfqdn().lower(),
       'bot_name': os.getenv('BOT_NAME', 'null'),
   }
-  handler = client.get_default_handler(labels=labels)#, transport=BackgroundThreadTransport)
+  handler = client.get_default_handler(labels=labels)
+
+  # Rate for the BackgroundThreadTransport to flush the logs
   handler.transport.worker._max_latency = 60
 
   def cloud_label_filter(record):

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -369,17 +369,18 @@ def configure_cloud_logging():
       'bot_name': os.getenv('BOT_NAME', 'null'),
   }
 
-  class MaxLatencyTransport(BackgroundThreadTransport):
+  class FlushIntervalTransport(BackgroundThreadTransport):
 
     def __init__(self, client, name, **kwargs):
       super().__init__(
           client,
           name,
-          max_latency=int(os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60')),
+          grace_period=int(os.getenv('LOGGING_CLOUD_GRACE_PERIOD', '15')),
+          max_latency=int(os.getenv('LOGGING_CLOUD_MAX_LATENCY', '10')),
           **kwargs)
 
   handler = CloudLoggingHandler(
-      client=client, labels=labels, transport=MaxLatencyTransport)
+      client=client, labels=labels, transport=FlushIntervalTransport)
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -370,7 +370,7 @@ def configure_cloud_logging():
 
   # Rate for the BackgroundThreadTransport to flush the logs.
   handler.transport.worker._max_latency = int(
-      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60')) # pylint: disable=protected-access
+      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60')) : disable=protected-access
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -368,8 +368,9 @@ def configure_cloud_logging():
   }
   handler = client.get_default_handler(labels=labels)
 
-  # Rate for the BackgroundThreadTransport to flush the logs
-  handler.transport.worker._max_latency = 60
+  # Rate for the BackgroundThreadTransport to flush the logs.
+  handler.transport.worker._max_latency = int(
+      os.getenv('LOGGING_CLOUD_MAX_LATENCY', 60))
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -370,7 +370,7 @@ def configure_cloud_logging():
 
   # Rate for the BackgroundThreadTransport to flush the logs.
   handler.transport.worker._max_latency = int(
-      os.getenv('LOGGING_CLOUD_MAX_LATENCY', 60))
+      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60')) # pylint: disable=protected-access
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -369,7 +369,7 @@ def configure_cloud_logging():
   handler = client.get_default_handler(labels=labels)
 
   # Rate for the BackgroundThreadTransport to flush the logs
-  handler.transport.worker._max_latency = 5
+  handler.transport.worker._max_latency = 60
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -370,7 +370,7 @@ def configure_cloud_logging():
 
   # Rate for the BackgroundThreadTransport to flush the logs.
   handler.transport.worker._max_latency = int(
-      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60')) : disable=protected-access
+      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60'))  # disable=protected-access
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -369,8 +369,8 @@ def configure_cloud_logging():
   handler = client.get_default_handler(labels=labels)
 
   # Rate for the BackgroundThreadTransport to flush the logs.
-  handler.transport.worker._max_latency = int(
-      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60'))  # pylint: disable=protected-access
+  handler.transport.worker._max_latency = int(  # pylint: disable=protected-access
+      os.getenv('LOGGING_CLOUD_MAX_LATENCY', '60'))
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -369,7 +369,7 @@ def configure_cloud_logging():
   handler = client.get_default_handler(labels=labels)
 
   # Rate for the BackgroundThreadTransport to flush the logs
-  handler.transport.worker._max_latency = 60
+  handler.transport.worker._max_latency = 5
 
   def cloud_label_filter(record):
     # Update the labels with additional information.

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -19,10 +19,5 @@ from clusterfuzz._internal.system import environment
 
 def execute(args):  #pylint: disable=unused-argument
   """Build keywords."""
-  # environment.set_bot_environment()
-  # oss_fuzz_apply_ccs.main()
-  import logging
-  from clusterfuzz._internal.metrics import logs
-  logs.configure('run_cron')
-  logs.emit(logging.INFO, 'test carlolemos transport')
-  1 == 1
+  environment.set_bot_environment()
+  oss_fuzz_apply_ccs.main()

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -19,11 +19,5 @@ from clusterfuzz._internal.system import environment
 
 def execute(args):  #pylint: disable=unused-argument
   """Build keywords."""
-  import logging
-  from clusterfuzz._internal.metrics import logs
-  logs.configure('run_cron')
-  logs.emit(logging.INFO, 'test flush time carlolemos')
-  1 == 1
-  # environment.set_bot_environment()
-  # oss_fuzz_apply_ccs.main()
-  1 == 1
+  environment.set_bot_environment()
+  oss_fuzz_apply_ccs.main()

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -19,5 +19,10 @@ from clusterfuzz._internal.system import environment
 
 def execute(args):  #pylint: disable=unused-argument
   """Build keywords."""
-  environment.set_bot_environment()
-  oss_fuzz_apply_ccs.main()
+  # environment.set_bot_environment()
+  # oss_fuzz_apply_ccs.main()
+  import logging
+  from clusterfuzz._internal.metrics import logs
+  logs.configure('run_cron')
+  logs.emit(logging.INFO, 'test carlolemos transport')
+  1 == 1

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -19,5 +19,11 @@ from clusterfuzz._internal.system import environment
 
 def execute(args):  #pylint: disable=unused-argument
   """Build keywords."""
-  environment.set_bot_environment()
-  oss_fuzz_apply_ccs.main()
+  import logging
+  from clusterfuzz._internal.metrics import logs
+  logs.configure('run_cron')
+  logs.emit(logging.INFO, 'test flush time carlolemos')
+  1 == 1
+  # environment.set_bot_environment()
+  # oss_fuzz_apply_ccs.main()
+  1 == 1


### PR DESCRIPTION
[AFAICT](https://cloud.google.com/logging/docs/agent/logging/configuration#cloud-fluentd-config) Google cloud Fluentd logs used to have a flush mechanism to log to GCP only when `buffer_chunk_limit` got over 512kb or every `flush_interval` (that [was set to 60 seconds](https://github.com/google/clusterfuzz/blob/af69605ef6c36af9b459d4ba6a5ebb055d363a17/configs/test/gce/android-init.bash#L95)). 

[Default GCP transport handler](https://cloud.google.com/python/docs/reference/logging/latest/google.cloud.logging_v2.handlers.transports.background_thread.BackgroundThreadTransport#google_cloud_logging_v2_handlers_transports_background_thread_BackgroundThreadTransport) has a `max_interval` (analogous to `flush_interval` IIUC) of 0 seconds. This means that we don't wait at all to send GCP logs. This is making our log writing rate much greater than usual, causing our logging quota to explode (b/405350230 and b/405972925).

This PR changes the `max_interval` and `grace_period` to a higher number.

Thanks @javanlacerda and @ViniciustCosta for taking a look into this with me. :)