### PR TITLE
[Tracing] Emiting TestcaseRejectionEvent during cleanup

### DIFF
--- a/src/clusterfuzz/_internal/cron/cleanup.py
+++ b/src/clusterfuzz/_internal/cron/cleanup.py
@@ -35,6 +35,7 @@ from clusterfuzz._internal.issue_management import issue_filer
 from clusterfuzz._internal.issue_management import issue_tracker_policy
 from clusterfuzz._internal.issue_management import issue_tracker_utils
 from clusterfuzz._internal.metrics import crash_stats
+from clusterfuzz._internal.metrics import events
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.metrics import monitoring_metrics
 
@@ -394,6 +395,11 @@ def delete_unreproducible_testcase_with_no_issue(testcase):
   testcase.key.delete()
   logs.info(
       f'Deleted unreproducible testcase {testcase.key.id()} with no issue.')
+  events.emit(
+      events.TestcaseRejectionEvent(
+          testcase=testcase,
+          rejection_reason=events.RejectionReason.
+          CLEANUP_UNREPRODUCIBLE_NO_ISSUE))
 
 
 def mark_duplicate_testcase_as_closed_with_no_issue(testcase):
@@ -417,6 +423,10 @@ def mark_duplicate_testcase_as_closed_with_no_issue(testcase):
   testcase.open = False
   testcase.put()
   logs.info(f'Closed duplicate testcase {testcase.key.id()} with no issue.')
+  events.emit(
+      events.TestcaseRejectionEvent(
+          testcase=testcase,
+          rejection_reason=events.RejectionReason.CLEANUP_DUPLICATE_NO_ISSUE))
 
 
 def mark_issue_as_closed_if_testcase_is_fixed(policy, testcase, issue):
@@ -543,6 +553,10 @@ def mark_unreproducible_testcase_as_fixed_if_issue_is_closed(testcase, issue):
   testcase.put()
   logs.info(f'Closed unreproducible testcase {testcase.key.id()} '
             'with issue closed.')
+  events.emit(
+      events.TestcaseRejectionEvent(
+          testcase=testcase,
+          rejection_reason=events.RejectionReason.CLEANUP_ISSUE_CLOSED))
 
 
 def mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
@@ -634,6 +648,11 @@ def mark_unreproducible_testcase_and_issue_as_closed_after_deadline(
 
   logs.info(f'Closed unreproducible testcase {testcase.key.id()} '
             'and associated issue.')
+  events.emit(
+      events.TestcaseRejectionEvent(
+          testcase=testcase,
+          rejection_reason=events.RejectionReason.
+          CLEANUP_UNREPRODUCIBLE_WITH_ISSUE))
 
 
 def mark_na_testcase_issues_as_wontfix(policy, testcase, issue):
@@ -728,6 +747,10 @@ def mark_testcase_as_closed_if_issue_is_closed(policy, testcase, issue):
   testcase.fixed = 'NA'
   testcase.put()
   logs.info(f'Closed testcase {testcase.key.id()} with issue closed.')
+  events.emit(
+      events.TestcaseRejectionEvent(
+          testcase=testcase,
+          rejection_reason=events.RejectionReason.CLEANUP_ISSUE_CLOSED))
 
 
 def mark_testcase_as_closed_if_job_is_invalid(testcase, jobs):
@@ -744,6 +767,10 @@ def mark_testcase_as_closed_if_job_is_invalid(testcase, jobs):
   testcase.fixed = 'NA'
   testcase.put()
   logs.info(f'Closed testcase {testcase.key.id()} with invalid job.')
+  events.emit(
+      events.TestcaseRejectionEvent(
+          testcase=testcase,
+          rejection_reason=events.RejectionReason.CLEANUP_INVALID_JOB))
 
 
 def notify_closed_issue_if_testcase_is_open(policy, testcase, issue):

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -54,6 +54,11 @@ class RejectionReason:
   """Explanation for the testcase rejection values."""
   ANALYZE_NO_REPRO = 'analyze_no_repro'
   ANALYZE_FLAKE_ON_FIRST_ATTEMPT = 'analyze_flake_on_first_attempt'
+  CLEANUP_UNREPRODUCIBLE_NO_ISSUE = 'cleanup_unreproducible_no_issue'
+  CLEANUP_DUPLICATE_NO_ISSUE = 'cleanup_duplicate_no_issue'
+  CLEANUP_UNREPRODUCIBLE_WITH_ISSUE = 'cleanup_unreproducible_with_issue'
+  CLEANUP_ISSUE_CLOSED = 'cleanup_issue_closed'
+  CLEANUP_INVALID_JOB = 'cleanup_invalid_job'
 
 
 @dataclass(kw_only=True)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/cleanup_test.py
@@ -20,6 +20,7 @@ import unittest
 from clusterfuzz._internal.cron import cleanup
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.issue_management import issue_tracker_policy
+from clusterfuzz._internal.metrics import events
 from clusterfuzz._internal.tests.test_libs import appengine_test_utils
 from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
@@ -74,10 +75,26 @@ class CleanupTest(unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.base.utils.utcnow',
         'clusterfuzz._internal.cron.cleanup.get_crash_occurrence_platforms',
+        'clusterfuzz._internal.metrics.events.emit',
+        'clusterfuzz._internal.metrics.events.TestcaseRejectionEvent',
     ])
     self.mock.utcnow.return_value = test_utils.CURRENT_TIME
