### PR TITLE
feat(ci): Enable parallel builds for Ubuntu 20.04 & 24.04 images

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,29 @@
 # limitations under the License.
 
 steps:
-- name: gcr.io/cloud-builders/docker
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Build latest'
   entrypoint: bash
   args:
   - -ex
   - build.sh
+  - latest
+  - ${_GIT_HASH}
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Build Ubuntu 20.04'
+  entrypoint: bash
+  args:
+  - -ex
+  - build.sh
+  - ubuntu-20-04
+  - ${_GIT_HASH}
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'Build Ubuntu 24.04'
+  entrypoint: bash
+  args:
+  - -ex
+  - build.sh
+  - ubuntu-24-04
   - ${_GIT_HASH}
 timeout: 14400s
 options:


### PR DESCRIPTION
Part of: [b/441792502](b/441792502)

## Description

This PR establishes the core technical foundation for our Ubuntu 24.04 migration. As part of this initiative, the CI/CD pipeline is being updated to build and publish Docker images for both Ubuntu 20.04 and 24.04 simultaneously.

This foundational work enables the platform to support both OS versions in parallel, ensuring a stable and incremental migration path without disrupting existing environments.

## Changes Made

- **Parallel Execution in `cloudbuild.yaml`**: The main `cloudbuild.yaml` was refactored to define three distinct, parallel build steps. Each step is responsible for triggering the build of a specific OS version (`latest`, `ubuntu-20-04`, `ubuntu-24-04`).

- **Parameterized Build Script (`build.sh`)**: The `build.sh` script is now parameterized to accept a version tag as an argument. This allows it to be reused by each Cloud Build step to perform the build for the specified version.

- **Dynamic Dockerfile Selection**: The script dynamically selects the correct `Dockerfile` based on the version argument (e.g., `base/ubuntu-24-04.Dockerfile` for the `ubuntu-24-04` version or the standard `base/Dockerfile` for `latest`).

- **Updated Tagging Scheme**: The image tagging convention has been updated to `[VERSION]-[GIT_HASH]-[DATE]` for versioned builds, providing clearer identification in the Artifact Registry. The `latest` tag maintains its existing format for backward compatibility.

## How to Verify

Once this PR is merged, observe the Cloud Build pipeline for a commit. The build should show three parallel steps ("Build latest", "Build Ubuntu 20.04", "Build Ubuntu 24.04") executing successfully.

Verify in the Artifact Registry that new images are pushed with the appropriate tags (e.g., `:latest`, `:ubuntu-20-04`, `:ubuntu-24-04`, and the corresponding unique `stamp` tags).