### PR TITLE
[Deployment Revisited][Staging] Fix runtime errors on the job exporter cron

### DIFF
--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -143,6 +143,10 @@ class EntityMigrator:
       blob_id = getattr(entity, blobstore_key, None)
       if blob_id:
         blob_gcs_path = blobs.get_gcs_path(blob_id)
+        if not storage.get(blob_gcs_path):
+          logs.warning(f'{blobstore_key} with id {blob_id} not present '
+                       f'for {entity.name}, skipping.')
+          continue
         blob_destination_path = f'{bucket_prefix}/{blobstore_key}'
         storage.copy_blob(blob_gcs_path, blob_destination_path)
 

--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -157,6 +157,10 @@ class EntityMigrator:
       logs.info(
           f'DataBundle {entity.name} has no related gcs bucket, skipping.')
       return
+    if not storage.get_bucket(entity.bucket_name):
+      logs.warning(f'Bucket {entity.bucket_name} missing for '
+                   f'data bundle {entity.name}, skipping.')
+      return
     source_location = f'gs://{entity.bucket_name}'
     target_location = f'{bucket_prefix}/contents'
     rsync_succeeded = self._rsync_client.rsync(source_location, target_location)

--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -213,9 +213,10 @@ class EntityMigrator:
             f'{blobstore_key} missing for {entity_name}, skipping blob import.')
         continue
       if not storage.get(source_blob_location):
-        raise ValueError(
-            f'Absent blob for {blobstore_key} in {entity_name}, it '
-            'should be present.')
+        logs.warning(f'Absent blob for {blobstore_key} in {entity_name}, it '
+                     'was expected be present. Marked as None and skipping.')
+        new_blob_ids[blobstore_key] = None
+        continue
       new_blob_id = blobs.generate_new_blob_name()
       target_blob_location = f'gs://{storage.blobs_bucket()}/{new_blob_id}'
       if not storage.copy_blob(source_blob_location, target_blob_location):

--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -297,9 +297,11 @@ class EntityMigrator:
 
     # Do not assume that name is a primary key, avoid having two
     # different keys with the same name.
-    preexisting_entity = self._target_cls.query(
-        self._target_cls.name == entity_name).get()
-    if preexisting_entity:
+    preexisting_entities = list(
+        self._target_cls.query(self._target_cls.name == entity_name))
+    logs.info(f'Found {len(preexisting_entities)} of type {self._entity_type}'
+              f' and name {entity_name}, deleting.')
+    for preexisting_entity in preexisting_entities:
       preexisting_entity.key.delete()
 
     self._persist_entity(entity_to_import)

--- a/src/clusterfuzz/_internal/cron/job_exporter.py
+++ b/src/clusterfuzz/_internal/cron/job_exporter.py
@@ -244,7 +244,9 @@ class EntityMigrator:
       call failed."""
     new_bundle_bucket = data_handler.get_data_bundle_bucket_name(bundle_name)
     storage.create_bucket_if_needed(new_bundle_bucket)
-    if not storage.get(source_location):
+    # There is no helper method to figure out if a folder exists, resort to
+    # checking if there are blobs under the path.
+    if not list(storage.get_blobs(source_location)):
       logs.warning(f'No source content for data bundle {bundle_name},'
                    ' skipping content import.')
       return new_bundle_bucket

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -940,6 +940,11 @@ def set_bucket_iam_policy(client, bucket_name, iam_policy):
   return None
 
 
+def get_bucket(bucket_name: str):
+  provider = _provider()
+  return provider.get_bucket(bucket_name)
+
+
 def create_bucket_if_needed(bucket_name,
                             object_lifecycle=None,
                             cors=None,


### PR DESCRIPTION
### Motivation

The following error scenarios were not caught in unit tests:

* During export, blob for which there is a key, but no corresponding object in the blobs bucket. This throws an Exception due to a 404 in the GCS API call. To address this, the blob will not be uploaded during export, and the key will be set to None during import
* During exports (and imports), data bundles that reference a non existing bucket would result in a 404 from the GCS API, throwing a fatal exception. To address this, the contents folder export will be skipped, and the rsync will be skipped during import.

Also, there was no error treatment for RSync, so we do not know if the operation was successful. The RSync methods were implementede to return True on successful completion, and false on failure. If the operation fails, an Exception is raised to force the cronjob to be retried.

### Carried over keys and project id

When serialized from a previous database, the Key entity will carry over the GCP project name, which will result in the following exception during the put call:

```
detail: "mismatched databases within request: <unknown!>~clusterfuzz-development vs. <unknown!>~cluster-fuzz"
, detail: "/Datastore.Commit to [2002:a05:6600:760b:b0:3ba:dcf:6bcb]:4001 : APP_ERROR(1) mismatched databases within request: <unknown!>~clusterfuzz-development vs. <unknown!>~cluster-fuzz"
]
```

For this reason, we cannot simply deserialize and put. The fields have to be manually retrieved and assigned to the new entity, and the key will be auto generated on every put. This was implemented by adding the '_persist_entity' method.

### Other changes

The public method 'get_bucket' was added to the storage module, so we can know if a GCS bucket already exists. This was already used internally, it is now exposed in the storage interface.


### Testing strategy

Reusing the test suite already in place, and doing a manual export/import from internal to chrome-development. The script finished successfully in both scenarios, and the output looks sane in dev