### PR TITLE
Add test for recent Chromium check failure.

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/check_file_line.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/check_file_line.txt
@@ -1,0 +1,3042 @@
+[844:844:0908/072005.733945:VERBOSE1:chrome/app/chrome_crash_reporter_client.cc:199] GetCollectStatsConsent(): is_official_chrome_build is false so returning false
+[844:844:0908/072005.759848:VERBOSE1:chrome/app/chrome_crash_reporter_client.cc:199] GetCollectStatsConsent(): is_official_chrome_build is false so returning false
+[854:854:0908/072006.202339:INFO:third_party/webrtc/rtc_base/cpu_info.cc:75] Available number of cores:2
+[854:854:0908/072006.203437:VERBOSE1:content/zygote/zygote_main_linux.cc:201] ZygoteMain: initializing 0 fork delegates
+[1:1:0908/072006.222535:INFO:third_party/webrtc/rtc_base/cpu_info.cc:75] Available number of cores:2
+[1:1:0908/072006.224851:VERBOSE1:content/zygote/zygote_main_linux.cc:201] ZygoteMain: initializing 0 fork delegates
+[844:844:0908/072006.236679:VERBOSE1:components/policy/core/common/config_dir_policy_loader.cc:121] Skipping mandatory platform policies because no policy file was found at: /etc/chromium/policies/managed
+[844:844:0908/072006.236719:VERBOSE1:components/policy/core/common/config_dir_policy_loader.cc:121] Skipping recommended platform policies because no policy file was found at: /etc/chromium/policies/recommended
+[844:844:0908/072006.245493:VERBOSE1:components/variations/service/variations_field_trial_creator.cc:580] Applying FieldTrialTestingConfig
+[844:844:0908/072006.250071:VERBOSE1:components/variations/service/variations_field_trial_creator.cc:354] VariationsSetupComplete
+[844:863:0908/072006.256406:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+[844:844:0908/072006.256654:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for browser/global.
+[844:844:0908/072006.256698:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for browser/*.
+[844:844:0908/072006.256723:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for browser/amsc.
+[844:844:0908/072006.414034:VERBOSE1:chrome/browser/media/webrtc/webrtc_event_log_manager.cc:122] WebRTC remote-bound event logging enabled.
+[844:844:0908/072006.415990:VERBOSE1:components/proxy_config/pref_proxy_config_tracker_impl.cc:199] 0x85c0074f200: set chrome proxy config service to 0x85c000e7400
+[844:844:0908/072006.445761:VERBOSE1:components/device_event_log/device_event_log_impl.cc:200] [07:20:06.428] Display: EVENT: x11_display_manager.cc:110 Displays updated, count:1
+[844:844:0908/072006.446361:VERBOSE1:components/device_event_log/device_event_log_impl.cc:200] [07:20:06.445] Display: EVENT: x11_display_manager.cc:112 Display[61] bounds=[0,0 1280x1024], workarea=[0,0 1280x999], scale=1, rotation=0, panel_rotation=0 external detected
+[844:863:0908/072006.452407:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+[844:863:0908/072006.452532:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+[844:866:0908/072006.468635:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::InitializeMaybeAsync([this=0x85c0013bc00])
+[844:866:0908/072006.468904:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MDM::MediaDevicesManager()
+[844:866:0908/072006.468957:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::MediaStreamManager([this=0x85c0013bc00]))
+[844:862:0908/072006.473977:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/Consent To Send Stats": No such file or directory (2)
+[844:844:0908/072006.482721:VERBOSE1:components/os_crypt/sync/key_storage_util_linux.cc:46] Password storage detected desktop environment: (unknown)
+[844:844:0908/072006.483313:VERBOSE1:components/os_crypt/sync/key_storage_linux.cc:116] Selected backend for OSCrypt: BASIC_TEXT
+[844:844:0908/072006.483369:VERBOSE1:components/os_crypt/sync/key_storage_linux.cc:135] OSCrypt did not initialize a backend.
+[844:844:0908/072006.495648:VERBOSE1:components/enterprise/browser/controller/chrome_browser_cloud_management_controller.cc:171] Cloud management controller initialization aborted as CBCM is not enabled. Please use the `--enable-chrome-browser-cloud-management` command line flag to enable it if you are not using the official Google Chrome build.
+[877:877:0908/072006.494044:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for gpu-process/global.
+[877:877:0908/072006.497894:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for gpu-process/*.
+[877:877:0908/072006.498018:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for gpu-process/amsc.
+[844:844:0908/072006.617188:WARNING:chrome/browser/signin/account_consistency_mode_manager.cc:74] Desktop Identity Consistency cannot be enabled as no OAuth client ID and client secret have been configured.
+[844:844:0908/072006.617339:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[844:862:0908/072006.637433:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/Default/Web Applications/Logs/WebAppInstallManager.log": No such file or directory (2)
+[844:844:0908/072006.656595:VERBOSE1:components/proxy_config/pref_proxy_config_tracker_impl.cc:199] 0x85c0074bc00: set chrome proxy config service to 0x85c00b7cb60
+[844:844:0908/072006.660547:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[844:844:0908/072006.665057:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:297] MutablePO2TS::MutablePO2TS
+[880:1:0908/072006.664670:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/global.
+[880:1:0908/072006.668397:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/*.
+[880:1:0908/072006.668542:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/amsc.
+[880:1:0908/072006.690924:VERBOSE1:sandbox/policy/linux/sandbox_linux.cc:87] Activated seccomp-bpf sandbox for process type: utility.
+[844:844:0908/072006.697929:VERBOSE1:components/proxy_config/pref_proxy_config_tracker_impl.cc:199] 0x85c0074ec00: set chrome proxy config service to 0x85c000e7dc0
+[844:844:0908/072006.703170:VERBOSE1:components/device_event_log/device_event_log_impl.cc:200] [07:20:06.699] Bluetooth: EVENT: bluetooth_api.cc:82 BluetoothAPI: 0x85c0005eac0
+[844:844:0908/072006.716632:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[844:844:0908/072006.719245:VERBOSE1:google_apis/gaia/gaia_auth_util.cc:55] Canonicalized @gmail.com to @gmail.com
+[844:844:0908/072006.719977:VERBOSE1:google_apis/gaia/gaia_auth_util.cc:55] Canonicalized @gmail.com to @gmail.com
+[844:844:0908/072006.725939:VERBOSE1:extensions/browser/api/bluetooth_low_energy/bluetooth_low_energy_event_router.cc:291] Initializing BluetoothLowEnergyEventRouter.
+[844:844:0908/072006.732683:VERBOSE1:chrome/browser/permissions/prediction_service/prediction_model_handler_provider_factory.cc:58] [PermissionsAI]: PredictionModelHandlerProviderFactory::BuildServiceInstanceForBrowserContext
+[844:844:0908/072006.736394:VERBOSE1:chrome/browser/permissions/prediction_service/prediction_model_handler_provider_factory.cc:82] [PermissionsAI]: PassageEmbeddingsServiceController available, passage_embedder setup.true
+[844:844:0908/072006.736471:VERBOSE1:chrome/browser/permissions/prediction_service/prediction_model_handler_provider.cc:31] [PermissionsAI] PredictionModelHandlerProvider ctor passage_embedder available: true
+[844:844:0908/072006.736506:VERBOSE1:chrome/browser/permissions/prediction_service/prediction_model_handler_provider.cc:34] [PermissionsAI] PredictionModelHandlerProvider ctor optimization_guide available: true
+[844:844:0908/072006.737224:VERBOSE1:chrome/browser/permissions/prediction_service/prediction_model_handler_provider.cc:67] [PermissionsAI] PredictionModelHandlerProvider init AIv4
+[844:844:0908/072006.739951:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072006.740144:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072006.767548:VERBOSE1:google_apis/gaia/gaia_auth_util.cc:55] Canonicalized @gmail.com to @gmail.com
+[844:844:0908/072006.767597:VERBOSE1:google_apis/gaia/gaia_auth_util.cc:55] Canonicalized @gmail.com to @gmail.com
+[844:844:0908/072006.768014:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[844:844:0908/072006.768069:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[844:844:0908/072006.768113:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[844:844:0908/072006.768165:VERBOSE1:components/signin/core/browser/account_reconcilor.cc:165] AccountReconcilor::AccountReconcilor
+[844:844:0908/072006.768210:VERBOSE1:components/signin/core/browser/account_reconcilor.cc:203] AccountReconcilor::Initialize
+[844:844:0908/072006.772177:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072006.801299:VERBOSE1:components/segmentation_platform/internal/database/cached_result_provider.cc:54] CachedResultProvider loaded prefs with results from previous session: PredictionResult: timestamp: 13401789490671844 result 0: 0 for segmentation key shopping_user
+[844:844:0908/072006.836725:VERBOSE1:extensions/browser/extension_registrar.cc:514] AddComponentExtension Web Store
+[844:844:0908/072006.845479:VERBOSE1:extensions/browser/extension_registrar.cc:514] AddComponentExtension Chromium PDF Viewer
+[844:844:0908/072006.852716:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072006.852770:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072006.853658:VERBOSE1:chrome/browser/profiles/profile_manager.cc:1906] ForceSigninCheck: 0, 0, 1
+[844:862:0908/072006.863404:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/Default/Policy/User Policy": No such file or directory (2)
+[844:862:0908/072006.863493:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/Default/Policy/Signing Key": No such file or directory (2)
+[877:877:0908/072006.875184:VERBOSE1:media/gpu/vaapi/vaapi_wrapper.cc:1585] GetHandle(): Either VADisplayStateSingleton::PreSandboxInitialization() hasn't been called or that method failed to find a suitable render node
+[844:844:0908/072006.879030:VERBOSE1:chrome/browser/profiles/profile_manager.cc:1276] AddKeepAlive(Default, kBrowserWindow). keep_alives=[kWaitingForFirstBrowserWindow (1), kBrowserWindow (1)]
+[844:844:0908/072006.879100:VERBOSE1:chrome/browser/profiles/profile_manager.cc:1358] ClearFirstBrowserWindowKeepAlive(Default). keep_alives=[kBrowserWindow (1)]
+[844:844:0908/072006.881798:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:864:0908/072006.882667:VERBOSE1:components/sessions/core/command_storage_backend.cc:606] CommandStorageBackend::ReadLastSessionCommands, reading commands from: /mnt/scratch0/tmp/user_profile_0/Default/Sessions/Tabs_13401789495029014
+[844:862:0908/072006.883437:VERBOSE1:components/sessions/core/command_storage_backend.cc:606] CommandStorageBackend::ReadLastSessionCommands, reading commands from: /mnt/scratch0/tmp/user_profile_0/Default/Sessions/Session_13401789487422167
+[877:877:0908/072006.886651:WARNING:ui/gfx/linux/gpu_memory_buffer_support_x11.cc:49] dri3 extension not supported.
+[877:877:0908/072006.899426:WARNING:sandbox/policy/linux/sandbox_linux.cc:414] InitializeSandbox() called with multiple threads in process gpu-process.
+[877:877:0908/072006.910687:VERBOSE1:components/viz/service/main/viz_main_impl.cc:86] VizNullHypothesis is disabled (not a warning)
+[844:844:0908/072006.943028:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072006.943928:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:863:0908/072007.010986:VERBOSE1:dbus/bus.cc:918] Method call: message_type: MESSAGE_METHOD_CALL
+interface: org.freedesktop.DBus
+member: GetNameOwner
+signature: s
+string "com.canonical.AppMenu.Registrar"
+[844:844:0908/072007.071742:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[878:878:0908/072007.098691:INFO:third_party/webrtc/rtc_base/cpu_info.cc:75] Available number of cores:2
+[878:878:0908/072007.104352:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/global.
+[878:878:0908/072007.104484:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/*.
+[878:878:0908/072007.104520:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/amsc.
+[878:878:0908/072007.111382:VERBOSE1:services/network/network_sandbox_hook_linux.cc:115] Using network service sandbox.
+[878:878:0908/072007.111479:VERBOSE1:services/network/network_sandbox_hook_linux.cc:81] Granting ReadWriteCreateRecursive permissions to /mnt/scratch0/tmp/user_profile_0/
+[878:878:0908/072007.111532:VERBOSE1:services/network/network_sandbox_hook_linux.cc:81] Granting ReadWriteCreateRecursive permissions to /mnt/scratch0/tmp/user_profile_0/
+[878:878:0908/072007.145155:VERBOSE1:sandbox/policy/linux/sandbox_linux.cc:87] Activated seccomp-bpf sandbox for process type: utility.
+[844:844:0908/072007.269244:VERBOSE1:chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc:233] enterprise.data_protection: same document navigation:0
+[844:844:0908/072007.269314:VERBOSE1:chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc:235] enterprise.data_protection: URL to scan: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html
+[908:1:0908/072007.278744:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/global.
+[908:1:0908/072007.280072:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/*.
+[908:1:0908/072007.280206:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/amsc.
+[844:844:0908/072007.285464:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.285538:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[909:1:0908/072007.297681:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/global.
+[909:1:0908/072007.298030:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/*.
+[909:1:0908/072007.298147:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/amsc.
+[908:1:0908/072007.313757:VERBOSE1:sandbox/policy/linux/sandbox_linux.cc:87] Activated seccomp-bpf sandbox for process type: renderer.
+[909:1:0908/072007.331175:VERBOSE1:sandbox/policy/linux/sandbox_linux.cc:87] Activated seccomp-bpf sandbox for process type: renderer.
+[844:844:0908/072007.468699:WARNING:device/bluetooth/dbus/bluez_dbus_manager.cc:209] Floss manager service not available, cannot set Floss enable/disable.
+[844:863:0908/072007.469775:VERBOSE1:dbus/bus.cc:918] Method call: message_type: MESSAGE_METHOD_CALL
+interface: org.freedesktop.DBus
+member: GetNameOwner
+signature: s
+string "org.freedesktop.portal.Desktop"
+[844:844:0908/072007.504545:VERBOSE1:ui/base/idle/idle_linux.cc:117] org.freedesktop.ScreenSaver D-Bus service does not exist
+[878:904:0908/072007.536623:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://accounts.google.com/ListAccounts?gpsia=1&source=ChromiumBrowser&laf=b64bin&json=standard
+[844:862:0908/072007.553773:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html
+[844:863:0908/072007.582630:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+[844:863:0908/072007.583040:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory
+[844:844:0908/072007.615192:VERBOSE1:ui/base/idle/idle_linux.cc:117] org.cinnamon.ScreenSaver D-Bus service does not exist
+[844:844:0908/072007.633245:WARNING:dbus/property.cc:94] Failed to connect to PropertiesChangedsignal.
+[844:844:0908/072007.633406:ERROR:dbus/object_proxy.cc:573] Failed to call method: org.freedesktop.DBus.Properties.GetAll: object_path= /org/freedesktop/UPower/devices/DisplayDevice: unknown error type:
+[844:844:0908/072007.633456:WARNING:dbus/property.cc:174] GetAll request failed for: org.freedesktop.UPower.Device
+[844:844:0908/072007.646746:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:211] Acquiring <PartitionedLockId>{id: 0x31, partition: 0} for Start@chrome/browser/web_applications/generated_icon_fix_manager.cc:60
+[844:844:0908/072007.646816:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:193] All locks acquired for Start@chrome/browser/web_applications/generated_icon_fix_manager.cc:60
+[844:844:0908/072007.664211:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Session.TotalDuration
+[844:844:0908/072007.664263:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Commerce.PriceDrops.ActiveTabNavigationComplete.IsProductDetailPage
+[844:844:0908/072007.664322:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:54] Segmentation platform started observing Autofill_PolledCreditCardSuggestions
+[844:844:0908/072007.664342:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing IOS.ParcelTracking.Tracked.AutoTrack
+[844:844:0908/072007.664364:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Omnibox.SuggestionUsed.ClientSummarizedResultType
+[844:844:0908/072007.664406:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:54] Segmentation platform started observing MetadataWriter
+[844:844:0908/072007.664429:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Blink.FedCm.AccountsDialogShown
+[844:844:0908/072007.664447:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Blink.FedCm.Status.RequestIdToken
+[844:844:0908/072007.664472:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Blink.FedCm.CancelReason
+[844:844:0908/072007.664503:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Blink.FedCm.IsSignInUser
+[844:844:0908/072007.664526:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Sync.DeviceCount2
+[844:844:0908/072007.664546:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Sync.DeviceCount2.Phone
+[844:844:0908/072007.664567:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Sync.DeviceCount2.Desktop
+[844:844:0908/072007.664585:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Sync.DeviceCount2.Tablet
+[844:844:0908/072007.664604:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:54] Segmentation platform started observing MobileBookmarkManagerOpen
+[844:844:0908/072007.664622:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:54] Segmentation platform started observing NewTabPage.MostVisited.Clicked
+[844:844:0908/072007.664640:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:54] Segmentation platform started observing TabGroup.Created.OpenInNewTab
+[844:844:0908/072007.664658:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:54] Segmentation platform started observing Android.HistoryPage.OpenItem
+[844:844:0908/072007.664677:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:54] Segmentation platform started observing MobileMenuRecentTabs
+[844:844:0908/072007.664697:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing PasswordManager.ManagePasswordsReferrer
+[844:844:0908/072007.664717:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing PasswordManager.ProfileStore.TotalAccountsHiRes3.WithScheme.Https
+[844:844:0908/072007.664737:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing PasswordManager.FillingAssistance
+[844:844:0908/072007.664754:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing PasswordManager.SavedPasswordIsGenerated
+[844:844:0908/072007.664772:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing PasswordManager.SaveUIDismissalReason
+[844:844:0908/072007.664791:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing PasswordManager.SaveUIDismissalReason
+[844:844:0908/072007.664811:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing IOS.CredentialExtension.IsEnabled.Startup
+[844:844:0908/072007.664848:VERBOSE1:components/segmentation_platform/internal/signals/signal_filter_processor.cc:61] Segmentation platform started observing Session.TotalDuration
+[844:844:0908/072007.667240:VERBOSE1:ui/base/idle/idle_linux.cc:117] org.gnome.ScreenSaver D-Bus service does not exist
+[844:844:0908/072007.673533:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[878:904:0908/072007.683190:VERBOSE1:net/third_party/quiche/src/quiche/quic/core/tls_handshaker.cc:107] TlsClient: Continuing handshake
+[878:904:0908/072007.698144:VERBOSE1:net/third_party/quiche/src/quiche/quic/core/tls_handshaker.cc:107] TlsClient: Continuing handshake
+[878:904:0908/072007.698242:VERBOSE1:net/third_party/quiche/src/quiche/quic/core/tls_handshaker.cc:107] TlsClient: Continuing handshake
+[878:904:0908/072007.701608:VERBOSE1:net/third_party/quiche/src/quiche/quic/core/tls_handshaker.cc:107] TlsClient: Continuing handshake
+[878:904:0908/072007.704512:VERBOSE1:net/third_party/quiche/src/quiche/quic/core/tls_handshaker.cc:107] TlsClient: Continuing handshake
+[878:904:0908/072007.704651:VERBOSE1:net/third_party/quiche/src/quiche/quic/core/tls_handshaker.cc:107] TlsClient: Continuing handshake
+[878:904:0908/072007.704845:VERBOSE1:net/third_party/quiche/src/quiche/quic/core/tls_handshaker.cc:107] TlsClient: Continuing handshake
+[844:844:0908/072007.720379:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:235] Releasing <PartitionedLockId>{id: 0x31, partition: 0} requested by Start@chrome/browser/web_applications/generated_icon_fix_manager.cc:60
+[844:844:0908/072007.738910:VERBOSE1:ui/base/idle/idle_linux.cc:117] org.mate.ScreenSaver D-Bus service does not exist
+[909:1:0908/072007.772240:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  0x23cc0044f430
+  URL:
+  context_type:           WEB_PAGE
+  effective extension id: (none)
+  effective context type: WEB_PAGE
+[909:1:0908/072007.776896:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  (nil)
+  URL:
+  context_type:           UNSPECIFIED
+  effective extension id: (none)
+  effective context type: UNSPECIFIED
+[909:1:0908/072007.779405:VERBOSE1:extensions/renderer/dispatcher.cc:575] Num tracked contexts:1
+[844:844:0908/072007.800019:VERBOSE1:ui/base/idle/idle_linux.cc:117] org.xfce.ScreenSaver D-Bus service does not exist
+[844:844:0908/072007.800057:WARNING:ui/base/idle/idle_linux.cc:98] None of the known D-Bus ScreenSaver services could be used.
+[844:844:0908/072007.827551:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:870:0908/072007.843995:VERBOSE1:components/signin/public/webdata/token_service_table.cc:202] Loaded tokens: result = 3 ; number of tokens loaded = 0
+[844:844:0908/072007.890800:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:502] MutablePO2TS::OnWebDataServiceRequestDone. Result type:5
+[844:844:0908/072007.890874:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:559] MutablePO2TS::LoadAllCredentialsIntoMemory; 0 credential(s).
+[844:844:0908/072007.891540:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.891604:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.891641:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.891687:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.891726:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.892011:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.892040:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.892078:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.892105:VERBOSE1:google_apis/gaia/gaia_auth_util.cc:55] Canonicalized @gmail.com to @gmail.com
+[844:844:0908/072007.892123:VERBOSE1:google_apis/gaia/gaia_auth_util.cc:55] Canonicalized @gmail.com to @gmail.com
+[844:844:0908/072007.895744:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.895946:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.896499:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072007.896532:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[878:904:0908/072007.904865:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://www.google.com/async/folae?async=_fmt:pb
+[878:904:0908/072007.921305:VERBOSE1:net/third_party/quiche/src/quiche/quic/core/tls_handshaker.cc:107] TlsClient: Continuing handshake
+[844:862:0908/072007.922454:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/mersenne.js
+[844:844:0908/072007.925387:VERBOSE1:components/segmentation_platform/internal/selection/segment_result_provider.cc:136] GetSegmentResult: segment=OPTIMIZATION_TARGET_SEGMENTATION_DEVICE_SWITCHER ignoring DB score, executing model.
+[844:844:0908/072007.925447:VERBOSE1:components/segmentation_platform/internal/selection/segment_result_provider.cc:277] ExecuteModelAndGetScore: segment=OPTIMIZATION_TARGET_SEGMENTATION_DEVICE_SWITCHER server segment info not available
+[844:844:0908/072007.925493:VERBOSE1:components/segmentation_platform/internal/selection/segment_result_provider.cc:210] OnGotModelScore: segment=OPTIMIZATION_TARGET_SEGMENTATION_DEVICE_SWITCHER failed to get database model score, trying default model.
+[844:862:0908/072007.931174:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/logo.jpg
+[878:904:0908/072007.999649:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://www.google.com/async/folae?async=_fmt:pb
+[844:844:0908/072008.157997:VERBOSE1:chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc:233] enterprise.data_protection: same document navigation:0
+[844:844:0908/072008.158058:VERBOSE1:chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc:235] enterprise.data_protection: URL to scan: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html
+[844:844:0908/072008.163492:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072008.163589:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[844:862:0908/072008.226603:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html
+[844:844:0908/072008.265844:VERBOSE1:chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc:233] enterprise.data_protection: same document navigation:0
+[844:844:0908/072008.265901:VERBOSE1:chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc:235] enterprise.data_protection: URL to scan: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html
+[844:844:0908/072008.269812:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072008.270434:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[909:1:0908/072008.288439:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  0x23cc005309d0
+  URL:
+  context_type:           WEB_PAGE
+  effective extension id: (none)
+  effective context type: WEB_PAGE
+[909:1:0908/072008.288733:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  (nil)
+  URL:
+  context_type:           UNSPECIFIED
+  effective extension id: (none)
+  effective context type: UNSPECIFIED
+[909:1:0908/072008.289001:VERBOSE1:extensions/renderer/dispatcher.cc:575] Num tracked contexts:2
+[844:844:0908/072008.340106:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072008.340196:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[878:904:0908/072008.343333:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://www.google.com/warmup.html
+[909:1:0908/072008.345071:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  0x23cc00549338
+  URL:
+  context_type:           WEB_PAGE
+  effective extension id: (none)
+  effective context type: WEB_PAGE
+[909:1:0908/072008.347313:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  (nil)
+  URL:
+  context_type:           UNSPECIFIED
+  effective extension id: (none)
+  effective context type: UNSPECIFIED
+[932:1:0908/072008.348226:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/global.
+[932:1:0908/072008.349293:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/*.
+[932:1:0908/072008.349423:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for renderer/amsc.
+[909:1:0908/072008.348944:VERBOSE1:extensions/renderer/dispatcher.cc:575] Num tracked contexts:3
+[844:844:0908/072008.362255:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072008.365407:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[878:904:0908/072008.366827:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://www.google.com/warmup.html
+[932:1:0908/072008.385190:VERBOSE1:sandbox/policy/linux/sandbox_linux.cc:87] Activated seccomp-bpf sandbox for process type: renderer.
+[844:862:0908/072008.388565:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html
+[844:844:0908/072008.418326:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[908:1:0908/072008.556118:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  0x23cc004581b8
+  URL:
+  context_type:           WEB_PAGE
+  effective extension id: (none)
+  effective context type: WEB_PAGE
+[908:1:0908/072008.560796:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  (nil)
+  URL:
+  context_type:           UNSPECIFIED
+  effective extension id: (none)
+  effective context type: UNSPECIFIED
+[908:1:0908/072008.562400:VERBOSE1:extensions/renderer/dispatcher.cc:575] Num tracked contexts:1
+[844:844:0908/072008.600193:VERBOSE1:content/browser/renderer_host/back_forward_cache_impl.cc:810] BackForwardCacheImpl::GetCurrentBackForwardCacheEligibility:  : No: not a main frame
+[878:904:0908/072008.604602:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://fonts.gstatic.com/s/googlesans/v29/4UaGrENHsxJlGDuGo1OIlL3Owp4.woff2
+[878:904:0908/072008.611805:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu4mxK.woff2
+[878:904:0908/072008.618427:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfBBc4.woff2
+[844:862:0908/072008.634381:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target.jpg
+[909:1:0908/072008.663914:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  0x23cc005384f0
+  URL:
+  context_type:           WEB_PAGE
+  effective extension id: (none)
+  effective context type: WEB_PAGE
+[909:1:0908/072008.664532:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  (nil)
+  URL:
+  context_type:           UNSPECIFIED
+  effective extension id: (none)
+  effective context type: UNSPECIFIED
+[909:1:0908/072008.664926:VERBOSE1:extensions/renderer/dispatcher.cc:575] Num tracked contexts:4
+[909:1:0908/072008.703027:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  0x23cc00588548
+  URL:
+  context_type:           WEB_PAGE
+  effective extension id: (none)
+  effective context type: WEB_PAGE
+[844:844:0908/072008.706204:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[909:1:0908/072008.704570:VERBOSE1:extensions/renderer/script_context.cc:150] Created context:
+  extension id:           (none)
+  frame:                  (nil)
+  URL:
+  context_type:           UNSPECIFIED
+  effective extension id: (none)
+  effective context type: UNSPECIFIED
+[909:1:0908/072008.706687:VERBOSE1:extensions/renderer/dispatcher.cc:575] Num tracked contexts:5
+[844:864:0908/072008.718225:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target.jpg
+[909:1:0908/072008.799598:VERBOSE1:third_party/blink/renderer/core/html/html_plugin_element.cc:769] EMBED Plugin URL: "text6.swf"
+[909:1:0908/072008.801406:VERBOSE1:third_party/blink/renderer/core/html/html_plugin_element.cc:770] Loaded URL: "file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/text6.swf"
+[909:1:0908/072008.845131:VERBOSE1:third_party/blink/renderer/core/html/html_plugin_element.cc:769] EMBED Plugin URL: "text6.swf"
+[909:1:0908/072008.845993:VERBOSE1:third_party/blink/renderer/core/html/html_plugin_element.cc:770] Loaded URL: "file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/text6.swf"
+[844:844:0908/072009.221233:VERBOSE1:content/browser/renderer_host/render_frame_host_impl.cc:8649]
+******** Formatted tree ********
+[document web] name='Target page' enabled focusable focused sensitive showing visible actions=(doDefault, showContextMenu) embedded-by=[frame] explicit-name:true name-from:related-element character_count=11 offset=0 offset=4 offset=7 text='￼￼￼X1. X￼X￼' hypertext='<obj0><obj1><obj2>X1. X<obj3>X<obj4>'
+++[push button] name='Choose File: No file chosen' enabled focusable sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=27 offset=0 text='Choose File: No file chosen' hypertext='Choose File: No file chosen'
+++[password text] editable enabled focusable sensitive showing single-line visible selectable-text actions=(doDefault, showContextMenu) text-input-type:password character_count=0
+++[link] name='Link' enabled focusable sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=4 offset=0 text='Link' hypertext='Link'
+++++[static] name='Link' enabled sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=4 offset=0 text='Link' hypertext='Link'
+++[static] name='X' enabled sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=1 offset=0 text='X' hypertext='X'
+++[static] name='1. ' enabled sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=3 offset=0 text='1. ' hypertext='1. '
+++[static] name='X' enabled sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=1 offset=0 text='X' hypertext='X'
+++[section] editable enabled focusable multi-line sensitive showing visible selectable-text actions=(doDefault, showContextMenu) id:editable character_count=0
+++[static] name='X' enabled sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=1 offset=0 text='X' hypertext='X'
+++[entry] editable enabled focusable multi-line sensitive showing visible selectable-text actions=(doDefault, showContextMenu) character_count=0
+*********************************
+[844:844:0908/072009.253824:VERBOSE1:content/browser/renderer_host/render_frame_host_impl.cc:8649]
+******** Formatted tree ********
+[document web] name='Target page' enabled focusable focused sensitive showing visible actions=(doDefault, showContextMenu) embedded-by=[frame] explicit-name:true name-from:related-element tag:#document text-align:left character_count=11 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr offset=5 bg-color=240,255,255 fg-color=0,0,238 family-name=Tinos size=12pt underline=single language=en-US direction=lr offset=6 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr offset=9 bg-color=240,255,255 fg-color=0,0,0 family-name=Cousine size=10pt language=en-US direction=lr offset=10 bg-color=255,255,255 fg-color=0,0,0 family-name=Cousine size=10pt language=en-US direction=lr text='￼￼￼￼￼￼￼￼￼￼￼' hypertext='<obj0><obj1><obj2><obj3><obj4><obj5><obj6><obj7><obj8><obj9><obj10>'
+++[embedded component] showing visible actions=(doDefault, showContextMenu) display:inline tag:object text-align:left character_count=0
+++[embedded component] showing visible actions=(doDefault, showContextMenu) display:inline tag:embed text-align:left character_count=0
+++[paragraph] enabled sensitive showing visible actions=(doDefault, showContextMenu) display:block tag:p text-align:left character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='￼' hypertext='<obj0>'
+++++[image] name='To get missing image descriptions, open the context menu.' enabled sensitive showing visible actions=(doDefault, showContextMenu) display:inline roledescription:Unlabeled image src:file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target.jpg tag:img text-align:left
+++[section] enabled sensitive showing visible actions=(doDefault, showContextMenu) display:block tag:form text-align:left character_count=2 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Arimo size=10pt language=en-US direction=lr offset=1 bg-color=255,255,255 fg-color=0,0,0 family-name=Arimo size=10pt language=en-US direction=lr text='￼￼' hypertext='<obj0><obj1>'
+++++[push button] name='Choose File: No file chosen' enabled focusable sensitive showing visible actions=(press, showContextMenu) display:inline-block name-from:contents tag:input text-align:left character_count=27 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Arimo size=10pt language=en-US direction=lr text='Choose File: No file chosen' hypertext='Choose File: No file chosen'
+++++[password text] editable enabled focusable sensitive showing single-line visible selectable-text actions=(activate, showContextMenu) display:inline-block tag:input text-align:left text-input-type:password character_count=0
+++[internal frame] enabled sensitive showing visible actions=(doDefault, showContextMenu) display:inline tag:iframe text-align:left character_count=0
+++[link] name='Link' enabled focusable sensitive showing visible actions=(jump, showContextMenu) display:inline name-from:contents tag:a text-align:left character_count=4 offset=0 bg-color=240,255,255 fg-color=0,0,238 family-name=Tinos size=12pt underline=single language=en-US direction=lr text='Link' hypertext='Link'
+++++[static] name='Link' enabled sensitive showing visible actions=(clickAncestor, showContextMenu) name-from:contents character_count=4 offset=0 bg-color=240,255,255 fg-color=0,0,238 family-name=Tinos size=12pt underline=single language=en-US direction=lr text='Link' hypertext='Link'
+++[section] enabled sensitive showing visible actions=(doDefault, showContextMenu) display:table tag:table text-align:left character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='￼' hypertext='<obj0>'
+++++[section] enabled sensitive showing visible actions=(doDefault, showContextMenu) display:table-row tag:tr text-align:left character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='￼' hypertext='<obj0>'
+++++++[section] name='X' enabled sensitive showing visible actions=(doDefault, showContextMenu) display:table-cell name-from:contents tag:td text-align:left character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='X' hypertext='X'
+++++++++[static] name='X' enabled sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='X' hypertext='X'
+++[list] enabled sensitive showing visible actions=(doDefault, showContextMenu) display:block setsize:1 tag:ol text-align:left character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='￼' hypertext='<obj0>'
+++++[list item] enabled sensitive showing visible actions=(doDefault, showContextMenu) display:list-item level:1 posinset:1 setsize:1 tag:li text-align:left character_count=4 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr offset=3 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='1. X' hypertext='1. X'
+++++++[static] name='1. ' enabled sensitive showing visible actions=(doDefault, showContextMenu) display:inline-block name-from:contents tag:::marker text-align:left character_count=3 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='1. ' hypertext='1. '
+++++++[static] name='X' enabled sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Tinos size=12pt language=en-US direction=lr text='X' hypertext='X'
+++[section] editable enabled focusable multi-line sensitive showing visible selectable-text actions=(activate, showContextMenu) display:block id:editable tag:div text-align:left character_count=0
+++[section] enabled sensitive showing visible actions=(doDefault, showContextMenu) display:block tag:xmp text-align:left character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Cousine size=10pt language=en-US direction=lr text='X' hypertext='X'
+++++[static] name='X' enabled sensitive showing visible actions=(doDefault, showContextMenu) name-from:contents character_count=1 offset=0 bg-color=240,255,255 fg-color=0,0,0 family-name=Cousine size=10pt language=en-US direction=lr text='X' hypertext='X'
+++[entry] editable enabled focusable multi-line sensitive showing visible selectable-text actions=(activate, showContextMenu) display:inline-block tag:textarea text-align:left character_count=0
+*********************************
+[844:844:0908/072009.293561:INFO:CONSOLE:1] "While navigator.cookieEnabled does return true for this file:// URL, this is done for web compatability reasons. Cookies will not actually be stored for file:// URLs. If you want this to change please leave feedback on crbug.com/378604901.", source:  (1)
+[909:1:0908/072009.470028:VERBOSE1:extensions/renderer/dispatcher.cc:774] Num tracked contexts:4
+[844:844:0908/072009.595514:INFO:CONSOLE:1] "requestStorageAccessFor: Invalid origin.", source:  (1)
+[844:844:0908/072009.618798:INFO:CONSOLE:1] "Attestation check for Protected Audience on file:// failed.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.621763:INFO:CONSOLE:1] "Failed to execute 'requestFullscreen' on 'Element': API can only be initiated by a user gesture.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[909:1:0908/072009.625351:VERBOSE1:extensions/renderer/script_context.cc:163] Destroyed context for extension
+  extension id:
+  effective extension id:
+[909:1:0908/072009.626131:VERBOSE1:extensions/renderer/script_context.cc:163] Destroyed context for extension
+  extension id:
+  effective extension id:
+[844:844:0908/072009.629994:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'register' on 'ServiceWorkerContainer': The provided value is not of type 'RegistrationOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.631223:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: Failed to get ServiceWorkerRegistration objects: The URL protocol of the current origin ('file://') is not supported.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.631793:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: Failed to get a ServiceWorkerRegistration: The URL protocol of the current origin ('file://') is not supported.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.632262:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.636570:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.636677:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'every' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.636769:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'toArray' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.636827:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'reduce' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.636894:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'runAdAuction' on 'Navigator': Failed to read the 'seller' property from 'AuctionAdConfig': Required member is undefined.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.636954:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'joinAdInterestGroup' on 'Navigator': The provided value is not of type 'AuctionAdInterestGroup'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.637019:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestMediaKeySystemAccess' on 'Navigator': The object must have a callable @@iterator property.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.637069:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'leaveAdInterestGroup' on 'Navigator': The provided value is not of type 'AuctionAdInterestGroupKey'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.637132:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestFullscreen' on 'Element': The provided value is not of type 'FullscreenOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.637180:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestPointerLock' on 'Element': The provided value is not of type 'PointerLockOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.637243:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: You must request access for at least one storage/communication medium.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072009.637320:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'exitFullscreen' on 'Document': Document not active", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.637403:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Failed to execute 'exitPictureInPicture' on 'Document': There is no Picture-in-Picture element in this document.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.637452:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'hasPrivateToken' on 'Document': hasPrivateToken: Private Token issuer origins must be both HTTP(S) and secure ("potentially trustworthy").", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.637515:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Invalid origin", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.637583:INFO:CONSOLE:1] "Uncaught (in promise) SyntaxError: Failed to execute 'whenDefined' on 'CustomElementRegistry': "false" is not a valid custom element name", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.637655:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'createImageBitmap' on 'Window': Overload resolution failed.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.637741:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'showSaveFilePicker' on 'Window': The provided value is not of type 'SaveFilePickerOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.637831:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'showOpenFilePicker' on 'Window': The provided value is not of type 'OpenFilePickerOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.637894:INFO:CONSOLE:1] "Failed to execute 'requestFullscreen' on 'Element': API can only be initiated by a user gesture.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.677854:INFO:CONSOLE:0] "Uncaught (in promise) NotAllowedError: Transient activation is required to request permission.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[909:1:0908/072009.716346:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMCI::RequestUserMedia({request_id=0}, {audio constraints=}, {video constraints=})
+[909:1:0908/072009.718710:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::ProcessRequest({request_id=0}, {audio=0}, {video=1})
+[909:1:0908/072009.719262:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::SetupVideoInput. request_id=0, video constraints=
+[909:1:0908/072009.719426:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::SelectVideoContentSettings. request_id=0.
+[909:1:0908/072009.719657:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::GenerateStreamForCurrentRequestInfo({request_id=0}, {audio.device_ids=}, {video.device_ids=})
+[844:866:0908/072009.736253:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::GenerateStreams({render_process_id=5}, {render_frame_id=8}, {requester_id=0}, {page_request_id=0})
+[844:866:0908/072009.736353:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::DR::DeviceRequest({requesting_process_id=5}, {requesting_frame_id=8}, {requester_id=0}, {request_type=MEDIA_GENERATE_STREAM})
+[844:866:0908/072009.736409:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::AddRequest([requester_id=0]) => (label=d4037201-4208-479d-bb58-75a074181155)
+[844:866:0908/072009.736458:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::SetUpRequest([requester_id=0] {label=d4037201-4208-479d-bb58-75a074181155})
+[844:866:0908/072009.736478:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::DR::SetAudioType([requester_id=0] {audio_type=NO_SERVICE})
+[844:866:0908/072009.736493:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::DR::CreateUIRequest([requester_id=0] {requested_audio_device_id=}, {requested_video_device_id=})
+[844:866:0908/072009.736512:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::PostRequestToUI({label=d4037201-4208-479d-bb58-75a074181155},
+[844:866:0908/072009.736526:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::DR::SetState([requester_id=0] {stream_type=DISPLAY_VIDEO_CAPTURE}, {new_state=STATE_PENDING_APPROVAL})
+[844:866:0908/072009.746577:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::HandleAccessRequestResponse({label=d4037201-4208-479d-bb58-75a074181155}, {request=MEDIA_GENERATE_STREAM}, {result=OK})
+[844:866:0908/072009.746754:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: VideoCaptureManager::Open, device.name = screen:-3:0, device.id = screen:-3:0, capture_session_id = (5E23EB2B93A9C5A0584E4489B8A369AB)
+[844:866:0908/072009.746818:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::DR::SetState([requester_id=0] {stream_type=DISPLAY_VIDEO_CAPTURE}, {new_state=STATE_OPENING})
+[844:866:0908/072009.746863:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::HandleAccessRequestResponse([label=d4037201-4208-479d-bb58-75a074181155]) => (opening device: [id: screen:-3:0, session_id: 5E23EB2B93A9C5A0584E4489B8A369AB])
+[844:866:0908/072009.746898:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::DR::SetAudioType([requester_id=0] {audio_type=NO_SERVICE})
+[844:866:0908/072009.746924:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::RequestDone({requester_id=0}, {request_type=MEDIA_GENERATE_STREAM})
+[844:866:0908/072009.747088:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::Opened({stream_type=DISPLAY_VIDEO_CAPTURE}, {session_id=5E23EB2B93A9C5A0584E4489B8A369AB})
+[844:866:0908/072009.747116:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::DR::SetState([requester_id=0] {stream_type=DISPLAY_VIDEO_CAPTURE}, {new_state=STATE_DONE})
+[844:866:0908/072009.747145:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::RequestDone({requester_id=0}, {request_type=MEDIA_GENERATE_STREAM})
+[844:866:0908/072009.747177:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::FinalizeGenerateStreams({label=d4037201-4208-479d-bb58-75a074181155}, {requester_id=0}, {request_type=MEDIA_GENERATE_STREAM})
+[844:866:0908/072009.747231:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::OnStreamStarted({label=d4037201-4208-479d-bb58-75a074181155}, {requester_id=0}, {request_type=MEDIA_GENERATE_STREAM})
+[844:866:0908/072009.749830:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] MSM::PanTiltZoomPermissionChecked({label=d4037201-4208-479d-bb58-75a074181155}, {requester_id=0}, {request_type=MEDIA_GENERATE_STREAM}, {pan_tilt_zoom_allowed=0})
+[909:1:0908/072009.799894:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::OnStreamsGenerated({request_id=0}, {label=d4037201-4208-479d-bb58-75a074181155}, {device=[id: screen:-3:0, name: screen:-3:0]})
+[909:1:0908/072009.801445:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::StartTracks({request_id=0}, {label=d4037201-4208-479d-bb58-75a074181155})
+[909:1:0908/072009.802878:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::InitializeVideoSourceObject({request_id=0}, {device=[id: screen:-3:0, name: screen:-3:0]})
+[909:1:0908/072009.806805:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] MSS::MediaStreamSource({id=screen:-3:0}, {type=Video}, {name=screen:-3:0}, {remote=0}, {ready_state=Live})
+[909:1:0908/072009.810958:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::RI::CreateAndStartVideoTrack({request_id=0})
+[844:866:0908/072009.815504:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: ConnectClient: session_id = (5E23EB2B93A9C5A0584E4489B8A369AB), request: (1280x1024)@30.000fps, pixel format: PIXEL_FORMAT_I420
+[844:866:0908/072009.815737:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: VideoCaptureManager queueing device start for device_id = screen:-3:0
+[844:866:0908/072009.815771:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: VideoCaptureManager::ProcessDeviceStartRequestQueue
+[844:866:0908/072009.815804:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: VideoCaptureController::CreateAndStartDeviceAsync: serial_id = 0, device_id = screen:-3:0
+[844:866:0908/072009.815906:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: InProcessVideoCaptureDeviceLauncher::LaunchDeviceAsync: Posting start request to device thread for device_id = screen:-3:0
+[844:866:0908/072009.816022:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: VideoCaptureController::AddClient(): id = (5E23EB2B93A9C5A0584E4489B8A369AB), session_id = 5E23EB2B93A9C5A0584E4489B8A369AB, params.requested_format = (1280x1024)@30.000fps, pixel format: PIXEL_FORMAT_I420
+[844:844:0908/072009.817070:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'showOpenFilePicker' on 'Window': The provided value is not of type 'OpenFilePickerOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.817179:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.817302:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'every' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.819338:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:866:0908/072009.819415:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: OnStarted
+[844:844:0908/072009.819574:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'toArray' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:866:0908/072009.819612:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: OnDeviceLaunched
+[844:866:0908/072009.819662:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: Launching device has succeeded. device_id = screen:-3:0
+[844:844:0908/072009.819669:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.819765:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'deprecatedURNToURL' on 'Navigator': Passed URL must be a valid URN URL.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.819823:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'leaveAdInterestGroup' on 'Navigator': The provided value is not of type 'AuctionAdInterestGroupKey'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.819898:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestMediaKeySystemAccess' on 'Navigator': The supportedConfigurations parameter is empty.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.819961:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'setAppBadge' on 'Navigator': Value is not of type 'unsigned long long'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072009.820033:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: Failed to execute 'showSaveFilePicker' on 'Window': Must be handling a user gesture to show a file picker.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:866:0908/072009.821885:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: VideoCaptureImpl changing state to VIDEO_CAPTURE_STATE_STARTED
+[844:866:0908/072009.892372:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: Pixel format: PIXEL_FORMAT_I420
+[844:866:0908/072009.904884:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: First frame received at VideoCaptureController
+[844:866:0908/072009.905450:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: First frame received for this VideoCaptureImpl instance
+[844:844:0908/072009.982761:VERBOSE1:components/device_event_log/device_event_log_impl.cc:200] [07:20:09.981] Serial: EVENT: serial_device_enumerator_linux.cc:196 Serial device added: path=/dev/ttyS0 vid=(none) pid=(none) serial=(none)
+[844:844:0908/072009.983043:VERBOSE1:components/device_event_log/device_event_log_impl.cc:200] [07:20:09.981] Serial: EVENT: serial_device_enumerator_linux.cc:196 Serial device added: path=/dev/ttyS1 vid=(none) pid=(none) serial=(none)
+[844:844:0908/072009.989462:VERBOSE1:components/device_event_log/device_event_log_impl.cc:200] [07:20:09.986] Serial: EVENT: serial_device_enumerator_linux.cc:196 Serial device added: path=/dev/ttyS2 vid=(none) pid=(none) serial=(none)
+[844:844:0908/072009.989790:VERBOSE1:components/device_event_log/device_event_log_impl.cc:200] [07:20:09.986] Serial: EVENT: serial_device_enumerator_linux.cc:196 Serial device added: path=/dev/ttyS3 vid=(none) pid=(none) serial=(none)
+[844:844:0908/072010.010779:INFO:CONSOLE:0] "Uncaught (in promise) SecurityError: Page needs to be visible.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:866:0908/072010.012987:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: LocalVideoCapturerSource::OnStateUpdate signaling to consumer that source is now running.
+[844:866:0908/072010.013070:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: MediaStreamVideoCapturerSource sending OnStartDone
+[844:866:0908/072010.013105:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: MediaStreamVideoSource changing state to STARTED
+[909:1:0908/072010.012627:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] MSS::SetReadyState({id=screen:-3:0}, {ready_state=Live})
+[909:1:0908/072010.013393:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::OnTrackStarted({session_id=5E23EB2B93A9C5A0584E4489B8A369AB}, {result=OK})
+[844:866:0908/072010.015866:VERBOSE1:content/browser/renderer_host/media/media_stream_manager.cc:1554] video capture: MediaStreamVideoSource invoking callback indicating result of starting track.
+[909:1:0908/072010.015422:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::OnCreateNativeTracksCompleted({request_id=0}, {label=d4037201-4208-479d-bb58-75a074181155})
+[909:1:0908/072010.015985:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::GetUserMediaRequestSucceeded({request_id=0})
+[909:1:0908/072010.019892:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] UMP::DelayedGetUserMediaRequestSucceeded({request_id=0}, {result=OK})
+[909:1:0908/072010.024174:VERBOSE1:third_party/blink/renderer/platform/webrtc/webrtc_logging.cc:35] MST::MediaStreamTrackImpl() [kind: video, id: 0a42ade5-3be8-4cb6-be31-740023a132de, label: screen:-3:0, enabled: true, muted: false, readyState: live, remote=false]
+[844:844:0908/072010.059076:INFO:CONSOLE:1] "While navigator.cookieEnabled does return true for this file:// URL, this is done for web compatability reasons. Cookies will not actually be stored for file:// URLs. If you want this to change please leave feedback on crbug.com/378604901.", source:  (1)
+[844:844:0908/072010.137043:VERBOSE1:chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc:233] enterprise.data_protection: same document navigation:0
+[844:844:0908/072010.137086:VERBOSE1:chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc:235] enterprise.data_protection: URL to scan: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html
+[844:844:0908/072010.149622:VERBOSE1:components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc:389] MutablePO2TS::RefreshTokenIsAvailable
+[844:844:0908/072010.149695:VERBOSE1:chrome/browser/signin/account_consistency_mode_manager.cc:207] Desktop Identity Consistency disabled as sign-in to Chrome is not allowed
+[844:862:0908/072010.180425:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html
+[844:844:0908/072010.181484:INFO:CONSOLE:0] "Attestation check for Shared Storage on file:// failed.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (0)
+[844:844:0908/072010.182008:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'delete' on 'SharedStorage': The provided value is not of type 'SharedStorageModifierMethodOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.182083:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'run' on 'SharedStorage': The provided value is not of type 'SharedStorageRunOperationMethodOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.182157:INFO:CONSOLE:1] "Uncaught (in promise) OperationError: Cannot call get() outside of a fenced frame.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.182230:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.184459:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.184607:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.184730:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'first' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.184820:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'reduce' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.184915:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'showOpenFilePicker' on 'Window': The provided value is not of type 'OpenFilePickerOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.184982:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'postTask' on 'Scheduler': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.185050:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: Failed to execute 'showSaveFilePicker' on 'Window': Must be handling a user gesture to show a file picker.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.185102:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: Failed to execute 'showDirectoryPicker' on 'Window': Must be handling a user gesture to show a file picker.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.187272:INFO:CONSOLE:0] "Uncaught (in promise) OperationError: sharedStorage is disabled", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (0)
+[844:870:0908/072010.190757:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/DeferredBrowserMetrics": No such file or directory (2)
+[844:864:0908/072010.190769:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/CrashpadMetrics.pma": No such file or directory (2)
+[844:870:0908/072010.191027:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/Default/Media Cache": No such file or directory (2)
+[844:864:0908/072010.191013:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/Breadcrumbs": No such file or directory (2)
+[844:870:0908/072010.193431:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/Default/databases": No such file or directory (2)
+[844:870:0908/072010.193606:VERBOSE1:base/files/file_util_posix.cc:316] Cannot stat "/mnt/scratch0/tmp/user_profile_0/Default/webrtc_event_logs": No such file or directory (2)
+[878:904:0908/072010.223434:VERBOSE1:net/base/network_delegate.cc:37] NetworkDelegate::NotifyBeforeURLRequest: https://android.clients.google.com/c2dm/register3
+[844:844:0908/072010.225994:VERBOSE1:chrome/browser/policy/cloud/fm_registration_token_uploader.cc:193] Client is missing for kUser scope
+[844:844:0908/072010.226113:VERBOSE1:chrome/browser/policy/cloud/fm_registration_token_uploader.cc:193] Client is missing for kUser scope
+[844:844:0908/072010.228357:VERBOSE1:chrome/browser/profiles/profile_manager.cc:1276] AddKeepAlive(Default, kExtensionUpdater). keep_alives=[kBrowserWindow (1), kExtensionUpdater (1)]
+[844:844:0908/072010.232948:VERBOSE1:chrome/browser/profiles/profile_manager.cc:1337] RemoveKeepAlive(Default, kExtensionUpdater). keep_alives=[kBrowserWindow (1)]
+[844:844:0908/072010.251315:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:211] Acquiring <PartitionedLockId>{id: 0x31, partition: 0} for SynchronizeInstalledApps@chrome/browser/web_applications/externally_managed_app_manager.cc:186
+[844:844:0908/072010.251388:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:193] All locks acquired for SynchronizeInstalledApps@chrome/browser/web_applications/externally_managed_app_manager.cc:186
+[844:844:0908/072010.281578:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:235] Releasing <PartitionedLockId>{id: 0x31, partition: 0} requested by SynchronizeInstalledApps@chrome/browser/web_applications/externally_managed_app_manager.cc:186
+[844:844:0908/072010.281636:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:267] Acquiring <PartitionedLockId>{id: 0x31, partition: 0} for SynchronizeInstalledApps@chrome/browser/web_applications/externally_managed_app_manager.cc:186
+[844:844:0908/072010.281663:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:193] All locks acquired for SynchronizeInstalledApps@chrome/browser/web_applications/externally_managed_app_manager.cc:186
+[844:844:0908/072010.304253:VERBOSE1:chrome/browser/web_applications/locks/partitioned_lock_manager.cc:235] Releasing <PartitionedLockId>{id: 0x31, partition: 0} requested by SynchronizeInstalledApps@chrome/browser/web_applications/externally_managed_app_manager.cc:186
+[844:863:0908/072010.329427:ERROR:google_apis/gcm/engine/registration_request.cc:292] Registration response error message: DEPRECATED_ENDPOINT
+[844:863:0908/072010.329545:VERBOSE1:google_apis/gcm/engine/registration_request.cc:256] Delaying GCM registration of app: com.google.android.gms, for 21708 milliseconds.
+[844:844:0908/072010.363004:INFO:CONSOLE:1] "Found a 'popover' attribute with an invalid value.", source:  (1)
+[844:844:0908/072010.506417:INFO:CONSOLE:1] "Found a 'popover' attribute with an invalid value.", source:  (1)
+[844:844:0908/072010.645871:INFO:CONSOLE:1] "Found a 'popover' attribute with an invalid value.", source:  (1)
+[844:844:0908/072010.693113:INFO:CONSOLE:0] "Uncaught (in promise) NotAllowedError: Transient activation is required to request permission.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (0)
+[844:844:0908/072010.696120:INFO:CONSOLE:0] "Uncaught (in promise) SecurityError: User activation is required.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (0)
+[945:1:0908/072010.795013:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/global.
+[945:1:0908/072010.798543:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/*.
+[945:1:0908/072010.799821:VERBOSE1:base/allocator/scheduler_loop_quarantine_config.cc:134] No entry found for utility/amsc.
+[945:1:0908/072010.829712:VERBOSE1:sandbox/policy/linux/sandbox_linux.cc:87] Activated seccomp-bpf sandbox for process type: utility.
+[844:844:0908/072010.864505:INFO:CONSOLE:1] "Found a 'popover' attribute with an invalid value.", source:  (1)
+[909:1:0908/072010.924097:VERBOSE1:extensions/renderer/dispatcher.cc:774] Num tracked contexts:3
+[844:844:0908/072010.963269:INFO:CONSOLE:1] "Uncaught [object Promise]", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072010.973070:INFO:CONSOLE:1] "Attestation check for Shared Storage on file:// failed.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072010.974410:INFO:CONSOLE:1] "Attestation check for Shared Storage on file:// failed.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072010.974572:INFO:CONSOLE:1] "Attestation check for Shared Storage on file:// failed.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[909:1:0908/072010.972959:VERBOSE1:extensions/renderer/script_context.cc:163] Destroyed context for extension
+  extension id:
+  effective extension id:
+[909:1:0908/072010.975621:VERBOSE1:extensions/renderer/script_context.cc:163] Destroyed context for extension
+  extension id:
+  effective extension id:
+[844:844:0908/072010.979621:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'createWorklet' on 'SharedStorage': The provided value is not of type 'SharedStorageWorkletOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.979738:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'batchUpdate' on 'SharedStorage': The object must have a callable @@iterator property.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.979828:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'every' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.979880:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.979956:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.980013:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'isSessionSupported' on 'XRSystem': The provided value '[object Object]' is not a valid enum value of type XRSessionMode.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.982042:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestFullscreen' on 'Element': The provided value is not of type 'FullscreenOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.982189:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Failed to execute 'exitPictureInPicture' on 'Document': There is no Picture-in-Picture element in this document.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html (1)
+[844:844:0908/072010.982326:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'createImageBitmap' on 'Window': Overload resolution failed.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072010.982398:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'showOpenFilePicker' on 'Window': The provided value is not of type 'OpenFilePickerOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072010.982489:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: Failed to execute 'showSaveFilePicker' on 'Window': Must be handling a user gesture to show a file picker.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072010.982553:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'fetch' on 'Window': The provided value is not of type 'RequestInit'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072010.982755:INFO:CONSOLE:0] "Uncaught (in promise) OperationError: sharedStorage is disabled", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:844:0908/072010.982843:INFO:CONSOLE:0] "Uncaught (in promise) OperationError: sharedStorage is disabled", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:844:0908/072010.982898:INFO:CONSOLE:0] "Uncaught (in promise) OperationError: sharedStorage is disabled", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:844:0908/072010.990105:INFO:CONSOLE:0] "Uncaught (in promise) SecurityError: User activation is required.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:844:0908/072011.020017:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Transition was aborted because of invalid state", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.108581:INFO:CONSOLE:1] "Found a 'popover' attribute with an invalid value.", source:  (1)
+[844:844:0908/072011.119020:INFO:CONSOLE:1] "Found a 'popover' attribute with an invalid value.", source:  (1)
+[844:844:0908/072011.189257:INFO:CONSOLE:1] "requestStorageAccessFor: Invalid origin.", source:  (1)
+[844:862:0908/072011.250848:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/[object%20EventCounts%20Iterator]
+[844:844:0908/072011.255888:INFO:CONSOLE:1] "Failed to execute 'requestFullscreen' on 'Element': API can only be initiated by a user gesture.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.262946:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestPointerLock' on 'Element': The provided value is not of type 'PointerLockOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263028:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'hasRedemptionRecord' on 'Document': hasRedemptionRecord: Private Token issuer origins must be both HTTP(S) and secure ("potentially trustworthy").", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263123:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'hasPrivateToken' on 'Document': hasPrivateToken: Private Token issuer origins must be both HTTP(S) and secure ("potentially trustworthy").", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263177:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Invalid origin", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263244:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'reduce' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263319:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263387:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263435:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'first' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263502:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Invalid key", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263567:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Invalid key", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263641:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'last' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263695:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263764:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'reduce' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263814:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Cannot go back", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263885:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Cannot go back", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.263992:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.264133:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.274624:INFO:CONSOLE:0] "Uncaught (in promise) TypeError: Permissions check failed", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:844:0908/072011.274910:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to fetch", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:862:0908/072011.336531:VERBOSE1:content/browser/loader/file_url_loader_factory.cc:474] FileURLLoader::Start: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/0
+[844:844:0908/072011.342058:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.344846:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: Failed to execute 'showDirectoryPicker' on 'Window': Must be handling a user gesture to show a file picker.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.344958:INFO:CONSOLE:1] "Uncaught (in promise) SecurityError: Failed to execute 'showOpenFilePicker' on 'Window': Must be handling a user gesture to show a file picker.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.345095:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'first' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.345172:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.348056:INFO:CONSOLE:0] "Uncaught (in promise) SecurityError: Page needs to be visible.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:844:0908/072011.348150:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.349826:INFO:CONSOLE:0] "Uncaught (in promise) NotAllowedError: Transient activation is required to request permission.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:844:0908/072011.349934:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to fetch", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.354807:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.354917:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.476143:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.477150:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.482381:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.485705:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.502248:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.505478:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.509540:INFO:CONSOLE:1] "Uncaught SyntaxError: Unexpected identifier 'Observable'", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.612027:INFO:CONSOLE:1] "Found a 'popover' attribute with an invalid value.", source:  (1)
+[844:844:0908/072011.638429:INFO:CONSOLE:1] "Found a 'popover' attribute with an invalid value.", source:  (1)
+[844:844:0908/072011.833110:INFO:CONSOLE:1] "document.execCommand() doesn't work with an invalid HTML structure. It is corrected automatically.", source:  (1)
+[844:844:0908/072011.868343:INFO:CONSOLE:1] "Uncaught #<DOMRect>", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.877723:INFO:CONSOLE:0] "Failed to execute 'requestFullscreen' on 'Element': API can only be initiated by a user gesture.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (0)
+[844:844:0908/072011.877956:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'every' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878086:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'toArray' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878157:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'first' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878311:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878391:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878474:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878533:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'every' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878648:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'reduce' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878719:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'last' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878832:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'every' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.878922:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.879025:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'reduce' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.879096:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'last' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.879185:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.879251:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.885779:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'getHighEntropyValues' on 'NavigatorUAData': The object must have a callable @@iterator property.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.885897:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'reduce' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886002:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'last' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886074:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886160:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886227:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Failed to execute 'exitPictureInPicture' on 'Document': There is no Picture-in-Picture element in this document.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886337:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'hasPrivateToken' on 'Document': hasPrivateToken: Private Token issuer origins must be both HTTP(S) and secure ("potentially trustworthy").", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886473:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'every' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886588:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886671:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestSession' on 'XRSystem': The provided value '[object Array Iterator]' is not a valid enum value of type XRSessionMode.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886759:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'isSessionSupported' on 'XRSystem': The provided value '[object Screen]' is not a valid enum value of type XRSessionMode.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886841:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestFullscreen' on 'Element': The provided value is not of type 'FullscreenOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886927:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'reduce' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.886996:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.887087:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.887152:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'requestPointerLock' on 'Element': The provided value is not of type 'PointerLockOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.887237:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.892589:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.892806:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.892878:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.892966:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'find' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.893032:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'some' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.893103:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'every' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.893155:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'forEach' on 'Observable': parameter 1 is not of type 'Function'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.893231:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'last' on 'Observable': The provided value is not of type 'SubscribeOptions'.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.893349:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'exitFullscreen' on 'Document': Document not active", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.893469:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'hasRedemptionRecord' on 'Document': hasRedemptionRecord: Private Token issuer origins must be both HTTP(S) and secure ("potentially trustworthy").", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.893546:INFO:CONSOLE:1] "Uncaught (in promise) InvalidStateError: Failed to execute 'exitPictureInPicture' on 'Document': There is no Picture-in-Picture element in this document.", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.893640:INFO:CONSOLE:1] "Uncaught (in promise) TypeError: Failed to execute 'hasPrivateToken' on 'Document': hasPrivateToken: Private Token issuer origins must be both HTTP(S) and secure ("potentially trustworthy").", source: file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-crossfuzz-1688962541.html (1)
+[844:844:0908/072011.896438:FATAL:ui/accessibility/platform/inspect/ax_tree_formatter_auralinux.cc:143] Check failed: atk_child.
+#0 0x5a175cd89ab8 base::debug::CollectStackTrace() [base/debug/stack_trace_posix.cc:1052:7]
+#1 0x5a175cd6d581 base::debug::StackTrace::StackTrace() [base/debug/stack_trace.cc:258:20]
+#2 0x5a175cbe018d logging::LogMessage::Flush() [base/logging.cc:705:29]
+#3 0x5a175cbdff03 logging::LogMessage::~LogMessage() [base/logging.cc:694:3]
+#4 0x5a175cbc5bc4 logging::(anonymous namespace)::CheckLogMessage::~CheckLogMessage() [base/check.cc:161:31]
+#5 0x5a175cbc51db logging::CheckNoreturnError::~CheckNoreturnError() [base/check.cc:321:16]
+#6 0x5a1761bbb146 ui::AXTreeFormatterAuraLinux::RecursiveBuildTree() [ui/accessibility/platform/inspect/ax_tree_formatter_auralinux.cc:143:5]
+#7 0x5a1761bbae41 ui::AXTreeFormatterAuraLinux::BuildTree() [ui/accessibility/platform/inspect/ax_tree_formatter_auralinux.cc:107:3]
+#8 0x5a1761b07d5a ui::AXTreeFormatterBase::Format() [ui/accessibility/platform/inspect/ax_tree_formatter_base.cc:56:21]
+#9 0x5a175737820c content::RenderFrameHostImpl::ExerciseAccessibilityForTest() [content/browser/renderer_host/render_frame_host_impl.cc:8647:47]
+#10 0x5a175739456d content::RenderFrameHostImpl::HandleAXEvents() [content/browser/renderer_host/render_frame_host_impl.cc:11411:3]
+#11 0x5a175649e9ba base::internal::DecayedFunctorTraits<>::Invoke<>() [base/functional/bind_internal.h:730:12]
+#12 0x5a175649e89c base::internal::Invoker<>::RunOnce() [base/functional/bind_internal.h:946:5]
+#13 0x5a175ccf4b92 base::internal::PostTaskAndReplyRelay::RunTaskAndPostReply() [base/functional/callback.h:155:12]
+#14 0x5a175ccf4d5b base::internal::Invoker<>::RunOnce() [base/functional/bind_internal.h:663:12]
+#15 0x5a175cc9d1bd base::TaskAnnotator::RunTaskImpl() [base/functional/callback.h:155:12]
+#16 0x5a175cce732b base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl() [base/task/common/task_annotator.h:104:5]
+#17 0x5a175cce62b5 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:348:40]
+#18 0x5a175cce7e7b base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
+#19 0x5a175cdb55c3 base::MessagePumpGlib::Run() [base/message_loop/message_pump_glib.cc:702:48]
+#20 0x5a175cce8ad2 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run() [base/task/sequence_manager/thread_controller_with_message_pump_impl.cc:649:12]
+#21 0x5a175cc64b1b base::RunLoop::Run() [base/run_loop.cc:134:14]
+#22 0x5a17566c47d5 content::BrowserMainLoop::RunMainMessageLoop() [content/browser/browser_main_loop.cc:1127:18]
+#23 0x5a17566ca327 content::BrowserMainRunnerImpl::Run() [content/browser/browser_main_runner_impl.cc:156:15]
+#24 0x5a17566bd408 content::BrowserMain() [content/browser/browser_main.cc:32:28]
+#25 0x5a175a4db0af content::RunBrowserProcessMain() [content/app/content_main_runner_impl.cc:701:10]
+#26 0x5a175a4de1f1 content::ContentMainRunnerImpl::RunBrowser() [content/app/content_main_runner_impl.cc:1278:10]
+#27 0x5a175a4dd9af content::ContentMainRunnerImpl::Run() [content/app/content_main_runner_impl.cc:1127:12]
+#28 0x5a175a4d8e50 content::RunContentProcess() [content/app/content_main.cc:346:36]
+#29 0x5a175a4d913d content::ContentMain() [content/app/content_main.cc:359:10]
+#30 0x5a1751273d6f ChromeMain [chrome/app/chrome_main.cc:228:12]
+#31 0x7a38220a9083 __libc_start_main
+#32 0x5a175125902a _start
+Task trace:
+#0 0x5a175649e26b content::RenderAccessibilityHost::HandleAXEvents() [content/browser/accessibility/render_accessibility_host.cc:77:7]
+#1 0x5a175d50d5d5 mojo::SimpleWatcher::Context::Notify() [mojo/public/cpp/system/simple_watcher.cc:102:13]
+Crash keys:
+  "ax_focus_top_frame" = "id=23 rootWebArea FOCUSABLE name=Target page name_from=relatedElement url=file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html clips_children child_ids=59,62,64,36,73,74,39,77 unignored_child_ids=59,62,64,36,-1000000002,38,74,3"
+  "ax_focus" = "id=23 rootWebArea FOCUSABLE name=Target page name_from=relatedElement url=file:///mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/targets/target2.html clips_children child_ids=59,62,64,36,73,74,39,77 unignored_child_ids=59,62,64,36,-1000000002,38,74,3"
+  "total-discardable-memory-allocated" = "4195794"
+  "gpu-gl-renderer" = "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver-5.0.0)"
+  "gpu-gl-vendor" = "Google Inc. (Google)"
+  "gpu-generation-intel" = "0"
+  "gpu-vsver" = "1.00"
+  "gpu-psver" = "1.00"
+  "gpu-driver" = "5.0.0"
+  "gpu_count" = "0"
+  "gpu-devid" = "0xffff"
+  "gpu-venid" = "0xffff"
+  "num-extensions" = "0"
+  "switch-32" = "/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-cross"
+  "ax_mode" = "kNativeAPIs | kWebContents | kExtendedProperties | kFormsAndLabe"
+  "chrome-trace-id" = "11150526844696341094"
+  "reentry_guard_tls_slot" = "unused"
+  "variations" = "db59f83a-3f4a17df,8bccc03b-3f4a17df,bd6dd170-b5b075b6,abd9debc-8fd8462d,f6f5c542-3f4a17df,82b178a6-3f4a17df,af00e384-3f4a17df,ae727645-d13781e7,81c84cff-84ebad58,f3ed486d-3f4a17df,da493d3c-3f4a17df,eef5d69a-1dca273f,f659c5ca-3f4a17df,a8045d2e-aaac510a,b45d023c-5fae3666,d625ae6a-5570cbfd,72bafd3e-cdb4c186,19593c6e-3f4a17df,3e15bfc6-3f4a17df,dd8dccfb-3f4a17df,b13ca3d9-84f6cff8,3dbad317-3f4a17df,11d973f6-3f4a17df,fc1790de-3f4a17df,a4ca7cb1-3f4a17df,acf2401-fc990a6f,102166ac-3f4a17df,4076100b-3f4a17df,97b1b2fe-3f4a17df,fc9ceed7-ee2a48b4,7e6af697-3f4a17df,56fa14f6-3f4a17df,181d1041-3f4a17df,c92d2cc4-3f4a17df,b28d8e30-3f4a17df,8f80c10-78198108,255aa854-194ea635,45a2f2f-f9e1b5a8,d1ae5bf4-3f4a17df,ea0d881d-fd860968,3e672fd9-be36868a,8f418b04-299bae22,cad2b12b-8ef57898,de785b07-3f4a17df,89eb0046-3f4a17df,d5f746a4-39aaf314,49ad328f-3f4a17df,e14ee5ee-c6d6098d,d3aecf6a-3f4a17df,260cfd7c-3f4a17df,999e8980-6ec7edcb,b56c57ae-8924bcae,a1e5b5f5-3f4a17df,bc7471e4-3f4a17df,ef4764d7-88fcaf7d,9359569a-9359569a,6314ed80-6314ed80,85bc7e1f-3f4a17df,532018f5-3f4a17df,669a7db8-3f4a17df,bcb58f65-3f4a17df,e9844d40-3f4a17df,2394f90f-ecc8f8cf,f7d06457-e9d42fcd,d7ce3099-d992c41f,d3566fbd-c6f74b94,c203d55b-3f4a17df,10713630-3f4a17df,b86bee04-3f4a17df,4d625646-3f4a17df,4c64b66a-3f4a17df,96d006a-c3a49e71,779782d3-3f4a17df,f9be514e-3f4a17df,caf19648-74472b0b,9850104b-395bafa,3ac9fcb9-3f4a17df,8c162025-3d47f4f4,151258bf-3f4a17df,5118384b-3f4a17df,8f4b3221-3f4a17df,4eb998ce-3f4a17df,a374fdf0-964ff297,f45c108d-65bced95,ea89c38c-3f4a17df,741e95d4-3f4a17df,a2f28ef8-d7d235fa,7dcaa2cd-3f4a17df,5abe5347-3f4a17df,e0e211ad-e0e211ad,820f17d2-e484eeec,68f499c8-d24710ce,44666d99-3d47f4f4,ef3132a9-3f4a17df,12733ec4-3f4a17df,8ec87690-cb114380,f112d133-3f4a17df,2bac9a6a-3f4a17df,893cc7a4-3f4a17df,3c978b59-3f4a17df,3b02c079-3f4a17df,6cc45990-3f4a17df,56aa5797-e5fec5a6,87684b46-4af1dc7d,6495cb0f-3f4a17df,e41e244a-3f4a17df,3fff8fa8-3f4a17df,8b679bb8-3f4a17df,88e285c2-3f4a17df,50e0c45a-79e7f69a,7ad58837-eb518a56,d06639a1-3f4a17df,a98def31-2a5a8f5d,54b15be4-1f4e6d62,1fce7d57-3f4a17df,cbe862f6-cbe862f6,35a386c3-3f4a17df,258151b3-3f4a17df,23226e84-65aafa13,e8c68789-49a20295,d990c4ac-3f4a17df,97063883-1f820d08,10a1256d-c22127cb,1b07e46e-3f4a17df,739df952-739df952,832b8234-3f4a17df,9e5c75f1-30e1b12b,1caa3332-20af8ffe,54be7848-3f4a17df,446d9644-3f4a17df,9540e055-f2018abe,2f4e13c7-3f4a17df,e8e963da-3f4a17df,40debc11-3f4a17df,b53f3ef9-3f4a17df,4a2d56fe-3f4a17df,15607410-b6e8dbb7,d8a79bce-db4354ff,8abceefd-f7ec9f66,cad46b80-3f4a17df,cb03b921-3f4a17df,b33256c0-3f4a17df,66657049-3f4a17df,6e4a21fe-efc28565,7262ef2c-140d00b2,36860c1b-3f4a17df,4146cc26-775f6248,f314f5b9-89ed2dc6,30cf4980-61673e6,b0f15b33-b0f15b33,5eb9e4fc-3f4a17df,d512da3a-513c429d,ad4acdda-3f4a17df,3d3963fc-5d65cee9,7c0e4650-3f4a17df,444b9649-3f4a17df,3f752d-3f4a17df,2d3e25b-3f4a17df,90860314-5ab828e2,2468d6e5-3f4a17df,f5a1eb9a-3f4a17df,ac59e11a-3f4a17df,d6284ba0-9610fd4e,57d6085b-3f4a17df,338d68c2-3f4a17df,b3d369b4-3f4a17df,44bf8ca-3f4a17df,e6d8687c-3f4a17df,dea320d8-3f4a17df,5bd55630-3f4a17df,708680a2-3f4a17df,afc2db99-3f4a17df,3c982172-3f4a17df,8f248ce7-3f4a17df,ad4ecc94-3f4a17df,8ffc578-3f4a17df,f419bc72-3f4a17df,470d37ba-3f4a17df,c55491ea-156838e5,2468be5e-5f6398dc,1aa5b0d5-fa79c490,a5ecfb95-3f4a17df,9c03fc0-3f4a17df,b446c562-3f4a17df,63831cab-3f4a17df,7ece8311-3f4a17df,7a32e64e-3f4a17df,f108c955-3f4a17df,8579ead7-3f4a17df,d2a642a0-3f4a17df,d500ce87-3f4a17df,59735726-3f4a17df,aa540f4f-3f4a17df,ae1581ef-35f6ea04,2c561bd6-3f4a17df,5133eb43-307b98b1,8e8365ea-3f4a17df,70404afa-803f8fc4,f3b6291d-c4414d29,14b2973a-5659f416,a85f151b-3f4a17df,fecdbadb-3f4a17df,b76b514f-3ac589b9,15d1b2d8-3f4a17df,fb92da45-3f4a17df,de028327-70abd7a5,68fef0c-3f4a17df,bf46f37a-3f4a17df,6ec84df5-3f4a17df,147e9ecd-3f4a17df,bcb143fe-3f4a17df,e3559213-3f4a17df,29990ed3-3f4a17df,707ac2b5-3f4a17df,c1e0d32e-3f4a17df,ccd5ee73-5ca664ae,a2db6721-3f4a17df,198413d6-3f4a17df,ec937206-3f4a17df,8782f1a1-3f4a17df,b4c2bd17-23db2647,57e6ff6b-3f4a17df,c75c6bbe-3f4a17df,578a5e44-3f4a17df,82b6db25-182c7a44,3f032b9f-3f4a17df,b1ceb06f-3f4a17df,4ae2f602-3f4a17df,350559e5-3f4a17df,91cba98-b3b3bb94,d4754f61-3f4a17df,8e9d6ad-3f4a17df,601dc969-3f4a17df,2f0a9b74-3f4a17df,e32097a3-3f4a17df,a62c052e-3f4a17df,da968c94-3f4a17df,6deb1450-3f4a17df,a88cddf3-3f4a17df,54d601a5-3f4a17df,b9ffbd4a-35efc336,66b7a83f-3f4a17df,f9664fa0-3f4a17df,137f6fe-3f4a17df,d721a76b-3f4a17df,2b68be8f-3f4a17df,c823d1e9-3d47f4f4,e2d38844-3f4a17df,afeeb5d0-3f4a17df,19e446cd-3f4a17df,f613598-3f4a17df,40de0170-3f4a17df,5baf22bc-3f4a17df,c8997723-3f4a17df,613081e8-3f4a17df,c49d2b35-3f4a17df,2faf225b-3f4a17df,2f6246c2-3f4a17df,7d758b3c-3f4a17df,45e0e828-3f4a17df,1ddbf293-3f4a17df,51d22fd4-3f4a17df,bea4a9c2-94315184,6332ffaf-3f4a17df,d04818be-3f4a17df,aa8204ea-3f4a17df,595f5eb0-f23d1dea,5910121-3f4a17df,f9a6f6e9-3f4a17df,46d7c84e-3f4a17df,3e45686e-d1bf3faa,864a51e5-aa32be6,7840af09-3d47f4f4,797fe373-3f4a17df,6f27bc8a-3f4a17df,55ba4cfa-3f4a17df,a2d45efe-2319ef5a,e5c8270a-3f4a17df,c297985a-3f4a17df,5870a003-3f4a17df,8382fe14-3f4a17df,e6ed801e-cf4f6ead,fd051c38-3f4a17df,3779be93-3f4a17df,4ea303a6-ecbb250e,3042ad4b-ad2fa222,b3c54bb3-88fcaf7d,facc182b-d8918098,58065933-e77f02dd,47a0a3b2-3f4a17df,17a43872-3f4a17df,2eb01e0a-d93a0620,a716fea0-3f4a17df,5ac9f58-3f4a17df,2ca06d17-3f4a17df,5eb745a8-3f4a17df,7c0d937f-3f4a17df,f2b6a878-3f4a17df,94b88ba6-3f4a17df,bef5c006-3f4a17df,580a9761-ef4576b6,1ffefb1a-3f4a17df,18324944-3f4a17df,2bac45ad-3f4a17df,9feae158-212c8bfa,ad9b71e2-3f4a17df,bb84837d-3f4a17df,377002b7-3f4a17df,762e8080-97dacb2,66abf9c6-3f4a17df,94e21eca-3f4a17df,836f1ad3-3f4a17df,6c7e9dc6-3f4a17df,f6264095-c3f8eab0,95a095bd-3f4a17df,2e7369a1-4aceb943,1683ee3a-b7cf2715,e0041356-e8edc07e,186d6e2c-36c0e608,26016f9f-4df4f25e,ec21b181-3f4a17df,1b0dc97-3f4a17df,52a20523-3f4a17df,14789165-3f4a17df,951dcd0c-3f4a17df,6ff79bbe-3f4a17df,c408951f-3f4a17df,3797f84b-3f4a17df,d5954b6b-3f4a17df,f1710f4a-7afaa0f9,935eb749-7a935877,10941cf2-3f4a17df,ed2195eb-3f4a17df,f42905ff-3f4a17df,5a474f9e-3f4a17df,6b7d4090-3f4a17df,39bb70f9-3f4a17df,5e4b4ebb-974ef86d,2a1c0800-3f4a17df,f079e901-3f4a17df,48a8d64c-3f4a17df,58035371-3f4a17df,"
+  "num-experiments" = "375"
+  "switch-31" = "--ozone-platform=x11"
+  "switch-30" = "--force-renderer-accessibility=form-controls"
+  "switch-29" = "--disable-in-process-stack-traces"
+  "switch-28" = "--use-fake-ui-for-media-stream"
+  "switch-27" = "--use-fake-device-for-media-stream"
+  "switch-26" = "--use-angle=swiftshader"
+  "switch-25" = "--use-gl=angle"
+  "switch-24" = "--enable-media-stream"
+  "switch-23" = "--enable-shadow-dom"
+  "switch-22" = "--no-process-singleton-dialog"
+  "switch-21" = "--no-first-run"
+  "switch-20" = "--no-default-browser-check"
+  "switch-19" = "--new-window"
+  "switch-18" = "--js-flags=--expose-gc"
+  "switch-17" = "--enable-extension-apps"
+  "switch-16" = "--enable-experimental-extension-apis"
+  "switch-15" = "--disable-prompt-on-repost"
+  "switch-14" = "--disable-popup-blocking"
+  "switch-13" = "--disable-metrics"
+  "switch-12" = "--disable-gpu-watchdog"
+  "switch-11" = "--metrics-recording-only"
+  "switch-10" = "--safebrowsing-disable-auto-update"
+  "switch-9" = "--disable-component-update"
+  "switch-8" = "--disable-default-apps"
+  "switch-7" = "--dns-prefetch-disable"
+  "switch-6" = "--disable-hang-monitor"
+  "switch-5" = "--disable-click-to-play"
+  "switch-4" = "--disable-gesture-requirement-for-media-playback"
+  "switch-3" = "--allow-file-access-from-files"
+  "switch-2" = "--enable-experimental-app-list"
+  "switch-1" = "--user-data-dir=/mnt/scratch0/tmp/user_profile_0"
+  "num-switches" = "36"
+  "osarch" = "x86_64"
+  "pid" = "844"
+  "ptype" = "browser"
+[0908/072017.127396:ERROR:third_party/crashpad/crashpad/util/file/file_io_posix.cc:145] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
+[0908/072017.129310:ERROR:third_party/crashpad/crashpad/util/file/file_io_posix.cc:145] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
+UndefinedBehaviorSanitizer:DEADLYSIGNAL
+==844==ERROR: UndefinedBehaviorSanitizer: ABRT on unknown address 0x05390000034c (pc 0x7a38220c800b bp 0x7fff5f8d2a40 sp 0x7fff5f8d2380 T844)
+[844:868:0908/072018.907649:VERBOSE1:chrome/browser/shutdown_signal_handlers_posix.cc:131] Handling shutdown for signal 15.
+[945:1:0100/000000.982152:VERBOSE1:base/metrics/statistics_recorder.cc:625] Collections of all histograms
+Histogram: HangWatcher.UtilityProcess.UncoveredStartupTime recorded 1 samples, mean = 32.0 (flags = 0x41)
+0   ...
+29  -O                                                                        (1 = 100.0%) {0.0%}
+34  ...
+Histogram: HeapProfiling.InProcess.Enabled recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HeapProfiling.InProcess.Enabled.Utility recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Memory.PartitionAlloc.PartitionRoot.ExtrasSize recorded 1 samples, mean = 4.0 (flags = 0x41)
+0  ...
+4  -O                                                                        (1 = 100.0%) {0.0%}
+5  ...
+Histogram: Mojo.Channel.WriteMessageSize recorded 1 samples, mean = 80.0 (flags = 0x41)
+0   ...
+76  -O                                                                        (1 = 100.0%) {0.0%}
+95  ...
+Histogram: Mojo.Channel.WriteSendMessageProcessType recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Mojo.EndToEndLatencyUs.ChildIOThread recorded 0 samples (flags = 0x41)
+0 ...
+Histogram: PerformanceManager.ChildScenarioMappingResult recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: PerformanceManager.InitializeChildProcessCoordination.RequestCount recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: PerformanceManager.InitializeChildProcessCoordination.ResponseCount recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Security.GwpAsan.Activated.Malloc.Utility recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Security.GwpAsan.Activated.PartitionAlloc.Utility recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Security.JSONParser.ParsingTime recorded 3 samples, mean = 31.7 (flags = 0x41)
+0   ...
+12  -O                                                                        (1 = 33.3%) {0.0%}
+16  ...
+28  -O                                                                        (1 = 33.3%) {33.3%}
+37  O                                                                         (0 = 0.0%) {66.7%}
+49  -O                                                                        (1 = 33.3%) {66.7%}
+65  ...
+Histogram: Startup.LoadTime.RecordedProcessCreation recorded 1 samples, mean = 1.0 (flags = 0x1)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: UMA.ChildProcess.Ping.SharedMemorySetUp recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: UMA.PersistentAllocator.EarlyHistograms.UtilityMetrics recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: UMA.PersistentAllocator.UtilityMetrics.UsedPct recorded 0 samples (flags = 0x41)
+0 ...
+Histogram: V8.CFIPageSizeMismatch recorded 1 samples, mean = 0.0 (flags = 0x1)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Variations.Limits.VariationKeySize.Default recorded 2 samples, mean = 6.0 (flags = 0x41)
+0  ...
+6  --O                                                                       (2 = 100.0%) {0.0%}
+7  ...
+[880:1:0100/000000.986379:VERBOSE1:base/metrics/statistics_recorder.cc:625] Collections of all histograms
+Histogram: DOMStorage.CommitMeasuredDelay recorded 16 samples, mean = 3817.7 (flags = 0x41)
+0     ...
+2074  ---O                                                                      (3 = 18.8%) {0.0%}
+2394  -O                                                                        (1 = 6.2%) {18.8%}
+2763  -O                                                                        (1 = 6.2%) {25.0%}
+3189  --O                                                                       (2 = 12.5%) {31.2%}
+3681  --O                                                                       (2 = 12.5%) {43.8%}
+4249  --O                                                                       (2 = 12.5%) {56.2%}
+4904  -----O                                                                    (5 = 31.2%) {68.8%}
+5660  ...
+Histogram: HangWatcher.IsThreadHung.Any recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HangWatcher.IsThreadHung.AnyCritical recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HangWatcher.IsThreadHung.UtilityProcess.IOThread recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HangWatcher.IsThreadHung.UtilityProcess.MainThread recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HangWatcher.UtilityProcess.UncoveredStartupTime recorded 1 samples, mean = 25.0 (flags = 0x41)
+0   ...
+24  -O                                                                        (1 = 100.0%) {0.0%}
+29  ...
+Histogram: HeapProfiling.InProcess.Enabled recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HeapProfiling.InProcess.Enabled.Utility recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: LevelDBEnv.DeleteTableBackupFile recorded 0 samples (flags = 0x41)
+0 ...
+Histogram: LevelDBWrapper.CommitDelay recorded 2 samples, mean = 5000.0 (flags = 0x41)
+0     ...
+4516  --O                                                                       (2 = 100.0%) {0.0%}
+6118  ...
+Histogram: LocalStorage.DatabaseOpen recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: LocalStorageContext.ShutDown.MaybeDroppedChanges recorded 2 samples, mean = 0.0 (flags = 0x40)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Memory.PartitionAlloc.PartitionRoot.ExtrasSize recorded 1 samples, mean = 4.0 (flags = 0x41)
+0  ...
+4  -O                                                                        (1 = 100.0%) {0.0%}
+5  ...
+Histogram: Mojo.Channel.WriteToReadLatencyUs recorded 1 samples, mean = 83.0 (flags = 0x41)
+0   ...
+77  -O                                                                        (1 = 100.0%) {0.0%}
+88  ...
+Histogram: Mojo.EndToEndLatencyUs.ChildIOThread recorded 0 samples (flags = 0x41)
+0 ...
+Histogram: PerformanceManager.ChildScenarioMappingResult recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: PerformanceManager.InitializeChildProcessCoordination.RequestCount recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: PerformanceManager.InitializeChildProcessCoordination.ResponseCount recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Security.GwpAsan.Activated.Malloc.Utility recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Security.GwpAsan.Activated.PartitionAlloc.Utility recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Security.JSONParser.ParsingTime recorded 3 samples, mean = 23.7 (flags = 0x41)
+0   ...
+7   -O                                                                        (1 = 33.3%) {0.0%}
+9   ...
+16  -O                                                                        (1 = 33.3%) {33.3%}
+21  ...
+37  -O                                                                        (1 = 33.3%) {66.7%}
+49  ...
+Histogram: SessionStorageContext.CacheSizeInKB recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: SessionStorageContext.ShutDown.MaybeDroppedChanges recorded 3 samples, mean = 0.0 (flags = 0x40)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Startup.LoadTime.RecordedProcessCreation recorded 1 samples, mean = 1.0 (flags = 0x1)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Storage.DomStorage.BatchTaskGrowthSizeBytes2 recorded 16 samples, mean = 83.2 (flags = 0x41)
+0    ---O                                                                      (3 = 18.8%)
+1    ...
+41   -O                                                                        (1 = 6.2%) {18.8%}
+60   -----O                                                                    (5 = 31.2%) {25.0%}
+88   --O                                                                       (2 = 12.5%) {56.2%}
+128  -----O                                                                    (5 = 31.2%) {68.8%}
+187  ...
+Histogram: ThreadPool.UnnecessaryWakeup.ContentChild.Foreground recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: UMA.ChildProcess.Ping.SharedMemorySetUp recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: UMA.PersistentAllocator.EarlyHistograms.UtilityMetrics recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: UMA.PersistentAllocator.UtilityMetrics.UsedPct recorded 0 samples (flags = 0x41)
+0 ...
+Histogram: V8.CFIPageSizeMismatch recorded 1 samples, mean = 0.0 (flags = 0x1)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Variations.Limits.VariationKeySize.Default recorded 8 samples, mean = 0.8 (flags = 0x41)
+0  --O                                                                       (2 = 25.0%)
+1  ------O                                                                   (6 = 75.0%) {25.0%}
+2  ...
+[878:878:0908/072020.084310:VERBOSE1:base/metrics/statistics_recorder.cc:625] Collections of all histograms
+Histogram: API.EffectiveStorageAccess.AllowedByStorageAccessType recorded 12 samples, mean = 0.0 (flags = 0x41)
+0  ------------O                                                             (12 = 100.0%)
+1  ...
+Histogram: API.StorageAccess.AllowedRequests4 recorded 44 samples, mean = 0.0 (flags = 0x41)
+0  --------------------------------------------O                             (44 = 100.0%)
+1  ...
+Histogram: API.StorageAccessHeader.SecFetchStorageAccessOutcome recorded 9 samples, mean = 0.4 (flags = 0x41)
+0  -----O                                                                    (5 = 55.6%)
+1  ----O                                                                     (4 = 44.4%) {55.6%}
+2  ...
+Histogram: API.StorageAccessHeader.StorageAccessStatusOutcome recorded 5 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -----O                                                                    (5 = 100.0%) {0.0%}
+2  ...
+Histogram: BrotliFilter.CompressionPercent recorded 2 samples, mean = 200.0 (flags = 0x41)
+0    ...
+101  --O                                                                       (2 = 100.0%) {0.0%}
+Histogram: ContentSettings.GetCookieSettingInternal.Duration recorded 2 samples, mean = 18.0 (flags = 0x41)
+0   ...
+16  --O                                                                       (2 = 100.0%) {0.0%}
+21  ...
+Histogram: Cookie.CookieSchemeRequestScheme recorded 5 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -----O                                                                    (5 = 100.0%) {0.0%}
+3  ...
+Histogram: Cookie.DaysSinceRefreshForRetrieval recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Cookie.EncryptedAndPlaintextValues recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Cookie.FirstPartySets.InitializationDuration.ContextReadyToServeQueries2 recorded 1 samples, mean = 2762.0 (flags = 0x41)
+0     ...
+2516  -O                                                                        (1 = 100.0%) {0.0%}
+2990  ...
+Histogram: Cookie.FirstPartySets.InitializationDuration.ReadyToServeQueries2 recorded 1 samples, mean = 301.0 (flags = 0x41)
+0    ...
+268  -O                                                                        (1 = 100.0%) {0.0%}
+318  ...
+Histogram: Cookie.FromStorageWithValidLength recorded 2 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  --O                                                                       (2 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Cookie.PartitionedCookiesInRequest recorded 5 samples, mean = 0.0 (flags = 0x41)
+0  -----O                                                                    (5 = 100.0%)
+1  ...
+Histogram: Cookie.SetCookieContainsPartitioned recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Cookie.TimeBlockedOnLoad recorded 2 samples, mean = 171.0 (flags = 0x41)
+0    ...
+26   -O                                                                        (1 = 50.0%) {0.0%}
+32   ...
+278  -O                                                                        (1 = 50.0%) {50.0%}
+345  ...
+Histogram: Cookie.TimeInitializeDB recorded 2 samples, mean = 21.0 (flags = 0x41)
+0   ...
+14  -O                                                                        (1 = 50.0%) {0.0%}
+17  ...
+26  -O                                                                        (1 = 50.0%) {50.0%}
+32  ...
+Histogram: Cookie.TimeOpsBlockedDueToGlobalOp recorded 2 samples, mean = 14.5 (flags = 0x41)
+0   -O                                                                        (1 = 50.0%)
+1   ...
+26  -O                                                                        (1 = 50.0%) {50.0%}
+32  ...
+Histogram: DataUse.BytesReceived3.Delegate recorded 5 samples, mean = 506.0 (flags = 0x41)
+0     --O                                                                       (2 = 40.0%)
+50    ...
+230   -O                                                                        (1 = 20.0%) {40.0%}
+297   ...
+494   -O                                                                        (1 = 20.0%) {60.0%}
+637   ...
+1366  -O                                                                        (1 = 20.0%) {80.0%}
+1761  ...
+Histogram: DataUse.BytesSent3.Delegate recorded 5 samples, mean = 188.4 (flags = 0x41)
+0    ...
+16   --O                                                                       (2 = 40.0%) {0.0%}
+21   O                                                                         (0 = 0.0%) {40.0%}
+28   -O                                                                        (1 = 20.0%) {40.0%}
+37   ...
+340  -O                                                                        (1 = 20.0%) {60.0%}
+448  -O                                                                        (1 = 20.0%) {80.0%}
+590  ...
+Histogram: HangWatcher.IsThreadHung.Any recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HangWatcher.IsThreadHung.AnyCritical recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HangWatcher.IsThreadHung.UtilityProcess.IOThread recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HangWatcher.IsThreadHung.UtilityProcess.MainThread recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HangWatcher.UtilityProcess.UncoveredStartupTime recorded 1 samples, mean = 42.0 (flags = 0x41)
+0   ...
+40  -O                                                                        (1 = 100.0%) {0.0%}
+48  ...
+Histogram: HeapProfiling.InProcess.Enabled recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HeapProfiling.InProcess.Enabled.NetworkService recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HttpCache.AccessToDone2 recorded 6 samples, mean = 34.5 (flags = 0x41)
+0   ...
+16  -O                                                                        (1 = 16.7%) {0.0%}
+18  ...
+22  -O                                                                        (1 = 16.7%) {16.7%}
+24  O                                                                         (0 = 0.0%) {33.3%}
+26  -O                                                                        (1 = 16.7%) {33.3%}
+28  -O                                                                        (1 = 16.7%) {50.0%}
+31  ...
+41  -O                                                                        (1 = 16.7%) {66.7%}
+45  ...
+71  -O                                                                        (1 = 16.7%) {83.3%}
+78  ...
+Histogram: HttpCache.AccessToDone2.SentRequest recorded 3 samples, mean = 47.7 (flags = 0x41)
+0   ...
+28  -O                                                                        (1 = 33.3%) {0.0%}
+31  ...
+41  -O                                                                        (1 = 33.3%) {33.3%}
+45  ...
+71  -O                                                                        (1 = 33.3%) {66.7%}
+78  ...
+Histogram: HttpCache.AccessToDone2.Used recorded 3 samples, mean = 21.3 (flags = 0x41)
+0   ...
+16  -O                                                                        (1 = 33.3%) {0.0%}
+17  ...
+22  -O                                                                        (1 = 33.3%) {33.3%}
+23  O                                                                         (0 = 0.0%) {66.7%}
+25  -O                                                                        (1 = 33.3%) {66.7%}
+27  ...
+Histogram: HttpCache.AddTransactionToEntry recorded 7 samples, mean = 1.4 (flags = 0x41)
+0  -----O                                                                    (5 = 71.4%)
+1  ...
+5  --O                                                                       (2 = 28.6%) {71.4%}
+6  ...
+Histogram: HttpCache.BeforeSend recorded 3 samples, mean = 4.3 (flags = 0x41)
+0  ...
+3  -O                                                                        (1 = 33.3%) {0.0%}
+4  -O                                                                        (1 = 33.3%) {33.3%}
+5  O                                                                         (0 = 0.0%) {66.7%}
+6  -O                                                                        (1 = 33.3%) {66.7%}
+7  ...
+Histogram: HttpCache.BeforeSend.CantConditionalize recorded 3 samples, mean = 4.3 (flags = 0x41)
+0  ...
+3  -O                                                                        (1 = 33.3%) {0.0%}
+4  -O                                                                        (1 = 33.3%) {33.3%}
+5  O                                                                         (0 = 0.0%) {66.7%}
+6  -O                                                                        (1 = 33.3%) {66.7%}
+7  ...
+Histogram: HttpCache.EntryRejectionStatus recorded 7 samples, mean = 1.9 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ----O                                                                     (4 = 57.1%) {0.0%}
+2  O                                                                         (0 = 0.0%) {57.1%}
+3  ---O                                                                      (3 = 42.9%) {57.1%}
+4  ...
+Histogram: HttpCache.Experimental.Read.EntryContentSize recorded 6 samples, mean = 23432.0 (flags = 0x41)
+0      ...
+13159  ----O                                                                     (4 = 66.7%) {0.0%}
+15839  ...
+33246  --O                                                                       (2 = 33.3%) {66.7%}
+40016  ...
+Histogram: HttpCache.Experimental.Read.EntryResponseInfoSize recorded 6 samples, mean = 3356.0 (flags = 0x41)
+0     ...
+2987  ------O                                                                   (6 = 100.0%) {0.0%}
+3595  ...
+Histogram: HttpCache.Experimental.Read.EntryTotalSize recorded 6 samples, mean = 26788.0 (flags = 0x41)
+0      ...
+15839  ----O                                                                     (4 = 66.7%) {0.0%}
+19065  ...
+40016  --O                                                                       (2 = 33.3%) {66.7%}
+48165  ...
+Histogram: HttpCache.HardReset recorded 1 samples, mean = 0.0 (flags = 0x40)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HttpCache.IsNoStore recorded 7 samples, mean = 0.0 (flags = 0x41)
+0  -------O                                                                  (7 = 100.0%)
+1  ...
+Histogram: HttpCache.IsNoStore.MainFrameHTML recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: HttpCache.MaxFileSizeOnInit recorded 1 samples, mean = 40960.0 (flags = 0x41)
+0      ...
+37526  -O                                                                        (1 = 100.0%) {0.0%}
+42713  ...
+Histogram: HttpCache.NoVarySearch.DirectoryCreateResult.Dedicated recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HttpCache.NoVarySearch.EntriesAddedDuringLoading recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HttpCache.NoVarySearch.EntriesLoaded recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HttpCache.NoVarySearch.HeaderParseResult recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ---O                                                                      (3 = 100.0%) {0.0%}
+2  ...
+Histogram: HttpCache.NoVarySearch.LoadResult recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HttpCache.NoVarySearch.LoadTime.Success recorded 1 samples, mean = 10.0 (flags = 0x41)
+0   ...
+10  -O                                                                        (1 = 100.0%) {0.0%}
+12  ...
+Histogram: HttpCache.NoVarySearch.LookupTime recorded 7 samples, mean = 8.7 (flags = 0x41)
+0  ...
+7  ---O                                                                      (3 = 42.9%) {0.0%}
+9  ----O                                                                     (4 = 57.1%) {42.9%}
+12 ...
+Histogram: HttpCache.NoVarySearch.LookupTime.Miss recorded 7 samples, mean = 8.7 (flags = 0x41)
+0  ...
+7  ---O                                                                      (3 = 42.9%) {0.0%}
+9  ----O                                                                     (4 = 57.1%) {42.9%}
+12 ...
+Histogram: HttpCache.NoVarySearch.RenameOrDeleteResult.Parent.Journal recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HttpCache.NoVarySearch.RenameOrDeleteResult.Parent.Snapshot recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: HttpCache.NoVarySearch.UseResult2 recorded 7 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -------O                                                                  (7 = 100.0%) {0.0%}
+2  ...
+Histogram: HttpCache.NoVarySearch.UseResult2.GoogleHost.MainFrameHTML recorded 2 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  --O                                                                       (2 = 100.0%) {0.0%}
+2  ...
+Histogram: HttpCache.OpenDiskEntry recorded 7 samples, mean = 4.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 14.3%) {0.0%}
+2  O                                                                         (0 = 0.0%) {14.3%}
+3  ----O                                                                     (4 = 57.1%) {14.3%}
+4  ...
+6  -O                                                                        (1 = 14.3%) {71.4%}
+7  O                                                                         (0 = 0.0%) {85.7%}
+8  -O                                                                        (1 = 14.3%) {85.7%}
+10 ...
+Histogram: HttpCache.Pattern recorded 7 samples, mean = 4.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 14.3%) {0.0%}
+2  O                                                                         (0 = 0.0%) {14.3%}
+3  ---O                                                                      (3 = 42.9%) {14.3%}
+4  ...
+6  ---O                                                                      (3 = 42.9%) {57.1%}
+7  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: HttpCache.Pattern.Font recorded 3 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  ---O                                                                      (3 = 100.0%) {0.0%}
+4  ...
+Histogram: HttpCache.Pattern.FontThirdParty recorded 3 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  ---O                                                                      (3 = 100.0%) {0.0%}
+4  ...
+Histogram: HttpCache.Pattern.MainFrameHTML recorded 2 samples, mean = 3.5 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 50.0%) {0.0%}
+2  ...
+6  -O                                                                        (1 = 50.0%) {50.0%}
+7  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: HttpCache.Pattern.NotCoveredReason recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: HttpCache.Pattern.NotCoveredReason.MainFrameHTML recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: HttpCache.ResponseFreshnessIsZero recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ---O                                                                      (3 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: HttpCache.TotalDiskCacheTimePerTransaction.Read recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: HttpCache.TotalDiskCacheTimePerTransaction.Write recorded 3 samples, mean = 7.7 (flags = 0x41)
+0   ...
+6   -O                                                                        (1 = 33.3%) {0.0%}
+7   -O                                                                        (1 = 33.3%) {33.3%}
+8   O                                                                         (0 = 0.0%) {66.7%}
+10  -O                                                                        (1 = 33.3%) {66.7%}
+12  ...
+Histogram: ImportantFile.SerializationDuration recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: ImportantFile.SerializationDuration.All recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: ImportantFile.SerializationDuration.TransportSecurityPersister recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: ImportantFile.WriteDuration recorded 1 samples, mean = 5.0 (flags = 0x41)
+0  ...
+5  -O                                                                        (1 = 100.0%) {0.0%}
+6  ...
+Histogram: ImportantFile.WriteDuration.All recorded 4 samples, mean = 1.8 (flags = 0x41)
+0  --O                                                                       (2 = 50.0%)
+1  O                                                                         (0 = 0.0%) {50.0%}
+2  -O                                                                        (1 = 25.0%) {50.0%}
+3  ...
+5  -O                                                                        (1 = 25.0%) {75.0%}
+6  ...
+Histogram: ImportantFile.WriteDuration.SCTAuditing recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: ImportantFile.WriteDuration.TransportSecurityPersister recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: Memory.PartitionAlloc.PartitionRoot.ExtrasSize recorded 1 samples, mean = 4.0 (flags = 0x41)
+0  ...
+4  -O                                                                        (1 = 100.0%) {0.0%}
+5  ...
+Histogram: Mojo.Channel.WriteToReadLatencyUs recorded 1 samples, mean = 15242.0 (flags = 0x41)
+0      ...
+13769  -O                                                                        (1 = 100.0%) {0.0%}
+15678  ...
+Histogram: Mojo.EndToEndLatencyUs.ChildIOThread recorded 0 samples (flags = 0x41)
+0 ...
+Histogram: Mojo.SharedMemoryVersion.SharedMemoryAllocationSucceeded recorded 5 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -----O                                                                    (5 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: NQE.RTT.Error.Absolute recorded 3 samples, mean = 102.7 (flags = 0x41)
+0    -O                                                                        (1 = 33.3%)
+1    ...
+135  --O                                                                       (2 = 66.7%) {33.3%}
+160  ...
+Histogram: NQE.RTT.Error.IsZero recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: NQE.RTT.Error.Negative recorded 2 samples, mean = 154.0 (flags = 0x41)
+0    ...
+135  --O                                                                       (2 = 100.0%) {0.0%}
+160  ...
+Histogram: NQE.RTT.Error.Positive recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: NQE.RTT.HittingThreshold.EndToEnd.FallbackSuccess recorded 5 samples, mean = 0.0 (flags = 0x41)
+0  -----O                                                                    (5 = 100.0%)
+1  ...
+Histogram: NQE.RTT.HittingThreshold.Transport.FallbackSuccess recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: NQE.RTT.ObservationSource recorded 13 samples, mean = 2.2 (flags = 0x41)
+0  ---O                                                                      (3 = 23.1%)
+1  ---O                                                                      (3 = 23.1%) {23.1%}
+2  ---O                                                                      (3 = 23.1%) {46.2%}
+3  -O                                                                        (1 = 7.7%) {69.2%}
+4  -O                                                                        (1 = 7.7%) {76.9%}
+5  O                                                                         (0 = 0.0%) {84.6%}
+6  -O                                                                        (1 = 7.7%) {84.6%}
+7  -O                                                                        (1 = 7.7%) {92.3%}
+8  ...
+Histogram: NQE.RTT.OnECTComputation recorded 10 samples, mean = 79.8 (flags = 0x41)
+0    ...
+20   ----O                                                                     (4 = 40.0%) {0.0%}
+24   ...
+81   ----O                                                                     (4 = 40.0%) {40.0%}
+96   ...
+160  --O                                                                       (2 = 20.0%) {80.0%}
+190  ...
+Histogram: NQE.TransportRTT.OnECTComputation recorded 9 samples, mean = 28.2 (flags = 0x41)
+0    ...
+6    -----O                                                                    (5 = 55.6%) {0.0%}
+7    ...
+29   ---O                                                                      (3 = 33.3%) {55.6%}
+34   ...
+114  -O                                                                        (1 = 11.1%) {88.9%}
+135  ...
+Histogram: Net.AcceptCHFrameInterceptor.MismatchClientHint2 recorded 7 samples, mean = 16.1 (flags = 0x41)
+0   ...
+9   -O                                                                        (1 = 14.3%) {0.0%}
+10  O                                                                         (0 = 0.0%) {14.3%}
+11  -O                                                                        (1 = 14.3%) {14.3%}
+12  ...
+14  -O                                                                        (1 = 14.3%) {28.6%}
+15  -O                                                                        (1 = 14.3%) {42.9%}
+16  -O                                                                        (1 = 14.3%) {57.1%}
+17  ...
+23  -O                                                                        (1 = 14.3%) {71.4%}
+24  O                                                                         (0 = 0.0%) {85.7%}
+25  -O                                                                        (1 = 14.3%) {85.7%}
+26  ...
+Histogram: Net.AcceptCHFrameInterceptor.NeedsObserverCheckReason recorded 1 samples, mean = 4.0 (flags = 0x41)
+0  ...
+4  -O                                                                        (1 = 100.0%) {0.0%}
+5  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.AlternativeServiceTypeForRequest recorded 19 samples, mean = 0.9 (flags = 0x41)
+0  --O                                                                       (2 = 10.5%)
+1  -----------------O                                                        (17 = 89.5%) {10.5%}
+2  ...
+Histogram: Net.CachingCertVerifier.Async.UncachedVerifyTime recorded 4 samples, mean = 96.5 (flags = 0x41)
+0    ...
+54   --O                                                                       (2 = 50.0%) {0.0%}
+61   -O                                                                        (1 = 25.0%) {50.0%}
+69   ...
+211  -O                                                                        (1 = 25.0%) {75.0%}
+239  ...
+Histogram: Net.CachingCertVerifier.Async.UncachedVerifyTime.Google recorded 4 samples, mean = 96.5 (flags = 0x41)
+0    ...
+54   --O                                                                       (2 = 50.0%) {0.0%}
+61   -O                                                                        (1 = 25.0%) {50.0%}
+69   ...
+211  -O                                                                        (1 = 25.0%) {75.0%}
+239  ...
+Histogram: Net.CachingCertVerifier.Async.UncachedVerifyTime.GoogleWithAlpnH3 recorded 1 samples, mean = 213.0 (flags = 0x41)
+0    ...
+211  -O                                                                        (1 = 100.0%) {0.0%}
+239  ...
+Histogram: Net.CachingCertVerifier.CacheHit recorded 4 samples, mean = 0.0 (flags = 0x41)
+0  ----O                                                                     (4 = 100.0%)
+1  ...
+Histogram: Net.CachingCertVerifier.CacheHit.Google recorded 4 samples, mean = 0.0 (flags = 0x41)
+0  ----O                                                                     (4 = 100.0%)
+1  ...
+Histogram: Net.CachingCertVerifier.CacheHit.GoogleWithAlpnH3 recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.CertVerifier_First_Job_Latency recorded 1 samples, mean = 213.0 (flags = 0x41)
+0    ...
+211  -O                                                                        (1 = 100.0%) {0.0%}
+239  ...
+Histogram: Net.CertVerifier_Job_Latency recorded 4 samples, mean = 96.2 (flags = 0x41)
+0    ...
+48   -O                                                                        (1 = 25.0%) {0.0%}
+54   -O                                                                        (1 = 25.0%) {25.0%}
+61   -O                                                                        (1 = 25.0%) {50.0%}
+69   ...
+211  -O                                                                        (1 = 25.0%) {75.0%}
+239  ...
+Histogram: Net.Certificate.TrustAnchor.Request recorded 5 samples (flags = 0x41)
+0  -----O                                                                    (5 = 100.0%)
+Histogram: Net.ContentEncodingType2 recorded 4 samples, mean = 1.0 (flags = 0x41)
+0  -O                                                                        (1 = 25.0%)
+1  --O                                                                       (2 = 50.0%) {25.0%}
+2  -O                                                                        (1 = 25.0%) {75.0%}
+3  ...
+Histogram: Net.Cors.AccessCheckResult recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.CountOfQuicServerInfos recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.DNS.DnsConfig.DnsClientCapability recorded 17 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -----------------O                                                        (17 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.DNS.DnsConfig.Nsswitch.Compatible recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.DNS.DnsConfig.Nsswitch.Read recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.DNS.DnsConfig.Nsswitch.TooLarge recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.DNS.DnsConfig.Resolv.Compatible recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.DNS.DnsHosts.Count recorded 1 samples, mean = 4.0 (flags = 0x41)
+0  ...
+4  -O                                                                        (1 = 100.0%) {0.0%}
+5  ...
+Histogram: Net.DNS.DnsHosts.EstimateMemoryUsage recorded 1 samples, mean = 360.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1000...
+Histogram: Net.DNS.DnsHosts.FileSize recorded 1 samples, mean = 1111.0 (flags = 0x41)
+0     ...
+1065  -O                                                                        (1 = 100.0%) {0.0%}
+1539  ...
+Histogram: Net.DNS.DnsTask.HasValidCnameRecords recorded 4 samples, mean = 0.5 (flags = 0x41)
+0  --O                                                                       (2 = 50.0%)
+1  --O                                                                       (2 = 50.0%) {50.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.DNS.DnsTask.Insecure.SuccessTime recorded 4 samples, mean = 7.8 (flags = 0x41)
+0   ...
+5   -O                                                                        (1 = 25.0%) {0.0%}
+6   ...
+8   --O                                                                       (2 = 50.0%) {25.0%}
+9   O                                                                         (0 = 0.0%) {75.0%}
+10  -O                                                                        (1 = 25.0%) {75.0%}
+12  ...
+Histogram: Net.DNS.DnsTask.SvcbHttpsTransactionError recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.DNS.DnsTransaction.AttemptType recorded 7 samples, mean = 0.0 (flags = 0x41)
+0  -------O                                                                  (7 = 100.0%)
+1  ...
+Histogram: Net.DNS.DnsTransaction.Insecure.Other.SuccessTime recorded 7 samples, mean = 5.3 (flags = 0x41)
+0  ...
+3  -O                                                                        (1 = 14.3%) {0.0%}
+4  -O                                                                        (1 = 14.3%) {14.3%}
+5  --O                                                                       (2 = 28.6%) {28.6%}
+6  ---O                                                                      (3 = 42.9%) {57.1%}
+8  ...
+Histogram: Net.DNS.H3SupportedGoogleHost.TaskTypeMetadataAvailability2 recorded 1 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  -O                                                                        (1 = 100.0%) {0.0%}
+4  ...
+Histogram: Net.DNS.HTTPSSVC.RecordHttps.Insecure.ExpectNoerror.DnsRcode recorded 3 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  ---O                                                                      (3 = 100.0%) {0.0%}
+4  ...
+Histogram: Net.DNS.HTTPSSVC.RecordHttps.Insecure.ExpectNoerror.Parsable recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.DNS.HTTPSSVC.RecordHttps.Insecure.ExpectNoerror.ResolveTimeAddress recorded 3 samples, mean = 7.0 (flags = 0x41)
+0  ...
+6  --O                                                                       (2 = 66.7%) {0.0%}
+8  -O                                                                        (1 = 33.3%) {66.7%}
+10 ...
+Histogram: Net.DNS.HTTPSSVC.RecordHttps.Insecure.ExpectNoerror.ResolveTimeExperimental recorded 3 samples, mean = 6.3 (flags = 0x41)
+0  ...
+5  -O                                                                        (1 = 33.3%) {0.0%}
+6  -O                                                                        (1 = 33.3%) {33.3%}
+8  -O                                                                        (1 = 33.3%) {66.7%}
+10 ...
+Histogram: Net.DNS.HTTPSSVC.RecordHttps.Insecure.ExpectNoerror.ResolveTimeRatio recorded 3 samples, mean = 8.3 (flags = 0x41)
+0  ...
+7  -O                                                                        (1 = 33.3%) {0.0%}
+8  O                                                                         (0 = 0.0%) {33.3%}
+9  --O                                                                       (2 = 66.7%) {33.3%}
+10 ...
+Histogram: Net.DNS.HostCache.Erase recorded 3 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  ---O                                                                      (3 = 100.0%) {0.0%}
+3  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.DNS.HostCache.Erase.GoogleHost recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.DNS.HostCache.EraseValid.ValidFor recorded 3 samples, mean = 129446.7 (flags = 0x41)
+0       ...
+37840   --O                                                                       (2 = 66.7%) {0.0%}
+51267   ...
+234039  -O                                                                        (1 = 33.3%) {66.7%}
+317087  ...
+Histogram: Net.DNS.HostCache.EraseValid.ValidFor.GoogleHost recorded 1 samples, mean = 287632.0 (flags = 0x41)
+0       ...
+234039  -O                                                                        (1 = 100.0%) {0.0%}
+317087  ...
+Histogram: Net.DNS.HostCache.Lookup recorded 12 samples, mean = 0.2 (flags = 0x41)
+0  -----------O                                                              (11 = 91.7%)
+1  O                                                                         (0 = 0.0%) {91.7%}
+2  -O                                                                        (1 = 8.3%) {91.7%}
+3  ...
+Histogram: Net.DNS.HostCache.Lookup.GoogleHost recorded 21 samples, mean = 1.9 (flags = 0x41)
+0  -O                                                                        (1 = 4.8%)
+1  O                                                                         (0 = 0.0%) {4.8%}
+2  --------------------O                                                     (20 = 95.2%) {4.8%}
+3  ...
+Histogram: Net.DNS.JobQueueTime.PerTransaction recorded 7 samples, mean = 0.3 (flags = 0x41)
+0  ------O                                                                   (6 = 85.7%)
+1  O                                                                         (0 = 0.0%) {85.7%}
+2  -O                                                                        (1 = 14.3%) {85.7%}
+3  ...
+Histogram: Net.DNS.JobQueueTime.Success recorded 4 samples, mean = 0.5 (flags = 0x41)
+0  ---O                                                                      (3 = 75.0%)
+1  O                                                                         (0 = 0.0%) {75.0%}
+2  -O                                                                        (1 = 25.0%) {75.0%}
+3  ...
+Histogram: Net.DNS.Request.TotalTime recorded 17 samples, mean = 0.5 (flags = 0x41)
+0  -----------------O                                                        (17 = 100.0%)
+10 ...
+Histogram: Net.DNS.Request.TotalTimeAsync recorded 1 samples, mean = 8.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+10 ...
+Histogram: Net.DNS.ResolveCategory recorded 4 samples, mean = 0.5 (flags = 0x41)
+0  ---O                                                                      (3 = 75.0%)
+1  O                                                                         (0 = 0.0%) {75.0%}
+2  -O                                                                        (1 = 25.0%) {75.0%}
+3  ...
+Histogram: Net.DNS.ResolveSuccessTime recorded 3 samples, mean = 9.0 (flags = 0x41)
+0   ...
+8   --O                                                                       (2 = 66.7%) {0.0%}
+9   O                                                                         (0 = 0.0%) {66.7%}
+10  -O                                                                        (1 = 33.3%) {66.7%}
+12  ...
+Histogram: Net.DNS.UpgradeConfig.HasPublicInsecureNameserver recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.DNS.UpgradeConfig.InsecureUpgradeSucceeded recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.DNS_Resolution_And_TCP_Connection_Latency2 recorded 1 samples, mean = 15.0 (flags = 0x41)
+0   ...
+14  -O                                                                        (1 = 100.0%) {0.0%}
+16  ...
+Histogram: Net.HttpJob.BytesReceived2 recorded 6 samples, mean = 421.7 (flags = 0x41)
+0     -O                                                                        (1 = 16.7%)
+1     ...
+39    --O                                                                       (2 = 33.3%) {16.7%}
+56    ...
+237   -O                                                                        (1 = 16.7%) {50.0%}
+340   O                                                                         (0 = 0.0%) {66.7%}
+488   -O                                                                        (1 = 16.7%) {66.7%}
+700   ...
+1440  -O                                                                        (1 = 16.7%) {83.3%}
+2065  ...
+Histogram: Net.HttpJob.BytesSent2 recorded 6 samples, mean = 157.0 (flags = 0x41)
+0    -O                                                                        (1 = 16.7%)
+1    ...
+13   --O                                                                       (2 = 33.3%) {16.7%}
+19   O                                                                         (0 = 0.0%) {50.0%}
+27   -O                                                                        (1 = 16.7%) {50.0%}
+39   ...
+340  -O                                                                        (1 = 16.7%) {66.7%}
+488  -O                                                                        (1 = 16.7%) {83.3%}
+700  ...
+Histogram: Net.HttpJob.IpProtection.JobResult recorded 5 samples, mean = 0.0 (flags = 0x41)
+0  -----O                                                                    (5 = 100.0%)
+1  ...
+Histogram: Net.HttpJob.PrefilterBytesRead recorded 9 samples, mean = 7879.6 (flags = 0x41)
+0      --O                                                                       (2 = 22.2%)
+1      ...
+6      --O                                                                       (2 = 22.2%) {22.2%}
+9      ...
+39     -O                                                                        (1 = 11.1%) {44.4%}
+56     ...
+488    -O                                                                        (1 = 11.1%) {55.6%}
+700    ...
+12523  --O                                                                       (2 = 22.2%) {66.7%}
+17959  ...
+36935  -O                                                                        (1 = 11.1%) {88.9%}
+52968  ...
+Histogram: Net.HttpJob.PrefilterBytesRead.Cache recorded 4 samples, mean = 17574.0 (flags = 0x41)
+0      -O                                                                        (1 = 25.0%)
+1      ...
+12523  --O                                                                       (2 = 50.0%) {25.0%}
+17959  ...
+36935  -O                                                                        (1 = 25.0%) {75.0%}
+52968  ...
+Histogram: Net.HttpJob.PrefilterBytesRead.Net recorded 5 samples, mean = 124.0 (flags = 0x41)
+0    -O                                                                        (1 = 20.0%)
+1    ...
+6    --O                                                                       (2 = 40.0%) {20.0%}
+9    ...
+39   -O                                                                        (1 = 20.0%) {60.0%}
+56   ...
+488  -O                                                                        (1 = 20.0%) {80.0%}
+700  ...
+Histogram: Net.HttpJob.TotalTime recorded 9 samples, mean = 51.7 (flags = 0x41)
+0    ...
+12   -O                                                                        (1 = 11.1%) {0.0%}
+14   -O                                                                        (1 = 11.1%) {11.1%}
+17   O                                                                         (0 = 0.0%) {22.2%}
+20   -O                                                                        (1 = 11.1%) {22.2%}
+24   --O                                                                       (2 = 22.2%) {33.3%}
+29   ...
+40   -O                                                                        (1 = 11.1%) {55.6%}
+48   ...
+68   -O                                                                        (1 = 11.1%) {66.7%}
+81   O                                                                         (0 = 0.0%) {77.8%}
+96   -O                                                                        (1 = 11.1%) {77.8%}
+114  O                                                                         (0 = 0.0%) {88.9%}
+135  -O                                                                        (1 = 11.1%) {88.9%}
+160  ...
+Histogram: Net.HttpJob.TotalTime.Secure.Quic recorded 7 samples, mean = 30.0 (flags = 0x41)
+0   ...
+10  -O                                                                        (1 = 14.3%) {0.0%}
+13  O                                                                         (0 = 0.0%) {14.3%}
+16  -O                                                                        (1 = 14.3%) {14.3%}
+20  --O                                                                       (2 = 28.6%) {28.6%}
+25  -O                                                                        (1 = 14.3%) {57.1%}
+32  O                                                                         (0 = 0.0%) {71.4%}
+41  -O                                                                        (1 = 14.3%) {71.4%}
+52  O                                                                         (0 = 0.0%) {85.7%}
+66  -O                                                                        (1 = 14.3%) {85.7%}
+84  ...
+Histogram: Net.HttpJob.TotalTime.TLS13.Google recorded 2 samples, mean = 127.5 (flags = 0x41)
+0    ...
+96   -O                                                                        (1 = 50.0%) {0.0%}
+114  O                                                                         (0 = 0.0%) {50.0%}
+135  -O                                                                        (1 = 50.0%) {50.0%}
+160  ...
+Histogram: Net.HttpJob.TotalTimeCached recorded 4 samples, mean = 18.2 (flags = 0x41)
+0   ...
+12  -O                                                                        (1 = 25.0%) {0.0%}
+14  -O                                                                        (1 = 25.0%) {25.0%}
+17  O                                                                         (0 = 0.0%) {50.0%}
+20  -O                                                                        (1 = 25.0%) {50.0%}
+24  -O                                                                        (1 = 25.0%) {75.0%}
+29  ...
+Histogram: Net.HttpJob.TotalTimeCancel recorded 1 samples, mean = 12.0 (flags = 0x41)
+0   ...
+12  -O                                                                        (1 = 100.0%) {0.0%}
+14  ...
+Histogram: Net.HttpJob.TotalTimeNotCached recorded 5 samples, mean = 78.4 (flags = 0x41)
+0    ...
+24   -O                                                                        (1 = 20.0%) {0.0%}
+29   ...
+40   -O                                                                        (1 = 20.0%) {20.0%}
+48   ...
+68   -O                                                                        (1 = 20.0%) {40.0%}
+81   O                                                                         (0 = 0.0%) {60.0%}
+96   -O                                                                        (1 = 20.0%) {60.0%}
+114  O                                                                         (0 = 0.0%) {80.0%}
+135  -O                                                                        (1 = 20.0%) {80.0%}
+160  ...
+Histogram: Net.HttpJob.TotalTimeNotCached.Secure.Quic recorded 3 samples, mean = 45.7 (flags = 0x41)
+0   ...
+25  -O                                                                        (1 = 33.3%) {0.0%}
+32  O                                                                         (0 = 0.0%) {33.3%}
+41  -O                                                                        (1 = 33.3%) {33.3%}
+52  O                                                                         (0 = 0.0%) {66.7%}
+66  -O                                                                        (1 = 33.3%) {66.7%}
+84  ...
+Histogram: Net.HttpJob.TotalTimeSuccess recorded 8 samples, mean = 56.6 (flags = 0x41)
+0    ...
+14   -O                                                                        (1 = 12.5%) {0.0%}
+17   O                                                                         (0 = 0.0%) {12.5%}
+20   -O                                                                        (1 = 12.5%) {12.5%}
+24   --O                                                                       (2 = 25.0%) {25.0%}
+29   ...
+40   -O                                                                        (1 = 12.5%) {50.0%}
+48   ...
+68   -O                                                                        (1 = 12.5%) {62.5%}
+81   O                                                                         (0 = 0.0%) {75.0%}
+96   -O                                                                        (1 = 12.5%) {75.0%}
+114  O                                                                         (0 = 0.0%) {87.5%}
+135  -O                                                                        (1 = 12.5%) {87.5%}
+160  ...
+Histogram: Net.HttpJob.TotalTimeSuccess.Priority1 recorded 4 samples, mean = 87.8 (flags = 0x41)
+0    ...
+24   -O                                                                        (1 = 25.0%) {0.0%}
+29   ...
+68   -O                                                                        (1 = 25.0%) {25.0%}
+81   O                                                                         (0 = 0.0%) {50.0%}
+96   -O                                                                        (1 = 25.0%) {50.0%}
+114  O                                                                         (0 = 0.0%) {75.0%}
+135  -O                                                                        (1 = 25.0%) {75.0%}
+160  ...
+Histogram: Net.HttpJob.TotalTimeSuccess.Priority5 recorded 4 samples, mean = 25.5 (flags = 0x41)
+0   ...
+14  -O                                                                        (1 = 25.0%) {0.0%}
+17  O                                                                         (0 = 0.0%) {25.0%}
+20  -O                                                                        (1 = 25.0%) {25.0%}
+24  -O                                                                        (1 = 25.0%) {50.0%}
+29  ...
+40  -O                                                                        (1 = 25.0%) {75.0%}
+48  ...
+Histogram: Net.HttpRequestSSLUpgradeDecision recorded 2 samples, mean = 5.0 (flags = 0x41)
+0  ...
+5  --O                                                                       (2 = 100.0%) {0.0%}
+6  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.HttpRequestStsState recorded 2 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  --O                                                                       (2 = 100.0%) {0.0%}
+3  ...
+Histogram: Net.HttpStreamPool.AttemptManagerAliveTime2 recorded 4 samples, mean = 126.0 (flags = 0x41)
+0    ...
+37   -O                                                                        (1 = 25.0%) {0.0%}
+43   ...
+89   --O                                                                       (2 = 50.0%) {25.0%}
+103  ...
+242  -O                                                                        (1 = 25.0%) {75.0%}
+279  ...
+Histogram: Net.HttpStreamPool.InitialAttemptState2 recorded 2 samples, mean = 4.0 (flags = 0x41)
+0  ...
+4  --O                                                                       (2 = 100.0%) {0.0%}
+5  ...
+Histogram: Net.HttpStreamPool.JobCompleteTime3.Unknown recorded 1 samples, mean = 262.0 (flags = 0x41)
+0    ...
+242  -O                                                                        (1 = 100.0%) {0.0%}
+279  ...
+Histogram: Net.HttpStreamPool.NewSpdySessionEstablishTime recorded 2 samples, mean = 72.0 (flags = 0x41)
+0   ...
+68  --O                                                                       (2 = 100.0%) {0.0%}
+81  ...
+Histogram: Net.HttpStreamPool.QuicAttemptTime.Success recorded 2 samples, mean = 135.0 (flags = 0x41)
+0    ...
+14   -O                                                                        (1 = 50.0%) {0.0%}
+17   ...
+226  -O                                                                        (1 = 50.0%) {50.0%}
+268  ...
+Histogram: Net.HttpStreamPool.TcpBasedAttemptDelay recorded 4 samples, mean = 152.5 (flags = 0x41)
+0    ...
+5    --O                                                                       (2 = 50.0%) {0.0%}
+6    ...
+268  --O                                                                       (2 = 50.0%) {50.0%}
+318  ...
+Histogram: Net.HttpStreamPool.TcpBasedAttemptTime2.Success recorded 2 samples, mean = 72.5 (flags = 0x41)
+0   ...
+66  --O                                                                       (2 = 100.0%) {0.0%}
+84  ...
+Histogram: Net.HttpTimeToFirstByte recorded 9 samples, mean = 77.6 (flags = 0x41)
+0    -O                                                                        (1 = 11.1%)
+10   O                                                                         (0 = 0.0%) {11.1%}
+12   --O                                                                       (2 = 22.2%) {11.1%}
+15   -O                                                                        (1 = 11.1%) {33.3%}
+18   O                                                                         (0 = 0.0%) {44.4%}
+22   -O                                                                        (1 = 11.1%) {44.4%}
+27   -O                                                                        (1 = 11.1%) {55.6%}
+33   ...
+50   -O                                                                        (1 = 11.1%) {66.7%}
+61   ...
+92   -O                                                                        (1 = 11.1%) {77.8%}
+113  ...
+389  -O                                                                        (1 = 11.1%) {88.9%}
+477  ...
+Histogram: Net.HttpTimeToFirstByte.TLS13.Google recorded 2 samples, mean = 272.5 (flags = 0x41)
+0    ...
+84   -O                                                                        (1 = 50.0%) {0.0%}
+107  ...
+356  -O                                                                        (1 = 50.0%) {50.0%}
+452  ...
+Histogram: Net.NetworkTransaction.ConnectedCallbackDelay recorded 1 samples, mean = 7.0 (flags = 0x41)
+0  ...
+7  -O                                                                        (1 = 100.0%) {0.0%}
+8  ...
+Histogram: Net.NetworkTransaction.CreateHttpStreamTime.GoogleHost.H3 recorded 4 samples, mean = 8.2 (flags = 0x41)
+0   ---O                                                                      (3 = 75.0%)
+1   ...
+29  -O                                                                        (1 = 25.0%) {75.0%}
+34  ...
+Histogram: Net.NetworkTransaction.CreateHttpStreamTime.GoogleHost.H3.IPv4 recorded 4 samples, mean = 8.2 (flags = 0x41)
+0   ---O                                                                      (3 = 75.0%)
+1   ...
+29  -O                                                                        (1 = 25.0%) {75.0%}
+34  ...
+Histogram: Net.NetworkTransaction.CreateHttpStreamTime.H2 recorded 2 samples, mean = 90.5 (flags = 0x41)
+0   ...
+81  --O                                                                       (2 = 100.0%) {0.0%}
+96  ...
+Histogram: Net.NetworkTransaction.CreateHttpStreamTime.H2.IPv4 recorded 2 samples, mean = 90.5 (flags = 0x41)
+0   ...
+81  --O                                                                       (2 = 100.0%) {0.0%}
+96  ...
+Histogram: Net.NetworkTransaction.GenerateServerAuthTokenBlocked.H2 recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.NetworkTransaction.GenerateServerAuthTokenBlockedGoogleHost.H3 recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.NetworkTransaction.InitializeStreamBlocked.H2 recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.NetworkTransaction.InitializeStreamBlockedGoogleHost.H3 recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.NetworkTransaction.NegotiatedProtocol recorded 2 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  --O                                                                       (2 = 100.0%) {0.0%}
+3  ...
+Histogram: Net.NetworkTransaction.NegotiatedProtocol.GoogleHost recorded 4 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  ----O                                                                     (4 = 100.0%) {0.0%}
+4  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.NetworkTransaction.StreamAddressFamily recorded 6 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ------O                                                                   (6 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.NetworkTransaction.StreamRequestCompleteTime2.GoogleHost.Success recorded 4 samples, mean = 8.2 (flags = 0x41)
+0   ---O                                                                      (3 = 75.0%)
+1   ...
+29  -O                                                                        (1 = 25.0%) {75.0%}
+34  ...
+Histogram: Net.NetworkTransaction.StreamRequestCompleteTime2.Success recorded 2 samples, mean = 90.5 (flags = 0x41)
+0   ...
+81  --O                                                                       (2 = 100.0%) {0.0%}
+96  ...
+Histogram: Net.NumQuicSessionsAtShutdown recorded 4 samples, mean = 0.2 (flags = 0x41)
+0  ---O                                                                      (3 = 75.0%)
+1  -O                                                                        (1 = 25.0%) {75.0%}
+2  ...
+Histogram: Net.QuicActiveSessionCount.CertVerifierChanged recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.QuicActiveSessions recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicChromiumClientStream.HandleOnCloseConnectionError recorded 3 samples (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+Histogram: Net.QuicChromiumClientStream.HandleOnCloseNetError recorded 3 samples (flags = 0x41)
+100  ---O                                                                      (3 = 100.0%)
+Histogram: Net.QuicChromiumClientStream.HandleOnCloseStreamError recorded 3 samples (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+Histogram: Net.QuicChromiumClientStream.HeaderDecodingDelay recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.QuicChromiumClientStream.HeaderDecodingDelayGoogle recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.QuicConnection.WritePacketStatus recorded 23 samples, mean = 0.0 (flags = 0x41)
+0  -----------------------O                                                  (23 = 100.0%)
+1  ...
+Histogram: Net.QuicCryptoClientConfig.PopulatedFromCanonicalConfig recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicDroppedPacketReason recorded 6 samples, mean = 6.0 (flags = 0x41)
+0  ...
+6  ------O                                                                   (6 = 100.0%) {0.0%}
+7  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicHandshakeState recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  -O                                                                        (1 = 33.3%)
+1  -O                                                                        (1 = 33.3%) {33.3%}
+2  -O                                                                        (1 = 33.3%) {66.7%}
+3  ...
+Histogram: Net.QuicHttpStream.ProcessResponseHeaderSuccess recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ---O                                                                      (3 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.AbortedPendingStreamRequests recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.AcceptChForOrigin recorded 4 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ----O                                                                     (4 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.AcceptChFrameReceivedViaAlps recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.AsyncRead recorded 24 samples, mean = 0.5 (flags = 0x41)
+0  -------------O                                                            (13 = 54.2%)
+1  -----------O                                                              (11 = 45.8%) {54.2%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.BlockedFrames.Received recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.BlockedFrames.Sent recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.CertVerificationResult recorded 1 samples (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.ClientSideMtu recorded 1 samples (flags = 0x41)
+1250  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.CloseAllSessionsError recorded 4 samples (flags = 0x41)
+3  ----O                                                                     (4 = 100.0%)
+Histogram: Net.QuicSession.CloseSessionOnError recorded 1 samples (flags = 0x41)
+3  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.ClosedDuringInitializeSession recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.CoalesceStreamFrameStatus recorded 15 samples, mean = 0.1 (flags = 0x41)
+0  -------------O                                                            (13 = 86.7%)
+1  --O                                                                       (2 = 13.3%) {86.7%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.ConnectRandomPortForHTTPS recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.ConnectionCloseErrorCodeClient recorded 1 samples (flags = 0x41)
+70  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.ConnectionCloseErrorCodeClient.HandshakeConfirmed recorded 1 samples (flags = 0x41)
+70  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.ConnectionCloseErrorCodeClientGoogle recorded 1 samples (flags = 0x41)
+70  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.ConnectionCloseErrorCodeClientGoogle.HandshakeConfirmed recorded 1 samples (flags = 0x41)
+70  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.ConnectionDuration recorded 1 samples, mean = 12080.0 (flags = 0x41)
+0      ...
+11597  -O                                                                        (1 = 100.0%) {0.0%}
+13386  ...
+Histogram: Net.QuicSession.ConnectionDuration.GoogleWithAlpnH3 recorded 1 samples, mean = 12080.0 (flags = 0x41)
+0      ...
+11597  -O                                                                        (1 = 100.0%) {0.0%}
+13386  ...
+Histogram: Net.QuicSession.ConnectionDuration.GoogleWithAlpnH3.Preconnect recorded 1 samples, mean = 12080.0 (flags = 0x41)
+0      ...
+11597  -O                                                                        (1 = 100.0%) {0.0%}
+13386  ...
+Histogram: Net.QuicSession.ConnectionDuration.Preconnect recorded 1 samples, mean = 12080.0 (flags = 0x41)
+0      ...
+11597  -O                                                                        (1 = 100.0%) {0.0%}
+13386  ...
+Histogram: Net.QuicSession.ConnectionFlowControlBlocked recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.ConnectionIpPooled recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.ConnectionTypeFromSelf recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.CryptoRetransmitCount.HandshakeConfirmed recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.DuplicatePacketsReceived recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.EncryptionEstablishedTime recorded 1 samples, mean = 239.0 (flags = 0x41)
+0    ...
+226  -O                                                                        (1 = 100.0%) {0.0%}
+268  ...
+Histogram: Net.QuicSession.FinchConfigIsValid recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ---O                                                                      (3 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.FindMatchingIpSessionResult recorded 13 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -------------O                                                            (13 = 100.0%) {0.0%}
+3  ...
+Histogram: Net.QuicSession.FindMatchingIpSessionResultGoogle recorded 13 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -------------O                                                            (13 = 100.0%) {0.0%}
+3  ...
+Histogram: Net.QuicSession.GoogleSearch.SessionCreationInitiator.Used recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.HandshakeConfirmedTime recorded 1 samples, mean = 243.0 (flags = 0x41)
+0    ...
+226  -O                                                                        (1 = 100.0%) {0.0%}
+268  ...
+Histogram: Net.QuicSession.HeaderCompressionRatioQpackReceived recorded 3 samples, mean = 2.7 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 33.3%) {0.0%}
+3  --O                                                                       (2 = 66.7%) {33.3%}
+4  ...
+Histogram: Net.QuicSession.HeaderCompressionRatioQpackSent recorded 3 samples, mean = 50.3 (flags = 0x41)
+0   ...
+34  -O                                                                        (1 = 33.3%) {0.0%}
+35  ...
+44  -O                                                                        (1 = 33.3%) {33.3%}
+45  ...
+73  -O                                                                        (1 = 33.3%) {66.7%}
+74  ...
+Histogram: Net.QuicSession.HostResolution.HandshakeConfirmedTime recorded 1 samples, mean = 254.0 (flags = 0x41)
+0    ...
+226  -O                                                                        (1 = 100.0%) {0.0%}
+268  ...
+Histogram: Net.QuicSession.IncorrectConnectionIDsReceived recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.InitialRttEsitmateSource recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.KeyUpdate.PerConnection2 recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.KeyUpdate.PotentialPeerKeyUpdateAttemptCount recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.MaxConsecutiveRtoWithForwardProgress recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.MinRTT recorded 1 samples, mean = 5.0 (flags = 0x41)
+0  ...
+5  -O                                                                        (1 = 100.0%) {0.0%}
+6  ...
+Histogram: Net.QuicSession.MtuProbesSent recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.NumDefaultPathDegrading recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.NumMigrations recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.NumOpenStreams recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ---O                                                                      (3 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.NumPingsSent recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.NumPingsSent.GoogleWithAlpnH3 recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.NumQueuedPacketsBeforeWrite recorded 24 samples, mean = 0.0 (flags = 0x41)
+0  ------------------------O                                                 (24 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.NumTotalStreams recorded 1 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  -O                                                                        (1 = 100.0%) {0.0%}
+4  ...
+Histogram: Net.QuicSession.OutOfOrderGapReceived recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: Net.QuicSession.OutOfOrderLargePacketsReceived recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.OutOfOrderPacketsReceived recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.OutgoingEcn recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.PacketGapReceived recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.PacketGapReceivedNearPing recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.QuicSession.PacketLossRate_CONNECTION_ETHERNET recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.PacketWriteTime.Synchronous recorded 23 samples, mean = 0.0 (flags = 0x41)
+0  -----------------------O                                                  (23 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.PreferAesGcm recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.Qpack.HeaderListCountWhenInsertionNotBlocked recorded 3 samples, mean = 2.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 33.3%) {0.0%}
+2  -O                                                                        (1 = 33.3%) {33.3%}
+3  -O                                                                        (1 = 33.3%) {66.7%}
+4  ...
+Histogram: Net.QuicSession.Qpack.HeaderListCountWhenNotBlockedStreamLimited recorded 3 samples, mean = 2.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 33.3%) {0.0%}
+2  -O                                                                        (1 = 33.3%) {33.3%}
+3  -O                                                                        (1 = 33.3%) {66.7%}
+4  ...
+Histogram: Net.QuicSession.QuicVersion recorded 1 samples (flags = 0x41)
+80  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.ReceivedSettings.BlockedStreams recorded 1 samples, mean = 100.0 (flags = 0x41)
+0   ...
+95  -O                                                                        (1 = 100.0%) {0.0%}
+107 ...
+Histogram: Net.QuicSession.ReceivedSettings.CountPlusOne recorded 1 samples, mean = 7.0 (flags = 0x41)
+0  ...
+7  -O                                                                        (1 = 100.0%) {0.0%}
+8  ...
+Histogram: Net.QuicSession.ReceivedSettings.MaxHeaderListSize2 recorded 1 samples, mean = 65536.0 (flags = 0x41)
+0      ...
+63662  -O                                                                        (1 = 100.0%) {0.0%}
+83848  ...
+Histogram: Net.QuicSession.ReceivedSettings.MaxTableCapacity2 recorded 1 samples, mean = 65536.0 (flags = 0x41)
+0      ...
+63662  -O                                                                        (1 = 100.0%) {0.0%}
+83848  ...
+Histogram: Net.QuicSession.ReceivedSettings.ReservedCountPlusOne recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: Net.QuicSession.SendPacketSize.ForwardSecure recorded 13 samples, mean = 125.5 (flags = 0x41)
+0    ...
+28   -O                                                                        (1 = 7.7%) {0.0%}
+32   -----O                                                                    (5 = 38.5%) {7.7%}
+36   --O                                                                       (2 = 15.4%) {46.2%}
+41   O                                                                         (0 = 0.0%) {61.5%}
+47   -O                                                                        (1 = 7.7%) {61.5%}
+53   ...
+68   -O                                                                        (1 = 7.7%) {69.2%}
+77   ...
+243  -O                                                                        (1 = 7.7%) {76.9%}
+276  ...
+406  -O                                                                        (1 = 7.7%) {84.6%}
+461  O                                                                         (0 = 0.0%) {92.3%}
+524  -O                                                                        (1 = 7.7%) {92.3%}
+595  ...
+Histogram: Net.QuicSession.SendPacketSize.Handshake recorded 7 samples, mean = 46.0 (flags = 0x41)
+0   ...
+36  ----O                                                                     (4 = 57.1%) {0.0%}
+41  --O                                                                       (2 = 28.6%) {57.1%}
+47  ...
+77  -O                                                                        (1 = 14.3%) {85.7%}
+87  ...
+Histogram: Net.QuicSession.SendPacketSize.Initial recorded 3 samples, mean = 630.3 (flags = 0x41)
+0    ...
+41   -O                                                                        (1 = 33.3%) {0.0%}
+47   ...
+872  --O                                                                       (2 = 66.7%) {33.3%}
+991  ...
+Histogram: Net.QuicSession.ServerSideMtu recorded 1 samples (flags = 0x41)
+1250  -O                                                                        (1 = 100.0%)
+Histogram: Net.QuicSession.SmoothedRTT recorded 1 samples, mean = 14.0 (flags = 0x41)
+0   ...
+14  -O                                                                        (1 = 100.0%) {0.0%}
+17  ...
+Histogram: Net.QuicSession.StreamCloseErrorCodeClient.HandshakeConfirmed recorded 0 samples (flags = 0x41)
+Histogram: Net.QuicSession.StreamFlowControlBlocked recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.StreamFrameDuplicatedShortConnection recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.TimeFromResolveHostToConfirmConnection recorded 1 samples, mean = 254.0 (flags = 0x41)
+0    ...
+226  -O                                                                        (1 = 100.0%) {0.0%}
+268  ...
+Histogram: Net.QuicSession.TooManyOpenStreams recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.TooSmallInitialSentPacket recorded 3 samples, mean = 569.7 (flags = 0x41)
+0     ...
+271   --O                                                                       (2 = 66.7%) {0.0%}
+307   ...
+1060  -O                                                                        (1 = 33.3%) {66.7%}
+1200  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.UndecryptablePacketsReceived recorded 1 samples, mean = 6.0 (flags = 0x41)
+0  ...
+5  -O                                                                        (1 = 100.0%) {0.0%}
+7  ...
+Histogram: Net.QuicSession.UndecryptablePacketsReceivedWithDecrypter recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.QuicSession.VerifyProofTime recorded 1 samples, mean = 220.0 (flags = 0x41)
+0    ...
+190  -O                                                                        (1 = 100.0%) {0.0%}
+226  ...
+Histogram: Net.QuicSession.VerifyProofTime.google recorded 1 samples, mean = 220.0 (flags = 0x41)
+0    ...
+190  -O                                                                        (1 = 100.0%) {0.0%}
+226  ...
+Histogram: Net.QuicSession.ZeroRttReason recorded 1 samples, mean = 5.0 (flags = 0x41)
+0  ...
+5  -O                                                                        (1 = 100.0%) {0.0%}
+6  ...
+Histogram: Net.QuicSession.ZeroRttReason.Google recorded 1 samples, mean = 5.0 (flags = 0x41)
+0  ...
+5  -O                                                                        (1 = 100.0%) {0.0%}
+6  ...
+Histogram: Net.QuicSession.ZeroRttReason.GoogleWithAlpnH3 recorded 1 samples, mean = 5.0 (flags = 0x41)
+0  ...
+5  -O                                                                        (1 = 100.0%) {0.0%}
+6  ...
+Histogram: Net.QuicSession.ZeroRttState recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.ZeroRttState.Google recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSession.ZeroRttState.GoogleWithAlpnH3 recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.QuicSessionAttempt.CompleteTime.Success recorded 1 samples, mean = 254.0 (flags = 0x41)
+0    ...
+226  -O                                                                        (1 = 100.0%) {0.0%}
+268  ...
+Histogram: Net.QuicSessionAttempt.CreateSessionTime.Success recorded 1 samples, mean = 10.0 (flags = 0x41)
+0   ...
+10  -O                                                                        (1 = 100.0%) {0.0%}
+12  ...
+Histogram: Net.QuicSessionAttempt.CryptoConnectTime.Success recorded 1 samples, mean = 254.0 (flags = 0x41)
+0    ...
+226  -O                                                                        (1 = 100.0%) {0.0%}
+268  ...
+Histogram: Net.Reporting.HeaderType recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.RestrictedCookieManager.GetCookiesString.Count30Seconds recorded 0 samples (flags = 0x41)
+0 ...
+Histogram: Net.SSL.TrustAnchorIDsResult recorded 3 samples, mean = 4.0 (flags = 0x41)
+0  ...
+4  ---O                                                                      (3 = 100.0%) {0.0%}
+5  ...
+Histogram: Net.SSLExtendedMainSecretSupported recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ---O                                                                      (3 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.SSLHandshakeDetails recorded 3 samples, mean = 6.0 (flags = 0x41)
+0  ...
+6  ---O                                                                      (3 = 100.0%) {0.0%}
+7  ...
+Histogram: Net.SSLHandshakeEarlyDataReason recorded 2 samples, mean = 5.0 (flags = 0x41)
+0  ...
+5  --O                                                                       (2 = 100.0%) {0.0%}
+6  ...
+Histogram: Net.SSLHandshakeEarlyDataReason.Google recorded 2 samples, mean = 5.0 (flags = 0x41)
+0  ...
+5  --O                                                                       (2 = 100.0%) {0.0%}
+6  ...
+Histogram: Net.SSLNegotiatedAlpnProtocol recorded 3 samples, mean = 1.3 (flags = 0x41)
+0  -O                                                                        (1 = 33.3%)
+1  O                                                                         (0 = 0.0%) {33.3%}
+2  --O                                                                       (2 = 66.7%) {33.3%}
+3  ...
+Histogram: Net.SSLRenegotiationInfoSupported recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ---O                                                                      (3 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.SSLSignatureAlgorithm recorded 3 samples (flags = 0x41)
+1027  ---O                                                                      (3 = 100.0%)
+Histogram: Net.SSLVersion recorded 3 samples, mean = 6.0 (flags = 0x41)
+0  ...
+6  ---O                                                                      (3 = 100.0%) {0.0%}
+7  ...
+Histogram: Net.SSL_CipherSuite recorded 3 samples (flags = 0x41)
+4865  ---O                                                                      (3 = 100.0%)
+Histogram: Net.SSL_Connection_Error recorded 3 samples (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+Histogram: Net.SSL_Connection_Latency_2 recorded 3 samples, mean = 65.0 (flags = 0x41)
+0   ...
+56  -O                                                                        (1 = 33.3%) {0.0%}
+62  -O                                                                        (1 = 33.3%) {33.3%}
+68  -O                                                                        (1 = 33.3%) {66.7%}
+75  ...
+Histogram: Net.SSL_KeyExchange.ECDHE recorded 3 samples (flags = 0x41)
+29    --O                                                                       (2 = 66.7%)
+4588  -O                                                                        (1 = 33.3%)
+Histogram: Net.SharedDictionaryManagerOnDisk.CacheMaxSize recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.SharedDictionaryStorageOnDisk.IsMetadataReadyOnFirstUse recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.SharedDictionaryStorageOnDisk.MetadataReadTime.Empty recorded 2 samples, mean = 7.5 (flags = 0x41)
+0   ...
+4   -O                                                                        (1 = 50.0%) {0.0%}
+5   ...
+10  -O                                                                        (1 = 50.0%) {50.0%}
+12  ...
+Histogram: Net.SharedDictionaryStore.DeleteExpiredDictionaries.Error recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SharedDictionaryStore.GetDictionaries.Error recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SharedDictionaryStore.ProcessEviction.Error recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.SpdyFrameStreamAndSessionFlowControlState recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdyHeadersCompressionPercentage recorded 2 samples, mean = 45.5 (flags = 0x41)
+0   ...
+41  -O                                                                        (1 = 50.0%) {0.0%}
+42  ...
+50  -O                                                                        (1 = 50.0%) {50.0%}
+51  ...
+Histogram: Net.SpdyResponseCode recorded 2 samples (flags = 0x41)
+200  -O                                                                        (1 = 50.0%)
+301  -O                                                                        (1 = 50.0%)
+Histogram: Net.SpdySession.AcceptChForOrigin recorded 2 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  --O                                                                       (2 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.SpdySession.AlpsAcceptChEntries recorded 2 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  --O                                                                       (2 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.SpdySession.AlpsDecoderStatus recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdySession.AlpsDecoderStatus.Bypassed recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdySession.AlpsSettingParameterCount recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdySession.ClosedOnError recorded 2 samples (flags = 0x41)
+3  --O                                                                       (2 = 100.0%)
+Histogram: Net.SpdySession.CreateStreamWithSocketConnected recorded 2 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  --O                                                                       (2 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.SpdySession.OnSettings.ActiveStreamCount2 recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdySession.OnSettings.CreatedAndActiveStreamCount2 recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdySession.OnSettings.CreatedStreamCount2 recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdySession.OnSettings.PendingStreamCount2 recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdySession.ServerSupportsWebSocket recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdySessionGet recorded 2 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  --O                                                                       (2 = 100.0%) {0.0%}
+4  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.SpdyStreamsAbandonedPerSession recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: Net.SpdyStreamsPerSession recorded 2 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  --O                                                                       (2 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.SqlDiskCache.Backend.DeleteLiveEntry.FailureTime recorded 2 samples, mean = 214.5 (flags = 0x41)
+0    ...
+105  -O                                                                        (1 = 50.0%) {0.0%}
+146  ...
+282  -O                                                                        (1 = 50.0%) {50.0%}
+391  ...
+Histogram: Net.SqlDiskCache.Backend.DeleteLiveEntry.Result recorded 2 samples, mean = 13.0 (flags = 0x41)
+0   ...
+13  --O                                                                       (2 = 100.0%) {0.0%}
+14  ...
+Histogram: Net.SqlDiskCache.Backend.Initialize.Result recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Net.SqlDiskCache.Backend.Initialize.SuccessTime recorded 1 samples, mean = 21548.0 (flags = 0x41)
+0      ...
+19866  -O                                                                        (1 = 100.0%) {0.0%}
+27562  ...
+Histogram: Net.SqlDiskCache.Backend.OpenEntry.Result recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.SqlDiskCache.Backend.OpenEntry.SuccessTime recorded 3 samples, mean = 81.7 (flags = 0x41)
+0   ...
+55  -O                                                                        (1 = 33.3%) {0.0%}
+76  --O                                                                       (2 = 66.7%) {33.3%}
+105 ...
+Histogram: Net.SqlDiskCache.Backend.OpenOrCreateEntry.Result recorded 4 samples, mean = 0.0 (flags = 0x41)
+0  ----O                                                                     (4 = 100.0%)
+1  ...
+Histogram: Net.SqlDiskCache.Backend.OpenOrCreateEntry.SuccessTime recorded 4 samples, mean = 149.8 (flags = 0x41)
+0    ...
+76   --O                                                                       (2 = 50.0%) {0.0%}
+105  -O                                                                        (1 = 25.0%) {50.0%}
+146  ...
+282  -O                                                                        (1 = 25.0%) {75.0%}
+391  ...
+Histogram: Net.SqlDiskCache.Backend.ReadEntryData.Result recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.SqlDiskCache.Backend.ReadEntryData.SuccessTime recorded 3 samples, mean = 344.0 (flags = 0x41)
+0    ...
+146  -O                                                                        (1 = 33.3%) {0.0%}
+203  ...
+391  --O                                                                       (2 = 66.7%) {33.3%}
+542  ...
+Histogram: Net.SqlDiskCache.Backend.UpdateEntryHeaderAndLastUsed.Result recorded 3 samples, mean = 0.0 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+1  ...
+Histogram: Net.SqlDiskCache.Backend.UpdateEntryHeaderAndLastUsed.SuccessTime recorded 3 samples, mean = 309.3 (flags = 0x41)
+0    ...
+203  --O                                                                       (2 = 66.7%) {0.0%}
+282  O                                                                         (0 = 0.0%) {66.7%}
+391  -O                                                                        (1 = 33.3%) {66.7%}
+542  ...
+Histogram: Net.SqlDiskCache.Backend.UpdateEntryLastUsed.Result recorded 4 samples, mean = 0.0 (flags = 0x41)
+0  ----O                                                                     (4 = 100.0%)
+1  ...
+Histogram: Net.SqlDiskCache.Backend.UpdateEntryLastUsed.SuccessTime recorded 4 samples, mean = 181.5 (flags = 0x41)
+0    ...
+76   -O                                                                        (1 = 25.0%) {0.0%}
+105  O                                                                         (0 = 0.0%) {25.0%}
+146  --O                                                                       (2 = 50.0%) {25.0%}
+203  O                                                                         (0 = 0.0%) {75.0%}
+282  -O                                                                        (1 = 25.0%) {75.0%}
+391  ...
+Histogram: Net.SqlDiskCache.Backend.WriteEntryData.Result recorded 7 samples, mean = 0.0 (flags = 0x41)
+0  -------O                                                                  (7 = 100.0%)
+1  ...
+Histogram: Net.SqlDiskCache.Backend.WriteEntryData.SuccessTime recorded 7 samples, mean = 952.3 (flags = 0x41)
+0     ...
+391   ----O                                                                     (4 = 57.1%) {0.0%}
+542   -O                                                                        (1 = 14.3%) {57.1%}
+752   O                                                                         (0 = 0.0%) {71.4%}
+1043  -O                                                                        (1 = 14.3%) {71.4%}
+1447  ...
+2786  -O                                                                        (1 = 14.3%) {85.7%}
+3865  ...
+Histogram: Net.SqlDiskCache.FakeIndexFileError recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: Net.SqlDiskCache.NormalOperationDelay recorded 26 samples, mean = 6.6 (flags = 0x41)
+0   ...
+3   -----O                                                                    (5 = 19.2%) {0.0%}
+4   -------O                                                                  (7 = 26.9%) {19.2%}
+6   ---------O                                                                (9 = 34.6%) {46.2%}
+8   -O                                                                        (1 = 3.8%) {80.8%}
+11  -O                                                                        (1 = 3.8%) {84.6%}
+15  ---O                                                                      (3 = 11.5%) {88.5%}
+21  ...
+Histogram: Net.TCP_Connection_Latency recorded 1 samples, mean = 6.0 (flags = 0x41)
+0  ...
+6  -O                                                                        (1 = 100.0%) {0.0%}
+7  ...
+Histogram: Net.TcpConnectAttempt.Latency.Success recorded 3 samples, mean = 3.7 (flags = 0x41)
+0  ---O                                                                      (3 = 100.0%)
+10 ...
+Histogram: Net.URLLoader.AcceptCH.RoundTripTime recorded 1 samples, mean = 7312.0 (flags = 0x41)
+0     ...
+5362  -O                                                                        (1 = 100.0%) {0.0%}
+7439  ...
+Histogram: Net.URLLoader.AcceptCH.RunObserverCall recorded 2 samples, mean = 0.5 (flags = 0x41)
+0  -O                                                                        (1 = 50.0%)
+1  -O                                                                        (1 = 50.0%) {50.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.URLLoader.AcceptCH.Status recorded 1 samples (flags = 0x41)
+3  -O                                                                        (1 = 100.0%)
+Histogram: Net.URLLoader.AcceptCHFrameReceivedOnHttp2 recorded 2 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  --O                                                                       (2 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.URLLoader.AcceptCHFrameReceivedOnHttp3 recorded 4 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ----O                                                                     (4 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Net.URLLoader.ProportionOfWritesBlockedByMojo recorded 5 samples, mean = 0.0 (flags = 0x41)
+0  -----O                                                                    (5 = 100.0%)
+1  ...
+Histogram: Net.URLRequest.ReferrerHasInformativePath.CrossOrigin recorded 9 samples, mean = 0.0 (flags = 0x41)
+0  ---------O                                                                (9 = 100.0%)
+1  ...
+Histogram: Net.URLRequest.ReferrerPolicyForRequest.CrossOrigin recorded 9 samples, mean = 1.9 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -----O                                                                    (5 = 55.6%) {0.0%}
+2  O                                                                         (0 = 0.0%) {55.6%}
+3  ----O                                                                     (4 = 44.4%) {55.6%}
+4  ...
+Histogram: NetworkService.NetworkLoaderCompletionTime2.DiskCache recorded 3 samples, mean = 22.7 (flags = 0x41)
+0   ...
+14  -O                                                                        (1 = 33.3%) {0.0%}
+17  ...
+24  --O                                                                       (2 = 66.7%) {33.3%}
+29  ...
+Histogram: NetworkService.NetworkLoaderCompletionTime2.DiskCache.HIGHEST recorded 3 samples, mean = 22.7 (flags = 0x41)
+0   ...
+14  -O                                                                        (1 = 33.3%) {0.0%}
+17  ...
+24  --O                                                                       (2 = 66.7%) {33.3%}
+29  ...
+Histogram: NetworkService.NetworkLoaderCompletionTime2.Network recorded 5 samples, mean = 140.6 (flags = 0x41)
+0    ...
+24   -O                                                                        (1 = 20.0%) {0.0%}
+29   ...
+40   -O                                                                        (1 = 20.0%) {20.0%}
+48   ...
+68   -O                                                                        (1 = 20.0%) {40.0%}
+81   O                                                                         (0 = 0.0%) {60.0%}
+96   -O                                                                        (1 = 20.0%) {60.0%}
+114  ...
+449  -O                                                                        (1 = 20.0%) {80.0%}
+533  ...
+Histogram: NetworkService.NetworkLoaderCompletionTime2.Network.HIGHEST recorded 1 samples, mean = 42.0 (flags = 0x41)
+0   ...
+40  -O                                                                        (1 = 100.0%) {0.0%}
+48  ...
+Histogram: NetworkService.NetworkLoaderCompletionTime2.Network.IDLE recorded 4 samples, mean = 165.2 (flags = 0x41)
+0    ...
+24   -O                                                                        (1 = 25.0%) {0.0%}
+29   ...
+68   -O                                                                        (1 = 25.0%) {25.0%}
+81   O                                                                         (0 = 0.0%) {50.0%}
+96   -O                                                                        (1 = 25.0%) {50.0%}
+114  ...
+449  -O                                                                        (1 = 25.0%) {75.0%}
+533  ...
+Histogram: NetworkService.ParsedHeaders.IPCHandleTime recorded 3 samples, mean = 653.0 (flags = 0x41)
+0     ...
+55    -O                                                                        (1 = 33.3%) {0.0%}
+76    ...
+391   -O                                                                        (1 = 33.3%) {33.3%}
+542   ...
+1447  -O                                                                        (1 = 33.3%) {66.7%}
+2008  ...
+Histogram: NetworkService.Requests.Multiplexed.MainFrame.Get.Success.TotalRequestSize recorded 1 samples, mean = 1191.0 (flags = 0x41)
+0     ...
+1122  -O                                                                        (1 = 100.0%) {0.0%}
+1404  ...
+Histogram: NetworkService.Requests.Multiplexed.MainFrame.Get.Success.TotalUrlSize recorded 1 samples, mean = 34.0 (flags = 0x41)
+0   ...
+31  -O                                                                        (1 = 100.0%) {0.0%}
+39  ...
+Histogram: PerformanceManager.ChildScenarioMappingResult recorded 2 samples, mean = 0.0 (flags = 0x41)
+0  --O                                                                       (2 = 100.0%)
+1  ...
+Histogram: PerformanceManager.InitializeChildProcessCoordination.RequestCount recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: PerformanceManager.InitializeChildProcessCoordination.ResponseCount recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: Prefs.JSonStore.SetValueKey recorded 1 samples (flags = 0x41)
+372921139  -O                                                                        (1 = 100.0%)
+Histogram: Privacy.3PCD.AdsHeuristicAddedToOverrides recorded 20 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  --------------------O                                                     (20 = 100.0%) {0.0%}
+2  ...
+Histogram: Privacy.3PCD.SecCookieDeprecationHeaderStatus recorded 5 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -----O                                                                    (5 = 100.0%) {0.0%}
+2  ...
+Histogram: ReportingAndNEL.NumberOfLoadedNELPolicies recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: ReportingAndNEL.NumberOfLoadedNELPolicies2 recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: ReportingAndNEL.NumberOfLoadedReportingEndpointGroups2 recorded 1 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  -O                                                                        (1 = 100.0%) {0.0%}
+4  ...
+Histogram: ReportingAndNEL.NumberOfLoadedReportingEndpoints2 recorded 1 samples, mean = 3.0 (flags = 0x41)
+0  ...
+3  -O                                                                        (1 = 100.0%) {0.0%}
+4  ...
+Histogram: ReportingAndNEL.TimeInitializeDB recorded 1 samples, mean = 23.0 (flags = 0x41)
+0   ...
+21  -O                                                                        (1 = 100.0%) {0.0%}
+26  ...
+Histogram: ResourceScheduler.RequestQueuingDuration.Priority1 recorded 4 samples, mean = 1.0 (flags = 0x41)
+0  ---O                                                                      (3 = 75.0%)
+1  ...
+4  -O                                                                        (1 = 25.0%) {75.0%}
+5  ...
+Histogram: ResourceScheduler.RequestQueuingDuration.Priority5 recorded 5 samples, mean = 0.0 (flags = 0x41)
+0  -----O                                                                    (5 = 100.0%)
+1  ...
+Histogram: Scheduling.ThreadController.ActiveIntervalDuration.Any.Other recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Scheduling.ThreadController.ActiveIntervalDuration.Short.Other recorded 1 samples, mean = 142.0 (flags = 0x41)
+0    ...
+142  -O                                                                        (1 = 100.0%) {0.0%}
+149  ...
+Histogram: Scheduling.ThreadController.ActiveIntervalOffCpuDuration.Any.Other recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Scheduling.ThreadController.ActiveIntervalOffCpuDuration.Short.Other recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: Scheduling.ThreadController.ActiveIntervalOnCpuDuration.Any.Other recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Scheduling.ThreadController.ActiveIntervalOnCpuDuration.Short.Other recorded 1 samples, mean = 140.0 (flags = 0x41)
+0    ...
+135  -O                                                                        (1 = 100.0%) {0.0%}
+142  ...
+Histogram: Scheduling.ThreadController.ActiveIntervalOnCpuPercentage.Any.Other recorded 1 samples, mean = 98.0 (flags = 0x41)
+0   ...
+98  -O                                                                        (1 = 100.0%) {0.0%}
+99  ...
+Histogram: Scheduling.ThreadController.ActiveIntervalOnCpuPercentage.Short.Other recorded 1 samples, mean = 98.0 (flags = 0x41)
+0   ...
+98  -O                                                                        (1 = 100.0%) {0.0%}
+99  ...
+Histogram: Scheduling.ThreadController.IdleDuration.Any.Other recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Scheduling.ThreadController.IdleDuration.Short.Other recorded 1 samples, mean = 780.0 (flags = 0x41)
+0    ...
+777  -O                                                                        (1 = 100.0%) {0.0%}
+817  ...
+Histogram: Security.GwpAsan.Activated.Malloc.Utility recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Security.GwpAsan.Activated.PartitionAlloc.Utility recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Security.JSONParser.ParsingTime recorded 15 samples, mean = 27.6 (flags = 0x41)
+0    ...
+2    -O                                                                        (1 = 6.7%) {0.0%}
+3    --O                                                                       (2 = 13.3%) {6.7%}
+4    -O                                                                        (1 = 6.7%) {20.0%}
+5    O                                                                         (0 = 0.0%) {26.7%}
+7    ---O                                                                      (3 = 20.0%) {26.7%}
+9    O                                                                         (0 = 0.0%) {46.7%}
+12   -O                                                                        (1 = 6.7%) {46.7%}
+16   ---O                                                                      (3 = 20.0%) {53.3%}
+21   -O                                                                        (1 = 6.7%) {73.3%}
+28   ...
+49   -O                                                                        (1 = 6.7%) {80.0%}
+65   -O                                                                        (1 = 6.7%) {86.7%}
+86   ...
+149  -O                                                                        (1 = 6.7%) {93.3%}
+196  ...
+Histogram: Security.PrivateNetworkAccess.CheckResult recorded 6 samples, mean = 0.0 (flags = 0x41)
+0  ------O                                                                   (6 = 100.0%)
+1  ...
+Histogram: Security.SCTAuditing.NumPersistedReportsLoaded recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: SharedDictionary.TimeInitializeDB recorded 1 samples, mean = 16.0 (flags = 0x41)
+0   ...
+14  -O                                                                        (1 = 100.0%) {0.0%}
+17  ...
+Histogram: SimpleCache.App.CacheSizeOnInit2 recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: SimpleCache.App.ConsistencyResult recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: SimpleCache.App.CreationToIndex recorded 1 samples, mean = 45.0 (flags = 0x41)
+0   ...
+40  -O                                                                        (1 = 100.0%) {0.0%}
+48  ...
+Histogram: SimpleCache.App.IndexFileStateOnLoad recorded 1 samples, mean = 2.0 (flags = 0x41)
+0  ...
+2  -O                                                                        (1 = 100.0%) {0.0%}
+3  ...
+Histogram: SimpleCache.App.IndexInitializeMethod recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: SimpleCache.App.IndexNumEntriesOnInit recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: SimpleCache.App.MaxCacheSizeOnInit2 recorded 1 samples, mean = 0.0 (flags = 0x41)
+0  -O                                                                        (1 = 100.0%)
+1  ...
+Histogram: Sql.Database.Success.OpenInternalTime.Cookie recorded 2 samples, mean = 6758.5 (flags = 0x41)
+0     ...
+4367  -O                                                                        (1 = 50.0%) {0.0%}
+5193  ...
+8732  -O                                                                        (1 = 50.0%) {50.0%}
+10384 ...
+Histogram: Sql.Database.Success.OpenInternalTime.HttpCacheDiskCache recorded 1 samples, mean = 20971.0 (flags = 0x41)
+0      ...
+20764  -O                                                                        (1 = 100.0%) {0.0%}
+24691  ...
+Histogram: Sql.Database.Success.OpenInternalTime.ReportingAndNEL recorded 1 samples, mean = 7882.0 (flags = 0x41)
+0     ...
+7343  -O                                                                        (1 = 100.0%) {0.0%}
+8732  ...
+Histogram: Sql.Database.Success.OpenInternalTime.SharedDictionary recorded 1 samples, mean = 10585.0 (flags = 0x41)
+0      ...
+10384  -O                                                                        (1 = 100.0%) {0.0%}
+12348  ...
+Histogram: Sql.Database.Success.OpenInternalTime.TrustTokens recorded 1 samples, mean = 5364.0 (flags = 0x41)
+0     ...
+5193  -O                                                                        (1 = 100.0%) {0.0%}
+6175  ...
+Histogram: Sql.Database.Success.SqliteOpenTime.Cookie recorded 2 samples, mean = 4486.5 (flags = 0x41)
+0     ...
+2597  -O                                                                        (1 = 50.0%) {0.0%}
+3088  ...
+6175  -O                                                                        (1 = 50.0%) {50.0%}
+7343  ...
+Histogram: Sql.Database.Success.SqliteOpenTime.HttpCacheDiskCache recorded 1 samples, mean = 17203.0 (flags = 0x41)
+0      ...
+14684  -O                                                                        (1 = 100.0%) {0.0%}
+17461  ...
+Histogram: Sql.Database.Success.SqliteOpenTime.ReportingAndNEL recorded 1 samples, mean = 1949.0 (flags = 0x41)
+0     ...
+1837  -O                                                                        (1 = 100.0%) {0.0%}
+2184  ...
+Histogram: Sql.Database.Success.SqliteOpenTime.SharedDictionary recorded 1 samples, mean = 4617.0 (flags = 0x41)
+0     ...
+4367  -O                                                                        (1 = 100.0%) {0.0%}
+5193  ...
+Histogram: Sql.Database.Success.SqliteOpenTime.TrustTokens recorded 1 samples, mean = 4003.0 (flags = 0x41)
+0     ...
+3672  -O                                                                        (1 = 100.0%) {0.0%}
+4367  ...
+Histogram: Sql.Statement.Cookie.VMSteps recorded 22 samples, mean = 14.0 (flags = 0x41)
+0   ...
+3   ------O                                                                   (6 = 27.3%) {0.0%}
+4   O                                                                         (0 = 0.0%) {27.3%}
+5   --O                                                                       (2 = 9.1%) {27.3%}
+6   O                                                                         (0 = 0.0%) {36.4%}
+7   -O                                                                        (1 = 4.5%) {36.4%}
+8   ...
+12  -------O                                                                  (7 = 31.8%) {40.9%}
+14  O                                                                         (0 = 0.0%) {72.7%}
+17  -O                                                                        (1 = 4.5%) {72.7%}
+20  --O                                                                       (2 = 9.1%) {77.3%}
+24  -O                                                                        (1 = 4.5%) {86.4%}
+29  O                                                                         (0 = 0.0%) {90.9%}
+34  -O                                                                        (1 = 4.5%) {90.9%}
+40  ...
+57  -O                                                                        (1 = 4.5%) {95.5%}
+68  ...
+Histogram: Sql.Statement.ExecutionTime.Cookie recorded 22 samples, mean = 1475.0 (flags = 0x41)
+0      O                                                                         (0 = 0.0%)
+1      --O                                                                       (2 = 9.1%) {0.0%}
+2      --O                                                                       (2 = 9.1%) {9.1%}
+3      -O                                                                        (1 = 4.5%) {18.2%}
+4      ...
+8      -O                                                                        (1 = 4.5%) {22.7%}
+10     O                                                                         (0 = 0.0%) {27.3%}
+12     -O                                                                        (1 = 4.5%) {27.3%}
+14     -O                                                                        (1 = 4.5%) {31.8%}
+17     ...
+193    -O                                                                        (1 = 4.5%) {36.4%}
+230    -O                                                                        (1 = 4.5%) {40.9%}
+273    ...
+649    ---O                                                                      (3 = 13.6%) {45.5%}
+772    O                                                                         (0 = 0.0%) {59.1%}
+918    --O                                                                       (2 = 9.1%) {59.1%}
+1092   -O                                                                        (1 = 4.5%) {68.2%}
+1299   ...
+2184   --O                                                                       (2 = 9.1%) {72.7%}
+2597   O                                                                         (0 = 0.0%) {81.8%}
+3088   --O                                                                       (2 = 9.1%) {81.8%}
+3672   ...
+5193   -O                                                                        (1 = 4.5%) {90.9%}
+6175   ...
+10384  -O                                                                        (1 = 4.5%) {95.5%}
+12348  ...
+Histogram: Sql.Statement.ExecutionTime.HttpCacheDiskCache recorded 85 samples, mean = 86.6 (flags = 0x41)
+0     O                                                                         (0 = 0.0%)
+1     -O                                                                        (1 = 1.2%) {0.0%}
+2     --O                                                                       (2 = 2.4%) {1.2%}
+3     -O                                                                        (1 = 1.2%) {3.5%}
+4     ---O                                                                      (3 = 3.5%) {4.7%}
+5     --O                                                                       (2 = 2.4%) {8.2%}
+6     ---O                                                                      (3 = 3.5%) {10.6%}
+7     ----O                                                                     (4 = 4.7%) {14.1%}
+8     ---------O                                                                (9 = 10.6%) {18.8%}
+10    -O                                                                        (1 = 1.2%) {29.4%}
+12    -O                                                                        (1 = 1.2%) {30.6%}
+14    --O                                                                       (2 = 2.4%) {31.8%}
+17    -O                                                                        (1 = 1.2%) {34.1%}
+20    -----O                                                                    (5 = 5.9%) {35.3%}
+24    --O                                                                       (2 = 2.4%) {41.2%}
+29    --O                                                                       (2 = 2.4%) {43.5%}
+34    --O                                                                       (2 = 2.4%) {45.9%}
+40    ----O                                                                     (4 = 4.7%) {48.2%}
+48    ---O                                                                      (3 = 3.5%) {52.9%}
+57    -----O                                                                    (5 = 5.9%) {56.5%}
+68    ----------O                                                               (10 = 11.8%) {62.4%}
+81    -------O                                                                  (7 = 8.2%) {74.1%}
+96    ----O                                                                     (4 = 4.7%) {82.4%}
+114   --O                                                                       (2 = 2.4%) {87.1%}
+136   -O                                                                        (1 = 1.2%) {89.4%}
+162   --O                                                                       (2 = 2.4%) {90.6%}
+193   --O                                                                       (2 = 2.4%) {92.9%}
+230   -O                                                                        (1 = 1.2%) {95.3%}
+273   O                                                                         (0 = 0.0%) {96.5%}
+325   -O                                                                        (1 = 1.2%) {96.5%}
+386   ...
+649   -O                                                                        (1 = 1.2%) {97.6%}
+772   ...
+1837  -O                                                                        (1 = 1.2%) {98.8%}
+2184  ...
+Histogram: Sql.Statement.ExecutionTime.ReportingAndNEL recorded 18 samples, mean = 1867.4 (flags = 0x41)
+0     -O                                                                        (1 = 5.6%)
+1     ...
+3     -O                                                                        (1 = 5.6%) {5.6%}
+4     ...
+8     -O                                                                        (1 = 5.6%) {11.1%}
+10    -O                                                                        (1 = 5.6%) {16.7%}
+12    O                                                                         (0 = 0.0%) {22.2%}
+14    -O                                                                        (1 = 5.6%) {22.2%}
+17    ...
+34    -O                                                                        (1 = 5.6%) {27.8%}
+40    ...
+325   -O                                                                        (1 = 5.6%) {33.3%}
+386   ...
+546   -O                                                                        (1 = 5.6%) {38.9%}
+649   ...
+1299  -O                                                                        (1 = 5.6%) {44.4%}
+1545  -O                                                                        (1 = 5.6%) {50.0%}
+1837  --O                                                                       (2 = 11.1%) {55.6%}
+2184  -O                                                                        (1 = 5.6%) {66.7%}
+2597  --O                                                                       (2 = 11.1%) {72.2%}
+3088  O                                                                         (0 = 0.0%) {83.3%}
+3672  -O                                                                        (1 = 5.6%) {83.3%}
+4367  ...
+6175  -O                                                                        (1 = 5.6%) {88.9%}
+7343  -O                                                                        (1 = 5.6%) {94.4%}
+8732  ...
+Histogram: Sql.Statement.ExecutionTime.SharedDictionary recorded 19 samples, mean = 1068.0 (flags = 0x41)
+0     O                                                                         (0 = 0.0%)
+1     -O                                                                        (1 = 5.3%) {0.0%}
+2     -O                                                                        (1 = 5.3%) {5.3%}
+3     -O                                                                        (1 = 5.3%) {10.5%}
+4     -O                                                                        (1 = 5.3%) {15.8%}
+5     -O                                                                        (1 = 5.3%) {21.1%}
+6     ...
+12    --O                                                                       (2 = 10.5%) {26.3%}
+14    O                                                                         (0 = 0.0%) {36.8%}
+17    -O                                                                        (1 = 5.3%) {36.8%}
+20    --O                                                                       (2 = 10.5%) {42.1%}
+24    ...
+230   --O                                                                       (2 = 10.5%) {52.6%}
+273   ...
+772   -O                                                                        (1 = 5.3%) {63.2%}
+918   -O                                                                        (1 = 5.3%) {68.4%}
+1092  ...
+1545  -O                                                                        (1 = 5.3%) {73.7%}
+1837  O                                                                         (0 = 0.0%) {78.9%}
+2184  -O                                                                        (1 = 5.3%) {78.9%}
+2597  -O                                                                        (1 = 5.3%) {84.2%}
+3088  O                                                                         (0 = 0.0%) {89.5%}
+3672  -O                                                                        (1 = 5.3%) {89.5%}
+4367  ...
+6175  -O                                                                        (1 = 5.3%) {94.7%}
+7343  ...
+Histogram: Sql.Statement.ExecutionTime.TrustTokens recorded 14 samples, mean = 7.0 (flags = 0x41)
+0   O                                                                         (0 = 0.0%)
+1   -O                                                                        (1 = 7.1%) {0.0%}
+2   --O                                                                       (2 = 14.3%) {7.1%}
+3   ---O                                                                      (3 = 21.4%) {21.4%}
+4   ---O                                                                      (3 = 21.4%) {42.9%}
+5   O                                                                         (0 = 0.0%) {64.3%}
+6   -O                                                                        (1 = 7.1%) {64.3%}
+7   -O                                                                        (1 = 7.1%) {71.4%}
+8   -O                                                                        (1 = 7.1%) {78.6%}
+10  O                                                                         (0 = 0.0%) {85.7%}
+12  -O                                                                        (1 = 7.1%) {85.7%}
+14  ...
+34  -O                                                                        (1 = 7.1%) {92.9%}
+40  ...
+Histogram: Sql.Statement.HttpCacheDiskCache.VMSteps recorded 85 samples, mean = 22.4 (flags = 0x41)
+0   ...
+3   ----------------------------------O                                       (34 = 40.0%) {0.0%}
+4   O                                                                         (0 = 0.0%) {40.0%}
+5   -O                                                                        (1 = 1.2%) {40.0%}
+6   ...
+12  ----O                                                                     (4 = 4.7%) {41.2%}
+14  O                                                                         (0 = 0.0%) {45.9%}
+17  ----------O                                                               (10 = 11.8%) {45.9%}
+20  ---------O                                                                (9 = 10.6%) {57.6%}
+24  ...
+34  -O                                                                        (1 = 1.2%) {68.2%}
+40  --------O                                                                 (8 = 9.4%) {69.4%}
+48  --------O                                                                 (8 = 9.4%) {78.8%}
+57  ----------O                                                               (10 = 11.8%) {88.2%}
+68  ...
+Histogram: Sql.Statement.ReportingAndNEL.VMSteps recorded 18 samples, mean = 18.8 (flags = 0x41)
+0   ...
+3   ----O                                                                     (4 = 22.2%) {0.0%}
+4   O                                                                         (0 = 0.0%) {22.2%}
+5   -O                                                                        (1 = 5.6%) {22.2%}
+6   -O                                                                        (1 = 5.6%) {27.8%}
+7   ...
+12  ---O                                                                      (3 = 16.7%) {33.3%}
+14  ...
+20  --O                                                                       (2 = 11.1%) {50.0%}
+24  -O                                                                        (1 = 5.6%) {61.1%}
+29  -O                                                                        (1 = 5.6%) {66.7%}
+34  -----O                                                                    (5 = 27.8%) {72.2%}
+40  ...
+Histogram: Sql.Statement.SharedDictionary.VMSteps recorded 19 samples, mean = 8.9 (flags = 0x41)
+0   ...
+3   --------O                                                                 (8 = 42.1%) {0.0%}
+4   O                                                                         (0 = 0.0%) {42.1%}
+5   -O                                                                        (1 = 5.3%) {42.1%}
+6   ...
+8   -O                                                                        (1 = 5.3%) {47.4%}
+10  O                                                                         (0 = 0.0%) {52.6%}
+12  ------O                                                                   (6 = 31.6%) {52.6%}
+14  O                                                                         (0 = 0.0%) {84.2%}
+17  --O                                                                       (2 = 10.5%) {84.2%}
+20  -O                                                                        (1 = 5.3%) {94.7%}
+24  ...
+Histogram: Sql.Statement.StepTime.Cookie recorded 24 samples, mean = 1352.1 (flags = 0x41)
+0      O                                                                         (0 = 0.0%)
+1      --O                                                                       (2 = 8.3%) {0.0%}
+2      --O                                                                       (2 = 8.3%) {8.3%}
+3      -O                                                                        (1 = 4.2%) {16.7%}
+4      ...
+8      -O                                                                        (1 = 4.2%) {20.8%}
+10     O                                                                         (0 = 0.0%) {25.0%}
+12     --O                                                                       (2 = 8.3%) {25.0%}
+14     -O                                                                        (1 = 4.2%) {33.3%}
+17     ...
+29     -O                                                                        (1 = 4.2%) {37.5%}
+34     ...
+193    -O                                                                        (1 = 4.2%) {41.7%}
+230    -O                                                                        (1 = 4.2%) {45.8%}
+273    ...
+649    ---O                                                                      (3 = 12.5%) {50.0%}
+772    O                                                                         (0 = 0.0%) {62.5%}
+918    --O                                                                       (2 = 8.3%) {62.5%}
+1092   -O                                                                        (1 = 4.2%) {70.8%}
+1299   ...
+1837   -O                                                                        (1 = 4.2%) {75.0%}
+2184   -O                                                                        (1 = 4.2%) {79.2%}
+2597   O                                                                         (0 = 0.0%) {83.3%}
+3088   --O                                                                       (2 = 8.3%) {83.3%}
+3672   ...
+5193   -O                                                                        (1 = 4.2%) {91.7%}
+6175   ...
+10384  -O                                                                        (1 = 4.2%) {95.8%}
+12348  ...
+Histogram: Sql.Statement.StepTime.HttpCacheDiskCache recorded 97 samples, mean = 75.9 (flags = 0x41)
+0     O                                                                         (0 = 0.0%)
+1     -O                                                                        (1 = 1.0%) {0.0%}
+2     --O                                                                       (2 = 2.1%) {1.0%}
+3     -O                                                                        (1 = 1.0%) {3.1%}
+4     ---O                                                                      (3 = 3.1%) {4.1%}
+5     --O                                                                       (2 = 2.1%) {7.2%}
+6     ---O                                                                      (3 = 3.1%) {9.3%}
+7     -----O                                                                    (5 = 5.2%) {12.4%}
+8     ------------O                                                             (12 = 12.4%) {17.5%}
+10    ----O                                                                     (4 = 4.1%) {29.9%}
+12    --O                                                                       (2 = 2.1%) {34.0%}
+14    ----O                                                                     (4 = 4.1%) {36.1%}
+17    ---O                                                                      (3 = 3.1%) {40.2%}
+20    -----O                                                                    (5 = 5.2%) {43.3%}
+24    --O                                                                       (2 = 2.1%) {48.5%}
+29    --O                                                                       (2 = 2.1%) {50.5%}
+34    ---O                                                                      (3 = 3.1%) {52.6%}
+40    ----O                                                                     (4 = 4.1%) {55.7%}
+48    ---O                                                                      (3 = 3.1%) {59.8%}
+57    --------O                                                                 (8 = 8.2%) {62.9%}
+68    -------O                                                                  (7 = 7.2%) {71.1%}
+81    --------O                                                                 (8 = 8.2%) {78.4%}
+96    --O                                                                       (2 = 2.1%) {86.6%}
+114   --O                                                                       (2 = 2.1%) {88.7%}
+136   -O                                                                        (1 = 1.0%) {90.7%}
+162   --O                                                                       (2 = 2.1%) {91.8%}
+193   ---O                                                                      (3 = 3.1%) {93.8%}
+230   ...
+325   -O                                                                        (1 = 1.0%) {96.9%}
+386   ...
+649   -O                                                                        (1 = 1.0%) {97.9%}
+772   ...
+1837  -O                                                                        (1 = 1.0%) {99.0%}
+2184  ...
+Histogram: Sql.Statement.StepTime.ReportingAndNEL recorded 24 samples, mean = 1400.5 (flags = 0x41)
+0     -O                                                                        (1 = 4.2%)
+1     O                                                                         (0 = 0.0%) {4.2%}
+2     -O                                                                        (1 = 4.2%) {4.2%}
+3     --O                                                                       (2 = 8.3%) {8.3%}
+4     ...
+6     --O                                                                       (2 = 8.3%) {16.7%}
+7     O                                                                         (0 = 0.0%) {25.0%}
+8     -O                                                                        (1 = 4.2%) {25.0%}
+10    -O                                                                        (1 = 4.2%) {29.2%}
+12    O                                                                         (0 = 0.0%) {33.3%}
+14    --O                                                                       (2 = 8.3%) {33.3%}
+17    -O                                                                        (1 = 4.2%) {41.7%}
+20    ...
+34    -O                                                                        (1 = 4.2%) {45.8%}
+40    ...
+325   -O                                                                        (1 = 4.2%) {50.0%}
+386   ...
+546   -O                                                                        (1 = 4.2%) {54.2%}
+649   ...
+1299  -O                                                                        (1 = 4.2%) {58.3%}
+1545  -O                                                                        (1 = 4.2%) {62.5%}
+1837  --O                                                                       (2 = 8.3%) {66.7%}
+2184  -O                                                                        (1 = 4.2%) {75.0%}
+2597  --O                                                                       (2 = 8.3%) {79.2%}
+3088  O                                                                         (0 = 0.0%) {87.5%}
+3672  -O                                                                        (1 = 4.2%) {87.5%}
+4367  ...
+6175  -O                                                                        (1 = 4.2%) {91.7%}
+7343  -O                                                                        (1 = 4.2%) {95.8%}
+8732  ...
+Histogram: Sql.Statement.StepTime.SharedDictionary recorded 19 samples, mean = 1068.0 (flags = 0x41)
+0     O                                                                         (0 = 0.0%)
+1     -O                                                                        (1 = 5.3%) {0.0%}
+2     -O                                                                        (1 = 5.3%) {5.3%}
+3     -O                                                                        (1 = 5.3%) {10.5%}
+4     -O                                                                        (1 = 5.3%) {15.8%}
+5     -O                                                                        (1 = 5.3%) {21.1%}
+6     ...
+12    --O                                                                       (2 = 10.5%) {26.3%}
+14    O                                                                         (0 = 0.0%) {36.8%}
+17    -O                                                                        (1 = 5.3%) {36.8%}
+20    --O                                                                       (2 = 10.5%) {42.1%}
+24    ...
+230   --O                                                                       (2 = 10.5%) {52.6%}
+273   ...
+772   -O                                                                        (1 = 5.3%) {63.2%}
+918   -O                                                                        (1 = 5.3%) {68.4%}
+1092  ...
+1545  -O                                                                        (1 = 5.3%) {73.7%}
+1837  O                                                                         (0 = 0.0%) {78.9%}
+2184  -O                                                                        (1 = 5.3%) {78.9%}
+2597  -O                                                                        (1 = 5.3%) {84.2%}
+3088  O                                                                         (0 = 0.0%) {89.5%}
+3672  -O                                                                        (1 = 5.3%) {89.5%}
+4367  ...
+6175  -O                                                                        (1 = 5.3%) {94.7%}
+7343  ...
+Histogram: Sql.Statement.StepTime.TrustTokens recorded 14 samples, mean = 7.0 (flags = 0x41)
+0   O                                                                         (0 = 0.0%)
+1   -O                                                                        (1 = 7.1%) {0.0%}
+2   --O                                                                       (2 = 14.3%) {7.1%}
+3   ---O                                                                      (3 = 21.4%) {21.4%}
+4   ---O                                                                      (3 = 21.4%) {42.9%}
+5   O                                                                         (0 = 0.0%) {64.3%}
+6   -O                                                                        (1 = 7.1%) {64.3%}
+7   -O                                                                        (1 = 7.1%) {71.4%}
+8   -O                                                                        (1 = 7.1%) {78.6%}
+10  O                                                                         (0 = 0.0%) {85.7%}
+12  -O                                                                        (1 = 7.1%) {85.7%}
+14  ...
+34  -O                                                                        (1 = 7.1%) {92.9%}
+40  ...
+Histogram: Sql.Statement.TrustTokens.VMSteps recorded 14 samples, mean = 12.8 (flags = 0x41)
+0   ...
+3   --O                                                                       (2 = 14.3%) {0.0%}
+4   O                                                                         (0 = 0.0%) {14.3%}
+5   -O                                                                        (1 = 7.1%) {14.3%}
+6   ---O                                                                      (3 = 21.4%) {21.4%}
+7   ...
+12  -----O                                                                    (5 = 35.7%) {42.9%}
+14  ...
+20  -O                                                                        (1 = 7.1%) {78.6%}
+24  O                                                                         (0 = 0.0%) {85.7%}
+29  -O                                                                        (1 = 7.1%) {85.7%}
+34  -O                                                                        (1 = 7.1%) {92.9%}
+40  ...
+Histogram: Sql.vfs.SyncTime recorded 11 samples, mean = 0.5 (flags = 0x41)
+0  --------O                                                                 (8 = 72.7%)
+1  -O                                                                        (1 = 9.1%) {72.7%}
+2  --O                                                                       (2 = 18.2%) {81.8%}
+3  ...
+Histogram: Startup.LoadTime.RecordedProcessCreation recorded 1 samples, mean = 1.0 (flags = 0x1)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: ThreadPool.UnnecessaryWakeup.ContentChild.Foreground recorded 3 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  ---O                                                                      (3 = 100.0%) {0.0%}
+2  O                                                                         (0 = 0.0%) {100.0%}
+Histogram: UMA.ChildProcess.Ping.SharedMemorySetUp recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: UMA.PersistentAllocator.EarlyHistograms.UtilityMetrics recorded 1 samples, mean = 1.0 (flags = 0x41)
+0  O                                                                         (0 = 0.0%)
+1  -O                                                                        (1 = 100.0%) {0.0%}
+2  ...
+Histogram: UMA.PersistentAllocator.UtilityMetrics.UsedPct recorded 0 samples (flags = 0x41)
+0 ...
+Histogram: Variations.Limits.VariationKeySize.Default recorded 28 samples, mean = 2.3 (flags = 0x41)
+0  ...
+2  -------------------O                                                      (19 = 67.9%) {0.0%}
+3  ---------O                                                                (9 = 32.1%) {67.9%}
+4  ...

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2499,6 +2499,23 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                     expected_state, expected_stacktrace,
                                     expected_security_flag)
 
+  def test_check_file_line(self):
+    """Tests a recent Chromium CHECK failure and file/line info parsing."""
+    data = self._read_test_data('check_file_line.txt')
+    expected_type = 'CHECK failure'
+    expected_address = ''
+    expected_state = (
+        'atk_child in 143\n'
+        'base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork\n'
+    )
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    environment.set_value('ASSERTS_HAVE_SECURITY_IMPLICATION', False)
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_oom(self):
     """Test an out of memory stacktrace."""
     data = self._read_test_data('oom.txt')


### PR DESCRIPTION
This shows the error, as the file name is incorrectly parsed. The resulting crash state's first line is:

```
atk_child in 143
```

Instead of what it should be:

```
atk_child in ax_tree_formatter_auralinux.cc
```

A subsequent PR will fix the stack trace parsing logic to extract the latter instead.

Bug: https://crbug.com/443678564