### PR TITLE
[Logging] Move error to warning for log context logs

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -795,7 +795,7 @@ def task_stage_context(stage: Stage):
       log_contexts.add_metadata('stage', stage)
       yield
     except Exception as e:
-      error(message='Error during task.')
+      warning(message='Error during task.')
       raise e
     finally:
       log_contexts.delete_metadata('stage')
@@ -816,7 +816,7 @@ def testcase_log_context(testcase: 'Testcase',
       log_contexts.add_metadata('fuzz_target', fuzz_target)
       yield
     except Exception as e:
-      error(message='Error during testcase context.')
+      warning(message='Error during testcase context.')
       raise e
     finally:
       log_contexts.delete_metadata('testcase')

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -816,6 +816,9 @@ def testcase_log_context(testcase: 'Testcase',
       log_contexts.add_metadata('fuzz_target', fuzz_target)
       yield
     except Exception as e:
+      # We've put as warning because this error will be
+      # handled in a upper level, and we would like to have
+      # a way to track it with the current context logs
       warning(message='Error during testcase context.')
       raise e
     finally:


### PR DESCRIPTION
We're moving the logging level from error to warning for exceptions that was caught during log context. We need to do this because this errors are already handled in the uper level, but we want to log it as warning to have visibility with the strucutred logs.