### PR TITLE
Fix UI to show when issue is from testcase group

### DIFF
--- a/src/appengine/private/components/testcase-detail/testcase-detail.html
+++ b/src/appengine/private/components/testcase-detail/testcase-detail.html
@@ -300,7 +300,9 @@
                     </span>
                     <span slot="f">
                       <if-else condition="[[info.testcase.group_bug_information]]">
-                        <a slot="t" href="[[info.issue_url]]">[[info.testcase.group_bug_information]]</a> (from its group)
+                        <span slot="t">
+                          <a slot="t" href="[[info.issue_url]]">[[info.testcase.group_bug_information]]</a> (from its group)
+                        </span>
                         <span slot="f">None</span>
                       </if-else>
                     </span>


### PR DESCRIPTION
Fix html from the testcase details page to actually show when the issue ID linked to the testcase is from its group.


Tests in App Engine staging:
* Same testcase from prod and staging:
<img width="3074" height="916" alt="image" src="https://github.com/user-attachments/assets/259fc367-41c4-43f2-9b6d-387048b77df5" />

<img width="3088" height="828" alt="image" src="https://github.com/user-attachments/assets/2d7fed69-7f65-4273-bacd-78139d547d4e" />

* This does not affect ungrouped testcases:

