### PR TITLE
[Logging] Extend testcase-based logs to Symbolize task

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
@@ -49,183 +49,191 @@ def handle_build_setup_error(output):
   tasks.add_task('symbolize', testcase_id, job_type, wait_time=build_fail_wait)
 
 
+def _utask_preprocess(testcase_id, job_type, uworker_env, testcase):
+  """Run preprocessing for symbolize task."""
+  # We should atleast have a symbolized debug or release build.
+  if not build_manager.has_symbolized_builds():
+    return None
+
+  data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
+
+  # Setup testcase and its dependencies.
+  setup_input = setup.preprocess_setup_testcase(testcase, uworker_env)
+
+  old_crash_stacktrace = data_handler.get_stacktrace(testcase)
+  return uworker_msg_pb2.Input(  # pylint: disable=no-member
+      job_type=job_type,
+      testcase_id=testcase_id,
+      uworker_env=uworker_env,
+      setup_input=setup_input,
+      testcase=uworker_io.entity_to_protobuf(testcase),
+      symbolize_task_input=uworker_msg_pb2.SymbolizeTaskInput(  # pylint: disable=no-member
+          old_crash_stacktrace=old_crash_stacktrace))
+
+
 def utask_preprocess(testcase_id, job_type, uworker_env):
-  """Runs preprocessing for symbolize task."""
+  """Set logs context and run preprocessing for symbolize task."""
   # Locate the testcase associated with the id.
   testcase = data_handler.get_testcase_by_id(testcase_id)
-
   with logs.symbolize_log_context(testcase, testcase.get_fuzz_target()):
-    # We should atleast have a symbolized debug or release build.
-    if not build_manager.has_symbolized_builds():
-      return None
+    return _utask_preprocess(testcase_id, job_type, uworker_env, testcase)
 
-    data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
-    # Setup testcase and its dependencies.
-    setup_input = setup.preprocess_setup_testcase(testcase, uworker_env)
+def _utask_main(uworker_input, testcase):
+  """Execute the untrusted part of a symbolize command."""
+  job_type = uworker_input.job_type
+  uworker_io.check_handling_testcase_safe(testcase)
+  job_type = uworker_input.job_type
+  setup_input = uworker_input.setup_input
 
