### PR TITLE
Support i386.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -117,6 +117,11 @@ RUN pip3.11 --no-cache-dir install pipenv==2022.8.5
 COPY setup_19.x /data
 RUN bash setup_19.x && apt-get update -y && apt-get install -y nodejs
 
+# Support i386.
+RUN dpkg --add-architecture i386
+RUN apt update && apt install libc6:i386 -y
+
+
 RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \


### PR DESCRIPTION
A few changes were made to the images over the past couple weeks. Some of these must have removed implicit support for i386. It's unclear how the oss-fuzz runner image supports it.

Related: https://github.com/google/oss-fuzz/issues/13152