### PR TITLE
Index last_run field in FuzzTargetJob to avoid cleanup timeouts

### DIFF
--- a/src/appengine/index.yaml
+++ b/src/appengine/index.yaml
@@ -106,6 +106,7 @@ indexes:
   properties:
   - name: engine
   - name: weight
+  - name: last_run
 
 - kind: ReportMetadata
   properties:


### PR DESCRIPTION
As per b/406250205, the cleanup cronjob in chrome is failing due to timeouts in the FuzzTargetJob entity, when querying for the last_run field. This PR intends to fix that by indexing the field in question.

This is the problematic line of code:

https://github.com/google/clusterfuzz/blob/aa7e6140da2f947f91a8e58e4399c50446723268/src/clusterfuzz/_internal/cron/cleanup.py#L195C1-L196C1

This entity is accessed in many parts of the code, so it is a prime candidate for contential. For instance:
https://github.com/google/clusterfuzz/blob/aa7e6140da2f947f91a8e58e4399c50446723268/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py#L2019