### PR TITLE
[Logging] Add logs context to Fuzz Task

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1990,8 +1990,8 @@ def utask_main(uworker_input):
         uworker_input.fuzz_task_input.fuzz_target, data_types.FuzzTarget)
   else:
     fuzz_target = None
-  with logs.fuzzer_log_context(uworker_input.fuzzer_name, uworker_input.job_type,
-                             fuzz_target):
+  with logs.fuzzer_log_context(uworker_input.fuzzer_name,
+                               uworker_input.job_type, fuzz_target):
     session = _make_session(uworker_input)
     return session.run()
 


### PR DESCRIPTION
### Description
This PR adds structured logging to the fuzz task by instrumenting it with the fuzzing-related logs context. 
Notes that for preprocess, the fuzz target is set to None until it is is picked.

### Tests
Onebox deployment to internal (chrome) GCE instance ([link to logs](https://cloudlogging.app.goo.gl/pWGNvea5jkaDkKm38)):
* Stage - Preprocess:
![image](https://github.com/user-attachments/assets/b4fdfa26-78eb-4997-a566-e8f62da7a0ae)


* Stage - Main:
![image](https://github.com/user-attachments/assets/8b6ddaed-fe49-439c-a353-1e215f2d0602)
