### PR TITLE
[Tracing] Fix events timestamp

### DIFF
--- a/src/clusterfuzz/_internal/metrics/events.py
+++ b/src/clusterfuzz/_internal/metrics/events.py
@@ -37,7 +37,7 @@ from clusterfuzz._internal.system import environment
 
 
 def _get_datetime_now(tz_aware=False):
-  """Returns the current datetime (useful for testing)."""
+  """Returns the current UTC datetime (useful for testing)."""
   utc_time = datetime.datetime.now(datetime.timezone.utc)
   if not tz_aware:
     # Remove tz info to comply with the format expected by datastore.


### PR DESCRIPTION
Force usage of UTC when retrieving the timestamp for events. To avoid having to change the timestamp property in datastore to use `tzinfo`, we strip out the the timezone information before converting into the datastore entity.

Per [documentation](https://googleapis.dev/python/python-ndb/latest/model.html#google.cloud.ndb.model.DateTimeProperty), datastore assumes that naive datetimes represent UTC.

This should fix the timestamp differences we having between events emitted from cronjobs and GCE/Batch.