### PR TITLE
[Tracing] Instrument code to emit Task Execution events

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/task_utils.py
+++ b/src/clusterfuzz/_internal/base/tasks/task_utils.py
@@ -35,3 +35,20 @@ def is_remotely_executing_utasks() -> bool:
 
 class UworkerMsgParseError(RuntimeError):
   """Error for parsing UworkerMsgs."""
+
+
+TESTCASE_BASED_TASKS = {
+    'analyze',
+    'blame',
+    'impact',
+    'minimize',
+    'progression',
+    'regression',
+    'symbolize',
+    'variant',
+}
+
+FUZZER_BASED_TASKS = {
+    'corpus_pruning',
+    'fuzz',
+}

--- a/src/clusterfuzz/_internal/base/tasks/task_utils.py
+++ b/src/clusterfuzz/_internal/base/tasks/task_utils.py
@@ -15,6 +15,7 @@
 any other module in tasks to prevent circular imports and issues with
 appengine."""
 
+from clusterfuzz._internal.protos import uworker_msg_pb2
 from clusterfuzz._internal.system import environment
 
 
@@ -52,3 +53,22 @@ FUZZER_BASED_TASKS = {
     'corpus_pruning',
     'fuzz',
 }
+
+
+def get_task_execution_event_data(
+    task_command: str,
+    task_argument: str | uworker_msg_pb2.Input | None,  # pylint: disable=no-member
+    job_type: str | None = None) -> dict:
+  """Returns a formatted dict with task execution event data."""
+  event_data = {'task_job': job_type}
+  if task_command in TESTCASE_BASED_TASKS:
+    event_data['testcase_id'] = (
+        task_argument.testcase_id
+        if isinstance(task_argument, uworker_msg_pb2.Input)  # pylint: disable=no-member
+        else task_argument)
+  elif task_command in FUZZER_BASED_TASKS:
+    event_data['task_fuzzer'] = (
+        task_argument.fuzzer_name
+        if isinstance(task_argument, uworker_msg_pb2.Input)  # pylint: disable=no-member
+        else task_argument)
+  return event_data

--- a/src/clusterfuzz/_internal/base/tasks/task_utils.py
+++ b/src/clusterfuzz/_internal/base/tasks/task_utils.py
@@ -60,12 +60,15 @@ def get_task_execution_event_data(
     task_argument: str | uworker_msg_pb2.Input | None,  # pylint: disable=no-member
     job_type: str | None = None) -> dict:
   """Returns a formatted dict with task execution event data."""
-  event_data = {'task_job': job_type}
+  event_data = {}
+  event_data['task_job'] = job_type
   if task_command in TESTCASE_BASED_TASKS:
-    event_data['testcase_id'] = (
+    testcase_id = (
         task_argument.testcase_id
         if isinstance(task_argument, uworker_msg_pb2.Input)  # pylint: disable=no-member
         else task_argument)
+    event_data['testcase_id'] = None if testcase_id is None else int(
+        testcase_id)
   elif task_command in FUZZER_BASED_TASKS:
     event_data['task_fuzzer'] = (
         task_argument.fuzzer_name

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -124,7 +124,7 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     self._event_data = None
     # Error type from utask main handled in postprocess.
     self.post_utask_main_failure = None
-    # Whether proprocess returned the uworker input.
+    # Whether preprocess returned the uworker input.
     self.preprocess_returned: bool | None = None
 
   def set_task_details(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -163,9 +163,14 @@ class _MetricRecorder(contextlib.AbstractContextManager):
   def emit_task_events(self, task_status: str,
                        task_outcome: str | None = None) -> None:
     """Helper to emit task execution events during the recorder context."""
-    if self._event_data is None or not environment.is_tworker():
-      # Either missing `_event_data`, which is set during `set_task_details`.
-      # Or events can't be sent from untrusted workers for now.
+    if not environment.is_tworker():
+      # Events can't be sent from untrusted workers for now.
+      logs.warning(f'Attempted emit of task execution event from untrusted worker.')
+      return
+
+    if self._event_data is None:
+      # Missing `_event_data`, which is set during `set_task_details`.
+      logs.warning(f'Missing event data for emitting utask execution event.')
       return
 
     event_task_exec = events.TaskExecutionEvent(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -398,9 +398,10 @@ def tworker_postprocess_no_io(utask_module, uworker_output, uworker_input):
 
     # This emit is needed because we are not sending events from utask main.
     # Thus, this confirms that main finished and postprocess will start.
-    recorder.emit_task_events(events.TaskStatus.FINISHED,
-                              uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
-                                  uworker_output.error_type))
+    recorder.emit_task_events(
+        events.TaskStatus.FINISHED,
+        uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
+            uworker_output.error_type))
 
     utask_module.utask_postprocess(uworker_output)
 
@@ -513,8 +514,9 @@ def tworker_postprocess(output_download_url) -> None:
 
     # This emit is needed because we are not sending events from utask main.
     # Thus, this confirms that main finished and postprocess will start.
-    recorder.emit_task_events(events.TaskStatus.FINISHED,
-                              uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
-                                  uworker_output.error_type))
+    recorder.emit_task_events(
+        events.TaskStatus.FINISHED,
+        uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
+            uworker_output.error_type))
 
     utask_module.utask_postprocess(uworker_output)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -71,23 +71,6 @@ def _get_execution_mode(utask_module, job_type):
   return Mode.BATCH
 
 
-def _get_task_execution_event_data(task_command, task_argument,
-                                   job_type=None) -> dict:
-  """Returns a formatted dict with task execution event data."""
-  event_data = {'task_job': job_type}
-  if task_command in task_utils.TESTCASE_BASED_TASKS:
-    event_data['testcase_id'] = (
-        task_argument.testcase_id
-        if isinstance(task_argument, uworker_msg_pb2.Input)  # pylint: disable=no-member
-        else task_argument)
-  elif task_command in task_utils.FUZZER_BASED_TASKS:
-    event_data['task_fuzzer'] = (
-        task_argument.fuzzer_name
-        if isinstance(task_argument, uworker_msg_pb2.Input)  # pylint: disable=no-member
-        else task_argument)
-  return event_data
-
-
 class _MetricRecorder(contextlib.AbstractContextManager):
   """Records task execution metrics, even in case of error and exceptions.
 
