### PR TITLE
[Logging] Add new log context for grouper-related structured logging

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -31,8 +31,11 @@ from typing import Any
 from typing import NamedTuple
 from typing import TYPE_CHECKING
 
+from google.cloud import ndb
+
 # This is needed to avoid circular import
 if TYPE_CHECKING:
+  from clusterfuzz._internal.cron.grouper import TestcaseAttributes
   from clusterfuzz._internal.datastore.data_types import FuzzTarget
   from clusterfuzz._internal.datastore.data_types import Testcase
 
@@ -694,6 +697,14 @@ def get_common_log_context() -> dict[str, str]:
     return {}
 
 
+def get_testcase_id(
+    testcase: 'Testcase | TestcaseAttributes') -> int | str | None:
+  """Return the ID for a testcase or testcase attribute object."""
+  if isinstance(testcase, ndb.Model):
+    return testcase.key.id()  # type: ignore
+  return getattr(testcase, 'id', None)
+
+
 class GenericLogStruct(NamedTuple):
   pass
 
@@ -729,6 +740,11 @@ class TestcaseLogStruct(NamedTuple):
   testcase_id: str
 
 
+class GrouperLogStruct(NamedTuple):
+  testcase_1_id: str
+  testcase_2_id: str
+
+
 class LogContextType(enum.Enum):
   """Log context types.
   
@@ -740,6 +756,7 @@ class LogContextType(enum.Enum):
   FUZZER = 'fuzzer'
   TESTCASE = 'testcase'
   CRON = 'cron'
+  GROUPER = 'grouper'
 
   def get_extras(self) -> NamedTuple:
     """Get the structured log for a given context"""
@@ -793,15 +810,8 @@ class LogContextType(enum.Enum):
 
     if self == LogContextType.TESTCASE:
       try:
-        testcase: 'Testcase | None' = log_contexts.meta.get('testcase')
-        if not testcase:
-          error(
-              'Testcase not found in log context metadata.',
-              ignore_context=True)
-          return GenericLogStruct()
-
-        return TestcaseLogStruct(testcase_id=testcase.key.id())  # type: ignore
-
+        return TestcaseLogStruct(
+            testcase_id=log_contexts.meta.get('testcase_id', 'null'))
       except:
         error(
             'Error retrieving context for testcase-based logs.',
@@ -816,6 +826,17 @@ class LogContextType(enum.Enum):
       except:
         error(
             'Error retrieving context for cron-based logs.',
+            ignore_context=True)
+        return GenericLogStruct()
+
+    if self == LogContextType.GROUPER:
+      try:
+        return GrouperLogStruct(
+            testcase_1_id=log_contexts.meta.get('testcase_1_id', 'null'),
+            testcase_2_id=log_contexts.meta.get('testcase_2_id', 'null'))
+      except:
+        error(
+            'Error retrieving context for grouper-based logs.',
             ignore_context=True)
         return GenericLogStruct()
 
@@ -925,7 +946,7 @@ def fuzzer_log_context(fuzzer_name: str, job_type: str,
 
 
 @contextlib.contextmanager
-def testcase_log_context(testcase: 'Testcase',
+def testcase_log_context(testcase: 'Testcase | TestcaseAttributes',
                          fuzz_target: 'FuzzTarget | None'):
   """Creates a testcase-based context for a given testcase.
 
