### PR TITLE
[Deployment Revisited][Staging] Add Fuzzer import feature to the job-exporter cronjob

### DIFF
--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -181,6 +181,13 @@ class EntityMigrator:
     for blob_key, blob_value in new_blob_ids.items():
       setattr(entity_to_import, blob_key, blob_value)
 
+    # Do not assume that name is a primary key, avoid having two
+    # different keys with the same name.
+    preexisting_entity = self._target_cls.query(
+        self._target_cls.name == entity_name).get()
+    if preexisting_entity:
+      preexisting_entity.key.delete()
+
     entity_to_import.put()
 
   def import_entities(self):

--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -147,10 +147,40 @@ class EntityMigrator:
       entity_names.add(entity_name)
     self._export_entity_names(entity_names, entity_bucket_prefix)
 
-  def _import_entity(self, entity_location: str):
-    """Imports entity into datastore, blobs if present, and databundle."""
+  def _import_blobs(self, entity: ndb.Model, entity_name: str,
+                    entity_location: str):
+    """Copies exported blobs to a new blob id, and updates the entity."""
+    new_blob_ids = {}
+    for blobstore_key in self.blobstore_keys:
+      source_blob_location = f'{entity_location}/{blobstore_key}'
+      if not getattr(entity, blobstore_key, None):
+        logs.info(
+            f'{blobstore_key} missing for {entity_name}, skipping blob import.')
+        continue
+      if not storage.get(source_blob_location):
+        raise ValueError(
+            f'Absent blob for {blobstore_key} in {entity_name}, it '
+            'should be present.')
+      new_blob_id = blobs.generate_new_blob_name()
+      target_blob_location = f'gs://{storage.blobs_bucket()}/{new_blob_id}'
+      if not storage.copy_blob(source_blob_location, target_blob_location):
+        raise ValueError(f'Failed to import blob from {source_blob_location} '
+                         'to {target_blob_location}.')
+      new_blob_ids[blobstore_key] = new_blob_id
+    return new_blob_ids
+
+  def _import_entity(self, entity_name: str, entity_location: str):
+    """Imports entity into datastore, blobs, databundle contents
+        and substitutes environment strings, if applicable."""
     entity_to_import = self._deserialize_entity_from_gcs(
         f'{entity_location}/entity.proto')
+
+    # Blobs are deployment specific, must be migrated
+    new_blob_ids = self._import_blobs(entity_to_import, entity_name,
+                                      entity_location)
+    for blob_key, blob_value in new_blob_ids.items():
+      setattr(entity_to_import, blob_key, blob_value)
+
     entity_to_import.put()
 
   def import_entities(self):
@@ -167,7 +197,7 @@ class EntityMigrator:
       entities_to_sync = entities_to_sync.decode('utf-8').split('\n')
     for entity_name in entities_to_sync:
       entity_location = f'{entity_bucket_prefix}/{entity_name}'
-      self._import_entity(entity_location)
+      self._import_entity(entity_name, entity_location)
 
 
 def main():

--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -195,6 +195,9 @@ class EntityMigrator:
       entities_to_sync = []
     else:
       entities_to_sync = entities_to_sync.decode('utf-8').split('\n')
+    for entity in self._target_cls.query():
+      if entity.name not in entities_to_sync:
+        entity.key.delete()
     for entity_name in entities_to_sync:
       entity_location = f'{entity_bucket_prefix}/{entity_name}'
       self._import_entity(entity_name, entity_location)

--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -119,22 +119,33 @@ class EntityMigrator:
     target_location = f'{bucket_prefix}/contents'
     self._rsync_client.rsync(entity.bucket_name, target_location)
 
-  def _export_entity(self, entity: ndb.Model):
+  def _export_entity(self, entity: ndb.Model, entity_bucket_prefix: str,
+                     entity_name: str):
     """Exports entity as protobuf and its respective blobs to GCS."""
     # Entitites get their name from the 'name' field in datastore
-    entity_name = getattr(entity, 'name', None)
-    assert entity_name
-    bucket_prefix = (f'gs://{self._export_bucket}/'
-                     f'{self._entity_type}/'
-                     f'{entity_name}')
+    bucket_prefix = f'{entity_bucket_prefix}/{entity_name}'
     entity_target_location = f'{bucket_prefix}/entity.proto'
     self._serialize_entity_to_gcs(entity, entity_target_location)
     self._export_blobs(entity, bucket_prefix)
     self._export_data_bundle_contents_if_applicable(entity, bucket_prefix)
 
+  def _export_entity_names(self, entities: set[str], entity_bucket_prefix: str):
+    """Writes entity name list to GCS."""
+    entity_list = '\n'.join(entities)
+    storage.write_data(
+        entity_list.encode('utf-8'), f'{entity_bucket_prefix}/entities')
+
   def export_entities(self):
+    """Exports individual entities of a certain type, and populates a list
+       the individual names of entities for future importing."""
+    entity_names = set()
+    entity_bucket_prefix = f'gs://{self._export_bucket}/{self._entity_type}'
     for entity in self._target_cls.query():
