### PR TITLE
Ignore ___interceptor_backtrace.

### DIFF
--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -437,6 +437,7 @@ STACK_FRAME_IGNORE_REGEXES = [
     r'^_L_unlock_',
     r'^_\$LT\$',
     r'^__GI_',
+    r'^___interceptor_backtrace',
     r'^__asan::',
     r'^__asan_',
     r'^__assert_',


### PR DESCRIPTION
It's not a useful stack frame.

Fixes: https://crbug.com/441556094