-    old_crash_stacktrace = data_handler.get_stacktrace(testcase)
-    return uworker_msg_pb2.Input(  # pylint: disable=no-member
-        job_type=job_type,
-        testcase_id=testcase_id,
-        uworker_env=uworker_env,
-        setup_input=setup_input,
-        testcase=uworker_io.entity_to_protobuf(testcase),
-        symbolize_task_input=uworker_msg_pb2.SymbolizeTaskInput(  # pylint: disable=no-member
-            old_crash_stacktrace=old_crash_stacktrace))
+  _, testcase_file_path, error = setup.setup_testcase(testcase, job_type,
+                                                      setup_input)
+  if error:
+    return error
+
+  # Initialize variables.
+  old_crash_stacktrace = (
+      uworker_input.symbolize_task_input.old_crash_stacktrace)
+  sym_crash_address = testcase.crash_address
+  sym_crash_state = testcase.crash_state
+  sym_redzone = DEFAULT_REDZONE
+  warmup_timeout = environment.get_value('WARMUP_TIMEOUT')
+
+  # Decide which build revision to use.
+  if testcase.crash_stacktrace == 'Pending':
+    # This usually happen when someone clicked the 'Update stacktrace from
+    # trunk' button on the testcase details page. In this case, we are forced
+    # to use trunk. No revision -> trunk build.
+    build_revision = None
+  else:
+    build_revision = testcase.crash_revision
+
+  fuzz_target = testcase_manager.get_fuzz_target_from_input(uworker_input)
+  fuzz_target = fuzz_target.binary if fuzz_target else None
+  # Set up a custom or regular build based on revision.
+  build = build_manager.setup_build(build_revision, fuzz_target)
+
+  # Get crash revision used in setting up build.
+  crash_revision = environment.get_value('APP_REVISION')
+
+  if not build or not build_manager.check_app_path():
+    return uworker_msg_pb2.Output(  # pylint: disable=no-member
+        error_message='Build setup failed',
+        error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)  # pylint: disable=no-member
+
+  # ASAN tool settings (if the tool is used).
+  # See if we can get better stacks with higher redzone sizes.
+  # A UAF might actually turn out to be OOB read/write with a bigger redzone.
+  if environment.tool_matches('ASAN', job_type) and testcase.security_flag:
+    redzone = MAX_REDZONE
+    while redzone >= MIN_REDZONE:
+      logs.info(f'Trying to reproduce crash with ASAN redzone size {redzone}.')
+
+      environment.reset_current_memory_tool_options(
+          redzone_size=testcase.redzone, disable_ubsan=testcase.disable_ubsan)
+
+      process_handler.terminate_stale_application_instances()
+      command = testcase_manager.get_command_line_for_application(
+          testcase_file_path, needs_http=testcase.http_flag)
+      return_code, crash_time, output = (
+          process_handler.run_process(
+              command, timeout=warmup_timeout, gestures=testcase.gestures))
+      crash_result = CrashResult(return_code, crash_time, output)
+
+      if crash_result.is_crash() and 'AddressSanitizer' in output:
+        state = crash_result.get_symbolized_data()
+        security_flag = crash_result.is_security_issue()
+
+        if crash_analyzer.ignore_stacktrace(state.crash_stacktrace):
+          logs.info(
+              f'Skipping crash with ASAN redzone size {redzone}: ' +
+              'stack trace should be ignored.',
+              stacktrace=state.crash_stacktrace)
+        elif security_flag != testcase.security_flag:
+          logs.info(
+              f'Skipping crash with ASAN redzone size {redzone}: ' +
+              f'mismatched security flag: old = {testcase.security_flag}, '
+              f'new = {security_flag}')
+        elif state.crash_type != testcase.crash_type:
+          logs.info(f'Skipping crash with ASAN redzone size {redzone}: ' +
+                    f'mismatched crash type: old = {testcase.crash_type}, '
+                    f'new = {state.crash_type}')
+        elif state.crash_state == sym_crash_state:
+          logs.info(f'Skipping crash with ASAN redzone size {redzone}: ' +
+                    f'same crash state = {sym_crash_state}')
+        else:
+          logs.info(f'Using crash with larger ASAN redzone size {redzone}: ' +
+                    f'old crash address = {sym_crash_address}, ' +
+                    f'new crash address = {state.crash_address}, ' +
+                    f'old crash state = {sym_crash_state}, ' +
+                    f'new crash state = {state.crash_state}')
+
+          sym_crash_address = state.crash_address
+          sym_crash_state = state.crash_state
+          sym_redzone = redzone
+          old_crash_stacktrace = state.crash_stacktrace
+          break
+
+      redzone /= 2
+
+  # We no longer need this build, delete it to save some disk space. We will
+  # download a symbolized release build to perform the symbolization.
+  build.delete()
+
+  # We should have atleast a symbolized debug or a release build.
+  symbolized_builds = build_manager.setup_symbolized_builds(crash_revision)
+  if (not symbolized_builds or
+      (not build_manager.check_app_path() and
+       not build_manager.check_app_path('APP_PATH_DEBUG'))):
+    return uworker_msg_pb2.Output(  # pylint: disable=no-member
+        error_message='Build setup failed',
+        error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)  # pylint: disable=no-member
+
+  # Increase malloc_context_size to get all stack frames. Default is 30.
+  environment.reset_current_memory_tool_options(
+      redzone_size=sym_redzone,
+      malloc_context_size=STACK_FRAME_COUNT,
+      symbolize_inline_frames=True,
+      disable_ubsan=testcase.disable_ubsan)
+
+  # TSAN tool settings (if the tool is used).
+  if environment.tool_matches('TSAN', job_type):
+    environment.set_tsan_max_history_size()
+
+  # Do the symbolization if supported by this application.
+  result, sym_crash_stacktrace = (
+      get_symbolized_stacktraces(testcase_file_path, testcase,
+                                 old_crash_stacktrace, sym_crash_state))
+
+  symbolize_task_output = uworker_msg_pb2.SymbolizeTaskOutput(  # pylint: disable=no-member
+      crash_type=testcase.crash_type,
+      crash_address=sym_crash_address,
+      crash_state=sym_crash_state,
+      crash_stacktrace=(data_handler.filter_stacktrace(sym_crash_stacktrace)),
+      symbolized=result,
+      crash_revision=int(crash_revision))
+
+  if result:
+    build_url = environment.get_value('BUILD_URL')
+    if build_url:
+      symbolize_task_output.build_url = str(build_url)
+
+  # Switch current directory before builds cleanup.
+  root_directory = environment.get_value('ROOT_DIR')
+  os.chdir(root_directory)
+
+  # Cleanup symbolized builds which are space-heavy.
+  symbolized_builds.delete()
+  return uworker_msg_pb2.Output(symbolize_task_output=symbolize_task_output)  # pylint: disable=no-member
 
 
 def utask_main(uworker_input):
-  """Execute the untrusted part of a symbolize command."""
-  job_type = uworker_input.job_type
+  """Set logs context and run the untrusted part of a symbolize command."""
   testcase = uworker_io.entity_from_protobuf(uworker_input.testcase,
                                              data_types.Testcase)
   with logs.symbolize_log_context(
       testcase, testcase_manager.get_fuzz_target_from_input(uworker_input)):
