### PR TITLE
Add step to pipeline for recreating the instances

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -93,6 +93,24 @@ steps:
     CURRENT_CLUSTERFUZZ_REVISION="$(cat src/appengine/resources/clusterfuzz-source.manifest)"
     gcloud compute project-info add-metadata --metadata=clusterfuzz-revision="$${CURRENT_CLUSTERFUZZ_REVISION}" --project "${PROJECT_ID}"
 
+- id: 'tf init'
+  name: 'hashicorp/terraform:1.8.2'
+  entrypoint: 'sh'
+  args:
+  - '-c'
+  - |
+    cd /workspace/clusterfuzz-config/configs/${_PROJECT}/terraform
+    terraform init || exit 1
+
+- id: 'tf run'
+  name: 'hashicorp/terraform:1.8.2'
+  entrypoint: 'sh'
+  args:
+  - '-c'
+  - |
+    /workspace/clusterfuzz-config/configs/${_PROJECT}/terraform
+    terraform apply -target=module.compute -auto-approve || exit 1
+
 timeout: 1200s
 options:
   machineType: E2_HIGHCPU_32


### PR DESCRIPTION
It creates the terraform steps on the deployment pipeline. These steps  recreates the bots instances for the project by setting the template metadata with the newer clusterfuzz revision. 

It enforces the new machines will be created in the newer version, deprecating the update task feature.

[Succesful run in dev](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/e99b395d-e100-4029-922a-36de2a8c2567?e=-13802955&project=clusterfuzz-development)