@@ -161,8 +144,8 @@ class _MetricRecorder(contextlib.AbstractContextManager):
         'mode': execution_mode.value,
         'platform': platform,
     }
-    self._event_data = _get_task_execution_event_data(task_command,
-                                                      task_argument, job_type)
+    self._event_data = task_utils.get_task_execution_event_data(
+        task_command, task_argument, job_type)
 
     if preprocess_start_time is not None:
       # We already know the start time if the subtask is preprocess.

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -26,6 +26,7 @@ from clusterfuzz._internal.base.tasks import task_utils
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.bot.webserver import http_server
 from clusterfuzz._internal.google_cloud_utils import storage
+from clusterfuzz._internal.metrics import events
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.protos import uworker_msg_pb2
@@ -70,6 +71,23 @@ def _get_execution_mode(utask_module, job_type):
   return Mode.BATCH
 
 
+def _get_task_execution_event_data(task_command, task_argument,
+                                   job_type=None) -> dict:
+  """Returns a formatted dict with task execution event data."""
+  event_data = {'task_job': job_type}
+  if task_command in task_utils.TESTCASE_BASED_TASKS:
+    event_data['testcase_id'] = (
+        task_argument.testcase_id
+        if isinstance(task_argument, uworker_msg_pb2.Input)  # pylint: disable=no-member
+        else task_argument)
+  elif task_command in task_utils.FUZZER_BASED_TASKS:
+    event_data['task_fuzzer'] = (
+        task_argument.fuzzer_name
+        if isinstance(task_argument, uworker_msg_pb2.Input)  # pylint: disable=no-member
+        else task_argument)
+  return event_data
+
+
 class _MetricRecorder(contextlib.AbstractContextManager):
   """Records task execution metrics, even in case of error and exceptions.
 
@@ -102,15 +120,26 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     else:
       self._preprocess_start_time_ns = None
 
-  def set_task_details(self,
-                       utask_module,
-                       job_type: str,
-                       execution_mode: Mode,
-                       platform: str,
-                       preprocess_start_time: Optional[Timestamp] = None):
+    # Events-related metadata.
+    self._event_data = None
+    # Error type from utask main handled in postprocess.
+    self.post_utask_main_failure = None
+    # Whether proprocess returned the uworker input.
+    self.preprocess_returned: bool | None = None
+
+  def set_task_details(
+      self,
+      utask_module,
+      job_type: str,
+      execution_mode: Mode,
+      platform: str,
+      preprocess_start_time: Optional[Timestamp] = None,
+      task_argument: Optional[str | uworker_msg_pb2.Input] = None):  # pylint: disable=no-member
     """Sets task details that might not be known at instantation time.
 
     Must be called once for metrics to be recorded when exiting the context.
+    In addition, it sets the events metadata to enable emitting task execution
+    events within the context.
 
     Args:
       utask_module: The Python module corresponding to the task being executed.
@@ -120,14 +149,20 @@ class _MetricRecorder(contextlib.AbstractContextManager):
       preprocess_start_time: Timestamp at which the preprocess subtask for
         this task started executing, possibly in a different process. Must be
         specified iff the subtask is not `Subtask.PREPROCESS`.
