### PR TITLE
[Chore] Add missing messages for skipping triage

### DIFF
--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -265,7 +265,8 @@ def _check_and_update_similar_bug(testcase, issue_tracker):
     if similar_testcase.open and not similar_testcase.one_time_crasher_flag:
       _add_triage_message(
           testcase, 'Delaying filing a bug since similar reproducible testcase '
-          f'({similar_testcase.key.id()}) in issue ({issue.id}) is open.')
+          f'({similar_testcase.key.id()} in issue {issue.id}) is not verified '
+          'yet.')
       return True
 
     # If the issue is still open, no need to file a duplicate bug.
@@ -298,7 +299,7 @@ def _check_and_update_similar_bug(testcase, issue_tracker):
       _add_triage_message(
           testcase,
           'Skipping filing unreproducible bug since one was already filed '
-          f'({similar_testcase.key.id()}).')
+          f'({similar_testcase.key.id()} in issue {issue.id}).')
       return True
 
     # If the issue is recently closed, wait certain time period to make sure


### PR DESCRIPTION
When a testcase skips opening a bug due to a similar open (or recently closed) testcase, we add a triage message to inform this on the UI. However, there were two cases that missed this message and were causing confusion to our users. This PR addresses them.

Request: b/435645636