### PR TITLE
[Cleanup Timeout] Force FuzzTargetJob query to use the DESC index on last_run

### DIFF
--- a/src/clusterfuzz/_internal/cron/cleanup.py
+++ b/src/clusterfuzz/_internal/cron/cleanup.py
@@ -197,7 +197,8 @@ def cleanup_unused_fuzz_targets_and_jobs():
   unused_target_jobs = data_types.FuzzTargetJob.query(
       data_types.FuzzTargetJob.last_run < last_run_cutoff)
   valid_target_jobs = data_types.FuzzTargetJob.query(
-      data_types.FuzzTargetJob.last_run >= last_run_cutoff)
+      data_types.FuzzTargetJob.last_run >= last_run_cutoff).order(
+          -data_types.FuzzTargetJob.last_run)
 
   to_delete = [t.key for t in unused_target_jobs]
 

--- a/src/clusterfuzz/_internal/cron/cleanup.py
+++ b/src/clusterfuzz/_internal/cron/cleanup.py
@@ -196,6 +196,7 @@ def cleanup_unused_fuzz_targets_and_jobs():
 
   unused_target_jobs = data_types.FuzzTargetJob.query(
       data_types.FuzzTargetJob.last_run < last_run_cutoff)
+  # The order by last_run DESC filter is from b/418807403
   valid_target_jobs = data_types.FuzzTargetJob.query(
       data_types.FuzzTargetJob.last_run >= last_run_cutoff).order(
           -data_types.FuzzTargetJob.last_run)


### PR DESCRIPTION
b/418807403

Attempting a workaround suggested by the datastore team, to avoid using the ascended index on last_run