+      task_argument: Task argument, which for preprocess is usually the
+      `testcase_id` or `fuzzer_name`, and for main/postprocess is the uworker
+      input proto.
     """
+    task_command = task_utils.get_command_from_module(utask_module.__name__)
     self._labels = {
-        'task': task_utils.get_command_from_module(utask_module.__name__),
+        'task': task_command,
         'job': job_type,
         'subtask': self._subtask.value,
         'mode': execution_mode.value,
         'platform': platform,
     }
+    self._event_data = _get_task_execution_event_data(task_command,
+                                                      task_argument, job_type)
 
     if preprocess_start_time is not None:
       # We already know the start time if the subtask is preprocess.
@@ -137,11 +172,57 @@ class _MetricRecorder(contextlib.AbstractContextManager):
       # Ensure we always have a value after this method returns.
       assert self._preprocess_start_time_ns is not None
 
+  def emit_task_events(self, task_status: str,
+                       task_outcome: str | None = None) -> None:
+    """Helper to emit task execution events during the recorder context."""
+    if self._event_data is None or not environment.is_tworker():
+      # Either missing `_event_data`, which is set during `set_task_details`.
+      # Or events can't be sent from untrusted workers for now.
+      return
+
+    event_task_exec = events.TaskExecutionEvent(
+        **self._event_data,
+        task_stage=self._subtask.value,
+        task_status=task_status,
+        task_outcome=task_outcome)
+    events.emit(event_task_exec)
+
   def _infer_uworker_main_outcome(self, exc_type, uworker_error) -> bool:
     """Returns True if task succeeded, False otherwise."""
     if exc_type or uworker_error not in self._utask_success_conditions:
       return False
     return True
+
+  def _emit_event_on_exit(self, exc_type):
+    """Resolves sending task execution events after a utask stage."""
+    if not environment.is_tworker():
+      # TODO(vtcosta): Currently, events can't be sent from untrusted workers
+      # due to denied permissions. We should try some workarounds to enable it.
+      return
+
+    if exc_type is not None:
+      self.emit_task_events(events.TaskStatus.EXCEPTION,
+                            events.TaskOutcome.UNHANDLED_EXCEPTION)
+      return
+
+    if self._subtask == _Subtask.PREPROCESS:
+      if self.preprocess_returned is None:
+        # Info about whether preprocess returned is missing.
+        return
+      if not self.preprocess_returned:
+        self.emit_task_events(events.TaskStatus.EXCEPTION,
+                              events.TaskOutcome.PREPROCESS_NO_RETURN)
+      else:
+        self.emit_task_events(events.TaskStatus.STARTED)
+        return
+
+    if self._subtask == _Subtask.POSTPROCESS:
+      task_outcome = None
+      if self.post_utask_main_failure is not None:
+        task_outcome = uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
+            self.post_utask_main_failure)
+      self.emit_task_events(events.TaskStatus.POST_COMPLETED, task_outcome)
+      return
 
   def __exit__(self, _exc_type, _exc_value, _traceback):
     # Ignore exception details, let Python continue unwinding the stack.
@@ -175,6 +256,7 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     else:
       error_condition = uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
           self.utask_main_failure)
+    self._emit_event_on_exit(_exc_type)
     # Get rid of job as a label, so we can have another metric to make
     # error conditions more explicit, respecting the 30k distinct
     # labels limit recommended by gcp.
@@ -207,16 +289,21 @@ def _preprocess(utask_module, task_argument, job_type, uworker_env,
   ensure_uworker_env_type_safety(uworker_env)
   set_uworker_env(uworker_env)
 
-  recorder.set_task_details(utask_module, job_type, execution_mode,
-                            environment.platform())
+  recorder.set_task_details(
+      utask_module,
+      job_type,
+      execution_mode,
+      environment.platform(),
+      task_argument=task_argument)
 
   logs.info('Starting utask_preprocess: %s.' % utask_module)
   uworker_input = utask_module.utask_preprocess(task_argument, job_type,
                                                 uworker_env)
   if not uworker_input:
+    recorder.preprocess_returned = False
     logs.error('No uworker_input returned from preprocess')
     return None
-
+  recorder.preprocess_returned = True
   logs.info('Preprocess finished.')
 
   task_payload = environment.get_value('TASK_PAYLOAD')
@@ -300,9 +387,20 @@ def tworker_postprocess_no_io(utask_module, uworker_output, uworker_input):
 
     set_uworker_env(uworker_output.uworker_input.uworker_env)
 
-    recorder.set_task_details(utask_module, uworker_input.job_type, Mode.QUEUE,
-                              environment.platform(),
-                              uworker_input.preprocess_start_time)
+    recorder.set_task_details(
+        utask_module,
+        uworker_input.job_type,
+        Mode.QUEUE,
+        environment.platform(),
+        uworker_input.preprocess_start_time,
+        task_argument=uworker_input)
+    recorder.post_utask_main_failure = uworker_output.error_type
+
+    # This emit is needed because we are not sending events from utask main.
+    # Thus, this confirms that main finished and postprocess will start.
+    recorder.emit_task_events(events.TaskStatus.FINISHED,
+                              uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
+                                  uworker_output.error_type))
 
     utask_module.utask_postprocess(uworker_output)
 
@@ -405,8 +503,18 @@ def tworker_postprocess(output_download_url) -> None:
     execution_mode = _get_execution_mode(utask_module,
                                          uworker_output.uworker_input.job_type)
     recorder.set_task_details(
-        utask_module, uworker_output.uworker_input.job_type, execution_mode,
+        utask_module,
+        uworker_output.uworker_input.job_type,
+        execution_mode,
         environment.platform(),
-        uworker_output.uworker_input.preprocess_start_time)
+        uworker_output.uworker_input.preprocess_start_time,
+        task_argument=uworker_output.uworker_input)
+    recorder.post_utask_main_failure = uworker_output.error_type
+
+    # This emit is needed because we are not sending events from utask main.
+    # Thus, this confirms that main finished and postprocess will start.
+    recorder.emit_task_events(events.TaskStatus.FINISHED,
+                              uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
+                                  uworker_output.error_type))
 
     utask_module.utask_postprocess(uworker_output)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -74,11 +74,16 @@ def _get_execution_mode(utask_module, job_type):
 class _MetricRecorder(contextlib.AbstractContextManager):
   """Records task execution metrics, even in case of error and exceptions.
 
