### PR TITLE
[Minor Fix] Use set for admins from iam policy to avoid duplicated ids

### DIFF
--- a/src/clusterfuzz/_internal/cron/sync_admins.py
+++ b/src/clusterfuzz/_internal/cron/sync_admins.py
@@ -24,9 +24,9 @@ from clusterfuzz._internal.metrics import logs
 
 
 def get_emails_from_bindings(iam_policy, principal_type,
-                             allowed_roles) -> List[str]:
+                             allowed_roles) -> set[str]:
   """Returns emails that should be admins, given constraints."""
-  admins = []
+  admins = set()
 
   assert principal_type in ['user', 'serviceAccount']
 
@@ -37,13 +37,13 @@ def get_emails_from_bindings(iam_policy, principal_type,
     for member in binding['members']:
       user_type, email = member.split(':', 2)
       if user_type == principal_type:
-        admins.append(email)
+        admins.add(email)
 
   return admins
 
 
 def admins_from_iam_policy(iam_policy):
-  """Gets a list of admins from the IAM policy."""
+  """Gets a set of admins from the IAM policy."""
   # Per
   # https://cloud.google.com/appengine/docs/standard/python/users/adminusers, An
   # administrator is a user who has the Viewer, Editor, or Owner primitive role,
@@ -61,7 +61,7 @@ def admins_from_iam_policy(iam_policy):
   service_account_admins = get_emails_from_bindings(
       iam_policy, 'serviceAccount', service_account_roles)
 
-  user_admins.extend(service_account_admins)
+  user_admins.update(service_account_admins)
   return user_admins
 
 

--- a/src/clusterfuzz/_internal/cron/sync_admins.py
+++ b/src/clusterfuzz/_internal/cron/sync_admins.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Cron to sync admin users."""
 
-from typing import List
-
 from googleapiclient import discovery
 
 from clusterfuzz._internal.base import utils


### PR DESCRIPTION
Recently, the sync admins cronjob was broken due to an [error related to multiple mutations of a single entity in datastore](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2025-05-29T17:00:17.181576919Z;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22clusterfuzz-external%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22clusterfuzz-cronjobs-gke%22%0Aresource.labels.namespace_name%3D%22cronjobs%22%0Alabels.k8s-pod%2Fjob-name:%22sync-admins-%22%0Atimestamp%3D%222025-05-29T17:00:17.181576919Z%22%0AinsertId%3D%229sbesn2zhl3x9rd9%22;startTime=2025-05-29T12:04:31.000Z?project=clusterfuzz-external). This was caused by a new member of the team being added to the GCP IAM policy with two "primitive" roles: `editor` and `owner` (instead of only the `owner` role), resulting in the code trying to create duplicated `Admin` entities in datastore within a single operation.
This PR makes the code resilient to this by using a set instead of a list for retrieving the admins, avoiding duplicated IDs.