### PR TITLE
[Logging] Create and add structured logs for Cleanup task

### DIFF
--- a/src/appengine/libs/handler.py
+++ b/src/appengine/libs/handler.py
@@ -17,6 +17,7 @@ import datetime
 import functools
 import json
 import re
+import uuid
 
 from flask import g
 from flask import make_response
@@ -97,6 +98,10 @@ def cron():
       if not self.is_cron():
         raise helpers.AccessDeniedError('You are not a cron.')
 
+      # Add env vars used by logs context for cleanup/triage.
+      task_id = uuid.uuid4()
+      environment.set_value('CF_TASK_ID', task_id)
+      environment.set_value('CF_TASK_NAME', self.__module__)
       with monitor.wrap_with_monitoring():
         result = func(self)
         if result is None:

--- a/src/appengine/libs/handler.py
+++ b/src/appengine/libs/handler.py
@@ -17,7 +17,6 @@ import datetime
 import functools
 import json
 import re
-import uuid
 
 from flask import g
 from flask import make_response
@@ -99,9 +98,8 @@ def cron():
         raise helpers.AccessDeniedError('You are not a cron.')
 
       # Add env vars used by logs context for cleanup/triage.
-      task_id = uuid.uuid4()
-      environment.set_value('CF_TASK_ID', task_id)
-      environment.set_value('CF_TASK_NAME', self.__module__)
+      environment.set_task_id_vars(self.__module__)
+
       with monitor.wrap_with_monitoring():
         result = func(self)
         if result is None:

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -20,6 +20,7 @@ import re
 import socket
 import subprocess
 import sys
+import uuid
 
 import yaml
 
@@ -1012,6 +1013,14 @@ def set_tsan_max_history_size():
                              'history_size=%d' % tsan_max_history_size))
 
   set_value('TSAN_OPTIONS', tsan_options)
+
+
+def set_task_id_vars(task_name, task_id=None):
+  """Sets environment vars for task name and ID."""
+  if not task_id:
+    task_id = uuid.uuid4()
+  set_value('CF_TASK_ID', task_id)
+  set_value('CF_TASK_NAME', task_name)
 
 
 def set_value(environment_variable, value, env=None):

--- a/src/python/bot/startup/run_cron.py
+++ b/src/python/bot/startup/run_cron.py
@@ -23,6 +23,7 @@ modules.fix_module_search_paths()
 import importlib
 import os
 import sys
+import uuid
 
 from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.datastore import ndb_init
@@ -59,6 +60,11 @@ def main():
   task = sys.argv[1]
 
   task_module_name = f'clusterfuzz._internal.cron.{task}'
+
+  task_id = uuid.uuid4()
+  environment.set_value('CF_TASK_ID', task_id)
+  environment.set_value('CF_TASK_NAME', task)
+
   with monitor.wrap_with_monitoring(), ndb_init.context():
     task_module = importlib.import_module(task_module_name)
     return 0 if task_module.main() else 1

--- a/src/python/bot/startup/run_cron.py
+++ b/src/python/bot/startup/run_cron.py
@@ -23,7 +23,6 @@ modules.fix_module_search_paths()
 import importlib
 import os
 import sys
-import uuid
 
 from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.datastore import ndb_init
@@ -61,9 +60,7 @@ def main():
 
   task_module_name = f'clusterfuzz._internal.cron.{task}'
 
-  task_id = uuid.uuid4()
-  environment.set_value('CF_TASK_ID', task_id)
-  environment.set_value('CF_TASK_NAME', task)
+  environment.set_task_id_vars(task)
 
   with monitor.wrap_with_monitoring(), ndb_init.context():
     task_module = importlib.import_module(task_module_name)


### PR DESCRIPTION
### Description
Adding structured logging to the cleanup cronjob. In order to enable this, the following changes on logs module were done:
* Added a new log context for cronjobs.
* Added a filter to the logs handler for both GAE/GKE to propagate the `extras` argument from python logging to the `json_fields` metadata in google cloud logging ([GCP reference](https://cloud.google.com/python/docs/reference/logging/latest/std-lib-integration#automatic-metadata-detection)). (Note that this is a workaround to enable the observability project for now. As a long-term solution, we should try to centralize the logs handlers/filters for all environments). 

For the cleanup module:
* Set env vars for task name and ID in the cron entrypoints (for k8s and appengine).
* Instrumented the cleanup code with the cron-based log context and with the testcase-based context. This latest is done for each testcase within the clean up unneeded open testcases method. 

### Tests
Running the cronjob locally with the debugger and sending logs to GCP.
* Setting `IS_K8S_ENV` to true ([link to logs](https://cloudlogging.app.goo.gl/Us8aHBMUyNoaPFbL8)):
![image](https://github.com/user-attachments/assets/4d268895-804d-483d-a426-174a3c8b5f4b)
