### PR TITLE
stack analyzer: Detect more numbers

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/v8_maglev_type_error.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/v8_maglev_type_error.txt
@@ -1,0 +1,80 @@
+[Environment] ASAN_OPTIONS=alloc_dealloc_mismatch=0:allocator_may_return_null=1:allow_user_segv_handler=1:check_malloc_usable_size=0:detect_leaks=1:detect_odr_violation=0:detect_stack_use_after_return=1:external_symbolizer_path=/mnt/scratch0/clusterfuzz/resources/platform/linux/llvm-symbolizer:fast_unwind_on_fatal=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:handle_sigtrap=1:print_scariness=1:print_summary=1:print_suppressions=0:redzone=128:strict_memcmp=0:symbolize=1:symbolize_inline_frames=false:use_sigaltstack=1
+[Command line] /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/d8 --fuzzing --fuzzing --allow-natives-syntax --disable-abortjs --disable-in-process-stack-traces --fuzzing --jit-fuzzing --maglev-future --turbolev /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzzilli.js
+
++----------------------------------------Debug Build Stacktrace----------------------------------------+
+V8 is running with experimental features enabled. Stability and security will suffer.
+
+
+#
+# Fatal error in ../../src/maglev/maglev-ir.cc, line 902
+# Type representation error: node #153 : Float64Add (input @1 = Int32Multiply) type Int32 is not HoleyFloat64
+#
+#
+#
+#FailureMessage Object: 0x79cf0bf58860
+==== C stack trace ===============================
+
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/d8(__interceptor_backtrace+0x46) [0x595866fd78e6]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8_libbase.so(v8::base::debug::StackTrace::StackTrace()+0x13) [0x7dcf1d344ca3]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8_libplatform.so(+0x3989a) [0x7dcf1d28c89a]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8_libbase.so(V8_Fatal(char const*, int, char const*, ...)+0x2a0) [0x7dcf1d30a700]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::maglev::CheckValueInputIs(v8::internal::maglev::NodeBase const*, int, v8::internal::maglev::ValueRepresentation)+0x397) [0x7dcf18077047]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::maglev::ProcessResult v8::internal::maglev::MaglevGraphVerifier::Process<v8::internal::maglev::Float64Add>(v8::internal::maglev::Float64Add*, v8::internal::maglev::ProcessingState const&)+0x53) [0x7dcf17912fb3]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::maglev::GraphProcessor<v8::internal::maglev::MaglevGraphVerifier>::ProcessGraph(v8::internal::maglev::Graph*)+0x5c2) [0x7dcf178f5032]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::compiler::turboshaft::RunMaglevOptimizations(v8::internal::compiler::turboshaft::PipelineData*, v8::internal::maglev::MaglevCompilationInfo*, v8::internal::maglev::Graph*)+0x3ec) [0x7dcf1adfd41c]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::compiler::turboshaft::TurbolevGraphBuildingPhase::Run(v8::internal::compiler::turboshaft::PipelineData*, v8::internal::Zone*, v8::internal::compiler::Linkage*)+0x543) [0x7dcf1ae01ad3]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(auto v8::internal::compiler::turboshaft::Pipeline::Run<v8::internal::compiler::turboshaft::TurbolevGraphBuildingPhase, v8::internal::compiler::Linkage*&>(v8::internal::compiler::Linkage*&)+0x2fb) [0x7dcf199b261b]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::compiler::turboshaft::Pipeline::CreateGraphWithMaglev(v8::internal::compiler::Linkage*)+0x211) [0x7dcf19981d31]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::compiler::PipelineCompilationJob::ExecuteJobImpl(v8::internal::RuntimeCallStats*, v8::internal::LocalIsolate*)+0x4c1) [0x7dcf19981691]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::OptimizedCompilationJob::ExecuteJob(v8::internal::RuntimeCallStats*, v8::internal::LocalIsolate*)+0x1ad) [0x7dcf14bbce3d]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(+0x582a2fd) [0x7dcf14c2a2fd]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(+0x57f5076) [0x7dcf14bf5076]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::Compiler::CompileOptimized(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::JSFunction>, v8::internal::ConcurrencyMode, v8::internal::CodeKind)+0x9be) [0x7dcf14bf182e]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(+0x7c32fc5) [0x7dcf17032fc5]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(+0x7c1fdb8) [0x7dcf1701fdb8]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(v8::internal::Runtime_OptimizeTurbofanEager(int, unsigned long*, v8::internal::Isolate*)+0x1ec) [0x7dcf1701f37c]
+    /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/libv8.so(+0x46c097d) [0x7dcf13ac097d]
+AddressSanitizer:DEADLYSIGNAL
+=================================================================
+==489==ERROR: AddressSanitizer: ABRT on unknown address 0x0539000001e9 (pc 0x7dcf0d85100b bp 0x7ffd3838b970 sp 0x7ffd3838b720 T0)
+SCARINESS: 10 (signal)
+    #0 0x7dcf0d85100b in raise /build/glibc-LcI20x/glibc-2.31/signal/../sysdeps/unix/sysv/linux/raise.c:51:1
+    #1 0x7dcf1d30a71b in V8_Fatal(char const*, int, char const*, ...) src/base/logging.cc:215:3
+    #2 0x7dcf18077046 in v8::internal::maglev::CheckValueInputIs(v8::internal::maglev::NodeBase const*, int, v8::internal::maglev::ValueRepresentation) src/maglev/maglev-ir.cc:902:5
+    #3 0x7dcf17912fb2 in v8::internal::maglev::ProcessResult v8::internal::maglev::MaglevGraphVerifier::Process<v8::internal::maglev::Float64Add>(v8::internal::maglev::Float64Add*, v8::internal::maglev::ProcessingState const&) src/maglev/maglev-ir.h:3061:9
+    #4 0x7dcf178f5031 in v8::internal::maglev::GraphProcessor<v8::internal::maglev::MaglevGraphVerifier>::ProcessGraph(v8::internal::maglev::Graph*) src/maglev/maglev-graph-processor.h:172:32
+    #5 0x7dcf1adfd41b in v8::internal::compiler::turboshaft::RunMaglevOptimizations(v8::internal::compiler::turboshaft::PipelineData*, v8::internal::maglev::MaglevCompilationInfo*, v8::internal::maglev::Graph*) src/compiler/turboshaft/turbolev-graph-builder.cc:6469:12
+    #6 0x7dcf1ae01ad2 in v8::internal::compiler::turboshaft::TurbolevGraphBuildingPhase::Run(v8::internal::compiler::turboshaft::PipelineData*, v8::internal::Zone*, v8::internal::compiler::Linkage*) src/compiler/turboshaft/turbolev-graph-builder.cc:6527:3
+    #7 0x7dcf199b261a in auto v8::internal::compiler::turboshaft::Pipeline::Run<v8::internal::compiler::turboshaft::TurbolevGraphBuildingPhase, v8::internal::compiler::Linkage*&>(v8::internal::compiler::Linkage*&) src/compiler/turboshaft/pipelines.h:92:27
+    #8 0x7dcf19981d30 in v8::internal::compiler::turboshaft::Pipeline::CreateGraphWithMaglev(v8::internal::compiler::Linkage*) src/compiler/turboshaft/pipelines.h:143:9
+    #9 0x7dcf19981690 in v8::internal::compiler::PipelineCompilationJob::ExecuteJobImpl(v8::internal::RuntimeCallStats*, v8::internal::LocalIsolate*) src/compiler/pipeline.cc:783:30
+    #10 0x7dcf14bbce3c in v8::internal::OptimizedCompilationJob::ExecuteJob(v8::internal::RuntimeCallStats*, v8::internal::LocalIsolate*) src/codegen/compiler.cc:451:22
+    #11 0x7dcf14c2a2fc in v8::internal::(anonymous namespace)::CompileTurbofan(v8::internal::Isolate*, v8::internal::Handle<v8::internal::JSFunction>, v8::internal::DirectHandle<v8::internal::SharedFunctionInfo>, v8::internal::ConcurrencyMode, v8::internal::BytecodeOffset, v8::internal::(anonymous namespace)::CompileResultBehavior) src/codegen/compiler.cc:1087:12
+    #12 0x7dcf14bf5075 in v8::internal::(anonymous namespace)::GetOrCompileOptimized(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::JSFunction>, v8::internal::ConcurrencyMode, v8::internal::CodeKind, v8::internal::BytecodeOffset, v8::internal::(anonymous namespace)::CompileResultBehavior) src/codegen/compiler.cc:1400:12
+    #13 0x7dcf14bf182d in v8::internal::Compiler::CompileOptimized(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::JSFunction>, v8::internal::ConcurrencyMode, v8::internal::CodeKind) src/codegen/compiler.cc:3175:7
+    #14 0x7dcf17032fc4 in v8::internal::(anonymous namespace)::CompileOptimized(v8::internal::DirectHandle<v8::internal::JSFunction>, v8::internal::ConcurrencyMode, v8::internal::CodeKind, v8::internal::Isolate*) src/runtime/runtime-compiler.cc:185:3
+    #15 0x7dcf1701fdb7 in v8::internal::__RT_impl_Runtime_OptimizeTurbofanEager(v8::internal::Arguments<(v8::internal::ArgumentsType)0>, v8::internal::Isolate*) src/runtime/runtime-compiler.cc:227:3
+    #16 0x7dcf1701f37b in v8::internal::Runtime_OptimizeTurbofanEager(int, unsigned long*, v8::internal::Isolate*) src/runtime/runtime-compiler.cc:222:1
+    #17 0x7dcf13ac097c in Builtins_CEntry_Return1_ArgvOnStack_NoBuiltinExit setup-isolate-deserialize.cc
+    #18 0x7dcf13571d48 in Builtins_OptimizeTurbofanEager setup-isolate-deserialize.cc
+    #19 0x7dcf1356e671 in Builtins_InterpreterEntryTrampoline setup-isolate-deserialize.cc
+    #20 0x7dcf1355fd66 in Builtins_JSEntryTrampoline setup-isolate-deserialize.cc
+    #21 0x7dcf1355faaa in Builtins_JSEntry setup-isolate-deserialize.cc
+    #22 0x7dcf15134f2d in v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) src/execution/simulator.h:212:12
+    #23 0x7dcf15139595 in v8::internal::Execution::CallScript(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::JSFunction>, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>) src/execution/execution.cc:542:10
+    #24 0x7dcf145cc89e in v8::Script::Run(v8::Local<v8::Context>, v8::Local<v8::Data>) src/api/api.cc:1937:7
+    #25 0x5958670b437f in v8::Shell::ExecuteString(v8::Isolate*, v8::Local<v8::String>, v8::Local<v8::String>, v8::Shell::ReportExceptions, v8::Global<v8::Value>*) src/d8/d8.cc:1033:44
+    #26 0x5958670f4a15 in v8::SourceGroup::Execute(v8::Isolate*) src/d8/d8.cc:5351:10
+    #27 0x5958671018b3 in v8::Shell::RunMainIsolate(v8::Isolate*, bool) src/d8/d8.cc:6307:37
+    #28 0x595867100884 in v8::Shell::RunMain(v8::Isolate*, bool) src/d8/d8.cc:6215:18
+    #29 0x5958671045c9 in v8::Shell::Main(int, char**) src/d8/d8.cc:7100:18
+    #30 0x7dcf0d832082 in __libc_start_main /build/glibc-LcI20x/glibc-2.31/csu/../csu/libc-start.c:308:16
+
+==489==Register values:
+rax = 0x0000000000000000  rbx = 0x00007dcf0f366940  rcx = 0x00007dcf0d85100b  rdx = 0x0000000000000000
+rdi = 0x0000000000000002  rsi = 0x00007ffd3838b720  rbp = 0x00007ffd3838b970  rsp = 0x00007ffd3838b720
+ r8 = 0x0000000000000000   r9 = 0x00007ffd3838b720  r10 = 0x0000000000000008  r11 = 0x0000000000000246
+r12 = 0x000079cf0bf58820  r13 = 0x00000fb9e1b3f6f0  r14 = 0x00007dcf0d9fb780  r15 = 0x000079cf0bf58860
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: ABRT /build/glibc-LcI20x/glibc-2.31/signal/../sysdeps/unix/sysv/linux/raise.c:51:1 in raise
+==489==ABORTING

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1281,6 +1281,25 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_v8_maglev_type_error(self):
+    """Test a type error in maglev, including a node number and input ID
+    which should be converted to `NUMBER` to avoid flooding us with identical
+    issues."""
+    data = self._read_test_data('v8_maglev_type_error.txt')
+    expected_type = 'Fatal error'
+    expected_address = ''
+    expected_state = (
+        'Type representation error: node #NUMBER : Float64Add (input @NUMBER = Int32Multi\n'
+        'v8::internal::maglev::CheckValueInputIs\n'
+        'v8::internal::maglev::ProcessResult v8::internal::maglev::MaglevGraphVerifier::P\n'
+    )
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_generic_segv(self):
     """Test a SEGV caught by a generic signal handler."""
     data = self._read_test_data('generic_segv.txt')

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -1373,9 +1373,12 @@ def filter_addresses_and_numbers(stack_frame):
   # Cases that we are avoiding:
   # - source.cc:1234
   # - libsomething-1.0.so (to avoid things like NUMBERso in replacements)
-  number_expression = r'(^|[^:0-9.])[0-9.]{4,}($|[^A-Za-z0-9.])'
-  number_replacement = r'\1NUMBER\2'
-  return re.sub(number_expression, number_replacement, result)
+  number_expression = r'''(?<![:0-9.])         # not preceeded by any of these
+                          (?:[0-9.]{4,}        # either >= 4 digits
+                             |(?<=[@#])[0-9]+) # or preceeded by @ or #
+                          (?![A-Za-z0-9.])     # not followed by any of these
+                          '''
+  return re.sub(number_expression, 'NUMBER', result, flags=re.X)
 
 
 def should_ignore_line_for_crash_processing(line, state):


### PR DESCRIPTION
This adds the patterns `@[0-9]` and `#[0-9]` and replaces them by `@NUMBER` and `#NUMBER` respectively.
These patterns are used in V8 for printing node IDs and input IDs. No other existing tests are affected by these new patterns.

This avoid flooding clusterfuzz with identical issues if such IDs are contained in the error message (see https://crbug.com/437859892).