-    uworker_io.check_handling_testcase_safe(testcase)
-    job_type = uworker_input.job_type
-    setup_input = uworker_input.setup_input
-
-    _, testcase_file_path, error = setup.setup_testcase(testcase, job_type,
-                                                        setup_input)
-    if error:
-      return error
-
-    # Initialize variables.
-    old_crash_stacktrace = (
-        uworker_input.symbolize_task_input.old_crash_stacktrace)
-    sym_crash_address = testcase.crash_address
-    sym_crash_state = testcase.crash_state
-    sym_redzone = DEFAULT_REDZONE
-    warmup_timeout = environment.get_value('WARMUP_TIMEOUT')
-
-    # Decide which build revision to use.
-    if testcase.crash_stacktrace == 'Pending':
-      # This usually happen when someone clicked the 'Update stacktrace from
-      # trunk' button on the testcase details page. In this case, we are forced
-      # to use trunk. No revision -> trunk build.
-      build_revision = None
-    else:
-      build_revision = testcase.crash_revision
-
-    fuzz_target = testcase_manager.get_fuzz_target_from_input(uworker_input)
-    fuzz_target = fuzz_target.binary if fuzz_target else None
-    # Set up a custom or regular build based on revision.
-    build = build_manager.setup_build(build_revision, fuzz_target)
-
-    # Get crash revision used in setting up build.
-    crash_revision = environment.get_value('APP_REVISION')
-
-    if not build or not build_manager.check_app_path():
-      return uworker_msg_pb2.Output(  # pylint: disable=no-member
-          error_message='Build setup failed',
-          error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)  # pylint: disable=no-member
-
-    # ASAN tool settings (if the tool is used).
-    # See if we can get better stacks with higher redzone sizes.
-    # A UAF might actually turn out to be OOB read/write with a bigger redzone.
-    if environment.tool_matches('ASAN', job_type) and testcase.security_flag:
-      redzone = MAX_REDZONE
-      while redzone >= MIN_REDZONE:
-        logs.info(
-            f'Trying to reproduce crash with ASAN redzone size {redzone}.')
-
-        environment.reset_current_memory_tool_options(
-            redzone_size=testcase.redzone, disable_ubsan=testcase.disable_ubsan)
-
-        process_handler.terminate_stale_application_instances()
-        command = testcase_manager.get_command_line_for_application(
-            testcase_file_path, needs_http=testcase.http_flag)
-        return_code, crash_time, output = (
-            process_handler.run_process(
-                command, timeout=warmup_timeout, gestures=testcase.gestures))
-        crash_result = CrashResult(return_code, crash_time, output)
-
-        if crash_result.is_crash() and 'AddressSanitizer' in output:
-          state = crash_result.get_symbolized_data()
-          security_flag = crash_result.is_security_issue()
-
-          if crash_analyzer.ignore_stacktrace(state.crash_stacktrace):
-            logs.info(
-                f'Skipping crash with ASAN redzone size {redzone}: ' +
-                'stack trace should be ignored.',
-                stacktrace=state.crash_stacktrace)
-          elif security_flag != testcase.security_flag:
-            logs.info(
-                f'Skipping crash with ASAN redzone size {redzone}: ' +
-                f'mismatched security flag: old = {testcase.security_flag}, '
-                f'new = {security_flag}')
-          elif state.crash_type != testcase.crash_type:
-            logs.info(f'Skipping crash with ASAN redzone size {redzone}: ' +
-                      f'mismatched crash type: old = {testcase.crash_type}, '
-                      f'new = {state.crash_type}')
-          elif state.crash_state == sym_crash_state:
-            logs.info(f'Skipping crash with ASAN redzone size {redzone}: ' +
-                      f'same crash state = {sym_crash_state}')
-          else:
-            logs.info(f'Using crash with larger ASAN redzone size {redzone}: ' +
-                      f'old crash address = {sym_crash_address}, ' +
-                      f'new crash address = {state.crash_address}, ' +
-                      f'old crash state = {sym_crash_state}, ' +
-                      f'new crash state = {state.crash_state}')
-
-            sym_crash_address = state.crash_address
-            sym_crash_state = state.crash_state
-            sym_redzone = redzone
-            old_crash_stacktrace = state.crash_stacktrace
-            break
-
-        redzone /= 2
-
-    # We no longer need this build, delete it to save some disk space. We will
-    # download a symbolized release build to perform the symbolization.
-    build.delete()
-
-    # We should have atleast a symbolized debug or a release build.
-    symbolized_builds = build_manager.setup_symbolized_builds(crash_revision)
-    if (not symbolized_builds or
-        (not build_manager.check_app_path() and
-         not build_manager.check_app_path('APP_PATH_DEBUG'))):
-      return uworker_msg_pb2.Output(  # pylint: disable=no-member
-          error_message='Build setup failed',
-          error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)  # pylint: disable=no-member
-
-    # Increase malloc_context_size to get all stack frames. Default is 30.
-    environment.reset_current_memory_tool_options(
-        redzone_size=sym_redzone,
-        malloc_context_size=STACK_FRAME_COUNT,
-        symbolize_inline_frames=True,
-        disable_ubsan=testcase.disable_ubsan)
-
-    # TSAN tool settings (if the tool is used).
-    if environment.tool_matches('TSAN', job_type):
-      environment.set_tsan_max_history_size()
-
-    # Do the symbolization if supported by this application.
-    result, sym_crash_stacktrace = (
-        get_symbolized_stacktraces(testcase_file_path, testcase,
-                                   old_crash_stacktrace, sym_crash_state))
-
-    symbolize_task_output = uworker_msg_pb2.SymbolizeTaskOutput(  # pylint: disable=no-member
-        crash_type=testcase.crash_type,
-        crash_address=sym_crash_address,
-        crash_state=sym_crash_state,
-        crash_stacktrace=(data_handler.filter_stacktrace(sym_crash_stacktrace)),
-        symbolized=result,
-        crash_revision=int(crash_revision))
-
-    if result:
-      build_url = environment.get_value('BUILD_URL')
-      if build_url:
-        symbolize_task_output.build_url = str(build_url)
-
-    # Switch current directory before builds cleanup.
-    root_directory = environment.get_value('ROOT_DIR')
-    os.chdir(root_directory)
-
-    # Cleanup symbolized builds which are space-heavy.
-    symbolized_builds.delete()
-    return uworker_msg_pb2.Output(symbolize_task_output=symbolize_task_output)  # pylint: disable=no-member
+    return _utask_main(uworker_input, testcase)
 
 
 def get_symbolized_stacktraces(testcase_file_path, testcase,
@@ -323,43 +331,49 @@ _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
 )
 
 
