### PR TITLE
MNT Truncate exception messages in logs to fit GCP limits

### DIFF
--- a/local/polymer_bundler.py
+++ b/local/polymer_bundler.py
@@ -35,9 +35,14 @@ def build_file(filename):
   """Build a single file using polymer-bundler."""
   input_filename = os.path.join('private', 'templates', filename)
   output_filename = os.path.join('templates', filename)
-  os.system('polymer-bundler --inline-scripts --inline-css --strip-comments '
-            '--out-file={output_filename} {input_filename}'.format(
-                output_filename=output_filename, input_filename=input_filename))
+  subprocess.run([
+      'polymer-bundler',
+      '--inline-scripts',
+      '--inline-css',
+      '--strip-comments',
+      f'--out-file={output_filename}',
+      input_filename
+  ], check=True)
 
   if os.path.exists(output_filename) and os.path.getsize(output_filename):
     return True

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -35,10 +35,11 @@ if TYPE_CHECKING:
   from clusterfuzz._internal.datastore.data_types import Testcase
 
 # The maximum allowed log entry size is 256 KB for GCP. We set the
-# STACKDRIVER_LOG_MESSAGE_LIMIT to approximately 100 KB to accommodate both the
-# primary log message and potential traceback exceptions. This reserves roughly
-# 200 KB (100 KB each) for message content, leaving sufficient space for
-# structured logging metadata within the 256 KB total limit.
+# STACKDRIVER_LOG_MESSAGE_LIMIT to approximately 80 KB (under 100 KB) to
+# accommodate both the primary log message and potential traceback exceptions.
+# This reserves roughly up to 200 KB (up to 100 KB each) for message content,
+# leaving sufficient space for structured logging metadata within the 256 KB
+# total limit.
 STACKDRIVER_LOG_MESSAGE_LIMIT = 80000
 LOCAL_LOG_MESSAGE_LIMIT = 100000
 LOCAL_LOG_LIMIT = 500000

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -34,7 +34,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
   from clusterfuzz._internal.datastore.data_types import Testcase
 
-STACKDRIVER_LOG_MESSAGE_LIMIT = 80000  # Allowed log entry size is 100 KB.
+# The maximum allowed log entry size is 256 KB for GCP. We set the
+# STACKDRIVER_LOG_MESSAGE_LIMIT to approximately 100 KB to accommodate both the
+# primary log message and potential traceback exceptions. This reserves roughly
+# 200 KB (100 KB each) for message content, leaving sufficient space for
+# structured logging metadata within the 256 KB total limit.
+STACKDRIVER_LOG_MESSAGE_LIMIT = 80000
 LOCAL_LOG_MESSAGE_LIMIT = 100000
 LOCAL_LOG_LIMIT = 500000
 _logger = None
@@ -267,7 +272,11 @@ def update_entry_with_exc(entry, exc_info):
     formatted_exception = ''.join(
         traceback.format_exception(exc_info[0], exc_info[1], exc_info[2]))
 
-    # Truncate the formatted exception if it's too long.
+    # Original message and traceback truncation are done separately before
+    # combining. The start and end of a traceback are most important. The
+    # truncate function keeps the start/end of the input string. Applying this
+    # to a merged message+traceback could cut off the message's end or
+    # traceback's start.
     truncated_exception = truncate(formatted_exception,
                                    STACKDRIVER_LOG_MESSAGE_LIMIT)
     entry['message'] += '\n' + truncated_exception

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -37,9 +37,8 @@ if TYPE_CHECKING:
 # The maximum allowed log entry size is 256 KB for GCP. We set the
 # STACKDRIVER_LOG_MESSAGE_LIMIT to approximately 80 KB (under 100 KB) to
 # accommodate both the primary log message and potential traceback exceptions.
-# This reserves roughly up to 200 KB (up to 100 KB each) for message content,
-# leaving sufficient space for structured logging metadata within the 256 KB
-# total limit.
+# This reserves roughly up to 200 KB for message content, leaving sufficient
+# space for structured logging metadata within the 256 KB total limit.
 STACKDRIVER_LOG_MESSAGE_LIMIT = 80000
 LOCAL_LOG_MESSAGE_LIMIT = 100000
 LOCAL_LOG_LIMIT = 500000

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -264,8 +264,13 @@ def update_entry_with_exc(entry, exc_info):
   if exc_info[0]:
     # we need to set the result of traceback.format_exception to the field
     # `message`. And we move our
-    entry['message'] += '\n' + ''.join(
+    formatted_exception = ''.join(
         traceback.format_exception(exc_info[0], exc_info[1], exc_info[2]))
+
+    # Truncate the formatted exception if it's too long.
+    truncated_exception = truncate(formatted_exception,
+                                   STACKDRIVER_LOG_MESSAGE_LIMIT)
+    entry['message'] += '\n' + truncated_exception
   else:
     # If we log error without exception, we need to set
     # `context.reportLocation`.

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -17,6 +17,7 @@ import inspect
 import json
 import logging
 import os
+import re
 import sys
 import unittest
 from unittest import mock
@@ -151,17 +152,21 @@ class UpdateEntryWithExc(unittest.TestCase):
     logs.update_entry_with_exc(entry, exc_info)  # pylint: disable=used-before-assignment
     self.maxDiff = None
 
+    # self.assertIn('original\nTraceback \n', entry['message'])
+    # self.assertIn('characters truncated...\naaaaaaaaa\n', entry['message'])
+    self.assertRegex(
+        entry['message'],
+        r'original\nTraceback \n\.\.\.\d+ characters truncated\.\.\.\naaaaaaaaa\n',
+        re.DOTALL)
+    del entry['message']
     self.assertEqual({
         'extras': {
             'test': 'value'
         },
-        'task_payload':
-            'task',
+        'task_payload': 'task',
         'serviceContext': {
             'service': 'bots'
-        },
-        'message':
-            'original\nTraceback \n...222 characters truncated...\naaaaaaaaa\n'
+        }
     }, entry)
 
 

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -152,13 +152,12 @@ class UpdateEntryWithExc(unittest.TestCase):
     logs.update_entry_with_exc(entry, exc_info)  # pylint: disable=used-before-assignment
     self.maxDiff = None
 
-    # self.assertIn('original\nTraceback \n', entry['message'])
-    # self.assertIn('characters truncated...\naaaaaaaaa\n', entry['message'])
     self.assertRegex(
         entry['message'],
         r'original\nTraceback \n\.\.\.\d+ characters truncated\.\.\.\naaaaaaaaa\n',
         re.DOTALL)
     del entry['message']
+
     self.assertEqual({
         'extras': {
             'test': 'value'


### PR DESCRIPTION
Recently, @paulsemel [observed](https://chat.google.com/room/AAAALIZtBQE/PsfB7Jr1zFk/Vu0oVjjUFoo?cls=10) that some logs were not being received because they exceeded the size limit allowed by GCP (for [example](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2025-04-01T08:19:42.923556Z;endTime=2025-04-01T08:30:00.000Z;query=%22regression%22%0Aseverity%20%3D%20%22ERROR%22%0A%22Failed%20to%20submit%22%0Atimestamp%3D%222025-04-01T08:19:42.923556Z%22%0AinsertId%3D%22nl5t4lfbvzgo8%22%0Atimestamp%3D%222025-04-01T08:19:42.923556Z%22%0AinsertId%3D%22nl5t4lfbvzgo8%22;startTime=2025-04-01T00:35:00.000Z?project=google.com:clusterfuzz)). This PR applies the same logic we use to truncate very large messages in the traceback of exceptions that are added to the log messages.

b/408173151