### PR TITLE
[Tracing] Implement events module

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -1619,6 +1619,46 @@ class TestcaseLifecycleEvent(Model):
   # Source location that emitted the event.
   source = ndb.StringProperty()
 
+  ### Common metadata.
+  # Source code commit hash.
+  clusterfuzz_version = ndb.StringProperty()
+
+  # Config code commit hash.
+  clusterfuzz_config_version = ndb.StringProperty()
+
+  # Identifier for the running instance on batch, GCE, GKE, etc.
+  instance_id = ndb.StringProperty()
+
+  # Operating system name.
+  operating_system = ndb.StringProperty()
+
+  # Operating system version.
+  os_version = ndb.StringProperty()
+
+  ### Testcase-related properties.
+  # Testcase identifier/key.
+  testcase_id = ndb.IntegerProperty()
+
+  # Name of the fuzzer associated with the testcase.
+  fuzzer = ndb.StringProperty()
+
+  # Type of the job associated with the testcase.
+  job = ndb.StringProperty()
+
+  # Revision that the testcase was created.
+  crash_revision = ndb.IntegerProperty()
+
+  ### Task-related properties.
+  # Task ID (artificial or corresponding to the utask execution).
+  task_id = ndb.StringProperty()
+
+  ### Testcase Creation.
+  # How testcase was created (manual upload, fuzz, corpus pruning).
+  origin = ndb.StringProperty()
+
+  # If testcase is manually uploaded, the user email.
+  uploader = ndb.StringProperty()
+
   def _pre_put_hook(self):
     self.ttl_expiry_timestamp = (
         datetime.datetime.now() + self.TESTCASE_EVENT_TTL)

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -187,7 +187,7 @@ class NDBEventRepository(IEventRepository, EventHandler):
       logs.error('Error deserializing Datastore entity to event.')
     return None
 
-  def store_event(self, event: Event) -> str | int | None:
+  def store_event(self, event: Event) -> int | None:
     """Stores a Datastore entity and returns its ID."""
     entity = self._serialize_event(event)
     if entity is None:
@@ -245,6 +245,8 @@ def config_handlers() -> None:
   ]
 
   for handler in event_handlers:
