### PR TITLE
[Tracing] Create Testcase Fixed events definition

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -1664,6 +1664,10 @@ class TestcaseLifecycleEvent(Model):
   # Explanation for the testcase rejection.
   rejection_reason = ndb.StringProperty()
 
+  ### Testcase fixed.
+  # Build revision in which the crash stopped reproducing.
+  fixed_revision = ndb.StringProperty()
+
   ### Issue Filing.
   # Name of the project associated with the issue tracker.
   issue_tracker_project = ndb.StringProperty()

--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -185,7 +185,7 @@ class TestcaseRejectionEvent(BaseTestcaseEvent, BaseTaskEvent):
 
 
 @dataclass(kw_only=True)
-class TestcaseFixed(BaseTestcaseEvent, BaseTaskEvent):
+class TestcaseFixedEvent(BaseTestcaseEvent, BaseTaskEvent):
   """Testcase fixed event."""
   event_type: str = field(default=EventTypes.TESTCASE_FIXED, init=False)
   # Build revision in which the crash stopped reproducing.
@@ -225,7 +225,7 @@ class TaskExecutionEvent(BaseTestcaseEvent, BaseTaskEvent):
 _EVENT_TYPE_CLASSES = {
     EventTypes.TESTCASE_CREATION: TestcaseCreationEvent,
     EventTypes.TESTCASE_REJECTION: TestcaseRejectionEvent,
-    EventTypes.TESTCASE_FIXED: TestcaseFixed,
+    EventTypes.TESTCASE_FIXED: TestcaseFixedEvent,
     EventTypes.ISSUE_FILING: IssueFilingEvent,
     EventTypes.TASK_EXECUTION: TaskExecutionEvent,
 }


### PR DESCRIPTION
This PR creates the `TestcaseFixedEvent` definition, which happens when a testcase is verified as fixed against the latest build. Instrumenting the code to emit the event in the correct places will be done in a further PR.

b/394055138