### PR TITLE
Set BadStateError message correctly

### DIFF
--- a/src/clusterfuzz/_internal/base/errors.py
+++ b/src/clusterfuzz/_internal/base/errors.py
@@ -66,7 +66,7 @@ class BadStateError(Error):
   """We are in an unexpected state that we cannot recover from."""
 
   def __init__(self, message=None):
-    super().__init__('Entered a bad state.' or message)
+    super().__init__(message or 'Entered a bad state.')
 
 
 class BuildNotFoundError(Error):


### PR DESCRIPTION
This commit fixes incorrect ordering, which makes BadStateError always initialize with the default message, instead of using the one from the argument.