+    if handler is None:
+      continue
     if not isinstance(handler, EventHandler):
       logs.error(
           f'Event handler of type {type(handler)} should subclass EventHandler.'

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Events definition and handling."""
+"""Events handling and emitting."""
 
 from abc import ABC
 from abc import abstractmethod
@@ -95,18 +95,9 @@ class TestcaseCreationEvent(TestcaseEvent, TaskEvent):
   uploader: str | None = None
 
 
-@dataclass(kw_only=True)
-class TestcaseRejectionEvent(TestcaseEvent, TaskEvent):
-  """Testcase rejection event."""
-  event_type: str = field(default='testcase_rejection', init=False)
-  # Reason for rejection (e.g., triage_duplicated)
-  reason: str | None = None
-
-
 # Mapping of specific event types to their classes.
 _EVENT_TYPE_CLASSES = {
     'testcase_creation': TestcaseCreationEvent,
-    'testcase_rejection': TestcaseRejectionEvent
 }
 
 

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -270,9 +270,11 @@ def emit(event: Event) -> None:
   handlers = get_handlers()
   if handlers is None:
     logs.error(
-        f'Failed setting event handlers. Event {event} will not be processed.')
+        f'Failed setting event handlers. Event will not be processed: {event}.')
     return
 
+  # Log as warning in case `handlers` is empty, since it could mean that the
+  # project config disabled all event handlers (not necessarily an error).
   if not handlers:
     logs.warning('No event handlers were registered for this project.')
     return

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -36,8 +36,7 @@ class Event:
   # Source location (optional).
   source: str | None = None
   # Timestamp when the event was created.
-  timestamp: datetime.datetime = field(
-      init=False, default=datetime.datetime.now())
+  timestamp: datetime.datetime = field(init=False)
 
   # Common metadata retrieved from running environment.
   clusterfuzz_version: str | None = field(init=False, default=None)
@@ -48,6 +47,7 @@ class Event:
 
   def __post_init__(self, **kwargs):
     del kwargs
+    self.timestamp = datetime.datetime.now()
     common_ctx = logs.get_common_log_context()
     for key, val in common_ctx.items():
       setattr(self, key, val)

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -1,0 +1,103 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Events definition and handling."""
+
+from abc import ABC
+from abc import abstractmethod
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+from dataclasses import InitVar
+import datetime
+from typing import Any
+
+from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.system import environment
+
+
+@dataclass(kw_only=True)
+class Event:
+  """Base class for ClusterFuzz events."""
+  # Event type (required if a generic event class is used).
+  event_type: str
+  # Source location (optional).
+  source: str | None = None
+  # Timestamp when the event was created.
+  timestamp: datetime.datetime = field(
+      init=False, default=datetime.datetime.now(datetime.timezone.utc))
+
+  # Common metadata retrieved from running environment.
+  clusterfuzz_version: str | None = field(init=False, default=None)
+  clusterfuzz_config_version: str | None = field(init=False, default=None)
+  instance_id: str | None = field(init=False, default=None)
+  operating_system: str | None = field(init=False, default=None)
+  os_version: str | None = field(init=False, default=None)
+
+  def __post_init__(self, **kwargs):
+    del kwargs
+    common_ctx = logs.get_common_log_context()
+    for key, val in common_ctx.items():
+      setattr(self, key, val)
+
+
+@dataclass(kw_only=True)
+class TestcaseEvent(Event):
+  """Base class for testcase-related events."""
+  # Testcase entity (only used in init to set the event data).
+  testcase: InitVar[data_types.Testcase | None] = None
+
+  # Testcase metadata (retrieved from the testcase entity, if available).
+  testcase_id: str | None = None
+  fuzzer: str | None = None
+  job: str | None = None
+  crash_revision: str | None = None
+
+  def __post_init__(self, testcase=None, **kwargs):
+    if testcase is not None:
+      self.testcase_id = testcase.key.id()
+      self.fuzzer = testcase.fuzzer_name
+      self.job = testcase.job_type
+      self.crash_revision = testcase.crash_revision
+    return super().__post_init__(**kwargs)
+
+
+@dataclass(kw_only=True)
+class TaskEvent(Event):
+  """Base class for task-related events."""
+  # Task ID retrieved from environment var (if not directly set).
+  task_id: str | None = None
+
+  def __post_init__(self, **kwargs):
+    if self.task_id is None:
+      self.task_id = environment.get_value('CF_TASK_ID', None)
+    return super().__post_init__(**kwargs)
+
+
+@dataclass(kw_only=True)
+class TestcaseCreationEvent(TestcaseEvent, TaskEvent):
+  """Testcase creation event."""
+  event_type: str = field(default='testcase_creation', init=False)
+  # Either manual upload, fuzz task or corpus pruning.
+  origin: str | None = None
+  # User email, if testcase manually uploaded.
+  uploader: str | None = None
+
+
+@dataclass(kw_only=True)
+class TestcaseRejectionEvent(TestcaseEvent, TaskEvent):
+  """Testcase rejection event."""
+  event_type: str = field(default='testcase_rejection', init=False)
+  # Reason for rejection (e.g., triage_duplicated)
+  reason: str | None = None

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -253,7 +253,7 @@ def config_handlers() -> None:
     _handlers.append(handler)
 
 
-def get_handlers():
+def get_handlers() -> list[EventHandler] | None:
   """Retrieve the list of configured event handlers."""
   if _handlers is None:
     config_handlers()

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -59,7 +59,7 @@ class TestcaseEvent(Event):
   testcase: InitVar[data_types.Testcase | None] = None
 
   # Testcase metadata (retrieved from the testcase entity, if available).
-  testcase_id: str | None = None
+  testcase_id: int | None = None
   fuzzer: str | None = None
   job: str | None = None
   crash_revision: int | None = None

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -163,15 +163,15 @@ class NDBEventRepository(IEventRepository, EventHandler):
         setattr(event_entity, key, val)
       return event_entity
     except:
-      logs.error(
-          f'Error serializing event of type {event.event_type} to Datastore.')
+      logs.error(f'Error serializing event to Datastore: {event}.')
     return None
 
   def _deserialize_event(self, entity: data_types.Model) -> Event | None:
     """Converts a Datastore entity into an event object, if possible."""
     try:
       if not hasattr(entity, 'event_type'):
-        raise TypeError('Datastore model should contain an event type.')
+        raise TypeError(
+            f'Datastore entity should contain an event_type: {entity.key}.')
 
       event_type = entity.event_type  # type: ignore
       event_class = _EVENT_TYPE_CLASSES.get(event_type, None)
@@ -184,7 +184,7 @@ class NDBEventRepository(IEventRepository, EventHandler):
           setattr(event, key, val)
       return event
     except:
-      logs.error('Error deserializing Datastore entity to event.')
+      logs.error(f'Error deserializing Datastore entity to event: {entity}.')
     return None
 
   def store_event(self, event: Event) -> int | None:
@@ -196,7 +196,7 @@ class NDBEventRepository(IEventRepository, EventHandler):
       entity.put()
       return entity.key.id()
     except:
-      logs.error('Error storing Datastore event entity.')
+      logs.error(f'Error storing Datastore event entity: {entity}.')
     return None
 
   def get_event(self, event_id: str | int,

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -36,7 +36,7 @@ class Event:
   source: str | None = None
   # Timestamp when the event was created.
   timestamp: datetime.datetime = field(
-      init=False, default=datetime.datetime.now(datetime.timezone.utc))
+      init=False, default=datetime.datetime.now())
 
   # Common metadata retrieved from running environment.
   clusterfuzz_version: str | None = field(init=False, default=None)
@@ -156,7 +156,8 @@ class NDBEventRepository(IEventRepository):
     else:
       event = event_class()
     for key, val in entity.to_dict().items():
-      setattr(event, key, val)
+      if hasattr(event, key):
+        setattr(event, key, val)
     return event
 
   def serialize_event(self, event: Event) -> data_types.Model | None:

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -62,7 +62,7 @@ class TestcaseEvent(Event):
   testcase_id: str | None = None
   fuzzer: str | None = None
   job: str | None = None
-  crash_revision: str | None = None
+  crash_revision: int | None = None
 
   def __post_init__(self, testcase=None, **kwargs):
     if testcase is not None:

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -249,7 +249,7 @@ def config_handlers() -> None:
       continue
     if not isinstance(handler, EventHandler):
       raise TypeError(
-          f'Event handler should inherit EventHandler class: {type(handler)}.')
+          f'Event handler should extend EventHandler class: {type(handler)}.')
     _handlers.append(handler)
 
 

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -248,10 +248,8 @@ def config_handlers() -> None:
     if handler is None:
       continue
     if not isinstance(handler, EventHandler):
