### PR TITLE
Implement dev immutable image

### DIFF
--- a/docker/build-immutable.sh
+++ b/docker/build-immutable.sh
@@ -15,6 +15,7 @@
 
 IMAGES=(
   gcr.io/clusterfuzz-images/chromium/base/immutable
+  gcr.io/clusterfuzz-images/chromium/base/immutable/dev
   gcr.io/clusterfuzz-images/base/immutable
 )
 

--- a/docker/chromium/base/immutable/dev/Dockerfile
+++ b/docker/chromium/base/immutable/dev/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM gcr.io/clusterfuzz-images/chromium/base
+
+ENV IMMUTABLE_IMAGE=true
+
+ARG CLUSTERFUZZ_SOURCE_DIR
+
+COPY ${CLUSTERFUZZ_SOURCE_DIR} /data/clusterfuzz
+
+RUN cd /data/clusterfuzz && bash local/install_deps.bash
+
+RUN cp -r /data/clusterfuzz/clusterfuzz-config/configs/chrome-development /data/clusterfuzz/src/appengine/config
+
+RUN rm -rf /data/clusterfuzz/clusterfuzz-config


### PR DESCRIPTION
Implement b/449958340

It implements the immutable image for development environment. The instances for development uses the same base image of internal, but changing its config. 

