### PR TITLE
[FIX] Fix the step to update the metadata 

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -82,7 +82,8 @@ steps:
     echo "✅ Running deploy for project config: $configpath"
     python3.11 butler.py deploy -c $configpath --prod --targets zips appengine --force
 
-- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+- id: update project metadata with revision
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: bash
   args:
   - -c
@@ -90,8 +91,30 @@ steps:
     if [ -n "${_CLUSTERFUZZ_REVISION}" ]; then
       cd clusterfuzz
     fi
+
+    METADATA_KEY="clusterfuzz-revision"
+    MAX_RETRIES=10
+    WAIT_SECONDS=10
+
     CURRENT_CLUSTERFUZZ_REVISION="$(cat src/appengine/resources/clusterfuzz-source.manifest)"
-    gcloud compute project-info add-metadata --metadata=clusterfuzz-revision="$${CURRENT_CLUSTERFUZZ_REVISION}" --project "${PROJECT_ID}"
+    echo "Starting asynchronous metadata update..."
+
+    # Step 1: Run the update command in the background
+    gcloud compute project-info add-metadata --metadata="$${METADATA_KEY}=$${CURRENT_CLUSTERFUZZ_REVISION}" --project "${PROJECT_ID}" > /dev/null 2>&1 &
+
+    # Step 2: Poll for the updated metadata value
+    for ((i=1; i<=$$MAX_RETRIES; i++)); do
+      echo "Attempt $$i of $$MAX_RETRIES: Checking project metadata..."
+      # Check if the metadata value has been updated
+      if gcloud compute project-info describe --project "${PROJECT_ID}" --format="value(commonInstanceMetadata.items.$${METADATA_KEY})" | grep -q "$${CURRENT_CLUSTERFUZZ_REVISION}"; then
+        echo "Metadata updated successfully!"
+        exit 0
+      fi
+      echo "Metadata not yet updated. Waiting $$WAIT_SECONDS seconds..."
+      sleep $$WAIT_SECONDS
+    done
+    echo "Operation timed out with failure"
+    exit 1
 
 - id: 'tf init'
   name: 'hashicorp/terraform:1.8.2'


### PR DESCRIPTION
It fixes the step to update the project metadata with the Clusterfuzz revision by moving it to an async approach.

The gcloud API has some limitations for the projects with higher demand like external and internal, where the simple command to update the metadata can timeout, but actually the command succeed.  [Example of a timed out build](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/c915cf71-c6dd-49ca-b571-0f4cc613e3ed;step=3?e=-13802955&mods=logs_tg_prod&project=clusterfuzz-external&supportedpurview=project) that spent 1800 seconds before erroring.

This approach runs the command to update the medatada in a deatached process and then creates a new one with a loop checking if the metadata was updated in the Google Cloud side. With this, we don't need to wait the update command attached to the stdout and move forward.

It worked for dev already.  [Build here](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/58852f49-a19d-4a3d-ad47-6d95566521ee?e=-13802955&mods=logs_tg_prod&project=clusterfuzz-development)