### PR TITLE
[Fix] Add explicit execution permission for root dir

### DIFF
--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -58,3 +58,4 @@ if [[ -z "$DISABLE_MOUNTS" ]]; then
 fi
 
 chown -R $USER:$USER $INSTALL_DIRECTORY
+chmod u+x $ROOT_DIR


### PR DESCRIPTION
After the analysis done on b/433928503, we noticed that for some machines, even though clusterfuzz is the owner of the root directory, it is created without execution permissions (needed to re-create some directories during clusterfuzz execution).

This PR tries to add this permission explicitly in order to avoid hitting these errors on different versions of the COS.
