### PR TITLE
Create cloudbuild.yaml for deployment pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /bot/*
 /coverage
 /deployment
+/clusterfuzz-config
 /local/bin/android-sdk/*
 /local/storage
 /paramiko.log

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -1,0 +1,76 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: gcr.io/cloud-builders/git
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    # First, clone the repository
+    git config --global credential.helper gcloud.sh
+    git clone https://clusterfuzz-config-472119376969-git.us-central1.sourcemanager.dev/clusterfuzz-testing/clusterfuzz-config.git /workspace/clusterfuzz-config
+    
+    # Move into the repository directory
+    cd /workspace/clusterfuzz-config
+    
+    # Conditionally run 'git reset'
+    if [ -n "${_CLUSTERFUZZ_CONFIG_REVISION}" ]; then
+      echo "✅ _CLUSTERFUZZ_CONFIG_REVISION is set. Resetting to commit: ${_CLUSTERFUZZ_CONFIG_REVISION}"
+      git reset --hard "${_CLUSTERFUZZ_CONFIG_REVISION}"
+    else
+      echo "☑️ _CLUSTERFUZZ_CONFIG_REVISION is not set. Using the latest commit."
+    fi
+- name: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    # Conditionally run 'git reset' if the revision is provided
+    if [ -n "${_CLUSTERFUZZ_REVISION}" ]; then
+      echo "✅ _CLUSTERFUZZ_REVISION is set. Resetting to commit: ${_CLUSTERFUZZ_REVISION}"
+      git reset --hard "${_CLUSTERFUZZ_REVISION}"
+    else
+      echo "☑️ _CLUSTERFUZZ_REVISION is not set. Using the latest commit."
+    fi
+    
+    # Install required deps for performing butler deploy
+    bash ./local/install_deps.bash
+    
+    # Get into the venv
+    source "$$(python3.11 -m pipenv --venv)/bin/activate"
+
+    # Check if the _PROJECT substitution was provided.
+    if [ -z "${_PROJECT}" ]; then
+      echo "❌ Error: The _PROJECT substitution variable must be provided."
+      exit 1
+    fi
+
+    # Construct the full path using the substitution variable.
+    configpath="/workspace/clusterfuzz-config/configs/${_PROJECT}"
+
+    # Verify that the configuration directory actually exists.
+    if [ ! -d "$configpath" ]; then
+      echo "❌ Error: Configuration directory not found at $configpath"
+      exit 1
+    fi
+
+    echo "✅ Running deploy for project config: $configpath"
+    python3.11 butler.py deploy -c $configpath --prod --targets=zips --force
+
+timeout: 1200s
+options:
+  machineType: E2_HIGHCPU_32
+  diskSizeGb: 500
+  logging: CLOUD_LOGGING_ONLY

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ steps:
     fi
 
     echo "✅ Running deploy for project config: $configpath"
-    python3.11 butler.py deploy -c $configpath --prod --targets=zips --force
+    python3.11 butler.py deploy -c $configpath --prod --targets zips appengine --force
 
 timeout: 1200s
 options:


### PR DESCRIPTION
fix b/437926994

Implement a pipeline for running deployment through butler deploy script.

The pipeline steps are:

1. Make git clone on clusterfuzz config for a given revision if the revision is provided as a `substituition`. Substituition is the GCB way to provide a kind of env vars. [documentation](https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values)
If the substituition key is not provided, the latest revision is used. 

2. Install deps and run the butler deploy for a also given revision as substituition. If the revision is not provided, the lastest is used. These step expected to receive an _PROJECT substituition that points to the project that should run the deployment, eg: staging, dev, internal, external...
The way to assure that the pipeline will run against the right environment is on the trigger definition, where the substituition can be hardcoded in the trigger definition. We will have a different trigger for each environment. 

Evidence of a successful run [here](https://github.com/google/clusterfuzz/runs/47932159422)