+    self.mock_rejection_event = unittest.mock.Mock()
+    self.mock.TestcaseRejectionEvent.side_effect = (
+        lambda testcase, rejection_reason: self._init_rejection_event(
+            testcase, rejection_reason))
     self.issue = appengine_test_utils.create_generic_issue()
     self.policy = issue_tracker_policy.get('test-project')
+
+  def _init_rejection_event(self, testcase, rejection_reason):
+    self.mock_rejection_event.testcase_id = testcase.key.id()
+    self.mock_rejection_event.rejection_reason = rejection_reason
+    return self.mock_rejection_event
+
+  def _assert_rejection_event_emitted(self, expected_reason):
+    self.mock.emit.assert_called_once_with(self.mock_rejection_event)
+    self.assertEqual(expected_reason,
+                     self.mock_rejection_event.rejection_reason)
 
   def test_mark_duplicate_testcase_as_closed_with_no_issue_1(self):
     """Ensure that a regular bug older than 7 days does not get closed."""
@@ -109,6 +126,8 @@ class CleanupTest(unittest.TestCase):
     testcase.put()
     cleanup.mark_duplicate_testcase_as_closed_with_no_issue(testcase=testcase)
     self.assertFalse(testcase.open)
+    self._assert_rejection_event_emitted(
+        events.RejectionReason.CLEANUP_DUPLICATE_NO_ISSUE)
 
   def test_mark_duplicate_testcase_as_closed_with_no_issue_4(self):
     """Ensure that a duplicate bug 7 days old does not get closed."""
@@ -152,6 +171,8 @@ class CleanupTest(unittest.TestCase):
     testcase.put()
     cleanup.delete_unreproducible_testcase_with_no_issue(testcase=testcase)
     self.assertFalse(test_utils.entity_exists(testcase))
+    self._assert_rejection_event_emitted(
+        events.RejectionReason.CLEANUP_UNREPRODUCIBLE_NO_ISSUE)
 
   def test_delete_unreproducible_testcase_with_no_issue_4(self):
     """Ensure that an unreproducible bug with crash in last 7 days does not get
@@ -489,6 +510,8 @@ class CleanupTest(unittest.TestCase):
     cleanup.mark_testcase_as_closed_if_job_is_invalid(
         testcase=testcase, jobs=jobs)
     self.assertFalse(testcase.open)
+    self._assert_rejection_event_emitted(
+        events.RejectionReason.CLEANUP_INVALID_JOB)
 
   def test_mark_unreproducible_testcase_as_fixed_if_issue_is_closed_1(self):
     """Ensure that a reproducible testcase with no associated issue is not
@@ -547,6 +570,8 @@ class CleanupTest(unittest.TestCase):
     cleanup.mark_unreproducible_testcase_as_fixed_if_issue_is_closed(
         testcase=testcase, issue=self.issue)
     self.assertFalse(testcase.open)
+    self._assert_rejection_event_emitted(
+        events.RejectionReason.CLEANUP_ISSUE_CLOSED)
 
   def test_mark_unreproducible_testcase_and_issue_as_closed_after_deadline_1(
       self):
@@ -684,6 +709,8 @@ class CleanupTest(unittest.TestCase):
         policy=self.policy, testcase=testcase, issue=self.issue)
     self.assertFalse(testcase.open)
     self.assertEqual('WontFix', self.issue.status)
+    self._assert_rejection_event_emitted(
+        events.RejectionReason.CLEANUP_UNREPRODUCIBLE_WITH_ISSUE)
 
   def test_mark_unreproducible_testcase_and_issue_as_closed_after_deadline_10(
       self):
@@ -736,6 +763,8 @@ class CleanupTest(unittest.TestCase):
         policy=self.policy, testcase=testcase, issue=self.issue)
     self.assertFalse(testcase.open)
     self.assertEqual('WontFix', self.issue.status)
+    self._assert_rejection_event_emitted(
+        events.RejectionReason.CLEANUP_UNREPRODUCIBLE_WITH_ISSUE)
 
   def test_notify_closed_issue_if_testcase_is_open_1(self):
     """Test that we don't do anything if testcase is already closed."""


### PR DESCRIPTION
This PR introduces the emits of `TestcaseRejectionEvent` in the desired steps of the cleanup task life cycle as discussed in the [comment section](https://github.com/google/clusterfuzz/pull/4827#discussion_r2145889364) of #4827. Supersedes #4827.

The other remaining cases where `TestcaseRejectionEvent` must be emitted (namely fuzz task, corpus pruning and grouper) will be addressed in separate PRs.

b/394056013