### PR TITLE
bump ubuntu to 24

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ permissions: read-all
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
It bumps the ubuntu version for basic tests workflow as the 20.04 version will be deprecated. https://github.com/actions/runner-images/issues/11101