### PR TITLE
move fuzz from UtaskLocalExecutor to Utask

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/task_types.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_types.py
@@ -227,7 +227,7 @@ COMMAND_TYPES = {
     'analyze': UTask,
     'blame': TrustedTask,
     'corpus_pruning': UTask,
-    'fuzz': UTaskLocalExecutor,
+    'fuzz': UTask,
     'impact': TrustedTask,
     'minimize': UTask,
     'progression': UTask,


### PR DESCRIPTION
Tries to fix b/446692241.

The fuzz task for black box fuzzer are failing on Batch.

Error stacktrace:

```
node:internal/fs/utils:347
    throw err;
    ^

Error: ENOENT: no such file or directory, scandir '/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-common-data-bundles/v8'
    at Object.readdirSync (node:fs:1450:3)
    at Object.readdirSync (pkg/prelude/bootstrap.js:1306:35)
    at walkDirectory (/snapshot/js_fuzzer/corpus.js:27:29)
    at walkDirectory.next (<anonymous>)
    at V8Corpus.create (/snapshot/js_fuzzer/corpus.js:91:16)
    at Object.create (/snapshot/js_fuzzer/corpus.js:333:49)
    at new RandomCorpusRunner (/snapshot/js_fuzzer/runner.js:81:20)
    at new RandomCorpusRunnerWithFuzzilli (/snapshot/js_fuzzer/runner.js:112:5)
    at ScriptMutator.createRunner (/snapshot/js_fuzzer/script_mutator.js:122:12)
    at main (/snapshot/js_fuzzer/run.js:121:26)
    at Object.<anonymous> (/snapshot/js_fuzzer/run.js:159:1)
    at Module._compile (pkg/prelude/bootstrap.js:1926:22)
    at Module._extensions..js (node:internal/modules/cjs/loader:1166:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Module._load (node:internal/modules/cjs/loader:834:12)
    at Function.runMain (pkg/prelude/bootstrap.js:1979:12)
    at node:internal/main/run_main_module:17:47 {
  errno: -2,
  syscall: 'scandir',
  code: 'ENOENT',
  path: '/mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-common-data-bundles/v8'
}

Node.js v18.5.0
```

It seems the cause it that the `v8` directory was not created, and it depends on downloading it from GCS. Then the suspicious is that the batch execution is not able to download. 

This PR attempts to solve this by moving the fuzz task command type to UTask, as it has the remote way to work, being able to download the required stuff and keeping the local execution as fallback.