### PR TITLE
[Tracing] Add the back-end structure for the event history table

### DIFF
--- a/src/appengine/handlers/testcase_detail/testcase_status_events.py
+++ b/src/appengine/handlers/testcase_detail/testcase_status_events.py
@@ -15,7 +15,7 @@
 from dataclasses import asdict
 import datetime
 import json
-from typing import Generator
+from typing import Iterator
 from typing import Mapping
 from typing import TypeAlias
 import urllib.parse
@@ -229,7 +229,7 @@ class TestcaseEventHistory:
     event_info['timestamp'] = _format_timestamp(event.timestamp)
     return event_info
 
-  def get_history(self) -> Generator[Mapping, None, None]:
+  def get_history(self) -> Iterator[Mapping]:
     """Get all testcase events information in reverse chronological order."""
     event_history = events.get_events_from_testcase(self._testcase_id)
     for event in event_history:

--- a/src/appengine/handlers/testcase_detail/testcase_status_events.py
+++ b/src/appengine/handlers/testcase_detail/testcase_status_events.py
@@ -12,13 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Helper functions for getting testcase status information from events."""
+from dataclasses import asdict
 import datetime
+import json
+from typing import Generator
 from typing import Mapping
 from typing import TypeAlias
+import urllib.parse
 
+from google.cloud import logging_v2
+
+from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.metrics import events
 
 EventInfo: TypeAlias = dict[str, str | None]
+
+
+def _format_timestamp(timestamp: datetime.datetime) -> str:
+  """Formats a timestamp."""
+  return timestamp.strftime('%Y-%m-%d %H:%M:%S.%f UTC')
 
 
 class TestcaseStatusInfo:
@@ -58,10 +70,6 @@ class TestcaseStatusInfo:
             self._format_testcase_grouping_event,
     }
 
-  def _format_timestamp(self, timestamp: datetime.datetime) -> str:
-    """Formats a timestamp."""
-    return timestamp.strftime('%Y-%m-%d %H:%M:%S.%f UTC')
-
   def _format_string(self, text: str | None) -> str | None:
     """Formats a string by capitalizing words and replacing underscores."""
     if not text:
@@ -76,7 +84,7 @@ class TestcaseStatusInfo:
         'task_stage': event.task_stage,
         'task_status': event.task_status,
         'task_outcome': event.task_outcome,
-        'timestamp': self._format_timestamp(event.timestamp),
+        'timestamp': _format_timestamp(event.timestamp),
     }
 
   def _format_lifecycle_events_common_fields(self,
@@ -84,7 +92,7 @@ class TestcaseStatusInfo:
     """Formats common fields for lifecycle events."""
     return {
         'event_type': self._format_string(event.event_type),
-        'timestamp': self._format_timestamp(event.timestamp),
+        'timestamp': _format_timestamp(event.timestamp),
         'event_info': None,
     }
 
@@ -184,6 +192,73 @@ class TestcaseStatusInfo:
     }
 
 
+class TestcaseEventHistory:
+  """Methods to retrieve the testcase events history."""
+
+  def __init__(self, testcase_id: int):
+    self._testcase_id = testcase_id
+
+  def _get_time_range_filter(self, days: int) -> str:
+    """Returns a filter string for a time range."""
+    start_time = utils.utcnow() - datetime.timedelta(days=days)
+    return f'timestamp >= "{start_time.isoformat()}Z"'
+
+  def _get_task_log_query_filter(self, task_id: str, task_name: str) -> str:
+    """Returns the filter string for querying task logs."""
+    query = (f'jsonPayload.extras.task_id="{task_id}" AND '
+             f'jsonPayload.extras.testcase_id="{self._testcase_id}" AND '
+             f'jsonPayload.extras.task_name="{task_name}"')
+    query += f' AND {self._get_time_range_filter(days=31)}'
+    return query
+
+  def _enrich_event_info_with_gcp_log_url(self, event_info: EventInfo) -> None:
+    """Adds the GCP log URL to the event info."""
+    project_id = utils.get_logging_cloud_project_id()
+    task_id = event_info.get('task_id')
+    task_name = event_info.get('task_name')
+    if project_id and task_id and task_name:
+      query = self._get_task_log_query_filter(task_id, task_name)
+      encoded_query = urllib.parse.quote(query)
+      event_info['gcp_log_url'] = (
+          f'https://console.cloud.google.com/logs/viewer'
+          f'?project={project_id}&query={encoded_query}')
+
+  def _format_event_for_history(self, event: events.Event) -> EventInfo:
+    """Formats an event for display in the event history table."""
+    event_info = {k: v for k, v in asdict(event).items() if v is not None}
+    event_info['timestamp'] = _format_timestamp(event.timestamp)
+    return event_info
+
+  def get_history(self) -> Generator[Mapping, None, None]:
+    """Get all testcase events information in reverse chronological order."""
+    event_history = events.get_events_from_testcase(self._testcase_id)
+    for event in event_history:
+      event_info = self._format_event_for_history(event)
+      self._enrich_event_info_with_gcp_log_url(event_info)
+      yield event_info
+
+  def get_task_log(self, task_id: str, task_name: str) -> str:
+    """Returns the logs for a given task as a string."""
+    project_id = utils.get_logging_cloud_project_id()
+    client = logging_v2.Client(project=project_id)
+    filter_str = self._get_task_log_query_filter(task_id, task_name)
+    entries = client.list_entries(
+        filter_=filter_str, max_results=500, order_by=logging_v2.ASCENDING)
+
+    return '\n'.join(
+        json.dumps(entry.to_api_repr(), indent=2) for entry in entries)
+
+
 def get_testcase_status_info(testcase_id: int) -> Mapping[str, list[EventInfo]]:
   """Public function to retrieve testcase status information."""
   return TestcaseStatusInfo(testcase_id).get_info()
+
+
+def get_testcase_event_history(testcase_id: int) -> list[Mapping]:
+  """Public function to get event history (reverse chronological order)."""
+  return list(TestcaseEventHistory(testcase_id).get_history())
+
+
+def get_task_log(testcase_id: int, task_id: str, task_name: str) -> str:
+  """Public function to return the logs for a given task as a string."""
+  return TestcaseEventHistory(testcase_id).get_task_log(task_id, task_name)

--- a/src/appengine/handlers/testcase_detail/testcase_status_events.py
+++ b/src/appengine/handlers/testcase_detail/testcase_status_events.py
@@ -27,6 +27,8 @@ from clusterfuzz._internal.metrics import events
 
 EventInfo: TypeAlias = dict[str, str | None]
 
+_BASE_LOGS_URL = 'https://console.cloud.google.com/logs/viewer'
+
 
 def _format_timestamp(timestamp: datetime.datetime) -> str:
   """Formats a timestamp."""
@@ -220,8 +222,7 @@ class TestcaseEventHistory:
       query = self._get_task_log_query_filter(task_id, task_name)
       encoded_query = urllib.parse.quote(query)
       event_info['gcp_log_url'] = (
-          f'https://console.cloud.google.com/logs/viewer'
-          f'?project={project_id}&query={encoded_query}')
+          _BASE_LOGS_URL + f'?project={project_id}&query={encoded_query}')
 
   def _format_event_for_history(self, event: events.Event) -> EventInfo:
     """Formats an event for display in the event history table."""

--- a/src/appengine/handlers/testcase_detail/testcase_status_events.py
+++ b/src/appengine/handlers/testcase_detail/testcase_status_events.py
@@ -243,10 +243,11 @@ class TestcaseEventHistory:
     client = logging_v2.Client(project=project_id)
     filter_str = self._get_task_log_query_filter(task_id, task_name)
     entries = client.list_entries(
-        filter_=filter_str, max_results=500, order_by=logging_v2.ASCENDING)
+        filter_=filter_str, max_results=500, order_by=logging_v2.DESCENDING)
 
     return '\n'.join(
-        json.dumps(entry.to_api_repr(), indent=2) for entry in entries)
+        json.dumps(entry.to_api_repr(), indent=2)
+        for entry in reversed(list(entries)))
 
 
 def get_testcase_status_info(testcase_id: int) -> Mapping[str, list[EventInfo]]:

--- a/src/appengine/index.yaml
+++ b/src/appengine/index.yaml
@@ -619,3 +619,9 @@ indexes:
   - name: event_type
   - name: timestamp
     direction: desc
+
+- kind: TestcaseLifecycleEvent
+  properties:
+  - name: testcase_id
+  - name: timestamp
+    direction: desc

--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -254,6 +254,11 @@ def get_application_id():
   return app_id
 
 
+def get_logging_cloud_project_id():
+  """Return logging cloud project id."""
+  return environment.get_value('LOGGING_CLOUD_PROJECT_ID')
+
+
 def get_clusterfuzz_release():
   return os.getenv('CLUSTERFUZZ_RELEASE', 'prod')
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/testcase_detail/testcase_status_events_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/testcase_detail/testcase_status_events_test.py
@@ -16,10 +16,11 @@
 
 import datetime
 import unittest
+from unittest import mock
 
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.metrics import events
-from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
+from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 from handlers.testcase_detail import testcase_status_events
 
@@ -32,8 +33,8 @@ class EventsInfoBasicTest(unittest.TestCase):
     self.testcase_id = self.testcase.key.id()
     self.status_info_instance = testcase_status_events.TestcaseStatusInfo(
         self.testcase_id)
-    test_helpers.patch(
-        self, ['clusterfuzz._internal.config.local_config.ProjectConfig'])
+    helpers.patch(self,
+                  ['clusterfuzz._internal.config.local_config.ProjectConfig'])
     self.mock.ProjectConfig.return_value = {'events.storage': 'datastore'}
 
 
@@ -106,6 +107,7 @@ class EventsInfoTest(EventsInfoBasicTest):
     data_types.TestcaseLifecycleEvent(
         testcase_id=self.testcase_id,
         event_type=events.EventTypes.TASK_EXECUTION,
+        task_id='1',
         task_name='analyze',
         task_stage='stage1',
         task_status='status1',
@@ -115,6 +117,7 @@ class EventsInfoTest(EventsInfoBasicTest):
     data_types.TestcaseLifecycleEvent(
         testcase_id=self.testcase_id,
         event_type=events.EventTypes.TASK_EXECUTION,
+        task_id='1',
         task_name='analyze',
         task_stage='stage2',
         task_status='status2',
@@ -124,6 +127,7 @@ class EventsInfoTest(EventsInfoBasicTest):
     data_types.TestcaseLifecycleEvent(
         testcase_id=self.testcase_id,
         event_type=events.EventTypes.TASK_EXECUTION,
+        task_id='2',
         task_name='minimize',
         task_stage='stage3',
         task_status='status3',
@@ -500,3 +504,254 @@ class GetLastEventInfoTest(EventsInfoTest):
     result = self.status_info_instance.get_last_event_info(
         event_type='non_existent_event_type')
     self.assertEqual(result, {})
+
+
+@test_utils.with_cloud_emulators('datastore')
+class GetTestcaseEventHistoryTest(EventsInfoTest):
+  """Test retrieving testcase event history."""
+
+  def setUp(self):
+    super().setUp()
+    helpers.patch(self, [
+        'clusterfuzz._internal.base.utils.get_logging_cloud_project_id',
+        'clusterfuzz._internal.base.utils.utcnow'
+    ])
+    self.mock.get_logging_cloud_project_id.return_value = 'test-project'
+    self.mock.utcnow.return_value = datetime.datetime(2025, 2, 1, 0, 0, 0)
+
+  def test_get_history(self):
+    """Verify that testcase event history is retrieved correctly."""
+    history = testcase_status_events.get_testcase_event_history(
+        self.testcase_id)
+
+    expected_history = [
+        {
+            'event_type': 'issue_closing',
+            'closing_reason': 'testcase_fixed',
+            'testcase_id': self.testcase_id,
+            'timestamp': '2023-01-04 00:00:00.000000 UTC',
+        },
+        {
+            'event_type': 'issue_filing',
+            'issue_created': True,
+            'issue_id': '123456',
+            'issue_reporter': '@gmail.com',
+            'testcase_id': self.testcase_id,
+            'timestamp': '2023-01-03 00:00:00.000000 UTC',
+        },
+        {
+            'event_type': 'testcase_fixed',
+            'fixed_revision': '123:456',
+            'testcase_id': self.testcase_id,
+            'timestamp': '2023-01-02 00:00:00.000000 UTC',
+        },
+        {
+            'event_type': 'task_execution',
+            'task_name': 'variant',
+            'task_stage': 'stage2',
+            'task_status': 'status3',
+            'task_outcome': 'outcome2',
+            'testcase_id': self.testcase_id,
+            'timestamp': '2023-01-01 14:00:00.000000 UTC',
+        },
+        {
+            'event_type': 'task_execution',
+            'task_name': 'blame',
+            'task_stage': 'stage4',
+            'task_status': 'status4',
+            'task_outcome': 'outcome5',
+            'testcase_id': self.testcase_id,
+            'timestamp': '2023-01-01 13:00:00.000000 UTC',
+        },
+        {
+            'event_type':
+                'task_execution',
+            'task_name':
+                'minimize',
+            'task_stage':
+                'stage3',
+            'task_status':
+                'status3',
+            'testcase_id':
+                self.testcase_id,
+            'task_id':
+                '2',
+            'timestamp':
+                '2023-01-01 11:04:09.000000 UTC',
+            'gcp_log_url': (
+                'https://console.cloud.google.com/logs/viewer'
+                '?project=test-project&query=jsonPayload.extras.task_id%3D%222%22%20AND%20'
+                f'jsonPayload.extras.testcase_id%3D%22{self.testcase_id}%22%20AND%20jsonPayload.extras.task_name'
+                '%3D%22minimize%22%20AND%20timestamp%20%3E%3D%20%222025-01-01T00%3A00%3A00Z%22'
+            )
+        },
+        {
+            'event_type':
+                'task_execution',
+            'task_name':
+                'analyze',
+            'task_stage':
+                'stage2',
+            'task_status':
+                'status2',
+            'testcase_id':
+                self.testcase_id,
+            'task_id':
+                '1',
+            'task_outcome':
+                'outcome2',
+            'timestamp':
+                '2023-01-01 11:03:11.000000 UTC',
+            'gcp_log_url': (
+                'https://console.cloud.google.com/logs/viewer'
+                '?project=test-project&query=jsonPayload.extras.task_id%3D%221%22%20AND%20'
+                f'jsonPayload.extras.testcase_id%3D%22{self.testcase_id}%22%20AND%20jsonPayload.extras.task_name'
+                '%3D%22analyze%22%20AND%20timestamp%20%3E%3D%20%222025-01-01T00%3A00%3A00Z%22'
+            )
+        },
+        {
+            'event_type':
+                'task_execution',
+            'task_name':
+                'analyze',
+            'task_stage':
+                'stage1',
+            'task_status':
+                'status1',
+            'testcase_id':
+                self.testcase_id,
+            'task_id':
+                '1',
+            'task_outcome':
+                'outcome1',
+            'timestamp':
+                '2023-01-01 10:00:00.000000 UTC',
+            'gcp_log_url': (
+                'https://console.cloud.google.com/logs/viewer'
+                '?project=test-project&query=jsonPayload.extras.task_id%3D%221%22%20AND%20'
+                f'jsonPayload.extras.testcase_id%3D%22{self.testcase_id}%22%20AND%20jsonPayload.extras.task_name'
+                '%3D%22analyze%22%20AND%20timestamp%20%3E%3D%20%222025-01-01T00%3A00%3A00Z%22'
+            )
+        },
+        {
+            'event_type': 'testcase_creation',
+            'creation_origin': 'manual_upload',
+            'uploader': '@gmail.com',
+            'testcase_id': self.testcase_id,
+            'timestamp': '2023-01-01 09:00:00.000000 UTC',
+        },
+    ]
+
+    self.assertEqual(list(history), expected_history)
+
+
+@test_utils.with_cloud_emulators('datastore')
+class TestcaseEventHistoryTest(unittest.TestCase):
+  """Tests for TestcaseEventHistory."""
+
+  def setUp(self):
+    """Set up test environment."""
+    super().setUp()
+    self.testcase = test_utils.create_generic_testcase()
+    self.testcase_id = self.testcase.key.id()
+    self.event_history = testcase_status_events.TestcaseEventHistory(
+        self.testcase_id)
+    helpers.patch(self, [
+        'clusterfuzz._internal.base.utils.get_logging_cloud_project_id',
+        'google.cloud.logging_v2.Client',
+        'clusterfuzz._internal.base.utils.utcnow'
+    ])
+    self.mock.utcnow.return_value = datetime.datetime(2025, 2, 1, 0, 0, 0)
+
+  def test_get_time_range_filter(self):
+    """Verify that the time range filter is generated correctly."""
+    result = self.event_history._get_time_range_filter(days=1)
+    self.assertEqual(result, 'timestamp >= "2025-01-31T00:00:00Z"')
+
+  def test_get_task_log_query_filter(self):
+    """Verify that the task log query filter is generated correctly."""
+    result = self.event_history._get_task_log_query_filter(
+        'task123', 'minimize')
+    expected = (f'jsonPayload.extras.task_id="task123" AND '
+                f'jsonPayload.extras.testcase_id="{self.testcase_id}" AND '
+                'jsonPayload.extras.task_name="minimize" AND '
+                'timestamp >= "2025-01-01T00:00:00Z"')
+    self.assertEqual(result, expected)
+
+  def test_enrich_event_info_with_gcp_log_url_no_project(self):
+    """Verify that no log URL is added when the project ID is missing."""
+    self.mock.get_logging_cloud_project_id.return_value = None
+    event_info = {'task_id': 'task123', 'task_name': 'minimize'}
+    self.event_history._enrich_event_info_with_gcp_log_url(event_info)
+    self.assertNotIn('gcp_log_url', event_info)
+
+  def test_enrich_event_info_with_gcp_log_url_no_task_id(self):
+    """Verify that no log URL is added when the task ID is missing."""
+    self.mock.get_logging_cloud_project_id.return_value = 'test-project'
+    event_info = {'other_key': 'value', 'task_name': 'minimize'}
+    self.event_history._enrich_event_info_with_gcp_log_url(event_info)
+    self.assertNotIn('gcp_log_url', event_info)
+
+  def test_enrich_event_info_with_gcp_log_url_no_task_name(self):
+    """Verify that no log URL is added when the task name is missing."""
+    self.mock.get_logging_cloud_project_id.return_value = 'test-project'
+    event_info = {'task_id': 'task123'}
+    self.event_history._enrich_event_info_with_gcp_log_url(event_info)
+    self.assertNotIn('gcp_log_url', event_info)
+
+  def test_enrich_event_info_with_gcp_log_url_success(self):
+    """Verify that the log URL is correctly added to the event info."""
+    self.mock.get_logging_cloud_project_id.return_value = 'test-project'
+    event_info = {'task_id': 'task123', 'task_name': 'minimize'}
+    self.event_history._enrich_event_info_with_gcp_log_url(event_info)
+
+    url_query = (
+        'jsonPayload.extras.task_id%3D%22task123%22%20AND%20jsonPayload.extras.'
+        'testcase_id%3D%221%22%20AND%20jsonPayload.extras.task_name%3D%22minimize%22%20AND%20timestamp'
+        '%20%3E%3D%20%222025-01-01T00%3A00%3A00Z%22')
+
+    self.assertIn('gcp_log_url', event_info)
+    self.assertIn('project=test-project', event_info['gcp_log_url'])
+    self.assertIn(f'query={url_query}', event_info['gcp_log_url'])
+
+  def test_format_event_for_history(self):
+    """Verify that an event is formatted correctly for the history view."""
+    test_event = events.TestcaseCreationEvent(
+        testcase_id=self.testcase_id,
+        creation_origin=events.TestcaseOrigin.MANUAL_UPLOAD,
+        uploader='user@example.com',
+        source=None)
+    test_event.timestamp = datetime.datetime(2023, 1, 1, 10, 0, 0)
+
+    result = self.event_history._format_event_for_history(test_event)
+    self.assertIn('timestamp', result)
+    self.assertEqual(result['timestamp'], '2023-01-01 10:00:00.000000 UTC')
+    self.assertEqual(result['creation_origin'], 'manual_upload')
+    self.assertNotIn('source', result)
+
+  def test_get_task_log_no_project_id(self):
+    """Verify that get_task_log returns an empty string if no project ID is available."""
+    self.mock.get_logging_cloud_project_id.return_value = None
+    self.mock.Client.return_value.list_entries.return_value = []
+    result = self.event_history.get_task_log('task123', 'minimize')
+    self.assertEqual(result, '')
+
+  def test_get_task_log_api_call(self):
+    """Verify that get_task_log calls the logging API correctly."""
+    self.mock.get_logging_cloud_project_id.return_value = 'test-project'
+    mock_client_instance = self.mock.Client.return_value
+    mock_entry1 = mock.Mock()
+    mock_entry1.to_api_repr.return_value = {'payload': 'log1'}
+    mock_client_instance.list_entries.return_value = [mock_entry1]
+    expected_filter = (
+        f'jsonPayload.extras.task_id="task123" AND '
+        f'jsonPayload.extras.testcase_id="{self.testcase_id}" AND '
+        'jsonPayload.extras.task_name="minimize" AND '
+        'timestamp >= "2025-01-01T00:00:00Z"')
+
+    result = self.event_history.get_task_log('task123', 'minimize')
+    self.mock.Client.assert_called_with(project='test-project')
+    mock_client_instance.list_entries.assert_called_with(
+        filter_=expected_filter, max_results=500, order_by=mock.ANY)
+    self.assertIn('"payload": "log1"', result)
+    self.assertEqual(result.count('\n'), 2)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/testcase_detail/testcase_status_events_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/testcase_detail/testcase_status_events_test.py
@@ -742,7 +742,9 @@ class TestcaseEventHistoryTest(unittest.TestCase):
     mock_client_instance = self.mock.Client.return_value
     mock_entry1 = mock.Mock()
     mock_entry1.to_api_repr.return_value = {'payload': 'log1'}
-    mock_client_instance.list_entries.return_value = [mock_entry1]
+    mock_entry2 = mock.Mock()
+    mock_entry2.to_api_repr.return_value = {'payload': 'log2'}
+    mock_client_instance.list_entries.return_value = [mock_entry2, mock_entry1]
     expected_filter = (
         f'jsonPayload.extras.task_id="task123" AND '
         f'jsonPayload.extras.testcase_id="{self.testcase_id}" AND '
@@ -753,5 +755,9 @@ class TestcaseEventHistoryTest(unittest.TestCase):
     self.mock.Client.assert_called_with(project='test-project')
     mock_client_instance.list_entries.assert_called_with(
         filter_=expected_filter, max_results=500, order_by=mock.ANY)
+
     self.assertIn('"payload": "log1"', result)
-    self.assertEqual(result.count('\n'), 2)
+    self.assertIn('"payload": "log2"', result)
+    self.assertLess(
+        result.find('"payload": "log1"'), result.find('"payload": "log2"'))
+    self.assertEqual(result.count('\n'), 5)


### PR DESCRIPTION
This PR adds the back-end structure for the event history table. A subsequent PR will use this structure to display a testcase event history table on the App Engine testcase detail webpage.

Key changes:
- Adds `get_history()`  to retrieve all events for a given testcase. The returned event information includes a URL that points to the GCP logs associated with the event task.
- Adds `get_task_log()` which retrieves the associated task logs from GCP.

Related to b/394060581.