-def utask_postprocess(output):
+def _utask_postprocess(output, testcase):
   """Handle the output from utask_main."""
+  if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
+    _ERROR_HANDLER.handle(output)
+    return
+
+  symbolize_task_output = output.symbolize_task_output
+
+  # Update crash parameters.
+  testcase.crash_type = symbolize_task_output.crash_type
+  testcase.crash_address = symbolize_task_output.crash_address
+  testcase.crash_state = symbolize_task_output.crash_state
+  testcase.crash_stacktrace = symbolize_task_output.crash_stacktrace
+
+  if not symbolize_task_output.symbolized:
+    data_handler.update_testcase_comment(
+        testcase, data_types.TaskState.ERROR,
+        'Unable to reproduce crash, skipping '
+        'stacktrace update')
+  else:
+    # Switch build url to use the less-optimized symbolized build with better
+    # stacktrace.
+    if symbolize_task_output.build_url:
+      testcase.set_metadata(
+          'build_url', symbolize_task_output.build_url, update_testcase=False)
+
+    data_handler.update_testcase_comment(testcase,
+                                         data_types.TaskState.FINISHED)
+
+  testcase.symbolized = True
+  testcase.crash_revision = symbolize_task_output.crash_revision
+  testcase.put()
+
+  # We might have updated the crash state. See if we need to marked as duplicate
+  # based on other testcases.
+  data_handler.handle_duplicate_entry(testcase)
+
+  task_creation.create_blame_task_if_needed(testcase)
+
+
+def utask_postprocess(output):
+  """Set logs context and handle the output from utask_main."""
+  # Retrieve the testcase associated with the id.
   testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
   with logs.symbolize_log_context(testcase, testcase.get_fuzz_target()):
-    if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
-      _ERROR_HANDLER.handle(output)
-      return
-
-    symbolize_task_output = output.symbolize_task_output
-
-    # Update crash parameters.
-    testcase.crash_type = symbolize_task_output.crash_type
-    testcase.crash_address = symbolize_task_output.crash_address
-    testcase.crash_state = symbolize_task_output.crash_state
-    testcase.crash_stacktrace = symbolize_task_output.crash_stacktrace
-
-    if not symbolize_task_output.symbolized:
-      data_handler.update_testcase_comment(
-          testcase, data_types.TaskState.ERROR,
-          'Unable to reproduce crash, skipping '
-          'stacktrace update')
-    else:
-      # Switch build url to use the less-optimized symbolized build with better
-      # stacktrace.
-      if symbolize_task_output.build_url:
-        testcase.set_metadata(
-            'build_url', symbolize_task_output.build_url, update_testcase=False)
-
-      data_handler.update_testcase_comment(testcase,
-                                           data_types.TaskState.FINISHED)
-
-    testcase.symbolized = True
-    testcase.crash_revision = symbolize_task_output.crash_revision
-    testcase.put()
-
-    # We might have updated the crash state. See if we need to marked as
-    # duplicate based on other testcases.
-    data_handler.handle_duplicate_entry(testcase)
-
-    task_creation.create_blame_task_if_needed(testcase)
+    return _utask_postprocess(output, testcase)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/symbolize_task.py
@@ -54,24 +54,25 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
   # Locate the testcase associated with the id.
   testcase = data_handler.get_testcase_by_id(testcase_id)
 
-  # We should atleast have a symbolized debug or release build.
-  if not build_manager.has_symbolized_builds():
-    return None
+  with logs.symbolize_log_context(testcase, testcase.get_fuzz_target()):
+    # We should atleast have a symbolized debug or release build.
+    if not build_manager.has_symbolized_builds():
+      return None
 
