### PR TITLE
Revert "Have a single index for last_run in FuzzTargetJob (#4764)"

### DIFF
--- a/src/appengine/index.yaml
+++ b/src/appengine/index.yaml
@@ -106,9 +106,6 @@ indexes:
   properties:
   - name: engine
   - name: weight
-
-- kind: FuzzTargetJob
-  properties:
   - name: last_run
 
 - kind: ReportMetadata


### PR DESCRIPTION
This reverts commit 0b0e24bb32f3a6077cee9a4adc4eda705bdfc6b1.

Single field indexes are builtin in datastore, there is some deeper contention issue going on