### PR TITLE
[WIP] Add import functionality for the  job exporter cronjob

### DIFF
--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -14,7 +14,6 @@
 """Exports Jobs, Fuzzer, DataBundles and their JobTemplates to GCS, 
     in order to mirror the workloads on testing environments."""
 
-import io
 import os
 
 from google.cloud import ndb
@@ -120,20 +119,20 @@ class EntityMigrator:
     target_location = f'{bucket_prefix}/contents'
     self._rsync_client.rsync(entity.bucket_name, target_location)
 
-  def _export_entity(self, entity: ndb.Model, entity_bucket_prefix: str, entity_name: str):
+  def _export_entity(self, entity: ndb.Model, entity_bucket_prefix: str,
+                     entity_name: str):
     """Exports entity as protobuf and its respective blobs to GCS."""
     # Entitites get their name from the 'name' field in datastore
-    bucket_prefix = (f'{entity_bucket_prefix}/{entity_name}')
+    bucket_prefix = f'{entity_bucket_prefix}/{entity_name}'
     entity_target_location = f'{bucket_prefix}/entity.proto'
     self._serialize_entity_to_gcs(entity, entity_target_location)
     self._export_blobs(entity, bucket_prefix)
     self._export_data_bundle_contents_if_applicable(entity, bucket_prefix)
 
   def _export_entity_names(self, entities: set[str], entity_bucket_prefix: str):
-    entity_list = ''
-    for entity in entities:
-      entity_list += f'{entity}\n'
-    storage.write_data(entity_list.encode('utf-8'), f'{entity_bucket_prefix}/entities')
+    entity_list = '\n'.join(entities)
+    storage.write_data(
+        entity_list.encode('utf-8'), f'{entity_bucket_prefix}/entities')
 
   def export_entities(self):
     entity_names = set()
@@ -143,7 +142,7 @@ class EntityMigrator:
       assert entity_name
       self._export_entity(entity, entity_bucket_prefix, entity_name)
       entity_names.add(entity_name)
-    
+
     self._export_entity_names(entity_names, entity_bucket_prefix)
 
   def import_entities(self):

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -279,6 +279,10 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
                                                   ['custom_binary_key'], 'job',
                                                   job_exporter.StorageRSync(),
                                                   self.target_bucket)
+
+    entity_list_location = f'gs://{self.target_bucket}/job/entities'
+    expected_persisted_entities = {'some-job', 'another-job'}
+
     job_blob_data = b'some-data'
     job_blob_id = 'some-blob'
     job_proto_location = f'gs://{self.target_bucket}/job/{job.name}/entity.proto'
@@ -309,6 +313,11 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
     self.assertTrue(_jobs_equal(another_job, deserialized_another_job_proto))
 
     self.assertFalse(_blob_is_present_in_gcs(another_job_blob_location))
+
+    self.assertTrue(_blob_is_present_in_gcs(entity_list_location))
+    self.assertTrue(
+        _entity_list_contains_expected_entities(entity_list_location,
+                                                expected_persisted_entities))
 
   def test_job_templates_are_correctly_exported(self):
     """Verifies job template proto is correctly uploaded."""

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -190,7 +190,6 @@ def _entity_list_contains_expected_entities(blob_path, expected_entities):
   return expected_entities == recovered_entities
 
 
-@unittest.skip('tmp')
 @test_utils.with_cloud_emulators('datastore')
 class TestEntitySerializationAndDeserializastion(unittest.TestCase):
   """Test the serialization and deserialization of entities."""
@@ -242,7 +241,6 @@ class TestEntitySerializationAndDeserializastion(unittest.TestCase):
     deserialized_fuzzer = entity_migrator._deserialize(serialized_fuzzer)
 
     self.assertTrue(_fuzzers_equal(fuzzer, deserialized_fuzzer))
-
 
 @test_utils.with_cloud_emulators('datastore')
 class TestEntitiesAreCorrectlyExported(unittest.TestCase):
@@ -1056,3 +1054,47 @@ class TestEntitiesAreCorrectlyImported(unittest.TestCase):
     self.assertEqual(platform, imported_job.platform)
 
     self.assertTrue(_entity_blob_was_correctly_imported(job_blob_data, imported_job.custom_binary_key))