-  data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
+    data_handler.update_testcase_comment(testcase, data_types.TaskState.STARTED)
 
-  # Setup testcase and its dependencies.
-  setup_input = setup.preprocess_setup_testcase(testcase, uworker_env)
+    # Setup testcase and its dependencies.
+    setup_input = setup.preprocess_setup_testcase(testcase, uworker_env)
 
-  old_crash_stacktrace = data_handler.get_stacktrace(testcase)
-  return uworker_msg_pb2.Input(  # pylint: disable=no-member
-      job_type=job_type,
-      testcase_id=testcase_id,
-      uworker_env=uworker_env,
-      setup_input=setup_input,
-      testcase=uworker_io.entity_to_protobuf(testcase),
-      symbolize_task_input=uworker_msg_pb2.SymbolizeTaskInput(  # pylint: disable=no-member
-          old_crash_stacktrace=old_crash_stacktrace))
+    old_crash_stacktrace = data_handler.get_stacktrace(testcase)
+    return uworker_msg_pb2.Input(  # pylint: disable=no-member
+        job_type=job_type,
+        testcase_id=testcase_id,
+        uworker_env=uworker_env,
+        setup_input=setup_input,
+        testcase=uworker_io.entity_to_protobuf(testcase),
+        symbolize_task_input=uworker_msg_pb2.SymbolizeTaskInput(  # pylint: disable=no-member
+            old_crash_stacktrace=old_crash_stacktrace))
 
 
 def utask_main(uworker_input):
@@ -79,149 +80,152 @@ def utask_main(uworker_input):
   job_type = uworker_input.job_type
   testcase = uworker_io.entity_from_protobuf(uworker_input.testcase,
                                              data_types.Testcase)
-  uworker_io.check_handling_testcase_safe(testcase)
-  job_type = uworker_input.job_type
-  setup_input = uworker_input.setup_input
+  with logs.symbolize_log_context(
+      testcase, testcase_manager.get_fuzz_target_from_input(uworker_input)):
+    uworker_io.check_handling_testcase_safe(testcase)
+    job_type = uworker_input.job_type
+    setup_input = uworker_input.setup_input
 
-  _, testcase_file_path, error = setup.setup_testcase(testcase, job_type,
-                                                      setup_input)
-  if error:
-    return error
+    _, testcase_file_path, error = setup.setup_testcase(testcase, job_type,
+                                                        setup_input)
+    if error:
+      return error
 
-  # Initialize variables.
-  old_crash_stacktrace = (
-      uworker_input.symbolize_task_input.old_crash_stacktrace)
-  sym_crash_address = testcase.crash_address
-  sym_crash_state = testcase.crash_state
-  sym_redzone = DEFAULT_REDZONE
-  warmup_timeout = environment.get_value('WARMUP_TIMEOUT')
+    # Initialize variables.
+    old_crash_stacktrace = (
+        uworker_input.symbolize_task_input.old_crash_stacktrace)
+    sym_crash_address = testcase.crash_address
+    sym_crash_state = testcase.crash_state
+    sym_redzone = DEFAULT_REDZONE
+    warmup_timeout = environment.get_value('WARMUP_TIMEOUT')
 
-  # Decide which build revision to use.
-  if testcase.crash_stacktrace == 'Pending':
-    # This usually happen when someone clicked the 'Update stacktrace from
-    # trunk' button on the testcase details page. In this case, we are forced
-    # to use trunk. No revision -> trunk build.
-    build_revision = None
-  else:
-    build_revision = testcase.crash_revision
+    # Decide which build revision to use.
+    if testcase.crash_stacktrace == 'Pending':
+      # This usually happen when someone clicked the 'Update stacktrace from
+      # trunk' button on the testcase details page. In this case, we are forced
+      # to use trunk. No revision -> trunk build.
+      build_revision = None
+    else:
+      build_revision = testcase.crash_revision
 
-  fuzz_target = testcase_manager.get_fuzz_target_from_input(uworker_input)
-  fuzz_target = fuzz_target.binary if fuzz_target else None
-  # Set up a custom or regular build based on revision.
-  build = build_manager.setup_build(build_revision, fuzz_target)
+    fuzz_target = testcase_manager.get_fuzz_target_from_input(uworker_input)
+    fuzz_target = fuzz_target.binary if fuzz_target else None
+    # Set up a custom or regular build based on revision.
+    build = build_manager.setup_build(build_revision, fuzz_target)
 
-  # Get crash revision used in setting up build.
-  crash_revision = environment.get_value('APP_REVISION')
+    # Get crash revision used in setting up build.
+    crash_revision = environment.get_value('APP_REVISION')
 
-  if not build or not build_manager.check_app_path():
-    return uworker_msg_pb2.Output(  # pylint: disable=no-member
-        error_message='Build setup failed',
-        error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)  # pylint: disable=no-member
+    if not build or not build_manager.check_app_path():
+      return uworker_msg_pb2.Output(  # pylint: disable=no-member
+          error_message='Build setup failed',
+          error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)  # pylint: disable=no-member
 
