### PR TITLE
[Fix] Fix metadata to retrieve fuzz target in testcase-based logging

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -683,10 +683,10 @@ class LogContextType(enum.Enum):
           return GenericLogStruct()
 
         fuzz_target = testcase.get_fuzz_target()
-        fuzz_target = fuzz_target.key.id() if fuzz_target else 'unknown'
+        fuzz_target_bin = fuzz_target.binary if fuzz_target else 'unknown'
         return TestcaseLogStruct(
             testcase_id=testcase.key.id(),  # type: ignore
-            fuzz_target=fuzz_target,
+            fuzz_target=fuzz_target_bin, # type: ignore
             job=testcase.job_type,  # type: ignore
             fuzzer=testcase.fuzzer_name  # type: ignore
         )

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -686,7 +686,7 @@ class LogContextType(enum.Enum):
         fuzz_target_bin = fuzz_target.binary if fuzz_target else 'unknown'
         return TestcaseLogStruct(
             testcase_id=testcase.key.id(),  # type: ignore
-            fuzz_target=fuzz_target_bin, # type: ignore
+            fuzz_target=fuzz_target_bin,  # type: ignore
             job=testcase.job_type,  # type: ignore
             fuzzer=testcase.fuzzer_name  # type: ignore
         )

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -539,7 +539,7 @@ class EmitTest(unittest.TestCase):
                 'target': 'bot',
                 'test': 'yes',
                 'testcase_id': 1,
-                'fuzz_target': 'libFuzzer_abc',
+                'fuzz_target': 'abc',
                 'job': 'test_job',
                 'fuzzer': 'test_fuzzer'
             },


### PR DESCRIPTION
Latest changes to add the fuzz target to the testcase-based structured logs was failing when retrieving the fuzz target as a key ID: [error](https://pantheon.corp.google.com/errors/detail/CNuqgM-PtKvgaA;locations=global;time=P30D?project=google.com:clusterfuzz&utm_source=error-reporting-notification&utm_medium=email&utm_content=new-error&e=-13802955&mods=logs_tg_prod&inv=1&invt=Abtmmg). 
This PR attempts to fix it by using the "binary" field from the FuzzTarget entity, which is also used in the ClusterFuzz frontend to represent the fuzz target.