### PR TITLE
fix: implement check and parse for namedtuple on truncate

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -219,6 +219,9 @@ def truncate(
   if dataclasses.is_dataclass(msg) and not isinstance(msg, type):
     msg = dataclasses.asdict(msg)
 
+  if isinstance(msg, tuple) and hasattr(msg, '_fields'):
+    msg = msg._asdict()  # type: ignore
+
   if isinstance(msg, dict):
     return {k: truncate(v, limit) for k, v in msg.items()}
 

--- a/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
+++ b/src/clusterfuzz/_internal/tests/core/metrics/logs_test.py
@@ -1207,6 +1207,79 @@ class TruncateTest(unittest.TestCase):
     self.assertIsInstance(result, tuple)
     self.assertEqual(expected_tuple, result)
 
+  def test_namedtuple_truncation(self):
+    """Tests namedtuple truncation worked properly"""
+    import collections
+    BatchWorkloadSpec = collections.namedtuple('BatchWorkloadSpec', [
+        'clusterfuzz_release',
+        'disk_size_gb',
+        'disk_type',
+        'docker_image',
+        'user_data',
+        'service_account_email',
+        'subnetwork',
+        'preemptible',
+        'project',
+        'machine_type',
+        'network',
+        'gce_region',
+        'priority',
+        'max_run_duration',
+        'retry',
+    ])
+    limit = 20
+    spec = BatchWorkloadSpec(
+        docker_image='a' * 100,
+        disk_size_gb=1,
+        disk_type='x',
+        user_data='foo',
+        service_account_email='bar',
+        preemptible=True,
+        machine_type='xpto',
+        gce_region='region',
+        network='brisanet',
+        subnetwork='brisa',
+        project='cf',
+        clusterfuzz_release='1.0',
+        priority='high',
+        max_run_duration=10,
+        retry=False,
+    )
+    result = logs.truncate(spec, limit)
+    expected = {
+        'clusterfuzz_release':
+            '1.0',
+        'disk_size_gb':
+            1,
+        'disk_type':
+            'x',
+        'docker_image':
+            'aaaaaaaaaa\n...80 characters truncated...\naaaaaaaaaa',
+        'user_data':
+            'foo',
+        'service_account_email':
+            'bar',
+        'subnetwork':
+            'brisa',
+        'preemptible':
+            True,
+        'project':
+            'cf',
+        'machine_type':
+            'xpto',
+        'network':
+            'brisanet',
+        'gce_region':
+            'region',
+        'priority':
+            'high',
+        'max_run_duration':
+            10,
+        'retry':
+            False
+    }
+    self.assertEqual(expected, result)
+
   def test_dict_truncation(self):
     """Tests recursive truncation of dictionary values."""
     limit = 7


### PR DESCRIPTION
We had an error when trying to truncate a NamedTuple, and the cause is that we are trying to deal with it as a `tuple` as tuple is a supertype of namedtuple.

The fix for it is having a checking line that deals with namedtuple properly. And the way to indentify it is checking if the type is tuple, and if the object has the attribute `_fields`.