### PR TITLE
[Tracing] Emiting `TestcaseRejectionEvent` during fuzz task

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -849,6 +849,10 @@ def postprocess_process_crashes(uworker_input: uworker_msg_pb2.Input,
           uworker_output=uworker_output,
           fully_qualified_fuzzer_name=fully_qualified_fuzzer_name)
     else:
+      events.emit(
+          events.TestcaseRejectionEvent(
+              testcase=existing_testcase,
+              rejection_reason=events.RejectionReason.FUZZ_DUPLICATE))
       _update_testcase_variant_if_needed(group, existing_testcase,
                                          fuzz_task_output.crash_revision,
                                          uworker_input.job_type)

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -54,6 +54,7 @@ class RejectionReason:
   """Explanation for the testcase rejection values."""
   ANALYZE_NO_REPRO = 'analyze_no_repro'
   ANALYZE_FLAKE_ON_FIRST_ATTEMPT = 'analyze_flake_on_first_attempt'
+  FUZZ_DUPLICATE = 'fuzz_duplicate'
 
 
 @dataclass(kw_only=True)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
@@ -1649,7 +1649,6 @@ class EmitTestcaseCreationEventTest(unittest.TestCase):
             uploader=None))
 
 
-
 @test_utils.with_cloud_emulators('datastore')
 class DuplicateTestcaseRejectionEventTest(unittest.TestCase):
   """Tests that duplicate crashes emit a rejection event."""
@@ -1673,6 +1672,7 @@ class DuplicateTestcaseRejectionEventTest(unittest.TestCase):
     self.mock.find_testcase.return_value = self.existing_testcase
 
   def test_duplicate_event_emitted(self):
+    """Test that a duplicated testcase event is emited."""
     crash = uworker_msg_pb2.FuzzTaskCrash(
         crash_type='type', crash_state='state', security_flag=True)
     group = uworker_msg_pb2.FuzzTaskCrashGroup(


### PR DESCRIPTION
This PR introduces the emits of `TestcaseRejectionEvent` in the desired steps of the fuzz task life cycle as stated in the "Testcase rejection" section of "Lightweight Clusterfuzz Tracing" doc.

We are also adding assertions for verification of the emit.

The other remaining cases where `TestcaseRejectionEvent` must be emitted (namely corpus pruning and grouper) will be addressed in separate PRs.

b/394056013