-      self._export_entity(entity)
+      entity_name = getattr(entity, 'name', None)
+      assert entity_name
+      self._export_entity(entity, entity_bucket_prefix, entity_name)
+      entity_names.add(entity_name)
+    self._export_entity_names(entity_names, entity_bucket_prefix)
 
   def import_entities(self):
     pass

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -99,6 +99,12 @@ def _blob_content_is_equal(blob_path, data):
   return data == fetched_data
 
 
+def _entity_list_contains_expected_entities(blob_path, expected_entities):
+  recovered_entities = set(
+      storage.read_data(blob_path).decode('utf-8').split('\n'))
+  return expected_entities == recovered_entities
+
+
 @test_utils.with_cloud_emulators('datastore')
 class TestEntitySerializationAndDeserializastion(unittest.TestCase):
   """Test the serialization and deserialization of entities."""
@@ -250,6 +256,14 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
     self.assertFalse(_blob_is_present_in_gcs(another_fuzzer_blob_location))
     self.assertFalse(_blob_is_present_in_gcs(another_fuzzer_testcase_location))
 
+    expected_persisted_entities = {'some-fuzzer', 'another-fuzzer'}
+    entity_list_location = f'gs://{self.target_bucket}/fuzzer/entities'
+
+    self.assertTrue(_blob_is_present_in_gcs(entity_list_location))
+    self.assertTrue(
+        _entity_list_contains_expected_entities(entity_list_location,
+                                                expected_persisted_entities))
+
   def test_jobs_are_correctly_exported(self):
     """Verifies job protos and custom binary blobs are uploaded. If no custom
         binary key is present, no blob is uploaded."""
@@ -296,6 +310,14 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
 
     self.assertFalse(_blob_is_present_in_gcs(another_job_blob_location))
 
+    expected_persisted_entities = {'some-job', 'another-job'}
+    entity_list_location = f'gs://{self.target_bucket}/job/entities'
+
+    self.assertTrue(_blob_is_present_in_gcs(entity_list_location))
+    self.assertTrue(
+        _entity_list_contains_expected_entities(entity_list_location,
+                                                expected_persisted_entities))
+
   def test_job_templates_are_correctly_exported(self):
     """Verifies job template proto is correctly uploaded."""
     template = _sample_job_template(
@@ -315,6 +337,14 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
     deserialized_template_proto = entity_migrator._deserialize(
         serialized_template_proto)
     self.assertTrue(_job_templates_equal(template, deserialized_template_proto))
+
+    expected_persisted_entities = {'some-job-template'}
+    entity_list_location = f'gs://{self.target_bucket}/jobtemplate/entities'
+
+    self.assertTrue(_blob_is_present_in_gcs(entity_list_location))
+    self.assertTrue(
+        _entity_list_contains_expected_entities(entity_list_location,
+                                                expected_persisted_entities))
 
   def test_data_bundles_are_correctly_exported(self):
     """Verifies the proto is uploaded and blobs are rsynced correctly."""
@@ -347,3 +377,11 @@ class TestEntitiesAreCorrectlyExported(unittest.TestCase):
 
     self.assertTrue(_blob_is_present_in_gcs(bundle_proto_location))
     self.assertTrue(_blob_content_is_equal(bundle_contents_location, blob_data))
+
+    expected_persisted_entities = {'some-data-bundle'}
+    entity_list_location = f'gs://{self.target_bucket}/databundle/entities'
+
+    self.assertTrue(_blob_is_present_in_gcs(entity_list_location))
+    self.assertTrue(
+        _entity_list_contains_expected_entities(entity_list_location,
+                                                expected_persisted_entities))


### PR DESCRIPTION
### Motivation

In order to kickstart fuzzing in a testing environment, we need to mirror the Job, Fuzzer and DataBundle entities.
This PR adds the capability of importing Fuzzers from the exported data, implemented in #4808 .

### Implementation

Assuming that all data was exported to $SOME_BUCKET, the folder structure for fuzzers looks like this:

```
$SOME_BUCKET/
    fuzzer/
        entities
        some-fuzzer/
            entity.proto
            blobstore_key
            sample_testcase
        another-fuzzer/
            entity.proto
            blobstore_key
            sample_testcase
```

The proto file is the serialized representation of a data_types.Fuzzer entity, and the other files are the associated blobs to the entity, if present.

The entities file contains line separated fuzzer names that were last exported. It was added in this PR.

To import said entities, the cronjob will:
* Parse entity names to be imported from the entities file
* Upload sample_testcase and blobstore_key to the target project's blobs bucket, and update the entity with new ids
* Deserialize the protobuf and persist the entity into datastore

### Testing strategy

Unit tests for:
* Correctly creating a fuzzer, from the state where it still does not exist
* Correctly deleting a fuzzer, when from the state where it is present in the target environment, in response to the export list not containing its name
* Correctly updating a fuzzer, once a newer revision with different blobs or fields is exported from the source project