### PR TITLE
Add ignore changes tempaltes to monitoring terraform

### DIFF
--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -21,7 +21,9 @@ provider "google" {
 resource "google_monitoring_dashboard" "clusterfuzz_sli_dashboard" {
   provider = google.monitoring
   lifecycle {
-    ignore_changes = true
+    ignore_changes = [
+      dashboard_json,
+    ]
   }
   dashboard_json = <<JSON
 {

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -20,6 +20,9 @@ provider "google" {
 
 resource "google_monitoring_dashboard" "clusterfuzz_sli_dashboard" {
   provider = google.monitoring
+  lifecycle {
+    ignore_changes = true
+  }
   dashboard_json = <<JSON
 {
   "displayName": "Clusterfuzz Relability Metrics",


### PR DESCRIPTION
It adds the flag to ignore changes on monitoring terraform. 

Its needed to reduce the noise on the terraform plan.

Terraform plan without the noise after changes.
<img width="1330" height="814" alt="image" src="https://github.com/user-attachments/assets/d7b7d75a-a2d3-4e54-b376-4b1acef525b5" />
