### PR TITLE
[Tracing] Create the Task Execution event

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -1681,8 +1681,8 @@ class TestcaseLifecycleEvent(Model):
   # Task status (e.g., started, finished, exception).
   task_status = ndb.StringProperty()
 
-  # UTask return code (defined in error types from uworker protobuf).
-  task_return_code = ndb.IntegerProperty()
+  # UTask return code based on error types from uworker protobuf.
+  task_outcome = ndb.StringProperty()
 
   def _pre_put_hook(self):
     self.ttl_expiry_timestamp = (

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -1674,6 +1674,16 @@ class TestcaseLifecycleEvent(Model):
   # If the issue filing attempt was successful.
   issue_created = ndb.BooleanProperty()
 
+  ### Task execution.
+  # Task stage, i.e., preprocess, main or postprocess.
+  task_stage = ndb.StringProperty()
+
+  # Task status (e.g., started, finished, exception).
+  task_status = ndb.StringProperty()
+
+  # UTask return code (defined in error types from uworker protobuf).
+  task_return_code = ndb.IntegerProperty()
+
   def _pre_put_hook(self):
     self.ttl_expiry_timestamp = (
         datetime.datetime.now() + self.TESTCASE_EVENT_TTL)

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -1684,6 +1684,12 @@ class TestcaseLifecycleEvent(Model):
   # UTask return code based on error types from uworker protobuf.
   task_outcome = ndb.StringProperty()
 
+  # Task-related job type.
+  task_job = ndb.StringProperty()
+
+  # Task-related fuzzer name.
+  task_fuzzer = ndb.StringProperty()
+
   def _pre_put_hook(self):
     self.ttl_expiry_timestamp = (
         datetime.datetime.now() + self.TESTCASE_EVENT_TTL)

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -41,6 +41,7 @@ class EventTypes:
   TESTCASE_CREATION = 'testcase_creation'
   TESTCASE_REJECTION = 'testcase_rejection'
   ISSUE_FILING = 'issue_filing'
+  TASK_EXECUTION = 'task_execution'
 
 
 class TestcaseOrigin:
@@ -54,6 +55,20 @@ class RejectionReason:
   """Explanation for the testcase rejection values."""
   ANALYZE_NO_REPRO = 'analyze_no_repro'
   ANALYZE_FLAKE_ON_FIRST_ATTEMPT = 'analyze_flake_on_first_attempt'
+
+
+class TaskStage:
+  """Task stage."""
+  PREPROCESS = 'preprocess'
+  MAIN = 'main'
+  POSTPROCESS = 'postprocess'
+  NA = 'n/a'
+
+
+class TaskStatus:
+  STARTED = 'started'
+  FINISHED = 'finished'
+  EXCEPTION = 'exception'
 
 
 @dataclass(kw_only=True)
@@ -160,11 +175,24 @@ class IssueFilingEvent(BaseTestcaseEvent, BaseTaskEvent):
   issue_created: bool | None = None
 
 
+@dataclass(kw_only=True)
+class TaskExecutionEvent(BaseTestcaseEvent, BaseTaskEvent):
+  """Task execution event."""
+  event_type: str = field(default=EventTypes.TASK_EXECUTION, init=False)
+  # Task stage (preprocess, main or postprocess).
+  task_stage: str | None = None
+  # Task status (e.g., started, finished, exception).
+  task_status: str | None = None
+  # UTask return code (defined in the uworker protobuf error types).
+  task_return_code: int | None = None
+
+
 # Mapping of specific event types to their data classes.
 _EVENT_TYPE_CLASSES = {
     EventTypes.TESTCASE_CREATION: TestcaseCreationEvent,
     EventTypes.TESTCASE_REJECTION: TestcaseRejectionEvent,
     EventTypes.ISSUE_FILING: IssueFilingEvent,
+    EventTypes.TASK_EXECUTION: TaskExecutionEvent,
 }
 
 

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -114,18 +114,21 @@ class BaseTestcaseEvent(Event):
   # Testcase entity (only used in init to set the event data).
   testcase: InitVar[data_types.Testcase | None] = None
 
+  # Testcase ID (either retrieved from testcase entity or directly set).
+  testcase_id: int | None = None
+
   # Testcase metadata (retrieved from the testcase entity, if available).
-  testcase_id: int | None = field(init=False, default=None)
   fuzzer: str | None = field(init=False, default=None)
   job: str | None = field(init=False, default=None)
   crash_revision: int | None = field(init=False, default=None)
 
   def __post_init__(self, testcase=None, **kwargs):
     if testcase is not None:
-      self.testcase_id = testcase.key.id()
-      self.fuzzer = testcase.fuzzer_name
-      self.job = testcase.job_type
-      self.crash_revision = testcase.crash_revision
+      if self.testcase_id is None:
+        self.testcase_id = testcase.key.id()
+      self.fuzzer = str(testcase.fuzzer_name)
+      self.job = str(testcase.job_type)
+      self.crash_revision = int(testcase.crash_revision)
     return super().__post_init__(**kwargs)
 
 
@@ -186,6 +189,11 @@ class TaskExecutionEvent(BaseTestcaseEvent, BaseTaskEvent):
   task_status: str | None = None
   # UTask return code based on error types from uworker protobuf.
   task_outcome: str | None = None
+
+  # Task-specific job type and fuzzer name - this is needed to disambiguate
+  # from testcase metadata.
+  task_job: str | None = None
+  task_fuzzer: str | None = None
 
 
 # Mapping of specific event types to their data classes.

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -58,7 +58,7 @@ class RejectionReason:
 
 
 class TaskStage:
-  """Task stage."""
+  """Task stage, usually applicable for untrusted tasks."""
   PREPROCESS = 'preprocess'
   MAIN = 'main'
   POSTPROCESS = 'postprocess'
@@ -66,6 +66,7 @@ class TaskStage:
 
 
 class TaskStatus:
+  """Task status."""
   STARTED = 'started'
   FINISHED = 'finished'
   EXCEPTION = 'exception'

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -184,8 +184,8 @@ class TaskExecutionEvent(BaseTestcaseEvent, BaseTaskEvent):
   task_stage: str | None = None
   # Task status (e.g., started, finished, exception).
   task_status: str | None = None
-  # UTask return code (defined in the uworker protobuf error types).
-  task_return_code: int | None = None
+  # UTask return code based on error types from uworker protobuf.
+  task_outcome: str | None = None
 
 
 # Mapping of specific event types to their data classes.


### PR DESCRIPTION
This PR adds the necessary code for emitting task execution events:
* Created the `TaskExecutionEvent` data model
* Updated the datastore entity with the new fields for this event.
* Updated the events unit test.

Instrumentation of the code to actually emit the event will be done in following PRs.

b/394059581