### PR TITLE
Create deployment error

### DIFF
--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -51,6 +51,10 @@ SERVICE_REGEX = re.compile(r'service\s*:\s*(.*)')
 Version = namedtuple('Version', ['id', 'deploy_time', 'traffic_split'])
 
 
+class DeploymentError(Exception):
+  """Deployment Error"""
+
+
 def now(tz=None):
   """Used for mocks."""
   return datetime.datetime.now(tz)
@@ -379,10 +383,6 @@ def _staging_deployment_helper():
 
   _deploy_app_staging(project, yaml_paths)
   print('Staging deployment finished.')
-
-
-class DeploymentError(Exception):
-  """Deployment Error"""
 
 
 # We need to import the wrap_with_monitoring through monitoring_metrics

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -381,6 +381,10 @@ def _staging_deployment_helper():
   print('Staging deployment finished.')
 
 
+class DeploymentError(Exception):
+  """Deployment Error"""
+
+
 # We need to import the wrap_with_monitoring through monitoring_metrics
 # monitor's import because we need to point to the same module instance
 # for assuring the same metric store we increment the metric will have
@@ -442,10 +446,10 @@ def _prod_deployment_helper(config_dir,
 
     print(f'Production deployment finished. {labels}')
     monitoring_metrics.PRODUCTION_DEPLOYMENT.increment(labels)
-  except Exception as ex:
+  except:
     labels.update({'success': False})
     monitoring_metrics.PRODUCTION_DEPLOYMENT.increment(labels)
-    raise ex
+    raise DeploymentError
 
 
 def _deploy_terraform(config_dir):

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -447,10 +447,10 @@ def _prod_deployment_helper(config_dir,
 
     print(f'Production deployment finished. {labels}')
     monitoring_metrics.PRODUCTION_DEPLOYMENT.increment(labels)
-  except:
+  except Exception as ex:
     labels.update({'success': False})
     monitoring_metrics.PRODUCTION_DEPLOYMENT.increment(labels)
-    raise DeploymentError
+    raise DeploymentError from ex
 
 
 def _deploy_terraform(config_dir):

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -427,6 +427,7 @@ def _prod_deployment_helper(config_dir,
   }
 
   try:
+    raise Exception
     # Appengine depends on Redis, which is managed by Terraform
     # Therefore, we need to deploy Terraform first
     if deploy_terraform:

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -427,7 +427,6 @@ def _prod_deployment_helper(config_dir,
   }
 
   try:
-    raise Exception
     # Appengine depends on Redis, which is managed by Terraform
     # Therefore, we need to deploy Terraform first
     if deploy_terraform:


### PR DESCRIPTION
Contribute towards b/440042223

It create a Deployment Error class and uses it for Deployment failure.

It also fixes the issuance of the metric for failures. It seems the way that the metrics client is implemented, it's not allowed to emit the metric in a exception handling block. 