### PR TITLE
[Tracing] Emiting `TestcaseRejectionEvent` during corpus pruning

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -876,6 +876,11 @@ def _process_corpus_crashes(output: uworker_msg_pb2.Output):  # pylint: disable=
           fuzz_target=fuzz_target.project_qualified_name())
       if existing_testcase:
         logs.info('_process_corpus_crashes figured out crash already exists.')
+        events.emit(
+            events.TestcaseRejectionEvent(
+                testcase=existing_testcase,
+                rejection_reason=events.RejectionReason.CORPUS_PRUNING_DUPLICATE
+            ))
         continue
 
       unit_name = os.path.basename(crash.unit_path)

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -54,6 +54,7 @@ class RejectionReason:
   """Explanation for the testcase rejection values."""
   ANALYZE_NO_REPRO = 'analyze_no_repro'
   ANALYZE_FLAKE_ON_FIRST_ATTEMPT = 'analyze_flake_on_first_attempt'
+  CORPUS_PRUNING_DUPLICATE = 'corpus_pruning_duplicate'
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
This PR introduces the emits of `TestcaseRejectionEvent` in the desired steps of the corpus pruning task life cycle as stated in the "Testcase rejection" section of "Lightweight Clusterfuzz Tracing" doc.

We are also adding assertions for verification of the emit.

The other remaining cases where `TestcaseRejectionEvent` must be emitted (namely grouper) will be addressed in separate PRs.

b/394056013