-  # ASAN tool settings (if the tool is used).
-  # See if we can get better stacks with higher redzone sizes.
-  # A UAF might actually turn out to be OOB read/write with a bigger redzone.
-  if environment.tool_matches('ASAN', job_type) and testcase.security_flag:
-    redzone = MAX_REDZONE
-    while redzone >= MIN_REDZONE:
-      logs.info(f'Trying to reproduce crash with ASAN redzone size {redzone}.')
+    # ASAN tool settings (if the tool is used).
+    # See if we can get better stacks with higher redzone sizes.
+    # A UAF might actually turn out to be OOB read/write with a bigger redzone.
+    if environment.tool_matches('ASAN', job_type) and testcase.security_flag:
+      redzone = MAX_REDZONE
+      while redzone >= MIN_REDZONE:
+        logs.info(
+            f'Trying to reproduce crash with ASAN redzone size {redzone}.')
 
-      environment.reset_current_memory_tool_options(
-          redzone_size=testcase.redzone, disable_ubsan=testcase.disable_ubsan)
+        environment.reset_current_memory_tool_options(
+            redzone_size=testcase.redzone, disable_ubsan=testcase.disable_ubsan)
 
-      process_handler.terminate_stale_application_instances()
-      command = testcase_manager.get_command_line_for_application(
-          testcase_file_path, needs_http=testcase.http_flag)
-      return_code, crash_time, output = (
-          process_handler.run_process(
-              command, timeout=warmup_timeout, gestures=testcase.gestures))
-      crash_result = CrashResult(return_code, crash_time, output)
+        process_handler.terminate_stale_application_instances()
+        command = testcase_manager.get_command_line_for_application(
+            testcase_file_path, needs_http=testcase.http_flag)
+        return_code, crash_time, output = (
+            process_handler.run_process(
+                command, timeout=warmup_timeout, gestures=testcase.gestures))
+        crash_result = CrashResult(return_code, crash_time, output)
 
-      if crash_result.is_crash() and 'AddressSanitizer' in output:
-        state = crash_result.get_symbolized_data()
-        security_flag = crash_result.is_security_issue()
+        if crash_result.is_crash() and 'AddressSanitizer' in output:
+          state = crash_result.get_symbolized_data()
+          security_flag = crash_result.is_security_issue()
 
-        if crash_analyzer.ignore_stacktrace(state.crash_stacktrace):
-          logs.info(
-              f'Skipping crash with ASAN redzone size {redzone}: ' +
-              'stack trace should be ignored.',
-              stacktrace=state.crash_stacktrace)
-        elif security_flag != testcase.security_flag:
-          logs.info(
-              f'Skipping crash with ASAN redzone size {redzone}: ' +
-              f'mismatched security flag: old = {testcase.security_flag}, '
-              f'new = {security_flag}')
-        elif state.crash_type != testcase.crash_type:
-          logs.info(f'Skipping crash with ASAN redzone size {redzone}: ' +
-                    f'mismatched crash type: old = {testcase.crash_type}, '
-                    f'new = {state.crash_type}')
-        elif state.crash_state == sym_crash_state:
-          logs.info(f'Skipping crash with ASAN redzone size {redzone}: ' +
-                    f'same crash state = {sym_crash_state}')
-        else:
-          logs.info(f'Using crash with larger ASAN redzone size {redzone}: ' +
-                    f'old crash address = {sym_crash_address}, ' +
-                    f'new crash address = {state.crash_address}, ' +
-                    f'old crash state = {sym_crash_state}, ' +
-                    f'new crash state = {state.crash_state}')
+          if crash_analyzer.ignore_stacktrace(state.crash_stacktrace):
+            logs.info(
+                f'Skipping crash with ASAN redzone size {redzone}: ' +
+                'stack trace should be ignored.',
+                stacktrace=state.crash_stacktrace)
+          elif security_flag != testcase.security_flag:
+            logs.info(
+                f'Skipping crash with ASAN redzone size {redzone}: ' +
+                f'mismatched security flag: old = {testcase.security_flag}, '
+                f'new = {security_flag}')
+          elif state.crash_type != testcase.crash_type:
+            logs.info(f'Skipping crash with ASAN redzone size {redzone}: ' +
+                      f'mismatched crash type: old = {testcase.crash_type}, '
+                      f'new = {state.crash_type}')
+          elif state.crash_state == sym_crash_state:
+            logs.info(f'Skipping crash with ASAN redzone size {redzone}: ' +
+                      f'same crash state = {sym_crash_state}')
+          else:
+            logs.info(f'Using crash with larger ASAN redzone size {redzone}: ' +
+                      f'old crash address = {sym_crash_address}, ' +
+                      f'new crash address = {state.crash_address}, ' +
+                      f'old crash state = {sym_crash_state}, ' +
+                      f'new crash state = {state.crash_state}')
 
