### PR TITLE
Check flag is_managed_by_argo_cd for k8s deploy

### DIFF
--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -502,6 +502,9 @@ def _enforce_safe_day_to_deploy():
 
 def _deploy_k8s(config_dir):
   """Deploys all k8s workloads."""
+  is_managed_by_argo_cd = environment.get_value('MANAGED_BY_ARGOCD', False)
+  if is_managed_by_argo_cd:
+    return
   k8s_dir = os.path.join('infra', 'k8s')
   k8s_instance_dir = os.path.join(config_dir, 'k8s')
   k8s_project = local_config.ProjectConfig().get('env.K8S_PROJECT')

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -502,12 +502,13 @@ def _enforce_safe_day_to_deploy():
 
 def _deploy_k8s(config_dir):
   """Deploys all k8s workloads."""
-  is_managed_by_argo_cd = environment.get_value('MANAGED_BY_ARGOCD', False)
-  if is_managed_by_argo_cd:
+  config = local_config.ProjectConfig()
+  is_argocd_enabled = config.get('argocd.enabled', False)
+  if is_argocd_enabled:
     return
   k8s_dir = os.path.join('infra', 'k8s')
   k8s_instance_dir = os.path.join(config_dir, 'k8s')
-  k8s_project = local_config.ProjectConfig().get('env.K8S_PROJECT')
+  k8s_project = config.get('env.K8S_PROJECT')
   redis_host = _get_redis_ip(k8s_project)
   os.environ['REDIS_HOST'] = redis_host
   common.execute(f'gcloud config set project {k8s_project}')


### PR DESCRIPTION
it adds a guard on deploy k8s function to check if it's configured to be managed by ArgoCD. We should deploy it only if it's not, to avoid overlap the deployments.