### PR TITLE
[Tracing] Emiting TestcaseRejectionEvent during grouper

### DIFF
--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -54,6 +54,8 @@ class RejectionReason:
   """Explanation for the testcase rejection values."""
   ANALYZE_NO_REPRO = 'analyze_no_repro'
   ANALYZE_FLAKE_ON_FIRST_ATTEMPT = 'analyze_flake_on_first_attempt'
+  GROUPER_DUPLICATE = 'grouper_duplicate'
+  GROUPER_OVERFLOW = 'grouper_overflow'
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
This PR introduces the emits of `TestcaseRejectionEvent` in the desired steps of the grouper life cycle as stated in b/394056013#comment9.

We are also adding assertions for verification of the emit.

This is the last `TestcaseRejectionEvent` emision pull request.

b/394056013