-          sym_crash_address = state.crash_address
-          sym_crash_state = state.crash_state
-          sym_redzone = redzone
-          old_crash_stacktrace = state.crash_stacktrace
-          break
+            sym_crash_address = state.crash_address
+            sym_crash_state = state.crash_state
+            sym_redzone = redzone
+            old_crash_stacktrace = state.crash_stacktrace
+            break
 
-      redzone /= 2
+        redzone /= 2
 
-  # We no longer need this build, delete it to save some disk space. We will
-  # download a symbolized release build to perform the symbolization.
-  build.delete()
+    # We no longer need this build, delete it to save some disk space. We will
+    # download a symbolized release build to perform the symbolization.
+    build.delete()
 
-  # We should have atleast a symbolized debug or a release build.
-  symbolized_builds = build_manager.setup_symbolized_builds(crash_revision)
-  if (not symbolized_builds or
-      (not build_manager.check_app_path() and
-       not build_manager.check_app_path('APP_PATH_DEBUG'))):
-    return uworker_msg_pb2.Output(  # pylint: disable=no-member
-        error_message='Build setup failed',
-        error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)  # pylint: disable=no-member
+    # We should have atleast a symbolized debug or a release build.
+    symbolized_builds = build_manager.setup_symbolized_builds(crash_revision)
+    if (not symbolized_builds or
+        (not build_manager.check_app_path() and
+         not build_manager.check_app_path('APP_PATH_DEBUG'))):
+      return uworker_msg_pb2.Output(  # pylint: disable=no-member
+          error_message='Build setup failed',
+          error_type=uworker_msg_pb2.ErrorType.SYMBOLIZE_BUILD_SETUP_ERROR)  # pylint: disable=no-member
 
-  # Increase malloc_context_size to get all stack frames. Default is 30.
-  environment.reset_current_memory_tool_options(
-      redzone_size=sym_redzone,
-      malloc_context_size=STACK_FRAME_COUNT,
-      symbolize_inline_frames=True,
-      disable_ubsan=testcase.disable_ubsan)
+    # Increase malloc_context_size to get all stack frames. Default is 30.
+    environment.reset_current_memory_tool_options(
+        redzone_size=sym_redzone,
+        malloc_context_size=STACK_FRAME_COUNT,
+        symbolize_inline_frames=True,
+        disable_ubsan=testcase.disable_ubsan)
 
-  # TSAN tool settings (if the tool is used).
-  if environment.tool_matches('TSAN', job_type):
-    environment.set_tsan_max_history_size()
+    # TSAN tool settings (if the tool is used).
+    if environment.tool_matches('TSAN', job_type):
+      environment.set_tsan_max_history_size()
 
-  # Do the symbolization if supported by this application.
-  result, sym_crash_stacktrace = (
-      get_symbolized_stacktraces(testcase_file_path, testcase,
-                                 old_crash_stacktrace, sym_crash_state))
+    # Do the symbolization if supported by this application.
+    result, sym_crash_stacktrace = (
+        get_symbolized_stacktraces(testcase_file_path, testcase,
+                                   old_crash_stacktrace, sym_crash_state))
 
-  symbolize_task_output = uworker_msg_pb2.SymbolizeTaskOutput(  # pylint: disable=no-member
-      crash_type=testcase.crash_type,
-      crash_address=sym_crash_address,
-      crash_state=sym_crash_state,
-      crash_stacktrace=(data_handler.filter_stacktrace(sym_crash_stacktrace)),
-      symbolized=result,
-      crash_revision=int(crash_revision))
+    symbolize_task_output = uworker_msg_pb2.SymbolizeTaskOutput(  # pylint: disable=no-member
+        crash_type=testcase.crash_type,
+        crash_address=sym_crash_address,
+        crash_state=sym_crash_state,
+        crash_stacktrace=(data_handler.filter_stacktrace(sym_crash_stacktrace)),
+        symbolized=result,
+        crash_revision=int(crash_revision))
 
-  if result:
-    build_url = environment.get_value('BUILD_URL')
-    if build_url:
-      symbolize_task_output.build_url = str(build_url)
+    if result:
+      build_url = environment.get_value('BUILD_URL')
+      if build_url:
+        symbolize_task_output.build_url = str(build_url)
 
-  # Switch current directory before builds cleanup.
-  root_directory = environment.get_value('ROOT_DIR')
-  os.chdir(root_directory)
+    # Switch current directory before builds cleanup.
+    root_directory = environment.get_value('ROOT_DIR')
+    os.chdir(root_directory)
 
