### PR TITLE
checkout on the same ref_name

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
     
     # Enforcing that the clusterfuzz and config are using the same branch
     # It makes sure that for dev deployments the deployment overrides the
-    # current version with master
+    # current version with dev
     echo "Checking out Clusterfuzz config to the branch $REF_NAME"
     git checkout $REF_NAME
 

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -25,7 +25,13 @@ steps:
     # Move into the repository directory
     cd /workspace/clusterfuzz-config
     
-    # Conditionally run 'git checkout'
+    # Enforcing that the clusterfuzz and config are using the same branch
+    # It makes sure that for dev deployments the deployment overrides the
+    # current version with master
+    echo "Checking out Clusterfuzz config to the branch $REF_NAME"
+    git checkout $REF_NAME
+
+    # Conditionally run 'git checkout' to a given revision
     if [ -n "${_CLUSTERFUZZ_CONFIG_REVISION}" ]; then
       echo "✅ _CLUSTERFUZZ_CONFIG_REVISION is set. Checking out to commit: ${_CLUSTERFUZZ_CONFIG_REVISION}"
       git checkout "${_CLUSTERFUZZ_CONFIG_REVISION}"


### PR DESCRIPTION
It updates the deployment step that gets the config to perform a checkout on the same branch that is the target for the Clusterfuzz.

Currently we work with two branches: dev and master.

For the current state, when deploying for dev from Clusterfuzz pipeline, the config version will always be the master, what can override the current config that can be tested, that is in the dev branch for the config repository.

This change enforeces to sync the branches during the deployment, so dev deployment will use the dev branch for config, and the same for master. 