### PR TITLE
Make schedule_fuzz CPU limit configurable

### DIFF
--- a/configs/test/project.yaml
+++ b/configs/test/project.yaml
@@ -139,3 +139,6 @@ env:
 # Pub/Sub topic for receiving issue updates.
 #issue_updates:
   #pubsub_topic: projects/test-project/topics/issue-updates
+
+schedule_fuzz:
+  cpu_limit: 100000

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -110,7 +110,9 @@ def get_cpu_usage(creds, project: str, region: str) -> int:
   # We need this because us-central1 and us-east4 have different numbers of
   # cores alloted to us in their quota. Treat them the same to simplify things.
   limit = quota['limit']
-  limit = min(limit, 100_000)
+  project_config = local_config.ProjectConfig()
+  # On OSS-Fuzz there is a limit to the number of CPUs we can use.
+  limit = min(limit, project_config.get('schedule_fuzz.cpu_limit', limit))
   return limit, quota['usage']
 
 


### PR DESCRIPTION
Previously limits were hardcoded or based on region limits. Now that we are turning on batch in us-west1, we need to have configurable limits that don't affect oss-fuzz.