### PR TITLE
[Fix] Fix type cast in events

### DIFF
--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -133,9 +133,9 @@ class BaseTestcaseEvent(Event):
     if testcase is not None:
       if self.testcase_id is None:
         self.testcase_id = testcase.key.id()
-      self.fuzzer = str(testcase.fuzzer_name)
-      self.job = str(testcase.job_type)
-      self.crash_revision = int(testcase.crash_revision)
+      self.fuzzer = testcase.fuzzer_name
+      self.job = testcase.job_type
+      self.crash_revision = testcase.crash_revision
     return super().__post_init__(**kwargs)
 
 


### PR DESCRIPTION
Reverts a change from https://github.com/google/clusterfuzz/pull/4857, where I added an explicit type casting for some testcase events metadata during development and forgot to remove. This type conversion is not needed and is breaking some tests due to metadata being `None`.