### PR TITLE
Move label is batch from boolean to str.

### DIFF
--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -144,7 +144,7 @@ FUZZER_TOTAL_FUZZ_TIME = monitor.CounterMetric(
         monitor.StringField('fuzzer'),
         monitor.BooleanField('timeout'),
         monitor.StringField('platform'),
-        monitor.BooleanField('is_batch')
+        monitor.StringField('is_batch')
     ],
 )
 
@@ -169,7 +169,7 @@ JOB_TOTAL_FUZZ_TIME = monitor.CounterMetric(
         monitor.StringField('job'),
         monitor.BooleanField('timeout'),
         monitor.StringField('platform'),
-        monitor.BooleanField('is_batch')
+        monitor.StringField('is_batch')
     ],
 )
 


### PR DESCRIPTION
It updates the label is batch to string because it uses the return of the function `is_uworker` as response, but this function doesn't return always boolean. For the case where it's not a batch environment, it returns None. The label is set as a string None for this case. 

That's the reason that some datapoints are missing on the dashboard. Before running the deployment for appengine, the new label was following the "default" pattern considering all as a String, but after the deployment, the descriptor has changed the label to Boolean, what stated to make the metric with `None` to be ignored.