### PR TITLE
[Staging Poc] Mute the issue tracker on staging environments

### DIFF
--- a/src/clusterfuzz/_internal/cron/cleanup.py
+++ b/src/clusterfuzz/_internal/cron/cleanup.py
@@ -38,6 +38,7 @@ from clusterfuzz._internal.issue_management import issue_tracker_utils
 from clusterfuzz._internal.metrics import crash_stats
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.metrics import monitoring_metrics
+from clusterfuzz._internal.config import local_config
 
 GENERIC_INCORRECT_COMMENT = (
     '\n\nIf this is incorrect, please add the {label_text}')
@@ -1144,6 +1145,9 @@ def _sanitize_ccs_list(ccs_list):
 def update_issue_ccs_from_owners_file(policy, testcase, issue):
   """Add cc to an issue based on owners list from owners file. This is
   currently applicable to fuzz targets only."""
+  if local_config.ProjectConfig().get('staging.enabled', False):
+    return
+
   auto_cc_label = policy.label('auto_cc_from_owners')
   if not auto_cc_label:
     return
@@ -1250,6 +1254,9 @@ def update_issue_owner_and_ccs_from_predator_results(policy,
                                                      only_allow_ccs=False):
   """Assign the issue to an appropriate owner if possible."""
   logs.info(f'{update_issue_owner_and_ccs_from_predator_results}')
+  if local_config.ProjectConfig().get('staging.enabled', False):
+    return
+  
   if not issue or not issue.is_open:
     return
 

--- a/src/clusterfuzz/_internal/cron/cleanup.py
+++ b/src/clusterfuzz/_internal/cron/cleanup.py
@@ -1256,7 +1256,6 @@ def update_issue_owner_and_ccs_from_predator_results(policy,
   logs.info(f'{update_issue_owner_and_ccs_from_predator_results}')
   if local_config.ProjectConfig().get('staging.enabled', False):
     return
-  
   if not issue or not issue.is_open:
     return
 

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -748,6 +748,11 @@ class Issue(issue_tracker.Issue):
   def save(self, new_comment=None, notify=True, skip_emails=[]):  # pylint: disable=dangerous-default-value
     """Saves the issue."""
     logs.info(f'Skipping supposed non gaia emails emails: {skip_emails}.')
+    # Just for a proof of concept
+    # Assert in runtime that we actually do not notify anyone
+    assert not self.assignee
+    assert not self.ccs
+    assert not self._collaborators
     if self._is_new:
       logs.info('google_issue_tracker: Creating new issue..')
       priority = _extract_label(self.labels, 'Pri-') or _DEFAULT_PRIORITY


### PR DESCRIPTION
There are some ways buganizer can send notifications to the following personas:

* Assignee
* Reporter
* Verifier
* CC
* Collaborator
* User mentioned in a comment
* Users who starred the issue

The clusterfuzz issue tracker code touches the assignee, collaborator and CC resposibilities:
* From predator info, an email can be tagged as assignee
* Users are CCd from owner files and from predator
* Collaborators can be added, from the _ext_collaborators field in the Project Tracker config

This PR mutes these notifications, and adds assertions so that the program exits early in case any issue tracker code path is hit with non empty collaborator/ccs/assignees, in order to execute the proof of concept