### PR TITLE
[Deployment Revisited][Staging] Add JobTemplate import logic to the job-exporter cronjob

### DIFF
--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -204,7 +204,7 @@ class EntityMigrator:
     # This avoids testing environments from using production
     # corpus, logs, backup or quarantine buckets, since these are hardcoded
     # into job env strings. See b/422759773
-    if isinstance(entity_to_import, data_types.Job):
+    if isinstance(entity_to_import, (data_types.Job, data_types.JobTemplate)):
       env_string = getattr(entity_to_import, 'environment_string', None)
       new_env_string = self._substitute_environment_string(env_string)
       setattr(entity_to_import, 'environment_string', new_env_string)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -861,3 +861,67 @@ class TestJobsAreCorrectlyImported(unittest.TestCase):
     self.assertTrue(
         _entity_blob_was_correctly_imported(another_custom_binary_data,
                                             imported_job.custom_binary_key))
+
+
+@test_utils.with_cloud_emulators('datastore')
+class TestJobTemplatesAreCorrectlyImported(unittest.TestCase):
+  """Test the job exporter job with Fuzzer entitites."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+    self.local_gcs_buckets_path = tempfile.mkdtemp()
+    self.blobs_bucket = 'BLOBS_BUCKET'
+    self.import_source_bucket = 'SOURCE_BUCKET'
+    os.environ['LOCAL_GCS_BUCKETS_PATH'] = self.local_gcs_buckets_path
+    os.environ['TEST_BLOBS_BUCKET'] = self.blobs_bucket
+    os.environ['EXPORT_BUCKET'] = self.import_source_bucket
+    storage.create_bucket_if_needed(self.blobs_bucket)
+    storage.create_bucket_if_needed(self.import_source_bucket)
+    helpers.patch(self, [
+        'clusterfuzz._internal.datastore.data_handler.get_data_bundle_bucket_name',
+    ])
+
+  def tearDown(self):
+    shutil.rmtree(self.local_gcs_buckets_path, ignore_errors=True)
+
+  def test_job_templates_are_correctly_imported(self):
+    """Tests if a job template, previously absent, is correctly created."""
+    template_name = 'some-template'
+    prod_corpus_bucket = 'PROD_CORPUS_BUCKET'
+    test_corpus_bucket = 'TEST_CORPUS_BUCKET'
+    prod_log_bucket = 'PROD_LOG_BUCKET'
+    test_log_bucket = 'TEST_LOG_BUCKET'
+    original_env_string = f'FUZZ_LOGS_BUCKET={prod_log_bucket};CORPUS_BUCKET={prod_corpus_bucket}'
+    expected_env_string = f'FUZZ_LOGS_BUCKET={test_log_bucket};CORPUS_BUCKET={test_corpus_bucket}'
+    substitutions = {
+        prod_log_bucket: test_log_bucket,
+        prod_corpus_bucket: test_corpus_bucket,
+    }
+    template = _sample_job_template(
+        name=template_name, environment_string=original_env_string)
+    _upload_entity_export_data(
+        entity=template,
+        entity_kind='jobtemplate',
+        source_bucket=self.import_source_bucket,
+        blobstore_key_content=None,
+        sample_testcase_contents=None,
+        custom_binary_contents=None,
+    )
+
+    job_template_base_location = f'gs://{self.import_source_bucket}/jobtemplate'
+    _upload_entity_list([template_name], job_template_base_location)
+
+    entity_migrator = job_exporter.EntityMigrator(
+        data_types.JobTemplate, [],
+        'jobtemplate',
+        job_exporter.StorageRSync(),
+        self.import_source_bucket,
+        env_string_substitutions=substitutions)
+    entity_migrator.import_entities()
+
+    templates = list(data_types.JobTemplate.query())
+    self.assertEqual(1, len(templates))
+
+    imported_template = templates[0]
+    self.assertEqual(template_name, imported_template.name)
+    self.assertEqual(expected_env_string, imported_template.environment_string)


### PR DESCRIPTION
### Motivation

In order to kickstart fuzzing in a testing environment, we need to mirror the Job, Fuzzer and DataBundle entities.
This PR adds the capability of importing Jobs from the exported data, implemented in https://github.com/google/clusterfuzz/pull/4808 .

### Implementation

Assuming that all data was exported to $SOME_BUCKET, the folder structure for JobTemplates looks like this:

```
$SOME_BUCKET/
    jobtemplate/
        entities
        some-job-template/
            entity.proto
        another-job-template/
            entity.proto
```

The proto file is the serialized representation of a data_types.Job entity, and the other files is the associated custom binary, if present.

The entities file contains line separated job template names that were last exported.

To import said entities, the cronjob will:
* Parse entity names to be imported from the entities file
* Deserialize the protobuf and persist the entity into datastore, by performing an environment string substitution

Environment string substitution behaves the same way as described in #4829 

Unit tests for:
* Correctly creating a JobTemplate, from the state where it still does not exist, and performing the desired env string substitution
* Correctly deleting a JobTemplate, when from the state where it is present in the target environment, in response to the export list not containing its name
* Correctly updating a JobTemplate, once a newer revision with different fields is exported from the source project, while also ensuring correct env string substitution