### PR TITLE
Add logs for investigating gaia retries on buganizer client

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -81,6 +81,7 @@ def retry_on_invalid_gaia_accounts(func):
     except Exception as e:
       # Try to handle the case where a 400 buganizer response is
       # received due to a non gaia email.
+      logs.warning(f'Buganizer exception when filing: {e}')
       email_regex = r'[\w\.\-\+]+@[\w\.-]+'
       emails_to_skip = re.findall(email_regex, str(e))
       return func(self, *args, **kwargs, skip_emails=emails_to_skip)


### PR DESCRIPTION
The cron is succeeding locally to skip gaia emails, but not in the prod environment. This is probably due to mismatch in the regex behavior in between the environments.

This log is meant to observe what happens, since we cannot reproduce the issue locally by point to prod with a debugger