### PR TITLE
[Deployment Revisited][Staging] Add DataBundle import logic to the job-exporter cronjob

### DIFF
--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/job_exporter_test.py
@@ -120,6 +120,7 @@ def _upload_entity_export_data(
     blobstore_key_content: bytes | None = None,
     sample_testcase_contents: bytes | None = None,
     custom_binary_contents: bytes | None = None,
+    data_bundle_blob_contents: bytes | None = None,
 ):
   """Dumps an entity in its blobs into the expect exported folder structure."""
   assert getattr(entity, 'name')
@@ -140,6 +141,10 @@ def _upload_entity_export_data(
   if custom_binary_contents:
     storage.write_data(custom_binary_contents,
                        f'{entity_location}/custom_binary_key')
+
+  if data_bundle_blob_contents:
+    storage.write_data(data_bundle_blob_contents,
+                       f'{entity_location}/contents/blob')
 
 
 def _register_entity_and_upload_blobs(
@@ -1020,3 +1025,69 @@ class TestJobTemplatesAreCorrectlyImported(unittest.TestCase):
     self.assertEqual(template_name, imported_template.name)
     self.assertEqual(env_string_after_import,
                      imported_template.environment_string)
+
+
+@test_utils.with_cloud_emulators('datastore')
+class TestDataBundlesAreCorrectlyImported(unittest.TestCase):
+  """Test the job exporter job with DataBundle entities."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+    self.local_gcs_buckets_path = tempfile.mkdtemp()
+    self.blobs_bucket = 'BLOBS_BUCKET'
+    self.import_source_bucket = 'SOURCE_BUCKET'
+    os.environ['LOCAL_GCS_BUCKETS_PATH'] = self.local_gcs_buckets_path
+    os.environ['TEST_BLOBS_BUCKET'] = self.blobs_bucket
+    os.environ['EXPORT_BUCKET'] = self.import_source_bucket
+    storage.create_bucket_if_needed(self.blobs_bucket)
+    storage.create_bucket_if_needed(self.import_source_bucket)
+    helpers.patch(self, [
+        'clusterfuzz._internal.datastore.data_handler.get_data_bundle_bucket_name',
+    ])
+
+  def tearDown(self):
+    shutil.rmtree(self.local_gcs_buckets_path, ignore_errors=True)
+
+  def test_data_bundles_are_correctly_imported(self):
+    """Tests if a data bundle entity was correctly imported, and the data
+      bundle contents were correctly copied to a new bucket."""
+    bundle_name = 'some-bundle'
+    bucket_name = 'old-bucket'
+    blob_data = b'some-data'
+    bundle = _sample_data_bundle(
+        name=bundle_name,
+        bucket_name=bucket_name,
+    )
+    _upload_entity_export_data(
+        entity=bundle,
+        entity_kind='databundle',
+        source_bucket=self.import_source_bucket,
+        blobstore_key_content=None,
+        sample_testcase_contents=None,
+        custom_binary_contents=None,
+        data_bundle_blob_contents=blob_data,
+    )
+
+    data_bundle_base_location = f'gs://{self.import_source_bucket}/databundle'
+    _upload_entity_list([bundle_name], data_bundle_base_location)
+
+    new_data_bundle_bucket = 'new-bundle-bucket'
+    self.mock.get_data_bundle_bucket_name.return_value = new_data_bundle_bucket
+
+    entity_migrator = job_exporter.EntityMigrator(data_types.DataBundle, [],
+                                                  'databundle',
+                                                  job_exporter.StorageRSync(),
+                                                  self.import_source_bucket)
+    entity_migrator.import_entities()
+
+    data_bundles = list(data_types.DataBundle.query())
+    self.assertEqual(1, len(data_bundles))
+
+    imported_bundle = data_bundles[0]
+    self.assertEqual(bundle_name, imported_bundle.name)
+    self.assertEqual(new_data_bundle_bucket, imported_bundle.bucket_name)
+
+    bundle_blob_location = f'gs://{new_data_bundle_bucket}/blob'
+
+    self.assertTrue(_blob_is_present_in_gcs(bundle_blob_location))
+    self.assertTrue(_blob_content_is_equal(bundle_blob_location, blob_data))


### PR DESCRIPTION
### Motivation

In order to kickstart fuzzing in a testing environment, we need to mirror the Job, Fuzzer and DataBundle entities.
This PR adds the capability of importing Jobs from the exported data, implemented in https://github.com/google/clusterfuzz/pull/4808 .

### Implementation

Assuming that all data was exported to $SOME_BUCKET, the folder structure for data bundles looks like this:

```
$SOME_BUCKET/
    databundle/
        entities
        some-bundle/
            entity.proto
            contents/
              blob1
              blob2
        another-bundle/
            entity.proto
            contents/
              blob3
              blob4
```

The proto file is the serialized representation of a data_types.DataBundle entity, and the files under the content folder are the original contents of the data bundle bucket.

The entities file contains line separated data bundle names that were last exported.

To import said entities, the cronjob will:
* Parse entity names to be imported from the entities file
* RSync the contents folder for the data bundle in question, to a new bucket in the target project. This is done through the [get_data_bundle_bucket_name](https://github.com/google/clusterfuzz/blob/ad39a91bd2756a9e84455d6f5de1eb5d9a7ce0ac/src/clusterfuzz/_internal/datastore/data_handler.py#L1026) function
* Deserialize the protobuf and persist the entity into datastore, while changing the bucket name field to the rsync target

Unit tests for:
* Correctly creating a DataBundle, from the state where it still does not exist, and copying over the data bundle contents
* Correctly deleting a DataBundle, when from the state where it is present in the target environment, in response to the export list not containing its name
* Correctly updating a DataBundle, once a newer revision with different fields is exported from the source project, while also ensuring the blobs remain up to date



### Attention points

The implementation for StorageRSync was incomplete. List_blobs returns the file names from the root bucket, and we want to use the file names starting from the contents folder. This worked for exporting the data bundles, since the blobs were on the top level folder, but not for the import:

For this reason, the storage rsync implementation was updated. It should not change the behavior in a real deployment, since it is a unit testing only class

```
gs://export-bucket/databundle/some-bundle/contents/blob

gsutil ls export-bucket:
databundle/some-bundle/contents/blob

gsutil cp gs://export-bucket/databundle/some-bundle/contents/blob gs://new-bucket/blob
```