+  Also responsible for emitting task execution events within the context.
+
   Members:
     start_time_ns (int): The time at which this recorder was constructed, in
       nanoseconds since the Unix epoch.
     utask_main_failure: this class stores the uworker_output.ErrorType 
       object returned by utask_main, and uses it to emmit a metric.
+    post_utask_main_failue: this also stores the uworker_output.ErrorType, but
+      during postprocess stage, where it will be handled.
+    preprocess_returned: Indicates if preprocess returned the uworker_input.
   """
 
   def __init__(self, subtask: _Subtask):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -393,7 +393,7 @@ def tworker_postprocess_no_io(utask_module, uworker_output, uworker_input):
     # This emit is needed because we are not sending events from utask main.
     # Thus, this confirms that main finished and postprocess will start.
     recorder.emit_task_events(
-        events.TaskStatus.FINISHED,
+        events.TaskStatus.POST_STARTED,
         uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
             uworker_output.error_type))
 
@@ -509,7 +509,7 @@ def tworker_postprocess(output_download_url) -> None:
     # This emit is needed because we are not sending events from utask main.
     # Thus, this confirms that main finished and postprocess will start.
     recorder.emit_task_events(
-        events.TaskStatus.FINISHED,
+        events.TaskStatus.POST_STARTED,
         uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
             uworker_output.error_type))
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -165,12 +165,13 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     """Helper to emit task execution events during the recorder context."""
     if not environment.is_tworker():
       # Events can't be sent from untrusted workers for now.
-      logs.warning(f'Attempted emit of task execution event from untrusted worker.')
+      logs.warning(
+          'Attempted emit of task execution event from untrusted worker.')
       return
 
     if self._event_data is None:
       # Missing `_event_data`, which is set during `set_task_details`.
-      logs.warning(f'Missing event data for emitting utask execution event.')
+      logs.warning('Missing event data for emitting utask execution event.')
       return
 
     event_task_exec = events.TaskExecutionEvent(

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -76,7 +76,15 @@ class TaskStatus:
   """Task status."""
   STARTED = 'started'
   FINISHED = 'finished'
+  POST_COMPLETED = 'post_completed'
   EXCEPTION = 'exception'
+
+
+class TaskOutcome:
+  """Task outcomes/exceptions to complement the uworker error types."""
+  # All caps to maintain style from error types proto.
+  PREPROCESS_NO_RETURN = 'PREPROCESS_NO_RETURN'
+  UNHANDLED_EXCEPTION = 'UNHANDLE_EXCEPTION'
 
 
 @dataclass(kw_only=True)

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -141,9 +141,9 @@ class BaseTestcaseEvent(Event):
     if testcase is not None:
       if self.testcase_id is None:
         self.testcase_id = testcase.key.id()
-      self.fuzzer = str(testcase.fuzzer_name)
-      self.job = str(testcase.job_type)
-      self.crash_revision = int(testcase.crash_revision)
+      self.fuzzer = testcase.fuzzer_name
+      self.job = testcase.job_type
+      self.crash_revision = testcase.crash_revision
     return super().__post_init__(**kwargs)
 
 

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -75,8 +75,9 @@ class TaskStage:
 class TaskStatus:
   """Task status."""
   STARTED = 'started'
-  FINISHED = 'finished'
-  POST_COMPLETED = 'post_completed'
+  MAIN_FINISHED = 'main_finished'
+  POST_STARTED = 'postprocess_started'
+  POST_COMPLETED = 'postprocess_completed'
   EXCEPTION = 'exception'
 
 

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/task_utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/task_utils_test.py
@@ -54,7 +54,7 @@ class GetTaskEventDataTest(unittest.TestCase):
     self.assertEqual(
         task_utils.get_task_execution_event_data(task_command, '1', 'job'), {
             'task_job': 'job',
-            'testcase_id': '1'
+            'testcase_id': 1
         })
 
     fuzzer_based = commands._COMMAND_MODULE_MAP.get('fuzz')
@@ -76,7 +76,7 @@ class GetTaskEventDataTest(unittest.TestCase):
         task_utils.get_task_execution_event_data(task_command, task_argument,
                                                  'job'), {
                                                      'task_job': 'job',
-                                                     'testcase_id': '1'
+                                                     'testcase_id': 1
                                                  })
 
     fuzzer_based = commands._COMMAND_MODULE_MAP.get('fuzz')

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/task_utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/task_utils_test.py
@@ -16,6 +16,7 @@ import unittest
 
 from clusterfuzz._internal.base.tasks import task_utils
 from clusterfuzz._internal.bot.tasks import commands
+from clusterfuzz._internal.protos import uworker_msg_pb2
 
 
 class GetCommandFromModuleTest(unittest.TestCase):
@@ -33,3 +34,57 @@ class GetCommandFromModuleTest(unittest.TestCase):
       task_utils.get_command_from_module('postprocess')
     with self.assertRaises(ValueError):
       task_utils.get_command_from_module('uworker_main')
+
+
+class GetTaskEventDataTest(unittest.TestCase):
+  # pylint: disable=protected-access
+  """Tests the helper methods for task execution event data."""
+
+  def test_task_based_lists(self):
+    """Asserts that the task names defined in type-based sets are correct."""
+    all_task_commands = set(commands._COMMAND_MODULE_MAP.keys())
+    self.assertTrue(task_utils.TESTCASE_BASED_TASKS.issubset(all_task_commands))
+    self.assertTrue(task_utils.FUZZER_BASED_TASKS.issubset(all_task_commands))
+
+  def test_get_task_event_data_preprocess(self):
+    """Tests retrieving event data directly from task argument."""
+    # Get one example of each task type.
+    testcase_based = commands._COMMAND_MODULE_MAP.get('minimize')
+    task_command = task_utils.get_command_from_module(testcase_based.__name__)
+    self.assertEqual(
+        task_utils.get_task_execution_event_data(task_command, '1', 'job'), {
+            'task_job': 'job',
+            'testcase_id': '1'
+        })
+
+    fuzzer_based = commands._COMMAND_MODULE_MAP.get('fuzz')
+    task_command = task_utils.get_command_from_module(fuzzer_based.__name__)
+    self.assertEqual(
+        task_utils.get_task_execution_event_data(task_command, 'fuzzer', 'job'),
+        {
+            'task_job': 'job',
+            'task_fuzzer': 'fuzzer'
+        })
+
+  def test_get_task_event_data_postprocess(self):
+    """Tests retrieving event data from uworker input."""
+    # Get one example of each task type.
+    testcase_based = commands._COMMAND_MODULE_MAP.get('minimize')
+    task_command = task_utils.get_command_from_module(testcase_based.__name__)
+    task_argument = uworker_msg_pb2.Input(testcase_id='1', job_type='job')
+    self.assertEqual(
+        task_utils.get_task_execution_event_data(task_command, task_argument,
+                                                 'job'), {
+                                                     'task_job': 'job',
+                                                     'testcase_id': '1'
+                                                 })
+
+    fuzzer_based = commands._COMMAND_MODULE_MAP.get('fuzz')
+    task_command = task_utils.get_command_from_module(fuzzer_based.__name__)
+    task_argument = uworker_msg_pb2.Input(fuzzer_name='fuzzer', job_type='job')
+    self.assertEqual(
+        task_utils.get_task_execution_event_data(task_command, task_argument,
+                                                 'job'), {
+                                                     'task_job': 'job',
+                                                     'task_fuzzer': 'fuzzer'
+                                                 })

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -45,6 +45,7 @@ class TworkerPreprocessTest(unittest.TestCase):
 
   def setUp(self):
     monitor.metrics_store().reset_for_testing()
+    helpers.patch_environ(self)
     helpers.patch(self, [
         'clusterfuzz._internal.bot.tasks.utasks._get_execution_mode',
         'clusterfuzz._internal.bot.tasks.utasks.uworker_io.get_uworker_output_urls',
@@ -57,14 +58,11 @@ class TworkerPreprocessTest(unittest.TestCase):
         self.OUTPUT_SIGNED_UPLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL)
     self.mock.serialize_and_upload_uworker_input.return_value = (
         self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL)
-    self.original_env = dict(os.environ)
     os.environ['CF_TASK_ID'] = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
     os.environ['CF_TASK_NAME'] = 'mock_task'
     os.environ['TWORKER'] = 'True'
 
   def tearDown(self):
-    os.environ.clear()
-    os.environ.update(self.original_env)
     task_utils.TESTCASE_BASED_TASKS.discard('mock')
 
   @parameterized.parameterized.expand([utasks.Mode.BATCH, utasks.Mode.SWARMING])
@@ -284,14 +282,11 @@ class TworkerPostprocessTest(unittest.TestCase):
         'clusterfuzz._internal.metrics.events._get_datetime_now',
     ])
     self.mock._get_datetime_now.return_value = datetime.datetime(2025, 1, 1)  # pylint: disable=protected-access
-    self.original_env = dict(os.environ)
     os.environ['CF_TASK_ID'] = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
     os.environ['CF_TASK_NAME'] = 'mock_task'
     os.environ['TWORKER'] = 'True'
 
   def tearDown(self):
-    os.environ.clear()
-    os.environ.update(self.original_env)
     task_utils.FUZZER_BASED_TASKS.discard('mock')
 
   @parameterized.parameterized.expand([utasks.Mode.BATCH, utasks.Mode.SWARMING])

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -191,7 +191,8 @@ class UworkerMainTest(unittest.TestCase):
         'clusterfuzz._internal.bot.tasks.utasks.uworker_io.download_and_deserialize_uworker_input',
         'clusterfuzz._internal.bot.tasks.utasks.uworker_io.serialize_and_upload_uworker_output',
         'clusterfuzz._internal.bot.tasks.utasks.get_utask_module',
-        'clusterfuzz._internal.system.environment.is_swarming_bot'
+        'clusterfuzz._internal.system.environment.is_swarming_bot',
+        'clusterfuzz._internal.metrics.events.emit',
     ])
     self.module = mock.MagicMock(__name__='tasks.analyze_task')
     self.mock.get_utask_module.return_value = self.module
@@ -253,6 +254,10 @@ class UworkerMainTest(unittest.TestCase):
     self.assertLess(e2e_durations.sum * 10**9,
                     end_time_ns - preprocess_start_time_ns)
     self.assertGreaterEqual(e2e_durations.sum, 42)
+
+    # Asserts that task events were not emitted from main (as these may cause
+    # a permission denied error if running in a untrusted worker).
+    self.mock.emit.assert_not_called()
 
 
 class GetUtaskModuleTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -124,6 +124,9 @@ class TworkerPreprocessTest(unittest.TestCase):
         task_outcome=None,
         task_job=self.JOB_TYPE,
         task_fuzzer=None)
+    # Asserts task id/name fields were retrieved in base event.
+    self.assertEqual(task_event.task_name, 'mock_task')
+    self.assertEqual(task_event.task_id, 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
     self.mock.emit.assert_called_once_with(task_event)
 
   def test_return_none(self):
@@ -143,6 +146,9 @@ class TworkerPreprocessTest(unittest.TestCase):
         task_outcome=events.TaskOutcome.PREPROCESS_NO_RETURN,
         task_job=self.JOB_TYPE,
         task_fuzzer=None)
+    # Asserts task id/name fields were retrieved in base event.
+    self.assertEqual(task_event.task_name, 'mock_task')
+    self.assertEqual(task_event.task_id, 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
     self.mock.emit.assert_called_once_with(task_event)
     self.mock.emit.reset_mock()
 
@@ -157,6 +163,9 @@ class TworkerPreprocessTest(unittest.TestCase):
         task_outcome=events.TaskOutcome.PREPROCESS_NO_RETURN,
         task_job=self.JOB_TYPE,
         task_fuzzer=None)
+    # Asserts task id/name fields were retrieved in base event.
+    self.assertEqual(task_event.task_name, 'mock_task')
+    self.assertEqual(task_event.task_id, 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
     self.mock.emit.assert_called_once_with(task_event)
 
 
@@ -350,7 +359,6 @@ class TworkerPostprocessTest(unittest.TestCase):
         task_status=events.TaskStatus.FINISHED,
         task_outcome=uworker_msg_pb2.ErrorType.Name(0),
         task_job='foo-job')
-    self.mock.emit.assert_any_call(task_finished_event)
     task_post_event = events.TaskExecutionEvent(
         testcase_id=None,
         task_fuzzer='fuzzer_test',
@@ -358,6 +366,15 @@ class TworkerPostprocessTest(unittest.TestCase):
         task_status=events.TaskStatus.POST_COMPLETED,
         task_outcome=uworker_msg_pb2.ErrorType.Name(0),
         task_job='foo-job')
+    # Asserts task id/name fields were retrieved in base event.
+    self.assertEqual(task_finished_event.task_name, 'mock_task')
+    self.assertEqual(task_finished_event.task_id,
+                     'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
+    self.assertEqual(task_post_event.task_name, 'mock_task')
+    self.assertEqual(task_post_event.task_id,
+                     'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
+
+    self.mock.emit.assert_any_call(task_finished_event)
     self.mock.emit.assert_any_call(task_post_event)
 
   @parameterized.parameterized.expand([utasks.Mode.BATCH, utasks.Mode.SWARMING])
@@ -398,7 +415,6 @@ class TworkerPostprocessTest(unittest.TestCase):
         task_status=events.TaskStatus.FINISHED,
         task_outcome=uworker_msg_pb2.ErrorType.Name(0),
         task_job='foo-job')
-    self.mock.emit.assert_any_call(task_finished_event)
     task_post_event = events.TaskExecutionEvent(
         testcase_id=None,
         task_fuzzer='fuzzer_test',
@@ -406,4 +422,13 @@ class TworkerPostprocessTest(unittest.TestCase):
         task_status=events.TaskStatus.EXCEPTION,
         task_outcome=events.TaskOutcome.UNHANDLED_EXCEPTION,
         task_job='foo-job')
+    # Asserts task id/name fields were retrieved in base event.
+    self.assertEqual(task_finished_event.task_name, 'mock_task')
+    self.assertEqual(task_finished_event.task_id,
+                     'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
+    self.assertEqual(task_post_event.task_name, 'mock_task')
+    self.assertEqual(task_post_event.task_id,
+                     'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
+
+    self.mock.emit.assert_any_call(task_finished_event)
     self.mock.emit.assert_any_call(task_post_event)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -268,6 +268,7 @@ class GetUtaskModuleTest(unittest.TestCase):
     module_name = analyze_task.__name__
     self.assertEqual(utasks.get_utask_module(module_name), analyze_task)
 
+
 @test_utils.with_cloud_emulators('datastore')
 class TworkerPostprocessTest(unittest.TestCase):
   """Tests that tworker_postprocess works as intended."""

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -354,7 +354,7 @@ class TworkerPostprocessTest(unittest.TestCase):
         testcase_id=None,
         task_fuzzer='fuzzer_test',
         task_stage=utasks._Subtask.POSTPROCESS.value,  # pylint: disable=protected-access
-        task_status=events.TaskStatus.FINISHED,
+        task_status=events.TaskStatus.POST_STARTED,
         task_outcome=uworker_msg_pb2.ErrorType.Name(0),
         task_job='foo-job')
     task_post_event = events.TaskExecutionEvent(
@@ -410,7 +410,7 @@ class TworkerPostprocessTest(unittest.TestCase):
         testcase_id=None,
         task_fuzzer='fuzzer_test',
         task_stage=utasks._Subtask.POSTPROCESS.value,  # pylint: disable=protected-access
-        task_status=events.TaskStatus.FINISHED,
+        task_status=events.TaskStatus.POST_STARTED,
         task_outcome=uworker_msg_pb2.ErrorType.Name(0),
         task_job='foo-job')
     task_post_event = events.TaskExecutionEvent(

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -60,7 +60,6 @@ class TworkerPreprocessTest(unittest.TestCase):
         self.INPUT_SIGNED_DOWNLOAD_URL, self.OUTPUT_DOWNLOAD_GCS_URL)
     os.environ['CF_TASK_ID'] = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
     os.environ['CF_TASK_NAME'] = 'mock_task'
-    os.environ['TWORKER'] = 'True'
 
   def tearDown(self):
     task_utils.TESTCASE_BASED_TASKS.discard('mock')
@@ -293,7 +292,6 @@ class TworkerPostprocessTest(unittest.TestCase):
     self.mock._get_datetime_now.return_value = datetime.datetime(2025, 1, 1)  # pylint: disable=protected-access
     os.environ['CF_TASK_ID'] = 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868'
     os.environ['CF_TASK_NAME'] = 'mock_task'
-    os.environ['TWORKER'] = 'True'
 
   def tearDown(self):
     task_utils.FUZZER_BASED_TASKS.discard('mock')

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -40,7 +40,7 @@ class TworkerPreprocessTest(unittest.TestCase):
   OUTPUT_DOWNLOAD_GCS_URL = '/download-output'
   INPUT_SIGNED_DOWNLOAD_URL = 'https://signed-download-input'
   UWORKER_ENV = {'ENVVAR': 'VALUE'}
-  TASK_ARGUMENT = 'testcase-id'
+  TASK_ARGUMENT = '1'  # testcase_id
   JOB_TYPE = 'libfuzzer_asan'
 
   def setUp(self):
@@ -117,7 +117,7 @@ class TworkerPreprocessTest(unittest.TestCase):
 
     # Asserts for task execution event.
     task_event = events.TaskExecutionEvent(
-        testcase_id=self.TASK_ARGUMENT,
+        testcase_id=int(self.TASK_ARGUMENT),
         task_stage=utasks._Subtask.PREPROCESS.value,  # pylint: disable=protected-access
         task_status=events.TaskStatus.STARTED,
         task_outcome=None,
@@ -139,7 +139,7 @@ class TworkerPreprocessTest(unittest.TestCase):
                                   self.UWORKER_ENV))
     # Asserts for task execution event.
     task_event = events.TaskExecutionEvent(
-        testcase_id=self.TASK_ARGUMENT,
+        testcase_id=int(self.TASK_ARGUMENT),
         task_stage=utasks._Subtask.PREPROCESS.value,  # pylint: disable=protected-access
         task_status=events.TaskStatus.EXCEPTION,
         task_outcome=events.TaskOutcome.PREPROCESS_NO_RETURN,
@@ -156,7 +156,7 @@ class TworkerPreprocessTest(unittest.TestCase):
                                         self.JOB_TYPE, self.UWORKER_ENV))
     # Asserts for task execution event.
     task_event = events.TaskExecutionEvent(
-        testcase_id=self.TASK_ARGUMENT,
+        testcase_id=int(self.TASK_ARGUMENT),
         task_stage=utasks._Subtask.PREPROCESS.value,  # pylint: disable=protected-access
         task_status=events.TaskStatus.EXCEPTION,
         task_outcome=events.TaskOutcome.PREPROCESS_NO_RETURN,

--- a/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/events_test.py
@@ -203,7 +203,7 @@ class EventsDataTest(unittest.TestCase):
         task_job=job_type,
         task_fuzzer=fuzzer_name,
         task_stage=events.TaskStage.POSTPROCESS,
-        task_status=events.TaskStatus.FINISHED,
+        task_status=events.TaskStatus.POST_COMPLETED,
         task_outcome=task_outcome)
     self._assert_event_common_fields(event_task_exec_post_finish, event_type,
                                      source)
@@ -211,7 +211,7 @@ class EventsDataTest(unittest.TestCase):
     self.assertEqual(event_task_exec_post_finish.task_stage,
                      events.TaskStage.POSTPROCESS)
     self.assertEqual(event_task_exec_post_finish.task_status,
-                     events.TaskStatus.FINISHED)
+                     events.TaskStatus.POST_COMPLETED)
     self.assertEqual(event_task_exec_post_finish.task_outcome, task_outcome)
     self.assertEqual(event_task_exec_post_finish.task_job, job_type)
     self.assertEqual(event_task_exec_post_finish.task_fuzzer, fuzzer_name)
@@ -394,7 +394,7 @@ class DatastoreEventsTest(unittest.TestCase):
         task_fuzzer=fuzzer_name,
         task_job=job_type,
         task_stage=events.TaskStage.POSTPROCESS,
-        task_status=events.TaskStatus.FINISHED,
+        task_status=events.TaskStatus.POST_COMPLETED,
         task_outcome=task_outcome)
     event_type = event_task_exec.event_type
     timestamp = event_task_exec.timestamp
@@ -412,7 +412,7 @@ class DatastoreEventsTest(unittest.TestCase):
 
     # TaskExecutionEvent specific assertions.
     self.assertEqual(event_entity.task_stage, events.TaskStage.POSTPROCESS)
-    self.assertEqual(event_entity.task_status, events.TaskStatus.FINISHED)
+    self.assertEqual(event_entity.task_status, events.TaskStatus.POST_COMPLETED)
     self.assertEqual(event_entity.task_outcome, task_outcome)
     self.assertEqual(event_entity.testcase_id, testcase_id)
     self.assertEqual(event_entity.task_job, job_type)


### PR DESCRIPTION
### Description
This PR instruments the code to emit `TaskExecutionEvents`  (defined at https://github.com/google/clusterfuzz/pull/4857) during utasks execution (events for trusted tasks will be added in a next PR).

The implementation leverages the `_MetricRecorder` from utasks module, since it already wraps the execution of all task stages while also storing important metadata from the task. This enables us sending events with context for each stage, even if unhandled exceptions happen during runtime.

Events are emitted in the following cases:
* After Preprocess executed:
  * If an exception occurs:   `Event: {TaskStatus=Exception, Outcome=Unhandled exception}`
  * If uworker input is NOT returned: `Event: {TaskStatus=Exception, Outcome=No preprocess return}`
  * Else preprocess is successful: `Event: {TaskStatus=Started, Outcome=None}`
* At the start of Postprocess:
  *  States that main executed: `Event: {TaskStatus=Postprocess Started, Outcome=<uworker_output.error_type>}`
* After Postprocess executed:
  * If an exception occurs: `Event: {TaskStatus=Exception, Outcome=Unhandled exception}`
  * Else postprocess finishes successfully: `Event: {TaskStatus=Postprocess Completed, Outcome=<uworker_output.error_type>}`

Notice that a known limitation is that we do not send events from utask main, since we currently don't have a workaround to access datastore from untrusted workers.

b/394059581

### Tests
Unit tests were added to verify all the instrumented codepaths and check the correctness of the events being emitted.

Runtime tests were done by deploying to dev environment.
* Task execution events created: 
<img width="3282" height="1248" alt="image" src="https://github.com/user-attachments/assets/f93da020-02f9-4b31-97be-00fe3a3a127a" />

* No new error groups related to the events:  [Error groups](https://pantheon.corp.google.com/errors;time=PT6H?project=clusterfuzz-development&e=-13802955&inv=1&invt=Ab2YGw&mods=logs_tg_prod)