### PR TITLE
feat(docker): Add BASE_OS_VERSION to Ubuntu 24.04 image

### DIFF
--- a/docker/base/ubuntu-24-04.Dockerfile
+++ b/docker/base/ubuntu-24-04.Dockerfile
@@ -127,6 +127,8 @@ WORKDIR $INSTALL_DIRECTORY
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV PYTHONIOENCODING UTF-8
+ENV BASE_OS_VERSION=ubuntu-24-04
+
 
 COPY Pipfile Pipfile.lock setup_common.sh setup_clusterfuzz.sh start_clusterfuzz.sh setup_mock_metadata.sh start.sh /data/
 RUN cd /data && \


### PR DESCRIPTION
This PR adds the `BASE_OS_VERSION` environment variable to the `ubuntu-24-04` Docker image.

This is a prerequisite for the OS-based task routing feature. Adding this in a separate, small PR allows the new image to be built and available sooner, unblocking the main feature rollout.

Once this is merged, bots running this image will have the necessary environment variable to identify their OS version and pull tasks from the correct, filtered Pub/Sub subscription.