-      logs.error(
-          f'Event handler of type {type(handler)} should subclass EventHandler.'
-      )
-      continue
+      raise TypeError(
+          f'Event handler should inherit EventHandler class: {type(handler)}.')
     _handlers.append(handler)
 
 

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -271,7 +271,12 @@ def emit(event: Event) -> None:
   """
   handlers = get_handlers()
   if handlers is None:
-    logs.error('Failed setting events module handlers.')
+    logs.error(
+        f'Failed setting event handlers. Event {event} will not be processed.')
+    return
+
+  if not handlers:
+    logs.warning('No event handlers were registered for this project.')
     return
 
   for handler in handlers:

--- a/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
@@ -1,0 +1,125 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Events handler tests."""
+import datetime
+import os
+import platform
+import unittest
+
+from clusterfuzz._internal.metrics import events
+from clusterfuzz._internal.tests.test_libs import helpers
+from clusterfuzz._internal.tests.test_libs import test_utils
+
+
+@test_utils.with_cloud_emulators('datastore')
+class EventsDataTest(unittest.TestCase):
+  """Test event dataclasses."""
+
+  def setUp(self):
+    helpers.patch(self, ['clusterfuzz._internal.base.utils.get_instance_name'])
+    self.original_env = dict(os.environ)
+    os.environ['OS_OVERRIDE'] = 'linux'
+    # Override reading the manifest file for the source version.
+    os.environ['SOURCE_VERSION_OVERRIDE'] = ('20250402153042-utc-40773ac0-user'
+                                             '-cad6977-prod')
+    self.mock.get_instance_name.return_value = 'linux-bot'
+    os.environ['CF_TASK_ID'] = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
+
+    # Common metadata used for every event.
+    self.common_metadata = {
+        'clusterfuzz_version': '40773ac0',
+        'clusterfuzz_config_version': 'cad6977',
+        'instance_id': 'linux-bot',
+        'operating_system': 'LINUX',
+        'os_version': platform.release()
+    }
+    return super().setUp()
+
+  def tearDown(self):
+    os.environ.clear()
+    os.environ.update(self.original_env)
+    return super().tearDown()
+
+  def _assert_event_common_fields(self, event, event_type, source):
+    """Asserts for common event fields."""
+    self.assertEqual(event.event_type, event_type)
+    self.assertEqual(event.source, source)
+    self.assertIsInstance(event.timestamp, datetime.datetime)
+    for key, val in self.common_metadata.items():
+      self.assertEqual(getattr(event, key, None), val)
+
+  def _assert_testcase_fields(self, event, testcase):
+    """Asserts for testcase-related event fields."""
+    self.assertEqual(event.testcase_id, testcase.key.id())
+    self.assertEqual(event.fuzzer, testcase.fuzzer_name)
+    self.assertEqual(event.job, testcase.job_type)
+    self.assertEqual(event.crash_revision, testcase.crash_revision)
+
+  def test_generic_event(self):
+    """Test base event class."""
+    event_type = 'generic_event'
+    source = 'events_test'
+    event = events.Event(event_type=event_type, source=source)
+    self._assert_event_common_fields(event, event_type, source)
+
+  def test_testcase_event(self):
+    """Test testcase event base class. """
+    event_type = 'testcase_event'
+    source = 'events_test'
+    testcase = test_utils.create_generic_testcase()
+
+    event = events.TestcaseEvent(
+        event_type=event_type, source=source, testcase=testcase)
+    self._assert_event_common_fields(event, event_type, source)
+    self._assert_testcase_fields(event, testcase)
+
+  def test_task_event(self):
+    """Test task-related event base class."""
+    event_type = 'testcase_event'
+    source = 'events_test'
+
+    event = events.TaskEvent(event_type=event_type, source=source)
+    self.assertEqual(event.task_id, 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
+    self._assert_event_common_fields(event, event_type, source)
+
+  def test_testcase_creation_events(self):
+    """Test testcase creation event class."""
+    source = 'events_test'
+    testcase = test_utils.create_generic_testcase()
+
+    event_creation_manual = events.TestcaseCreationEvent(
+        source=source,
+        testcase=testcase,
+        origin='manual_upload',
+        uploader='test@gmail.com')
+    self._assert_event_common_fields(event_creation_manual, 'testcase_creation',
+                                     source)
+    self.assertEqual(event_creation_manual.origin, 'manual_upload')
+    self.assertEqual(event_creation_manual.uploader, 'test@gmail.com')
+
+    event_creation_fuzz = events.TestcaseCreationEvent(
+        source=source, testcase=testcase, origin='fuzz_task')
+    self._assert_event_common_fields(event_creation_fuzz, 'testcase_creation',
+                                     source)
+    self.assertEqual(event_creation_fuzz.origin, 'fuzz_task')
+    self.assertIsNone(event_creation_fuzz.uploader)
+
+  def test_testcase_rejection_event(self):
+    """Test testcase rejection event class."""
+    source = 'events_test'
+    testcase = test_utils.create_generic_testcase()
+
+    event_rejection = events.TestcaseRejectionEvent(
+        source=source, testcase=testcase, reason='triage_duplicate_testcase')
+    self.assertEqual(event_rejection.reason, 'triage_duplicate_testcase')

--- a/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
@@ -114,12 +114,3 @@ class EventsDataTest(unittest.TestCase):
                                      source)
     self.assertEqual(event_creation_fuzz.origin, 'fuzz_task')
     self.assertIsNone(event_creation_fuzz.uploader)
