### PR TITLE
docker: base: add Ruby to runtime images

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -86,6 +86,16 @@ RUN curl -sS https://releases.nixos.org/patchelf/patchelf-0.9/patchelf-0.9.tar.b
     make install && \
     rm -rf /tmp/patchelf-*
 
+# Install Ruby, for Ruby fuzzing.
+RUN apt-get install -y binutils xz-utils libyaml-dev libffi-dev zlib1g-dev && \
+    RUBY_VERSION=3.3.1 && \
+    curl -O https://cache.ruby-lang.org/pub/ruby/3.3/ruby-$RUBY_VERSION.tar.gz && \
+    tar -xvf ruby-$RUBY_VERSION.tar.gz && \
+    cd ruby-$RUBY_VERSION && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install
+
 # Install OpenJDK 17 for Jazzer (Java fuzzer).
 # Copied from gcr.io/oss-fuzz-base/base-runner.
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64

--- a/docker/base/ubuntu-20-04.Dockerfile
+++ b/docker/base/ubuntu-20-04.Dockerfile
@@ -86,6 +86,16 @@ RUN curl -sS https://releases.nixos.org/patchelf/patchelf-0.9/patchelf-0.9.tar.b
     make install && \
     rm -rf /tmp/patchelf-*
 
+# Install Ruby, for Ruby fuzzing.
+RUN apt-get install -y binutils xz-utils libyaml-dev libffi-dev zlib1g-dev && \
+    RUBY_VERSION=3.3.1 && \
+    curl -O https://cache.ruby-lang.org/pub/ruby/3.3/ruby-$RUBY_VERSION.tar.gz && \
+    tar -xvf ruby-$RUBY_VERSION.tar.gz && \
+    cd ruby-$RUBY_VERSION && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install
+
 # Install OpenJDK 17 for Jazzer (Java fuzzer).
 # Copied from gcr.io/oss-fuzz-base/base-runner.
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64

--- a/docker/base/ubuntu-24-04.Dockerfile
+++ b/docker/base/ubuntu-24-04.Dockerfile
@@ -63,6 +63,16 @@ RUN curl -sS https://releases.nixos.org/patchelf/patchelf-0.9/patchelf-0.9.tar.b
     make install && \
     rm -rf /tmp/patchelf-*
 
+# Install Ruby, for Ruby fuzzing.
+RUN apt-get install -y binutils xz-utils libyaml-dev libffi-dev zlib1g-dev && \
+    RUBY_VERSION=3.3.1 && \
+    curl -O https://cache.ruby-lang.org/pub/ruby/3.3/ruby-$RUBY_VERSION.tar.gz && \
+    tar -xvf ruby-$RUBY_VERSION.tar.gz && \
+    cd ruby-$RUBY_VERSION && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install
+
 # Install OpenJDK 17 for Jazzer (Java fuzzer).
 # Copied from gcr.io/oss-fuzz-base/base-runner.
 ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64


### PR DESCRIPTION
We need Ruby in the runtime of the bots. This is to complete the set up initiated in https://github.com/google/oss-fuzz/pull/12034 although there has been a few changes on OSS-Fuzz since then. Ruby was only ever added to the OSS-Fuzz images in the OSS-Fuzz repository https://github.com/google/oss-fuzz/blob/483914a15ba37b5cb157f3c4f87656adf8279644/infra/base-images/base-runner/Dockerfile#L112-L118 but not here. So it never worked on the actual bots.

Related PR on OSS-Fuzz: https://github.com/google/oss-fuzz/pull/14239