### PR TITLE
Add settings file for Gemini configuration

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,3 @@
+{
+  "contextFileName": "AGENTS.md"
+}


### PR DESCRIPTION
Add Gemini settings file

This change adds the `.gemini/settings.json` file to configure the context file name for the agent. The file is created in the `.gemini` directory in the root of the repository.

https://google-gemini.github.io/gemini-cli/docs/cli/configuration.html#available-settings-in-settingsjson