-
-  def test_testcase_rejection_event(self):
-    """Test testcase rejection event class."""
-    source = 'events_test'
-    testcase = test_utils.create_generic_testcase()
-
-    event_rejection = events.TestcaseRejectionEvent(
-        source=source, testcase=testcase, reason='triage_duplicate_testcase')
-    self.assertEqual(event_rejection.reason, 'triage_duplicate_testcase')

--- a/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
@@ -15,8 +15,11 @@
 import datetime
 import os
 import platform
+import time
 import unittest
 
+from clusterfuzz._internal.datastore import data_handler
+from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.metrics import events
 from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
@@ -35,15 +38,6 @@ class EventsDataTest(unittest.TestCase):
                                              '-cad6977-prod')
     self.mock.get_instance_name.return_value = 'linux-bot'
     os.environ['CF_TASK_ID'] = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
-
-    # Common metadata used for every event.
-    self.common_metadata = {
-        'clusterfuzz_version': '40773ac0',
-        'clusterfuzz_config_version': 'cad6977',
-        'instance_id': 'linux-bot',
-        'operating_system': 'LINUX',
-        'os_version': platform.release()
-    }
     return super().setUp()
 
   def tearDown(self):
@@ -56,15 +50,20 @@ class EventsDataTest(unittest.TestCase):
     self.assertEqual(event.event_type, event_type)
     self.assertEqual(event.source, source)
     self.assertIsInstance(event.timestamp, datetime.datetime)
