### PR TITLE
Remove logs filter that adds extras to json_fields

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -353,7 +353,6 @@ def configure_appengine():
   import google.cloud.logging
   client = google.cloud.logging.Client()
   handler = client.get_default_handler()
-  handler.addFilter(json_fields_filter)
   logging.getLogger().addHandler(handler)
 
 
@@ -393,7 +392,6 @@ def configure_k8s():
     return record
 
   logging.setLogRecordFactory(record_factory)
-  logging.getLogger().addFilter(json_fields_filter)
   logging.getLogger().setLevel(logging.INFO)
 
 


### PR DESCRIPTION
In order to enable the structured logging project for cronjobs in GKE/GAE, it was necessary to add a logs filter that inserts the python logging `extras` into the `json_fields` for GCP logging (https://github.com/google/clusterfuzz/pull/4781).
However, this is breaking some of the logs ([Error log](https://pantheon.corp.google.com/errors/detail/CK2Sz6Tk9f-wrwE;time=PT1H;locations=global?e=-13802955&inv=1&invt=AbxY7Q&mods=logs_tg_prod&project=google.com:clusterfuzz)), thus this PR temporarily removes this filter until we can debug these errors.