### PR TITLE
feat: Add USE_GCLOUD_STORAGE_RSYNC=1 to batch fallback init script

### DIFF
--- a/configs/test/gce/linux-init.yaml
+++ b/configs/test/gce/linux-init.yaml
@@ -46,7 +46,7 @@ write_files:
       [Service]
       Environment="HOME=/home/root"
       ExecStartPre=/usr/bin/docker-credential-gcr configure-docker
-      ExecStart=/bin/bash -c 'export IMAGE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/docker-image) && /usr/bin/docker pull $IMAGE && /usr/bin/docker run --memory-swappiness=40 --shm-size=1.9g --rm --net=host -e HOST_UID=1337 -P --privileged --cap-add=all -v /var/scratch0:/mnt/scratch0 --name=clusterfuzz $IMAGE'
+      ExecStart=/bin/bash -c 'export IMAGE=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/docker-image) && /usr/bin/docker pull $IMAGE && /usr/bin/docker run --memory-swappiness=40 --shm-size=1.9g --rm --net=host -e HOST_UID=1337 -e USE_GCLOUD_STORAGE_RSYNC=1 -P --privileged --cap-add=all -v /var/scratch0:/mnt/scratch0 --name=clusterfuzz $IMAGE'
       ExecStop=/usr/bin/docker stop clusterfuzz
       ExecStopPost=/usr/bin/docker rm clusterfuzz
       Restart=always


### PR DESCRIPTION
This commit adds the USE_GCLOUD_STORAGE_RSYNC=1 environment variable to the linux-init.yaml fallback script used by Cloud Batch jobs.

This ensures that all Cloud Batch containers (bots and batch jobs) will have this environment variable set, enabling rsync for GCS operations.

File modified:
- configs/test/gce/linux-init.yaml
  - Added '-e USE_GCLOUD_STORAGE_RSYNC=1' to the 'docker run' command in the ExecStart section.