### PR TITLE
[Logging] Adding task argument and job_name to struc log, remove old task_id

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -277,10 +277,6 @@ def process_command(task):
                               task.high_end, task.is_command_override)
 
 
-def _get_task_id(task_name, task_argument, job_name):
-  return f'{task_name},{task_argument},{job_name},{uuid.uuid4()}'
-
-
 # pylint: disable=too-many-nested-blocks
 # TODO(mbarbella): Rewrite this function to avoid nesting issues.
 @set_task_payload
@@ -296,8 +292,11 @@ def process_command_impl(task_name, task_argument, job_name, high_end,
     # "postprocess".
     task_id = None
   else:
-    task_id = _get_task_id(task_name, task_argument, job_name)
+    task_id = uuid.uuid4()
   environment.set_value('CF_TASK_ID', task_id)
+  environment.set_value('CF_TASK_NAME', task_name)
+  environment.set_value('CF_TASK_ARGUMENT', task_argument)
+  environment.set_value('CF_TASK_JOB_NAME', job_name)
   if job_name != 'none':
     job = data_types.Job.query(data_types.Job.name == job_name).get()
     # Job might be removed. In that case, we don't want an exception
@@ -451,6 +450,9 @@ def process_command_impl(task_name, task_argument, job_name, high_end,
     uworker_env['TASK_ARGUMENT'] = task_argument
     uworker_env['JOB_NAME'] = job_name
     uworker_env['CF_TASK_ID'] = task_id
+    uworker_env['CF_TASK_NAME'] = task_name
+    uworker_env['CF_TASK_ARGUMENT'] = task_argument
+    uworker_env['CF_TASK_JOB_NAME'] = job_name
 
   # Match the cpu architecture with the ones required in the job definition.
   # If they don't match, then bail out and recreate task.
@@ -474,5 +476,9 @@ def process_command_impl(task_name, task_argument, job_name, high_end,
   finally:
     # Final clean up.
     cleanup_task_state()
-    if 'CF_TASK_ID' in os.environ:
-      del os.environ['CF_TASK_ID']
+    tear_down_envs = [
+        'CF_TASK_ID', 'CF_TASK_NAME', 'CF_TASK_ARGUMENT', 'CF_TASK_JOB_NAME'
+    ]
+    for env_key in tear_down_envs:
+      if env_key in os.environ:
+        del os.environ[env_key]

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -202,8 +202,6 @@ class JsonFormatter(logging.Formatter):
             record.name,
         'pid':
             os.getpid(),
-        'task_id':
-            os.getenv('CF_TASK_ID', 'null'),
         'release':
             os.getenv('CLUSTERFUZZ_RELEASE', 'prod'),
         'docker_image':
@@ -619,6 +617,8 @@ class GenericLogStruct(NamedTuple):
 class TaskLogStruct(NamedTuple):
   task_id: str
   task_name: str
+  task_argument: str
+  task_job_name: str
   stage: str
 
 
@@ -638,10 +638,16 @@ class LogContextType(enum.Enum):
       # TODO(javanlacerda): Remove this csv task_id and propagate it
       # properly, after cheking it works in production
       try:
-        current_task_id = os.getenv('CF_TASK_ID', '').split(",")
-        task_id = current_task_id[-1]
-        task_name = current_task_id[0]
-        return TaskLogStruct(task_id=task_id, task_name=task_name, stage=stage)
+        task_id = os.getenv('CF_TASK_ID', 'null')
+        task_name = os.getenv('CF_TASK_NAME', 'null')
+        task_argument = os.getenv('CF_TASK_ARGUMENT', 'null')
+        task_job_name = os.getenv('CF_TASK_JOB_NAME', 'null')
+        return TaskLogStruct(
+            task_id=task_id,
+            task_name=task_name,
+            task_argument=task_argument,
+            stage=stage,
+            task_job_name=task_job_name)
       except Exception as e:
         # This flag is necessary to avoid
         # infinite loop in this context verification


### PR DESCRIPTION
It adds `task argument` and `task job name` as properties of task structured log. 

It also removes the deprecated `task_id` that follows a csv pattern. 