-    for key, val in self.common_metadata.items():
-      self.assertEqual(getattr(event, key, None), val)
+
+    self.assertEqual(event.clusterfuzz_version, '40773ac0')
+    self.assertEqual(event.clusterfuzz_config_version, 'cad6977')
+    self.assertEqual(event.instance_id, 'linux-bot')
+    self.assertEqual(event.operating_system, 'LINUX')
+    self.assertEqual(event.os_version, platform.release())
 
   def _assert_testcase_fields(self, event, testcase):
     """Asserts for testcase-related event fields."""
     self.assertEqual(event.testcase_id, testcase.key.id())
-    self.assertEqual(event.fuzzer, testcase.fuzzer_name)
-    self.assertEqual(event.job, testcase.job_type)
-    self.assertEqual(event.crash_revision, testcase.crash_revision)
+    # Values based on `test_utils.create_generic_testcase`.
+    self.assertEqual(event.fuzzer, 'fuzzer1')
+    self.assertEqual(event.job, 'test_content_shell_drt')
+    self.assertEqual(event.crash_revision, 1)
 
   def test_generic_event(self):
     """Test base event class."""
@@ -73,13 +72,21 @@ class EventsDataTest(unittest.TestCase):
     event = events.Event(event_type=event_type, source=source)
     self._assert_event_common_fields(event, event_type, source)
 
+  def test_event_timestamp(self):
+    """Test event creation timestamp."""
+    event_type = 'generic_event'
+    early_event = events.Event(event_type=event_type)
+    time.sleep(1)
+    late_event = events.Event(event_type=event_type)
+    self.assertGreater(late_event.timestamp, early_event.timestamp)
+
   def test_testcase_event(self):
     """Test testcase event base class. """
     event_type = 'testcase_event'
     source = 'events_test'
     testcase = test_utils.create_generic_testcase()
 
