### PR TITLE
[Deployment Revisited][Staging] Add terraform resources for testcase replication

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -132,3 +132,25 @@ resource "google_compute_router_nat" "nat_config" {
     filter = "ALL"
   }
 }
+
+resource "google_pubsub_topic" "crash_replication" {
+  name    = "crash-replication"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "crash_replication_push_to_appengine" {
+  ack_deadline_seconds = 120
+
+  name                       = "crash-replication-push-to-appengine"
+  project                    =  var.project_id
+
+  push_config {
+    oidc_token {
+      service_account_email = var.appengine_service_account
+    }
+
+    push_endpoint = var.testcase_replication_push_endpoint
+  }
+
+  topic = google_pubsub_topic.crash_replication.name
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -54,3 +54,13 @@ variable "network_description" {
   default = ""
   description = "The network description"
 }
+
+variable "appengine_service_account" {
+  default = ""
+  description = "AppEngine service account for the clusterfuzz deployment"
+}
+
+variable "testcase_replication_push_endpoint" {
+  default = ""
+  description = "Endpoint to push testcase replication messages to"
+}


### PR DESCRIPTION
Fuzz task will publish, during postprocess, sampled crashes to the crash-replication topic. This, in turn, will cause a push notification to appengine, that will consume the message and upload the testcase through a handler yet to be implemented.

This PR implements the new terraform resources in the main clusterfuzz module, to enable this functionality