+
+  def test_jobs_are_correctly_deleted(self):
+    job_name = 'some-job'
+    platform = 'some-platform'
+    env_string = 'some-env-string'
+    custom_binary_key = None
+
+    job = _sample_job(
+        name=job_name,
+        custom_binary_key=custom_binary_key,
+        platform=platform,
+        environment_string=env_string)
+
+    _register_entity_and_upload_blobs(
+      entity=job,
+      entity_kind='job',
+      blobstore_key_content=None,
+      sample_testcase_contents=None,
+      custom_binary_contents=None,
+      blobs_bucket=self.blobs_bucket,
+      data_bundle_blob_contents=None,
+    )
+
+    jobs = [job for job in data_types.Job.query()]
+
+    self.assertEqual(1, len(jobs))
+    imported_job = jobs[0]
+
+    self.assertEqual(env_string, imported_job.environment_string)
+    self.assertEqual(job_name, imported_job.name)
+    self.assertEqual(platform, imported_job.platform)
+    self.assertEqual(custom_binary_key, imported_job.custom_binary_key)
+
+    job_base_location = f'gs://{self.import_source_bucket}/job'
+    _upload_entity_list([], job_base_location)
+
+    entity_migrator = job_exporter.EntityMigrator(
+      data_types.Job, ['custom_binary_key'], 'job',
+      job_exporter.StorageRSync(), self.import_source_bucket)
+    entity_migrator.import_entities()
+
+    post_import_jobs = [job for job in data_types.Job.query()]
+
+    self.assertEqual(0, len(post_import_jobs))

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -154,6 +154,12 @@ def _blob_content_is_equal(blob_path, data):
   return data == fetched_data
 
 
+def _entity_blob_was_correctly_imported(expected_content: any, blob_id: str):
+  gcs_path = blobs.get_gcs_path(blob_id)
+  return (_blob_is_present_in_gcs(gcs_path) and 
+          _blob_content_is_equal(gcs_path, expected_content))
+
+
 def _entity_list_contains_expected_entities(blob_path, expected_entities):
   recovered_entities = set(
       storage.read_data(blob_path).decode('utf-8').split('\n'))
@@ -509,15 +515,9 @@ class TestEntitiesAreCorrectlyImported(unittest.TestCase):
     self.assertEqual(data_bundle_name, imported_fuzzer.data_bundle_name)
     self.assertEqual(jobs, imported_fuzzer.jobs)
 
-    blobstore_key_new_id = imported_fuzzer.blobstore_key
-    blobstore_key_new_url = blobs.get_gcs_path(blobstore_key_new_id)
-    self.assertTrue(_blob_is_present_in_gcs(blobstore_key_new_url))
-    self.assertTrue(_blob_content_is_equal(blobstore_key_new_url, blobstore_key_payload))
+    self.assertTrue(_entity_blob_was_correctly_imported(blobstore_key_payload, imported_fuzzer.blobstore_key))
+    self.assertTrue(_entity_blob_was_correctly_imported(sample_testcase_payload, imported_fuzzer.sample_testcase))
 
-    sample_testcase_new_id = imported_fuzzer.sample_testcase
-    sample_testcase_new_url = blobs.get_gcs_path(sample_testcase_new_id)
-    self.assertTrue(_blob_is_present_in_gcs(sample_testcase_new_url))
-    self.assertTrue(_blob_content_is_equal(sample_testcase_new_url, sample_testcase_payload))
 
   def test_fuzzers_are_correctly_modified(self):
     fuzzer_name = 'some-fuzzer'
@@ -587,15 +587,9 @@ class TestEntitiesAreCorrectlyImported(unittest.TestCase):
     self.assertEqual(another_data_bundle_name, imported_fuzzer.data_bundle_name)
     self.assertEqual(other_jobs, imported_fuzzer.jobs)
 
-    blobstore_key_new_id = imported_fuzzer.blobstore_key
-    blobstore_key_new_url = blobs.get_gcs_path(blobstore_key_new_id)
-    self.assertTrue(_blob_is_present_in_gcs(blobstore_key_new_url))
-    self.assertTrue(_blob_content_is_equal(blobstore_key_new_url, other_blobstore_key_payload))
+    self.assertTrue(_entity_blob_was_correctly_exported(other_blobstore_key_payload, imported_fuzzer.blobstore_key))
+    self.assertTrue(_entity_blob_was_correctly_exported(other_sample_testcase_payload, imported_fuzzer.sample_testcase))
 
