### PR TITLE
Fix signing secret name in butler create config

### DIFF
--- a/src/local/butler/create_config.py
+++ b/src/local/butler/create_config.py
@@ -405,7 +405,7 @@ def execute(args):
                            'roles/storage.objectAdmin')
   # Create gcs-signer-secret from the signer service account
   json_key = get_json_key_from_service_account(gcloud, signer_service_account)
-  create_secret(gcloud, 'gcs-signer-secret', json_key)
+  create_secret(gcloud, 'gcs-signer-key', json_key)
   # Create buckets now that domain is verified.
   create_buckets(args.project_id, [bucket for _, bucket in bucket_replacements])
   #Creates the required pubsub triggers from buckets


### PR DESCRIPTION
The expected secret name is gcs-signer-key, not gcs-signer-secret

Code reference:

https://github.com/google/clusterfuzz/blob/1fca134ba1b3435870a21b24bf15bb43602ac85a/src/clusterfuzz/_internal/google_cloud_utils/credentials.py#L44