### PR TITLE
Catch ValueError to prevent fatal exception during bearer token parsing

### DIFF
--- a/src/appengine/libs/auth.py
+++ b/src/appengine/libs/auth.py
@@ -16,7 +16,6 @@
 import collections
 
 from firebase_admin import auth
-from google.auth.exceptions import MalformedError
 from google.auth.transport import requests as google_requests
 from google.cloud import ndb
 from google.oauth2 import id_token


### PR DESCRIPTION
b/438753301

Both MalformedException and binascii.Error inherit from ValueError, so catching this more generic exception should prevent the fatal exception

<img width="1080" height="206" alt="image" src="https://github.com/user-attachments/assets/9a95b336-08a0-4097-bf28-9fb5be4d554c" />

<img width="476" height="84" alt="image" src="https://github.com/user-attachments/assets/a37c4f72-45b4-4092-b603-59a2e1a07c34" />

