### PR TITLE
[CLI] lint: run butler format on CLI files

### DIFF
--- a/cli/casp/src/casp/__init__.py
+++ b/cli/casp/src/casp/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/casp/src/casp/commands/__init__.py
+++ b/cli/casp/src/casp/commands/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/casp/src/casp/commands/init.py
+++ b/cli/casp/src/casp/commands/init.py
@@ -15,6 +15,7 @@
 
 import click
 
+
 @click.command(name='init', help='Initializes the CLI')
 def cli():
   """Initializes the CLI"""

--- a/cli/casp/src/casp/commands/reproduce.py
+++ b/cli/casp/src/casp/commands/reproduce.py
@@ -15,6 +15,7 @@
 
 import click
 
+
 @click.command(name='reproduce', help='Reproduces a testcase locally')
 def cli():
   """Reproduces a testcase locally"""

--- a/cli/casp/src/casp/commands/run_task.py
+++ b/cli/casp/src/casp/commands/run_task.py
@@ -15,6 +15,7 @@
 
 import click
 
+
 @click.command(name='run_task', help='Runs a given task locally')
 def cli():
   """Runs a given task locally"""


### PR DESCRIPTION
This PR fixes some feel lint errors in the `cli/` folder

_Note:_ 
To isolate and fix the errors in this specific folder, I temporarily modified the file discovery logic in `butler/lint.py` and `butler/format.py` to target only the `cli/` path:

```python
_, output = common.execute('git ls-files cli') # here's the tmp change
file_paths = [
    f.decode('utf-8') for f in output.splitlines() if os.path.exists(f)
]
```