### PR TITLE
Allow issue filing without impact task when regression fails.

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -920,8 +920,10 @@ def critical_tasks_completed(testcase):
   if not utils.is_chromium():
     return testcase.minimized_keys and testcase.regression
 
+  impact_satisfied = testcase.is_impact_set_flag or testcase.regression == 'NA'
+
   return bool(testcase.minimized_keys and testcase.regression and
-              testcase.is_impact_set_flag and not testcase.analyze_pending)
+              impact_satisfied and not testcase.analyze_pending)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Regression task will fail in a number of expected scenarios such as when a bug is temporarily fixed and then broken again in a later revision. Out-of-memory and timeout are particularly vulnerable to this.

There are a number of other issues why regression task can fail. Rather than hide bugs where this happens, we should report them.