### PR TITLE
Install git and clone the repository when revision is present

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -40,6 +40,9 @@ steps:
     # Conditionally run 'git checkout' if the revision is provided
     if [ -n "${_CLUSTERFUZZ_REVISION}" ]; then
       echo "✅ _CLUSTERFUZZ_REVISION is set. Checking out to commit: ${_CLUSTERFUZZ_REVISION}"
+      apt install git -y
+      git clone https://github.com/google/clusterfuzz.git
+      cd clusterfuzz
       git checkout "${_CLUSTERFUZZ_REVISION}"
     else
       echo "☑️ _CLUSTERFUZZ_REVISION is not set. Using the latest commit."

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -32,20 +32,30 @@ steps:
     else
       echo "☑️ _CLUSTERFUZZ_CONFIG_REVISION is not set. Using the latest commit."
     fi
-- name: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
+
+- name: gcr.io/cloud-builders/git
   entrypoint: bash
   args:
   - -c
   - |
-    # Conditionally run 'git checkout' if the revision is provided
+    # Conditionally clone the upstream clusterfuzz and 'git checkout' if the revision is provided
     if [ -n "${_CLUSTERFUZZ_REVISION}" ]; then
       echo "✅ _CLUSTERFUZZ_REVISION is set. Checking out to commit: ${_CLUSTERFUZZ_REVISION}"
-      apt install git -y
       git clone https://github.com/google/clusterfuzz.git
       cd clusterfuzz
       git checkout "${_CLUSTERFUZZ_REVISION}"
     else
       echo "☑️ _CLUSTERFUZZ_REVISION is not set. Using the latest commit."
+    fi
+
+- name: gcr.io/clusterfuzz-images/base:091c6c2-202409251610
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    # Conditionally run go into the cloned clusterfuzz
+    if [ -n "${_CLUSTERFUZZ_REVISION}" ]; then
+      cd clusterfuzz
     fi
     
     # Install required deps for performing butler deploy


### PR DESCRIPTION
I've added a command to install git and clone the clusterfuzz repository if the clusterfuzz revision is passed as a substituition.

This is needed because GCB doesn't pass the content of the respository as a git project, then we're not able to change the version in the build time. 

The workaround for this is to clone the repository in build time and then checkout in the given revision.