### PR TITLE
[Tracing] Add task_name to events data

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -1652,6 +1652,9 @@ class TestcaseLifecycleEvent(Model):
   # Task ID (artificial or corresponding to the utask execution).
   task_id = ndb.StringProperty()
 
+  # Task name.
+  task_name = ndb.StringProperty()
+
   ### Testcase Creation.
   # How testcase was created (manual upload, fuzz, corpus pruning).
   creation_origin = ndb.StringProperty()

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -104,12 +104,15 @@ class BaseTaskEvent(Event):
   """Base class for task-related events."""
   # Task ID retrieved from environment var (if not directly set).
   task_id: str | None = None
+  # Task name retrieved from environment var (if not directly set).
+  task_name: str | None = None
 
   def __post_init__(self, **kwargs):
     if self.task_id is None:
       self.task_id = environment.get_value('CF_TASK_ID', None)
+    if self.task_name is None:
+      self.task_name = environment.get_value('CF_TASK_NAME', None)
     return super().__post_init__(**kwargs)
-
 
 @dataclass(kw_only=True)
 class TestcaseCreationEvent(BaseTestcaseEvent, BaseTaskEvent):

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -114,6 +114,7 @@ class BaseTaskEvent(Event):
       self.task_name = environment.get_value('CF_TASK_NAME', None)
     return super().__post_init__(**kwargs)
 
+
 @dataclass(kw_only=True)
 class TestcaseCreationEvent(BaseTestcaseEvent, BaseTaskEvent):
   """Testcase creation event."""


### PR DESCRIPTION
Although not previously defined in the tracing design doc, this field is useful to allow disabling issue notifications from events for specific tasks (which will be done in the next PR).