@@ -936,10 +957,12 @@ def testcase_log_context(testcase: 'Testcase',
   with wrap_log_context(
       contexts=[LogContextType.FUZZER, LogContextType.TESTCASE]):
     try:
-      log_contexts.add_metadata('testcase', testcase)  # type: ignore
+      log_contexts.add_metadata('testcase', testcase)
       if testcase:
-        log_contexts.add_metadata('fuzzer_name', testcase.fuzzer_name)
-        log_contexts.add_metadata('job_type', testcase.job_type)
+        log_contexts.add_metadata('testcase_id', get_testcase_id(testcase))
+        log_contexts.add_metadata('fuzzer_name',
+                                  testcase.fuzzer_name)  # type: ignore
+        log_contexts.add_metadata('job_type', testcase.job_type)  # type: ignore
         if fuzz_target and fuzz_target.binary:
           fuzz_target_bin = fuzz_target.binary
         else:
@@ -955,6 +978,7 @@ def testcase_log_context(testcase: 'Testcase',
       raise e
     finally:
       log_contexts.delete_metadata('testcase')
+      log_contexts.delete_metadata('testcase_id')
       log_contexts.delete_metadata('fuzzer_name')
       log_contexts.delete_metadata('job_type')
       log_contexts.delete_metadata('fuzz_target')
@@ -962,9 +986,29 @@ def testcase_log_context(testcase: 'Testcase',
 
 @contextlib.contextmanager
 def cron_log_context():
+  """Creates a cronjob log context, mainly for triage/cleanup tasks."""
   with wrap_log_context(contexts=[LogContextType.CRON]):
     try:
       yield
     except Exception as e:
       warning(message='Error during cronjob context.')
       raise e
+
+
+@contextlib.contextmanager
+def grouper_log_context(testcase_1: 'Testcase | TestcaseAttributes',
+                        testcase_2: 'Testcase | TestcaseAttributes'):
+  """Creates a grouper context for a given pair of testcases."""
+  with wrap_log_context(contexts=[LogContextType.GROUPER]):
+    try:
+      if testcase_1:
+        log_contexts.add_metadata('testcase_1_id', get_testcase_id(testcase_1))
+      if testcase_2:
+        log_contexts.add_metadata('testcase_2_id', get_testcase_id(testcase_2))
+      yield
+    except Exception as e:
+      warning(message='Error during grouper context.')
+      raise e
+    finally:
+      log_contexts.delete_metadata('testcase_1_id')
+      log_contexts.delete_metadata('testcase_2_id')

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -664,6 +664,7 @@ def log_fatal_and_exit(message, **extras):
 
 def get_common_log_context() -> dict[str, str]:
   """Return common context to be propagated by logs."""
+  # Avoid circular imports on the top level.
   from clusterfuzz._internal.base import utils
   from clusterfuzz._internal.system import environment
 
@@ -697,7 +698,9 @@ def get_common_log_context() -> dict[str, str]:
 
 def get_testcase_id(
     testcase: 'Testcase | TestcaseAttributes') -> int | str | None:
-  """Return the ID for a testcase or testcase attribute object."""
+  """Return the ID for a testcase or testcase attributes object."""
+  # Importing here as 3P libs becomes accessible during runtime, after modules
+  # path search is resolved (and logs may be imported before that).
   from google.cloud import ndb
 
   if isinstance(testcase, ndb.Model):

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -742,7 +742,9 @@ class TestcaseLogStruct(NamedTuple):
 
 class GrouperLogStruct(NamedTuple):
   testcase_1_id: str
+  testcase_1_group: str | int
   testcase_2_id: str
+  testcase_2_group: str | int
 
 
 class LogContextType(enum.Enum):
@@ -833,7 +835,9 @@ class LogContextType(enum.Enum):
       try:
         return GrouperLogStruct(
             testcase_1_id=log_contexts.meta.get('testcase_1_id', 'null'),
-            testcase_2_id=log_contexts.meta.get('testcase_2_id', 'null'))
+            testcase_2_id=log_contexts.meta.get('testcase_2_id', 'null'),
+            testcase_1_group=log_contexts.meta.get('testcase_1_group', 'null'),
+            testcase_2_group=log_contexts.meta.get('testcase_2_group', 'null'))
       except:
         error(
             'Error retrieving context for grouper-based logs.',
@@ -1003,8 +1007,10 @@ def grouper_log_context(testcase_1: 'Testcase | TestcaseAttributes',
     try:
       if testcase_1:
         log_contexts.add_metadata('testcase_1_id', get_testcase_id(testcase_1))
+        log_contexts.add_metadata('testcase_1_group', getattr(testcase_1, 'group_id', 0))
       if testcase_2:
         log_contexts.add_metadata('testcase_2_id', get_testcase_id(testcase_2))
+        log_contexts.add_metadata('testcase_2_group', getattr(testcase_2, 'group_id', 0))
       yield
     except Exception as e:
       warning(message='Error during grouper context.')
@@ -1012,3 +1018,5 @@ def grouper_log_context(testcase_1: 'Testcase | TestcaseAttributes',
     finally:
       log_contexts.delete_metadata('testcase_1_id')
       log_contexts.delete_metadata('testcase_2_id')
+      log_contexts.delete_metadata('testcase_1_group')
+      log_contexts.delete_metadata('testcase_2_group')

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -1007,10 +1007,12 @@ def grouper_log_context(testcase_1: 'Testcase | TestcaseAttributes',
     try:
       if testcase_1:
         log_contexts.add_metadata('testcase_1_id', get_testcase_id(testcase_1))
-        log_contexts.add_metadata('testcase_1_group', getattr(testcase_1, 'group_id', 0))
+        log_contexts.add_metadata('testcase_1_group',
+                                  getattr(testcase_1, 'group_id', 0))
       if testcase_2:
         log_contexts.add_metadata('testcase_2_id', get_testcase_id(testcase_2))
-        log_contexts.add_metadata('testcase_2_group', getattr(testcase_2, 'group_id', 0))
+        log_contexts.add_metadata('testcase_2_group',
+                                  getattr(testcase_2, 'group_id', 0))
       yield
     except Exception as e:
       warning(message='Error during grouper context.')

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -31,8 +31,6 @@ from typing import Any
 from typing import NamedTuple
 from typing import TYPE_CHECKING
 
-from google.cloud import ndb
-
 # This is needed to avoid circular import
 if TYPE_CHECKING:
   from clusterfuzz._internal.cron.grouper import TestcaseAttributes
@@ -700,6 +698,8 @@ def get_common_log_context() -> dict[str, str]:
 def get_testcase_id(
     testcase: 'Testcase | TestcaseAttributes') -> int | str | None:
   """Return the ID for a testcase or testcase attribute object."""
+  from google.cloud import ndb
+
   if isinstance(testcase, ndb.Model):
     return testcase.key.id()  # type: ignore
   return getattr(testcase, 'id', None)

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -878,8 +878,8 @@ class EmitTest(unittest.TestCase):
   @logs.cron_log_context()
   def test_grouper_log_context(self):
     """Test the logger call and metadata for a grouper-based context."""
-    from clusterfuzz._internal.datastore import data_types
     from clusterfuzz._internal.cron.grouper import TestcaseAttributes
+    from clusterfuzz._internal.datastore import data_types
     from clusterfuzz._internal.system.environment import set_task_id_vars
     task_name = 'triage'
     task_id = 'abcd-12345'

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -849,7 +849,7 @@ class EmitTest(unittest.TestCase):
     logger = mock.MagicMock()
     self.mock.get_logger.return_value = logger
     self.assertEqual(logs.log_contexts.contexts,
-                      [logs.LogContextType.COMMON, logs.LogContextType.CRON])
+                     [logs.LogContextType.COMMON, logs.LogContextType.CRON])
     logs_extra = {'target': 'bot', 'test': 'yes'}
     logs_extra.update(self.common_context)
     logs_extra.update({


### PR DESCRIPTION
Changes to the logs module in order to enable structured logging for the grouper task:
* Adapting the testcase-based context to also accept the `TestcaseAttributes` class (used by the grouper).
* Adding a new log context for grouping, which is an edge case where pairs of testcases are processed each step.

In addition, this PR also adds unit tests and comments that were missing in the logs module.