### PR TITLE
Add unicode escape minimization to JS minimization pipeline

### DIFF
--- a/src/clusterfuzz/_internal/bot/minimizer/unicode_minimizer.py
+++ b/src/clusterfuzz/_internal/bot/minimizer/unicode_minimizer.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unicode escape minimizer. Does a single attempt to replace all
+unicode escapes with their corresponding UTF-8 encoded characters."""
+
+import re
+
+from . import errors
+from . import minimizer
+from . import utils
+
+UNICODE_TOKEN_PATTERN = rb'(\\u[0-9a-fA-F]{4})'
+
+
+def is_unicode_escape(s):
+  """Returns true if string matches \\uXXXX pattern."""
+
+  return re.fullmatch(UNICODE_TOKEN_PATTERN, s)
+
+
+def split_and_decode_unicode_literal(s):
+  """Splits the input file by unicode escapes.
+  Then for each of unicode escapes creates two tokens:
+  (1) unicode escape itself (2) utf-8 encoding of unicode escape."""
+
+  intermediate_tokens = re.split(UNICODE_TOKEN_PATTERN, s)
+  tokens = []
+  for token in intermediate_tokens:
+    tokens.append(token)
+    if re.fullmatch(UNICODE_TOKEN_PATTERN, token):
+      hex_code = token[2:]
+      decoded_char = int(hex_code, 16)
+      # JS engines require UTF-8 encoding
+      tokens.append(chr(decoded_char).encode('utf-8'))
+  return tokens
+
+
+def combine_tokens(tokens):
+  """If unicode token is still present,
+  remove the token that was supposed to replace it."""
+  final_tokens = []
+  i = 0
+  while i < len(tokens):
+    final_tokens.append(tokens[i])
+    if is_unicode_escape(tokens[i]):
+      i += 1
+    i += 1
+
+  return b''.join(final_tokens)
+
+
+class UnicodeMinimizer(minimizer.Minimizer):
+  """Minimizer to replace \\u0041 -> a, etc. It works the following way:
+  Let's assume there's 'some text\\u0042some other text\\u0444end' string
+  Tokenizer will split it into ['some text', '\u0042', 'ф', 'some other text',
+  'A', 'end']. So for each unicode-escaped symbol, we will add its
+  corresponding non-escaped symbol into tokens. All tokens together DON'T
+  concat (but combine) to original string. That's the hack that we willingly do.
+  We create a single hypothesis with all unicode escapes.
+  """
+
+  def __init__(self, *args, **kwargs):
+    kwargs['tokenizer'] = split_and_decode_unicode_literal
+    kwargs['token_combiner'] = combine_tokens
+    minimizer.Minimizer.__init__(self, *args, **kwargs)
+
+  def _execute(self, data):
+    testcase = minimizer.Testcase(data, self)
+    if not self.validate_tokenizer(data, testcase):
+      raise errors.TokenizationFailureError('Unicode minimizer')
+    tokens = testcase.tokens
+
+    unicode_hypothesis = []
+    for i, token in enumerate(tokens):
+      if is_unicode_escape(token):
+        unicode_hypothesis.append(i)
+
+    testcase.prepare_test(unicode_hypothesis)
+
+    testcase.process()
+    return testcase
+
+  @staticmethod
+  def run(data, thread_count=minimizer.DEFAULT_THREAD_COUNT, file_extension=''):
+    """Try to minimize |data| using a simple line tokenizer."""
+    unicode_minimizer = UnicodeMinimizer(
+        utils.test, max_threads=thread_count, file_extension=file_extension)
+    return unicode_minimizer.minimize(data)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
@@ -36,6 +36,7 @@ from clusterfuzz._internal.bot.minimizer import errors as minimizer_errors
 from clusterfuzz._internal.bot.minimizer import html_minimizer
 from clusterfuzz._internal.bot.minimizer import js_minimizer
 from clusterfuzz._internal.bot.minimizer import minimizer
+from clusterfuzz._internal.bot.minimizer import unicode_minimizer
 from clusterfuzz._internal.bot.tasks import setup
 from clusterfuzz._internal.bot.tasks import task_creation
 from clusterfuzz._internal.bot.tasks.utasks import uworker_handle_errors
@@ -1338,6 +1339,26 @@ def do_ipc_dump_minimization(test_function, get_temp_file, file_path, deadline,
   return current_minimizer.minimize(file_path)
 
 
+def do_unicode_minimization(test_function, get_temp_file, data, deadline,
+                            threads, cleanup_interval, delete_temp_files):
+  """Attempts unicode escapes minimization."""
+
+  try:
+    current_minimizer = unicode_minimizer.UnicodeMinimizer(
+        test_function=test_function,
+        max_threads=threads,
+        deadline=deadline,
+        cleanup_function=process_handler.cleanup_stale_processes,
+        single_thread_cleanup_interval=cleanup_interval,
+        get_temp_file=get_temp_file,
+        delete_temp_files=delete_temp_files,
+        progress_report_function=logs.info)
+    return current_minimizer.minimize(data)
+  # shouldn't happen, but let's not block whole JS minimization on it.
+  except minimizer_errors.TokenizationFailureError:
+    return data
+
+
 def do_js_minimization(test_function, get_temp_file, data, deadline, threads,
                        cleanup_interval, delete_temp_files):
   """Javascript minimization strategy."""
@@ -1347,6 +1368,9 @@ def do_js_minimization(test_function, get_temp_file, data, deadline, threads,
   for _ in range(2):
     data = do_line_minimization(test_function, get_temp_file, data, deadline,
                                 threads, cleanup_interval, delete_temp_files)
+
+  data = do_unicode_minimization(test_function, get_temp_file, data, deadline,
+                                 threads, cleanup_interval, delete_temp_files)
 
   tokenizer = AntlrTokenizer(JavaScriptLexer)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/minimizer/unicode_minimizer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/minimizer/unicode_minimizer_test.py
@@ -1,0 +1,110 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unicode minimizer unit tests."""
+
+import re
+import unittest
+
+from clusterfuzz._internal.bot.minimizer import unicode_minimizer
+
+
+def replace_unicode(data):
+
+  def replacer(match):
+    hex_code = match.group(1)
+    code_point = int(hex_code, 16)
+    # JS engines require UTF-8 encoded input.
+    return chr(code_point).encode('utf-8')
+
+  pattern = rb'\\u([0-9a-fA-F]{4})'
+  return re.sub(pattern, replacer, data)
+
+
+class UnicodeMinimizerTest(unittest.TestCase):
+  """Helper class for unicode minimization"""
+
+  def setUp(self):
+    self.crash_programs = []
+    self.no_crash_programs = []
+    self._minimizer = unicode_minimizer.UnicodeMinimizer(
+        self._mock_test_function)
+
+  def _mock_test_function(self, data_file):
+    data = open(data_file, 'rb').read()
+    if data in self.crash_programs:
+      return False
+    if data in self.no_crash_programs:
+      return True
+    self.fail("Unreachable code")
+    return True
+
+  def test_minimize_simple_string(self):
+    """Minimizer does not break on simple data."""
+    data = b'simple'
+    self.no_crash_programs.append(data)
+
+    result = self._minimizer.minimize(data)
+
+    self.assertEqual(result, data)
+
+  def test_minimize_buggy_unicode_escape(self):
+    """Program crashes because of \\u0045."""
+    data = b'text \\u0045 text'
+    self.crash_programs.append(data)
+    self.no_crash_programs.append(replace_unicode(data))
+
+    result = self._minimizer.minimize(data)
+
+    self.assertEqual(result, b'text \\u0045 text')
+
+  def test_minimize_not_buggy_unicode_escape(self):
+    """Program crashes not because of \\u0047."""
+    data = b'text \\u0047 text'
+    self.crash_programs.append(data)
+    self.crash_programs.append(replace_unicode(data))
+
+    result = self._minimizer.minimize(data)
+
+    self.assertEqual(result, b'text G text')
+
+  def test_minimize_not_buggy_unicode_escape_not_ascii(self):
+    """Program crashes not because of \\u0444."""
+    data = b'text \\u0444 text'
+    self.crash_programs.append(data)
+    self.crash_programs.append(replace_unicode(data))
+
+    result = self._minimizer.minimize(data)
+
+    self.assertEqual(result.decode('utf-8'), 'text ф text')
+
+  def test_minimize_buggy_unicode_escape_multi_unicode(self):
+    """Program crashes because of \\u0045."""
+    data = b'text \\u0045 text \\u0047 some text \\u0048 some other text \\u0049 yet another text'
+    self.crash_programs.append(data)
+    self.no_crash_programs.append(replace_unicode(data))
+
+    result = self._minimizer.minimize(data)
+
+    self.assertEqual(result, data)
+
+  def test_minimize_not_buggy_unicode_escape_multi_unicode(self):
+    """Program doesn't crash because of unicode"""
+    data = b'text \\u0045 text \\u0047 some text \\u0048 some other text \\u0049 yet another text'
+    self.crash_programs.append(data)
+    self.crash_programs.append(replace_unicode(data))
+
+    result = self._minimizer.minimize(data)
+
+    self.assertEqual(
+        result, b'text E text G some text H some other text I yet another text')


### PR DESCRIPTION
We are now fuzzing by replacing characters in JS identifiers with their Unicode escapes:
console.log(42); -> consol\u0065.log(42);

Most often Unicode escapes won't be the problem, so we want to minimize them back to the original character:
consol\u0065.log(42); -> console.log(42);

Thus we add a Unicode minimizer to JS minimization pipeline. Unicode minimizer makes a single attempt at replacing all Unicode escapes with their corresponding UTF-8 characters and seeing if the crash still reproduces after. If it doesn't reproduce after, Unicode minimizer keeps the program as it was.

The difference with the other minimizers is that they were implemented to remove tokens, while this one is replacing tokens.

Thus when we tokenize "consol\u0065.log(42);", we tokenize it into ["consol", "\u0065", "e", ".log(42);"]. Then we try to remove Unicode escapes. If unsuccessful we combine Unicode escapes with their corresponding token by keeping only Unicode escapes: ["consol", "\u0065", "e", ".log(42);"] -> ["consol", "\u0065", ".log(42);"] -> consol\u0065.log(42); 

The code was unit tested and tested from the UI with a local deployment of Clusterfuzz.