### PR TITLE
[Tracing] Add constants for testcase creation events and remove enum

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -1654,7 +1654,7 @@ class TestcaseLifecycleEvent(Model):
 
   ### Testcase Creation.
   # How testcase was created (manual upload, fuzz, corpus pruning).
-  origin = ndb.StringProperty()
+  creation_origin = ndb.StringProperty()
 
   # If testcase is manually uploaded, the user email.
   uploader = ndb.StringProperty()

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import InitVar
 import datetime
-from enum import Enum
 from typing import Any
 
 from clusterfuzz._internal.config import local_config
@@ -35,10 +34,17 @@ def _get_datetime_now():
   return datetime.datetime.now()
 
 
-class EventTypes(Enum):
+class EventTypes:
   """Specific event types."""
   TESTCASE_CREATION = 'testcase_creation'
   TESTCASE_REJECTION = 'testcase_rejection'
+
+
+class TestcaseOrigin:
+  """Testcase creation origins."""
+  MANUAL_UPLOAD = 'manual_upload'
+  FUZZ_TASK = 'fuzz_task'
+  CORPUS_PRUNING = 'corpus_pruning'
 
 
 @dataclass(kw_only=True)
@@ -102,10 +108,9 @@ class BaseTaskEvent(Event):
 @dataclass(kw_only=True)
 class TestcaseCreationEvent(BaseTestcaseEvent, BaseTaskEvent):
   """Testcase creation event."""
-  event_type: str = field(
-      default=EventTypes.TESTCASE_CREATION.value, init=False)
+  event_type: str = field(default=EventTypes.TESTCASE_CREATION, init=False)
   # Either manual upload, fuzz task or corpus pruning.
-  origin: str | None = None
+  creation_origin: str | None = None
   # User email, if testcase manually uploaded.
   uploader: str | None = None
 
@@ -113,8 +118,7 @@ class TestcaseCreationEvent(BaseTestcaseEvent, BaseTaskEvent):
 @dataclass(kw_only=True)
 class TestcaseRejectionEvent(BaseTestcaseEvent, BaseTaskEvent):
   """Testcase rejection event."""
-  event_type: str = field(
-      default=EventTypes.TESTCASE_REJECTION.value, init=False)
+  event_type: str = field(default=EventTypes.TESTCASE_REJECTION, init=False)
   # Explanation for the testcase rejection, e.g., analyze_flake_on_first_attempt
   # or analyze_no_repro or triage_duplicate_testcase.
   rejection_reason: str | None = None
@@ -122,8 +126,8 @@ class TestcaseRejectionEvent(BaseTestcaseEvent, BaseTaskEvent):
 
 # Mapping of specific event types to their data classes.
 _EVENT_TYPE_CLASSES = {
-    EventTypes.TESTCASE_CREATION.value: TestcaseCreationEvent,
-    EventTypes.TESTCASE_REJECTION.value: TestcaseRejectionEvent,
+    EventTypes.TESTCASE_CREATION: TestcaseCreationEvent,
+    EventTypes.TESTCASE_REJECTION: TestcaseRejectionEvent,
 }
 
 


### PR DESCRIPTION
As discussed in https://github.com/google/clusterfuzz/pull/4821, this PR defines constant values for the origin field in testcase creation events (also changes the name of the property to be more clear). 

It also removes unnecessary use of enum for the event types.