### PR TITLE
MNT Truncate for non string objects

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -184,8 +184,33 @@ def get_logging_config_dict(name):
   }
 
 
-def truncate(msg, limit):
-  """We need to truncate the message in the middle if it gets too long."""
+def truncate(
+    msg: Any,
+    limit: int,
+) -> Any:
+  """We need to truncate the message in the middle if it gets too long.
+
+  If the message is a string and exceeds the character `limit`, it is
+  truncated in the middle, with a notice indicating how many characters
+  were removed.
+
+  For dictionaries, lists, and tuples, the function recurses over their
+  values/items. For dataclasses, it first converts them to dictionaries
+  before recursing.
+
+  Certain types defined in `NON_TRUNCATABLE_TYPES` are returned as-is.
+  All other types are coerced to strings before truncation.
+
+  Args:
+    msg: The message or collection to truncate.
+    limit: The maximum character length for strings.
+
+  Returns:
+    The truncated message, which may be a string or a collection of
+    the same type as the input. While basic types like strings, lists, and
+    dictionaries retain their type, be aware that dataclasses are converted
+    to dictionaries, and other unhandled objects are converted to strings.
+  """
   if isinstance(msg, NON_TRUNCATABLE_TYPES):
     return msg
 

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -190,26 +190,27 @@ def truncate(
 ) -> Any:
   """We need to truncate the message in the middle if it gets too long.
 
-  If the message is a string and exceeds the character `limit`, it is
-  truncated in the middle, with a notice indicating how many characters
-  were removed.
+  If the message is a string and exceeds the character `limit`, it is truncated
+  in the middle, with a notice indicating how many characters were removed.
 
   For dictionaries, lists, and tuples, the function recurses over their
-  values/items. For dataclasses, it first converts them to dictionaries
-  before recursing.
+  values/items. For dataclasses, it first converts them to dictionaries before
+  recursing.
 
-  Certain types defined in `NON_TRUNCATABLE_TYPES` are returned as-is.
-  All other types are coerced to strings before truncation.
+  Certain types defined in `NON_TRUNCATABLE_TYPES` are returned as-is. All other
+  types are coerced to strings before truncation.
+
+  While basic types like strings, lists, and dictionaries retain their type, be
+  aware that dataclasses are converted to dictionaries, and other unhandled
+  objects are converted to strings. This function should only be used in the
+  logs module.
 
   Args:
     msg: The message or collection to truncate.
     limit: The maximum character length for strings.
 
   Returns:
-    The truncated message, which may be a string or a collection of
-    the same type as the input. While basic types like strings, lists, and
-    dictionaries retain their type, be aware that dataclasses are converted
-    to dictionaries, and other unhandled objects are converted to strings.
+    The truncated message. 
   """
   if isinstance(msg, NON_TRUNCATABLE_TYPES):
     return msg

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -14,6 +14,7 @@
 """Logging functions."""
 
 import contextlib
+import dataclasses
 import datetime
 import enum
 import functools
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
 # This reserves roughly up to 200 KB for message content, leaving sufficient
 # space for structured logging metadata within the 256 KB total limit.
 STACKDRIVER_LOG_MESSAGE_LIMIT = 80000
+NON_TRUNCATABLE_TYPES = (int, float, bool, type(None))
 LOCAL_LOG_MESSAGE_LIMIT = 100000
 LOCAL_LOG_LIMIT = 500000
 _logger = None
@@ -184,7 +186,24 @@ def get_logging_config_dict(name):
 
 def truncate(msg, limit):
   """We need to truncate the message in the middle if it gets too long."""
-  if not isinstance(msg, str) or len(msg) <= limit:
+  if isinstance(msg, NON_TRUNCATABLE_TYPES):
+    return msg
+
+  # Handle collections and objects by recursing
+  if dataclasses.is_dataclass(msg) and not isinstance(msg, type):
+    msg = dataclasses.asdict(msg)
+
+  if isinstance(msg, dict):
+    return {k: truncate(v, limit) for k, v in msg.items()}
+
+  if isinstance(msg, (list, tuple)):
+    return type(msg)(truncate(item, limit) for item in msg)
+
+  # Coerce all other types to a string
+  if not isinstance(msg, str):
+    msg = str(msg)
+
+  if len(msg) <= limit:
     return msg
 
   half = limit // 2

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -238,10 +238,10 @@ class FormatRecordTest(unittest.TestCase):
           'simple_extras',
           {
               'a': 1
-          },
+          },  # input_extras
           {
               'a': 1
-          },
+          },  # expected_extras_json
       ),
       (
           'no_extras',

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -287,7 +287,7 @@ class FormatRecordTest(unittest.TestCase):
   ])
   @mock.patch(
       'clusterfuzz._internal.metrics.logs.STACKDRIVER_LOG_MESSAGE_LIMIT', 20)
-  def test_format_record(self, name, input_extras, expected_extras_json):
+  def test_format_record(self, _, input_extras, expected_extras_json):
     """Test formatting a LogRecord with different 'extras' payloads."""
     os.environ['FUZZ_TARGET'] = 'fuzz_target1'
     record = self.get_record()


### PR DESCRIPTION
@ViniciustCosta realized that we don't truncate values that are not strings, even though we might want to truncate them for being too large to be logged (b/414397533).

This PR implements recursive truncation for dict-like objects (such as dictionaries and dataclasses) and lists/tuples by applying truncate to their values. We do this to keep the structure logging as smooth as possible. When that is not possible, we simply transform the object into its string representation and truncate that.

Evidence that the PR works:
- [Debugger config and script ran](https://paste.googleplex.com/6527399831011328).
- [GCP log](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2025-06-28T02:14:55.125773Z;endTime=2025-06-28T02:17:12Z;query=SEARCH%2528%22aaaaatruncatedaaaa%22%2529%0A--%20jsonPayload.extras.extras.class.integer%20%3D%2010%0Atimestamp%3D%222025-06-28T02:14:55.125773Z%22%0AinsertId%3D%22rsii28efzr6u%22;startTime=2025-06-28T02:12:12Z?project=google.com:clusterfuzz).
- Prints of the log (because of TTL):[1](https://screenshot.googleplex.com/AzVYTwy8k5HPQmz), [2](https://screenshot.googleplex.com/4MviMwVMEiBb3FG).

b/414397533