### PR TITLE
Run cleanup before tasks even it's not running update task.

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -341,11 +341,11 @@ def update_tests_if_needed():
   tasks.track_task_end()
 
 
-def run():
-  """Run update task."""
-  # Since this code is particularly sensitive for bot stability, continue
-  # execution but store the exception if anything goes wrong during one of these
-  # steps.
+def prepare_environment_for_new_task():
+  """
+  It performs all requirements to cleanup and prepare the 
+  environment for receiving a new task.
+  """
   try:
     # Update heartbeat with current time.
     data_handler.update_heartbeat()
@@ -358,8 +358,16 @@ def run():
     if not environment.is_uworker():
       update_tests_if_needed()
   except Exception:
-    logs.error('Error occurred while running update task.')
+    logs.error('Error occurred while cleaning the environment before the task')
 
+
+def run():
+  """Run update task."""
+  # Since this code is particularly sensitive for bot stability, continue
+  # execution but store the exception if anything goes wrong during one of these
+  # steps.
+
+  prepare_environment_for_new_task()
   # Even if there is an exception in one of the other steps, we want to try to
   # update the source. If for some reason the source code update fails, it is
   # not necessary to run the init scripts.

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -125,7 +125,10 @@ def task_loop():
         update_task.run()
         update_task.track_revision()
       else:
-        logs.info("Update task not enabled. Running platform init scripts.")
+        logs.info(
+            "Update task not enabled. Running environment cleanup and platform init scripts."
+        )
+        update_task.prepare_environment_for_new_task()
         update_task.run_platform_init_scripts()
 
       if environment.is_uworker():


### PR DESCRIPTION
fix: https://g-issues.chromium.org/issues/446692241

The update_task has several actions that goes inside its execution, and one of them is cleaning up the environment for the next task. As the update task was disabled for our platform, we were not cleaning up and setting up the environment for the next task. 

This PR's refact the code enabling the task_loop to prepare the environment before each task. 