### PR TITLE
Have a single index for last_run in FuzzTargetJob

### DIFF
--- a/src/appengine/index.yaml
+++ b/src/appengine/index.yaml
@@ -106,6 +106,9 @@ indexes:
   properties:
   - name: engine
   - name: weight
+
+- kind: FuzzTargetJob
+  properties:
   - name: last_run
 
 - kind: ReportMetadata


### PR DESCRIPTION
#4763 wrongly added the last_run field to a preexisting composite index, it should have been a new index only for last_run