-    sample_testcase_new_id = imported_fuzzer.sample_testcase
-    sample_testcase_new_url = blobs.get_gcs_path(sample_testcase_new_id)
-    self.assertTrue(_blob_is_present_in_gcs(sample_testcase_new_url))
-    self.assertTrue(_blob_content_is_equal(sample_testcase_new_url, other_sample_testcase_payload))
 
   def test_fuzzers_are_correctly_deleted(self):
     fuzzer_name = 'some-fuzzer'

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -25,6 +25,7 @@ from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 
+
 def _sample_data_bundle(name='some_bundle',
                         bucket_name='some-data-bundle-bucket'):
   return data_types.DataBundle(
@@ -97,11 +98,12 @@ def _blob_content_is_equal(blob_path, data):
   fetched_data = storage.read_data(blob_path)
   return data == fetched_data
 
+
 def _entity_list_contains_expected_entities(blob_path, expected_entities):
-  recovered_entities = set(storage.read_data(blob_path).decode('utf-8').split('\n'))
-  # \n separator will produce an empty string in the set, remove it
-  recovered_entities = {entity for entity in recovered_entities if entity}
+  recovered_entities = set(
+      storage.read_data(blob_path).decode('utf-8').split('\n'))
   return expected_entities == recovered_entities
+
 
 @test_utils.with_cloud_emulators('datastore')
 class TestEntitySerializationAndDeserializastion(unittest.TestCase):
@@ -258,7 +260,9 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
     self.assertFalse(_blob_is_present_in_gcs(another_fuzzer_testcase_location))
 
     self.assertTrue(_blob_is_present_in_gcs(entity_list_location))
-    self.assertTrue(_entity_list_contains_expected_entities(entity_list_location, expected_persisted_entities))
+    self.assertTrue(
+        _entity_list_contains_expected_entities(entity_list_location,
+                                                expected_persisted_entities))
 
   def test_jobs_are_correctly_exported(self):
     """Verifies job protos and custom binary blobs are uploaded. If no custom

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -790,3 +790,76 @@ class TestEntitiesAreCorrectlyImported(unittest.TestCase):
 
     remaining_data_bundles = [data_bundle for data_bundle in data_types.DataBundle.query()]
     self.assertEqual(0, len(remaining_data_bundles))
+
+  def test_data_bundles_are_correctly_modified(self):
+    bundle_name = 'some-bundle'
+    bucket_name = 'some-bucket'
+    blob_data = b'some-data'
+    bundle = _sample_data_bundle(
+      name=bundle_name,
+      bucket_name=bucket_name,
+    )
+    _register_entity_and_upload_blobs(
+      entity=bundle,
+      entity_kind='databundle',
+      blobstore_key_content=None,
+      sample_testcase_contents=None,
+      custom_binary_contents=None,
+      blobs_bucket=self.blobs_bucket,
+      data_bundle_blob_contents=blob_data,
+    )
+
+    data_bundles = [data_bundle for data_bundle in data_types.DataBundle.query()]
+    self.assertEqual(1, len(data_bundles))
+
+    # Enforce precondition: the previous data bundle was there, with the expected
+    # contents.
+
+    imported_bundle = data_bundles[0]
+    self.assertEqual(bundle_name, imported_bundle.name)
+    self.assertEqual(bucket_name, imported_bundle.bucket_name)
+
+    bundle_blob_location = f'gs://{bucket_name}/blob'
+
+    self.assertTrue(_blob_is_present_in_gcs(bundle_blob_location))
+    self.assertTrue(_blob_content_is_equal(bundle_blob_location, blob_data))
+
+    another_blob_data = b'some-other-data'
+    another_bucket = 'some-other-bucket'
+    new_blob_data = b'some-data'
+    updated_bundle = _sample_data_bundle(
+      name=bundle_name,
+      bucket_name=another_bucket,
+    )
+    _upload_entity_export_data(
+      entity=updated_bundle,
+      entity_kind='databundle',
+      source_bucket=self.import_source_bucket,
+      blobstore_key_content=None,
+      sample_testcase_contents=None,
+      custom_binary_contents=None,
+      data_bundle_blob_contents=new_blob_data,
+    )
+
+    # No entities to be imported, implies deletion of the current one
+    data_bundle_base_location = f'gs://{self.import_source_bucket}/databundle'
+    _upload_entity_list([bundle_name], data_bundle_base_location)
+
+    self.mock.get_data_bundle_bucket_name.return_value = another_bucket
+
+    entity_migrator = job_exporter.EntityMigrator(
+      data_types.DataBundle, [], 'databundle',
+      job_exporter.StorageRSync(), self.import_source_bucket)    
+    entity_migrator.import_entities()
+
+    data_bundles = [data_bundle for data_bundle in data_types.DataBundle.query()]
+    self.assertEqual(1, len(data_bundles))
+
+    imported_bundle = data_bundles[0]
+    self.assertEqual(bundle_name, imported_bundle.name)
+    self.assertEqual(another_bucket, imported_bundle.bucket_name)
+
+    bundle_blob_location = f'gs://{another_bucket}/blob'
+
+    self.assertTrue(_blob_is_present_in_gcs(bundle_blob_location))
+    self.assertTrue(_blob_content_is_equal(bundle_blob_location, new_blob_data))

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -366,6 +366,11 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
     storage.write_data(blob_data, f'gs://{data_bundle.bucket_name}/blob')
 
     entity_migrator.export_entities()
+
+    entity_list_location = (f'gs://{self.target_bucket}/'
+                            f'databundle/entities')
+    expected_persisted_entities = {'some-data-bundle'}
+
     bundle_proto_location = (f'gs://{self.target_bucket}/'
                              f'databundle/{data_bundle.name}/'
                              f'entity.proto')
@@ -380,3 +385,8 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
 
     self.assertTrue(_blob_is_present_in_gcs(bundle_proto_location))
     self.assertTrue(_blob_content_is_equal(bundle_contents_location, blob_data))
+
+    self.assertTrue(_blob_is_present_in_gcs(entity_list_location))
+    self.assertTrue(
+        _entity_list_contains_expected_entities(entity_list_location,
+                                                expected_persisted_entities))

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -940,3 +940,64 @@ class TestEntitiesAreCorrectlyImported(unittest.TestCase):
 
     templates = [template for template in data_types.JobTemplate.query()]
     self.assertEqual(0, len(templates))
+
+  def test_job_templates_are_correctly_updated(self):
+    template_name = 'some-template'
+    env_string = 'some-env-string'
+    template = _sample_job_template(
+      name=template_name,
+      environment_string=env_string
+    )
+    _register_entity_and_upload_blobs(
+      entity=template,
+      entity_kind='jobtemplate',
+      blobstore_key_content=None,
+      sample_testcase_contents=None,
+      custom_binary_contents=None,
+      blobs_bucket=self.blobs_bucket,
+      data_bundle_blob_contents=None,
+    )
+
+    templates = [template for template in data_types.JobTemplate.query()]
+    self.assertEqual(1, len(templates))
+
+    imported_template = templates[0]
+    self.assertEqual(template_name, imported_template.name)
+    self.assertEqual(env_string, imported_template.environment_string)
+
+    env_string_before_import = 'some-data'
+    env_string_after_import = 'another-data'
+    substitutions = {
+        env_string_before_import: env_string_after_import,
+    }
+
+    updated_template = _sample_job_template(
+      name=template_name,
+      environment_string=env_string_before_import,
+    )
+
+    _upload_entity_export_data(
+      entity=updated_template,
+      entity_kind='jobtemplate',
+      source_bucket=self.import_source_bucket,
+      blobstore_key_content=None,
+      sample_testcase_contents=None,
+      custom_binary_contents=None,
+      data_bundle_blob_contents=None,
+    )
+
+    job_template_base_location = f'gs://{self.import_source_bucket}/jobtemplate'
+    _upload_entity_list([template_name], job_template_base_location)
+
+    entity_migrator = job_exporter.EntityMigrator(
+      data_types.JobTemplate, [], 'jobtemplate',
+      job_exporter.StorageRSync(), self.import_source_bucket,
+      env_string_substitutions=substitutions)
+    entity_migrator.import_entities()
+
+    templates = [template for template in data_types.JobTemplate.query()]
+    self.assertEqual(1, len(templates))
+
+    imported_template = templates[0]
+    self.assertEqual(template_name, imported_template.name)
+    self.assertEqual(env_string_after_import, imported_template.environment_string)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -328,6 +328,11 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
                                                   'jobtemplate',
                                                   job_exporter.StorageRSync(),
                                                   self.target_bucket)
+
+    entity_list_location = (f'gs://{self.target_bucket}/'
+                            f'jobtemplate/entities')
+    expected_persisted_entities = {'some-job-template'}
+
     template_proto_location = (f'gs://{self.target_bucket}/'
                                f'jobtemplate/{template.name}/'
                                f'entity.proto')
@@ -338,6 +343,11 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
     deserialized_template_proto = entity_migrator._deserialize(
         serialized_template_proto)
     self.assertTrue(_job_templates_equal(template, deserialized_template_proto))
+
+    self.assertTrue(_blob_is_present_in_gcs(entity_list_location))
+    self.assertTrue(
+        _entity_list_contains_expected_entities(entity_list_location,
+                                                expected_persisted_entities))
 
   def test_data_bundles_are_correctly_exported(self):
     """Verifies the proto is uploaded and blobs are rsynced correctly."""

--- a/src/local/butler/scripts/run_cron.py
+++ b/src/local/butler/scripts/run_cron.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Executes update task locally, so we can run it through a debugger."""
 
-from clusterfuzz._internal.cron import oss_fuzz_apply_ccs
+from clusterfuzz._internal.cron import job_exporter
 from clusterfuzz._internal.system import environment
 
 
 def execute(args):  #pylint: disable=unused-argument
   """Build keywords."""
   environment.set_bot_environment()
-  oss_fuzz_apply_ccs.main()
+  job_exporter.main()


### PR DESCRIPTION
### Motivation

#4808 implemented the entity exporting feature for testing environments, now we need the respective import logic. This PR implements that

### Changes

* For each entity type to be exported, also exports an entities file, containing line separated names of exported entities

### Testing strategy

Unit tests, and manual execution in the dev environment