### PR TITLE
[Fix] Add fuzz target as argument for logs context to avoid access deny to DB

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/progression_task.py
@@ -436,7 +436,7 @@ def _set_regression_testcase_upload_url(
 def utask_preprocess(testcase_id, job_type, uworker_env):
   """Runs preprocessing for progression task."""
   testcase = data_handler.get_testcase_by_id(testcase_id)
-  with logs.progression_log_context(testcase):
+  with logs.progression_log_context(testcase, testcase.get_fuzz_target()):
     if not testcase:
       return None
     if testcase.fixed:
@@ -684,7 +684,8 @@ def utask_main(uworker_input):
   """Executes the untrusted part of progression_task."""
   testcase = uworker_io.entity_from_protobuf(uworker_input.testcase,
                                              data_types.Testcase)
-  with logs.progression_log_context(testcase):
+  with logs.progression_log_context(
+      testcase, testcase_manager.get_fuzz_target_from_input(uworker_input)):
     uworker_io.check_handling_testcase_safe(testcase)
     return find_fixed_range(uworker_input)
 
@@ -714,7 +715,7 @@ def utask_postprocess(output: uworker_msg_pb2.Output):  # pylint: disable=no-mem
   """Trusted: Cleans up after a uworker execute_task, writing anything needed to
   the db."""
   testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
-  with logs.progression_log_context(testcase):
+  with logs.progression_log_context(testcase, testcase.get_fuzz_target()):
     _maybe_clear_progression_last_min_max_metadata(testcase, output)
     _cleanup_stacktrace_blob_from_storage(output)
     task_output = None

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/regression_task.py
@@ -592,7 +592,7 @@ def utask_preprocess(testcase_id: str, job_type: str,
   Runs on a trusted worker.
   """
   testcase = data_handler.get_testcase_by_id(testcase_id)
-  with logs.regression_log_context(testcase):
+  with logs.regression_log_context(testcase, testcase.get_fuzz_target()):
     if testcase.regression:
       logs.error(
           f'Regression range is already set as {testcase.regression}, skip.')
@@ -634,7 +634,8 @@ def utask_main(
   """
   testcase = uworker_io.entity_from_protobuf(uworker_input.testcase,
                                              data_types.Testcase)
-  with logs.regression_log_context(testcase):
+  with logs.regression_log_context(
+      testcase, testcase_manager.get_fuzz_target_from_input(uworker_input)):
     uworker_io.check_handling_testcase_safe(testcase)
     return find_regression_range(uworker_input)
 
@@ -731,7 +732,7 @@ def utask_postprocess(output: uworker_msg_pb2.Output) -> None:  # pylint: disabl
   testcase_id = output.uworker_input.testcase_id
   # Retrieve the testcase early to be used by logs context.
   testcase = data_handler.get_testcase_by_id(testcase_id)
-  with logs.regression_log_context(testcase):
+  with logs.regression_log_context(testcase, testcase.get_fuzz_target()):
     testcase_utils.emit_testcase_triage_duration_metric(
         int(testcase_id),
         testcase_utils.TESTCASE_TRIAGE_DURATION_REGRESSION_COMPLETED_STEP)

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -804,7 +804,12 @@ def task_stage_context(stage: Stage):
 @contextlib.contextmanager
 def testcase_log_context(testcase: 'Testcase',
                          fuzz_target: 'FuzzTarget | None'):
-  """Creates a testcase context for a given testcase"""
+  """Creates a testcase-based context for a given testcase.
+
+  Fuzz target as an argument is needed since retrieving this entity depends on
+  the task's stage. In trusted part, it can be retrieved by querying the DB,
+  while in untrusted part is only accessible through the protobuf.
+  """
   with wrap_log_context(contexts=[LogContextType.TESTCASE]):
     try:
       log_contexts.add_metadata('testcase', testcase)

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -557,11 +557,14 @@ class EmitTest(unittest.TestCase):
         fuzzer_name="test_fuzzer", job_type='test_job')
     testcase.put()
 
-    with logs.progression_log_context(testcase):
+    with logs.progression_log_context(testcase, fuzz_target):
       self.assertEqual(
           logs.log_contexts.contexts,
           [logs.LogContextType.TESTCASE, logs.LogContextType.PROGRESSION])
-      self.assertEqual(logs.log_contexts.meta, {'testcase': testcase})
+      self.assertEqual(logs.log_contexts.meta, {
+          'testcase': testcase,
+          'fuzz_target': fuzz_target
+      })
       statement_line = inspect.currentframe().f_lineno + 1
       logs.emit(logging.ERROR, 'msg', exc_info='ex', target='bot', test='yes')
 

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -656,6 +656,47 @@ class EmitTest(unittest.TestCase):
             },
         })
 
+  def test_missing_fuzz_target_in_log_context(self):
+    """Test the testcase-based log context when the fuzz target is missing."""
+    from clusterfuzz._internal.datastore import data_types
+    logger = mock.MagicMock()
+    self.mock.get_logger.return_value = logger
+    testcase = data_types.Testcase(
+        fuzzer_name="test_fuzzer", job_type='test_job')
+    testcase.set_metadata('fuzzer_binary_name', 'fuzz_abc')
+    testcase.put()
+
+    with logs.regression_log_context(testcase, None):
+      self.assertEqual(
+          logs.log_contexts.contexts,
+          [logs.LogContextType.TESTCASE, logs.LogContextType.REGRESSION])
+      self.assertEqual(logs.log_contexts.meta, {
+          'testcase': testcase,
+          'fuzz_target': None
+      })
+      statement_line = inspect.currentframe().f_lineno + 1
+      logs.emit(logging.ERROR, 'msg', exc_info='ex', target='bot', test='yes')
+
+    logger.log.assert_called_with(
+        logging.ERROR,
+        'msg',
+        exc_info='ex',
+        extra={
+            'extras': {
+                'target': 'bot',
+                'test': 'yes',
+                'testcase_id': 1,
+                'fuzz_target': 'fuzz_abc',
+                'job': 'test_job',
+                'fuzzer': 'test_fuzzer'
+            },
+            'location': {
+                'path': os.path.abspath(__file__).rstrip('c'),
+                'line': statement_line,
+                'method': 'test_missing_fuzz_target_in_log_context'
+            },
+        })
+
 
 class TruncateTest(unittest.TestCase):
   """Test truncate."""


### PR DESCRIPTION
After adding structured logs to testcase-based tasks (https://github.com/google/clusterfuzz/pull/4736), a new error group started showing up due to insufficient permissions/no current context for accessing datastore. This is probably due to querying for the testcase's fuzz target during `utask_main` execution in logs.

This tries to solve it by adding the fuzz target as an argument for the logs context, since we can retrieve it from the datastore entity in trusted part and from the protobuf during the untrusted part of the task.