-  # Cleanup symbolized builds which are space-heavy.
-  symbolized_builds.delete()
-  return uworker_msg_pb2.Output(symbolize_task_output=symbolize_task_output)  # pylint: disable=no-member
+    # Cleanup symbolized builds which are space-heavy.
+    symbolized_builds.delete()
+    return uworker_msg_pb2.Output(symbolize_task_output=symbolize_task_output)  # pylint: disable=no-member
 
 
 def get_symbolized_stacktraces(testcase_file_path, testcase,
@@ -321,40 +325,41 @@ _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
 
 def utask_postprocess(output):
   """Handle the output from utask_main."""
-  if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
-    _ERROR_HANDLER.handle(output)
-    return
-
-  symbolize_task_output = output.symbolize_task_output
-
-  # Update crash parameters.
   testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
-  testcase.crash_type = symbolize_task_output.crash_type
-  testcase.crash_address = symbolize_task_output.crash_address
-  testcase.crash_state = symbolize_task_output.crash_state
-  testcase.crash_stacktrace = symbolize_task_output.crash_stacktrace
+  with logs.symbolize_log_context(testcase, testcase.get_fuzz_target()):
+    if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
+      _ERROR_HANDLER.handle(output)
+      return
 
-  if not symbolize_task_output.symbolized:
-    data_handler.update_testcase_comment(
-        testcase, data_types.TaskState.ERROR,
-        'Unable to reproduce crash, skipping '
-        'stacktrace update')
-  else:
-    # Switch build url to use the less-optimized symbolized build with better
-    # stacktrace.
-    if symbolize_task_output.build_url:
-      testcase.set_metadata(
-          'build_url', symbolize_task_output.build_url, update_testcase=False)
+    symbolize_task_output = output.symbolize_task_output
 
-    data_handler.update_testcase_comment(testcase,
-                                         data_types.TaskState.FINISHED)
+    # Update crash parameters.
+    testcase.crash_type = symbolize_task_output.crash_type
+    testcase.crash_address = symbolize_task_output.crash_address
+    testcase.crash_state = symbolize_task_output.crash_state
+    testcase.crash_stacktrace = symbolize_task_output.crash_stacktrace
 
-  testcase.symbolized = True
-  testcase.crash_revision = symbolize_task_output.crash_revision
-  testcase.put()
+    if not symbolize_task_output.symbolized:
+      data_handler.update_testcase_comment(
+          testcase, data_types.TaskState.ERROR,
+          'Unable to reproduce crash, skipping '
+          'stacktrace update')
+    else:
+      # Switch build url to use the less-optimized symbolized build with better
+      # stacktrace.
+      if symbolize_task_output.build_url:
+        testcase.set_metadata(
+            'build_url', symbolize_task_output.build_url, update_testcase=False)
 
-  # We might have updated the crash state. See if we need to marked as duplicate
-  # based on other testcases.
-  data_handler.handle_duplicate_entry(testcase)
+      data_handler.update_testcase_comment(testcase,
+                                           data_types.TaskState.FINISHED)
 
-  task_creation.create_blame_task_if_needed(testcase)
+    testcase.symbolized = True
+    testcase.crash_revision = symbolize_task_output.crash_revision
+    testcase.put()
+
+    # We might have updated the crash state. See if we need to marked as
+    # duplicate based on other testcases.
+    data_handler.handle_duplicate_entry(testcase)
+
+    task_creation.create_blame_task_if_needed(testcase)

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -799,7 +799,7 @@ class LogContextType(enum.Enum):
       # Field to add specific metadata for variant.
       return GenericLogStruct()
 
-    elif self == LogContextType.SYMBOLIZE:
+    if self == LogContextType.SYMBOLIZE:
       # Field to add specific metadata for symbolize.
       return GenericLogStruct()
 

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -672,6 +672,7 @@ class LogContextType(enum.Enum):
   REGRESSION = 'regression'
   MINIMIZE = 'minimize'
   VARIANT = 'variant'
+  SYMBOLIZE = 'symbolize'
 
   def get_extras(self) -> NamedTuple:
     """Get the structured log for a given context"""
@@ -736,6 +737,10 @@ class LogContextType(enum.Enum):
 
     elif self == LogContextType.VARIANT:
       # Field to add specific metadata for variant.
+      return GenericLogStruct()
+
+    elif self == LogContextType.SYMBOLIZE:
+      # Field to add specific metadata for symbolize.
       return GenericLogStruct()
 
     return GenericLogStruct()
@@ -871,4 +876,12 @@ def minimize_log_context(testcase: 'Testcase',
 def variant_log_context(testcase: 'Testcase', fuzz_target: 'FuzzTarget | None'):
   with testcase_log_context(testcase, fuzz_target):
     with wrap_log_context(contexts=[LogContextType.VARIANT]):
+      yield
+
+
+@contextlib.contextmanager
+def symbolize_log_context(testcase: 'Testcase',
+                          fuzz_target: 'FuzzTarget | None'):
+  with testcase_log_context(testcase, fuzz_target):
+    with wrap_log_context(contexts=[LogContextType.SYMBOLIZE]):
       yield


### PR DESCRIPTION
Adding structured logs to the symbolize task by extending the testcase-based context.
For postprocess step, it was necessary to move the code to retrieve the testcase to the beginning of the method, in order to pass it to the context manager.