-    event = events.TestcaseEvent(
+    event = events.BaseTestcaseEvent(
         event_type=event_type, source=source, testcase=testcase)
     self._assert_event_common_fields(event, event_type, source)
     self._assert_testcase_fields(event, testcase)
@@ -89,12 +96,13 @@ class EventsDataTest(unittest.TestCase):
     event_type = 'testcase_event'
     source = 'events_test'
 
-    event = events.TaskEvent(event_type=event_type, source=source)
+    event = events.BaseTaskEvent(event_type=event_type, source=source)
     self.assertEqual(event.task_id, 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
     self._assert_event_common_fields(event, event_type, source)
 
   def test_testcase_creation_events(self):
     """Test testcase creation event class."""
+    event_type = events.EventTypes.TESTCASE_CREATION.value
     source = 'events_test'
     testcase = test_utils.create_generic_testcase()
 
@@ -103,14 +111,178 @@ class EventsDataTest(unittest.TestCase):
         testcase=testcase,
         origin='manual_upload',
         uploader='test@gmail.com')
-    self._assert_event_common_fields(event_creation_manual, 'testcase_creation',
-                                     source)
+    self._assert_event_common_fields(event_creation_manual, event_type, source)
     self.assertEqual(event_creation_manual.origin, 'manual_upload')
     self.assertEqual(event_creation_manual.uploader, 'test@gmail.com')
 
     event_creation_fuzz = events.TestcaseCreationEvent(
         source=source, testcase=testcase, origin='fuzz_task')
-    self._assert_event_common_fields(event_creation_fuzz, 'testcase_creation',
-                                     source)
+    self._assert_event_common_fields(event_creation_fuzz, event_type, source)
     self.assertEqual(event_creation_fuzz.origin, 'fuzz_task')
     self.assertIsNone(event_creation_fuzz.uploader)
+
+  def test_mapping_event_classes(self):
+    """Assert that all defined event types are in the classes map."""
+    event_types = [e.value for e in events.EventTypes]
+    event_types_classes = list(events._EVENT_TYPE_CLASSES.keys())  # pylint: disable=protected-access
+    self.assertCountEqual(event_types, event_types_classes)
+
+
+@test_utils.with_cloud_emulators('datastore')
+class DatastoreEventsTest(unittest.TestCase):
+  """Test event handling and emission with datastore repository."""
+
+  def setUp(self):
+    helpers.patch(self, ['clusterfuzz._internal.base.utils.get_instance_name'])
+    self.original_env = dict(os.environ)
+
+    self.repository = events.NDBEventRepository()
+
+    # Set common metadata used by events.
+    os.environ['OS_OVERRIDE'] = 'linux'
+    # Override reading the manifest file for the source version.
+    os.environ['SOURCE_VERSION_OVERRIDE'] = ('20250402153042-utc-40773ac0-user'
+                                             '-cad6977-prod')
+    self.mock.get_instance_name.return_value = 'linux-bot'
+    os.environ['CF_TASK_ID'] = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
+    return super().setUp()
+
+  def tearDown(self):
+    os.environ.clear()
+    os.environ.update(self.original_env)
+    return super().tearDown()
+
+  def _set_common_event_fields(self, entity):
+    """Set the common event fields to a datastore entity."""
+    entity.clusterfuzz_version = '40773ac0'
+    entity.clusterfuzz_config_version = 'cad6977'
+    entity.instance_id = 'linux-bot'
+    entity.operating_system = 'LINUX'
+    entity.os_version = platform.release()
+
+  def _assert_common_event_fields(self, event):
+    """Assert common fields from an event."""
+    self.assertEqual(event.clusterfuzz_version, '40773ac0')
+    self.assertEqual(event.clusterfuzz_config_version, 'cad6977')
+    self.assertEqual(event.instance_id, 'linux-bot')
+    self.assertEqual(event.operating_system, 'LINUX')
+    self.assertEqual(event.os_version, platform.release())
+
+  def test_serialize_generic_event(self):
+    """Test serializing a generic event into a datastore entity."""
+    event_type = 'generic_event'
+    source = 'events_test'
+    event_gen = events.Event(event_type=event_type, source=source)
+    event_entity = self.repository._serialize_event(event_gen)  # pylint: disable=protected-access
+
+    self.assertIsNotNone(event_entity)
+    # Currently, only the TestcaseLifecycleEvent data model is used.
+    self.assertIsInstance(event_entity, data_types.TestcaseLifecycleEvent)
+
+    self.assertEqual(event_entity.event_type, event_type)
+    self.assertEqual(event_entity.source, source)
+    self.assertEqual(event_entity.timestamp, event_gen.timestamp)
+    self._assert_common_event_fields(event_entity)
+
+  def test_serialize_testcase_specific_event(self):
+    """Test serializing a testcase specific event into a datastore entity."""
+    testcase = test_utils.create_generic_testcase()
+    source = 'events_test'
+    # Using testcase creation event for testing should be enough to test any
+    # event type as long as it is mapped in the events module.
+    event_tc_creation = events.TestcaseCreationEvent(
+        source=source, testcase=testcase, origin='fuzz_task')
+    event_type = event_tc_creation.event_type
+
+    event_entity = self.repository._serialize_event(event_tc_creation)  # pylint: disable=protected-access
+    self.assertIsNotNone(event_entity)
+    self.assertIsInstance(event_entity, data_types.TestcaseLifecycleEvent)
+    self.assertEqual(event_entity.event_type, event_type)
+    self.assertEqual(event_entity.source, source)
+    self.assertEqual(event_entity.timestamp, event_tc_creation.timestamp)
+    self._assert_common_event_fields(event_entity)
+
+    self.assertEqual(event_entity.origin, 'fuzz_task')
+    self.assertIsNone(event_entity.uploader)
+
+  def test_deserialize_generic_event(self):
+    """Test deserializing a datastore event entity into an event class."""
+    event_entity = data_types.TestcaseLifecycleEvent(event_type='generic_event')
+    date_now = datetime.datetime.now()
+    event_entity.timestamp = date_now
+    event_entity.source = 'events_test'
+    self._set_common_event_fields(event_entity)
+    event_entity.put()
+
+    event = self.repository._deserialize_event(event_entity)  # pylint: disable=protected-access
+    self.assertIsNotNone(event)
+    self.assertIsInstance(event, events.Event)
+    self.assertEqual(event.event_type, 'generic_event')
+    self.assertEqual(event.source, 'events_test')
+    self.assertEqual(event.timestamp, date_now)
+    self._assert_common_event_fields(event)
+
+  def test_deserialize_testcase_event(self):
+    """Test deserializing a datastore event entity into an specific event."""
+    event_type = events.EventTypes.TESTCASE_CREATION.value
+    date_now = datetime.datetime.now()
+
+    event_entity = data_types.TestcaseLifecycleEvent(event_type=event_type)
+    event_entity.timestamp = date_now
+    event_entity.source = 'events_test'
+    self._set_common_event_fields(event_entity)
+    event_entity.task_id = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
+    event_entity.testcase_id = 1
+    event_entity.fuzzer = 'fuzzer1'
+    event_entity.job = 'test_job'
+    event_entity.crash_revision = 2
+    event_entity.origin = 'manual_upload'
+    event_entity.uploader = 'test@gmail.com'
+    event_entity.put()
+
+    event = self.repository._deserialize_event(event_entity)  # pylint: disable=protected-access
+    self.assertIsNotNone(event)
+    self.assertIsInstance(event, events.TestcaseCreationEvent)
+    self.assertEqual(event.event_type, event_type)
+    self.assertEqual(event.source, 'events_test')
+    self.assertEqual(event.timestamp, date_now)
+    self._assert_common_event_fields(event)
+    self.assertEqual(event.task_id, 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
+    self.assertEqual(event.testcase_id, 1)
+    self.assertEqual(event.fuzzer, 'fuzzer1')
+    self.assertEqual(event.job, 'test_job')
+    self.assertEqual(event.crash_revision, 2)
+    self.assertEqual(event.origin, 'manual_upload')
+    self.assertEqual(event.uploader, 'test@gmail.com')
+
+  def test_store_event(self):
+    """Test storing an event into datastore."""
+    testcase = test_utils.create_generic_testcase()
+    source = 'events_test'
+
+    event_tc_creation = events.TestcaseCreationEvent(
+        source=source, testcase=testcase, origin='fuzz_task')
+    event_type = event_tc_creation.event_type
+    eid = self.repository.store_event(event_tc_creation)
+    self.assertIsNotNone(eid)
+
+    event_entity = data_handler.get_entity_by_type_and_id(
+        data_types.TestcaseLifecycleEvent, eid)
+    self.assertIsNotNone(event_entity)
+    self.assertEqual(event_entity.event_type, event_type)
+
+  def test_get_event(self):
+    """Test retrieving an event from datastore."""
+    event_entity = data_types.TestcaseLifecycleEvent(
+        event_type='generic_event_test')
+    date_now = datetime.datetime.now()
+    event_entity.timestamp = date_now
+    event_entity.source = 'events_test'
+    self._set_common_event_fields(event_entity)
+    event_entity.put()
+    event_id = event_entity.key.id()
+
+    event = self.repository.get_event(event_id)
+    self.assertIsNotNone(event)
+    self.assertEqual(event.event_type, 'generic_event_test')
+    self.assertIsInstance(event, events.Event)

--- a/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
@@ -339,6 +339,8 @@ class EmitEventTest(unittest.TestCase):
   def test_emit_datastore_event(self):
     """Test emit event with datastore repository."""
     self.project_config['events.storage'] = 'datastore'
+    os.environ['CF_TASK_ID'] = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
+
     testcase = test_utils.create_generic_testcase()
     events.emit(
         events.TestcaseCreationEvent(
@@ -347,8 +349,16 @@ class EmitEventTest(unittest.TestCase):
     # Assert that the event was stored in datastore.
     all_events = data_types.TestcaseLifecycleEvent.query().fetch()
     self.assertEqual(len(all_events), 1)
-    event = all_events[0]
-    self.assertEqual(event.event_type,
+    event_entity = all_events[0]
+
+    self.assertEqual(event_entity.event_type,
                      events.EventTypes.TESTCASE_CREATION.value)
-    self.assertEqual(event.source, 'events_test')
-    self.assertEqual(event.origin, 'fuzz_task')
+    self.assertIsNotNone(event_entity.timestamp)
+    self.assertEqual(event_entity.source, 'events_test')
+    self.assertEqual(event_entity.origin, 'fuzz_task')
+    self.assertEqual(event_entity.task_id,
+                     'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
+    self.assertEqual(event_entity.testcase_id, testcase.key.id())
+    self.assertEqual(event_entity.fuzzer, 'fuzzer1')
+    self.assertEqual(event_entity.job, 'test_content_shell_drt')
+    self.assertEqual(event_entity.crash_revision, 1)


### PR DESCRIPTION
Implementing the module responsible for handling clusterfuzz events (mainly testcase lifecycle events).
This module defines the event data classes and enables emitting these events throughout the codebase to be persisted in a generic repository. The default repository is the datastore and testcase lifecycle events are stored under the `TestcaseLifecycleEvent` entity.

In summary, this PR:
* Creates the generic data model to describe ClusterFuzz events.
* Extends this as base classes for testcase lifecycle events (implementing one specific event as an example).
* Creates an abstract repository interface for handling and persisting events.
* Implements the repository methods for Datastore.
* Creates the functions to emit the events, i.e., serialize and store them into the underlying repository.
* Adds unit tests for this module.