### PR TITLE
[fix] Move the place to set base os version to bulk add tasks

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -817,7 +817,7 @@ def bulk_add_tasks(tasks, queue=None, eta_now=False):
     if job.base_os_version:
       task.extra_info['base_os_version'] = job.base_os_version
 
-    if job.is_external():
+    if utils.is_oss_fuzz():
       oss_fuzz_project = data_types.OssFuzzProject.query(
           data_types.OssFuzzProject.name == job.project).get()
       if oss_fuzz_project and oss_fuzz_project.base_os_version:

--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -274,7 +274,7 @@ def _get_config_names(
 
     # If we are running in the oss-fuzz context, the project-specific config
     # is more specific and overrides the job-level one.
-    if job.is_external():
+    if utils.is_oss_fuzz():
       oss_fuzz_project = data_types.OssFuzzProject.query(
           data_types.OssFuzzProject.name == job.project).get()
       if oss_fuzz_project and oss_fuzz_project.base_os_version:

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
@@ -358,13 +358,14 @@ class AddTasksTest(unittest.TestCase):
 
   @mock.patch('clusterfuzz._internal.google_cloud_utils.pubsub.PubSubClient')
   @mock.patch('clusterfuzz._internal.base.tasks.data_types.Job.query')
-  def test_bulk_add_tasks_internal_job_with_os_version(self, mock_job_query,
-                                                       mock_pubsub_client):
+  @mock.patch('clusterfuzz._internal.base.tasks.utils.is_oss_fuzz')
+  def test_bulk_add_tasks_internal_job_with_os_version(
+      self, mock_is_oss_fuzz, mock_job_query, mock_pubsub_client):
     """Test bulk_add_tasks with an internal job and an OS version."""
+    mock_is_oss_fuzz.return_value = False
     mock_job = mock.MagicMock()
     mock_job.base_os_version = 'ubuntu-20-04'
     mock_job.project = 'd8'
-    mock_job.is_external.return_value = False
     mock_job_query.return_value.get.return_value = mock_job
 
     task = tasks.Task("regression", "123", "linux_asan_d8_dbg")
@@ -377,13 +378,14 @@ class AddTasksTest(unittest.TestCase):
 
   @mock.patch('clusterfuzz._internal.google_cloud_utils.pubsub.PubSubClient')
   @mock.patch('clusterfuzz._internal.base.tasks.data_types.Job.query')
-  def test_bulk_add_tasks_external_job_with_os_version(self, mock_job_query,
-                                                       mock_pubsub_client):
+  @mock.patch('clusterfuzz._internal.base.tasks.utils.is_oss_fuzz')
+  def test_bulk_add_tasks_external_job_with_os_version(
+      self, mock_is_oss_fuzz, mock_job_query, mock_pubsub_client):
     """Test bulk_add_tasks with an external (OSS-Fuzz) job and an OS version."""
+    mock_is_oss_fuzz.return_value = True
     mock_job = mock.MagicMock()
     mock_job.base_os_version = None  # No version on job.
     mock_job.project = 'd8'
-    mock_job.is_external.return_value = True
     mock_job_query.return_value.get.return_value = mock_job
 
     task = tasks.Task("regression", "123", "linux_asan_d8_dbg")

--- a/src/clusterfuzz/_internal/tests/core/google_cloud_utils/batch_test.py
+++ b/src/clusterfuzz/_internal/tests/core/google_cloud_utils/batch_test.py
@@ -149,23 +149,25 @@ class GetSpecsFromConfigTest(unittest.TestCase):
         [batch.BatchTask('fuzz', job_name, None)])
     self.assertEqual(spec['fuzz', job_name].disk_size_gb, overridden_size)
 
-  @mock.patch('clusterfuzz._internal.google_cloud_utils.batch.environment')
+  @mock.patch(
+      'clusterfuzz._internal.google_cloud_utils.batch.utils.is_oss_fuzz')
   @mock.patch('clusterfuzz._internal.datastore.data_types.OssFuzzProject.query')
   @mock.patch('clusterfuzz._internal.datastore.ndb_utils.get_all_from_query')
-  def test_get_config_names_os_version(self, mock_get_jobs, mock_query_project,
-                                       mock_env):
+  def test_get_config_names_os_version(self, mock_get_all_from_query,
+                                       mock_oss_fuzz_project_query,
+                                       mock_is_oss_fuzz):
     """Test the hierarchical logic for determining base_os_version."""
     # Test Case 1: Internal project, job-level OS version is used.
-    mock_env.get_value.return_value = 'internal-project'
+    mock_is_oss_fuzz.return_value = False
     job1 = data_types.Job(
         name='job1', platform='LINUX', base_os_version='job-os-ubuntu-20')
-    mock_get_jobs.return_value = [job1]
+    mock_get_all_from_query.return_value = [job1]
     config_map = batch._get_config_names(
         [batch.BatchTask('fuzz', 'job1', None)])
     self.assertEqual(config_map[('fuzz', 'job1')][2], 'job-os-ubuntu-20')
 
     # Test Case 2: OSS-Fuzz project, project-level version overrides job-level.
-    mock_env.get_value.return_value = 'oss-fuzz'
+    mock_is_oss_fuzz.return_value = True
     job2 = data_types.Job(
         name='job2',
         project='my-project',
@@ -173,35 +175,35 @@ class GetSpecsFromConfigTest(unittest.TestCase):
         base_os_version='job-os-ubuntu-20')
     project = data_types.OssFuzzProject(
         name='my-project', base_os_version='project-os-ubuntu-24')
-    mock_get_jobs.return_value = [job2]
-    mock_query_project.return_value.get.return_value = project
+    mock_get_all_from_query.return_value = [job2]
+    mock_oss_fuzz_project_query.return_value.get.return_value = project
     config_map = batch._get_config_names(
         [batch.BatchTask('fuzz', 'job2', None)])
     self.assertEqual(config_map[('fuzz', 'job2')][2], 'project-os-ubuntu-24')
 
     # Test Case 3: OSS-Fuzz project, only project-level version exists.
     job3 = data_types.Job(name='job3', project='my-project', platform='LINUX')
-    mock_get_jobs.return_value = [job3]
-    mock_query_project.return_value.get.return_value = project
+    mock_get_all_from_query.return_value = [job3]
+    mock_oss_fuzz_project_query.return_value.get.return_value = project
     config_map = batch._get_config_names(
         [batch.BatchTask('fuzz', 'job3', None)])
     self.assertEqual(config_map[('fuzz', 'job3')][2], 'project-os-ubuntu-24')
 
     # Test Case 4: Internal project, no version is set, should be None.
-    mock_env.get_value.return_value = 'internal-project'
+    mock_is_oss_fuzz.return_value = False
     job4 = data_types.Job(name='job4', platform='LINUX')
-    mock_get_jobs.return_value = [job4]
+    mock_get_all_from_query.return_value = [job4]
     config_map = batch._get_config_names(
         [batch.BatchTask('fuzz', 'job4', None)])
     self.assertIsNone(config_map[('fuzz', 'job4')][2])
 
     # Test Case 5: OSS-Fuzz project, but no versions are set anywhere.
-    mock_env.get_value.return_value = 'oss-fuzz'
+    mock_is_oss_fuzz.return_value = True
     job5 = data_types.Job(
         name='job5', project='my-project-no-version', platform='LINUX')
     project_no_version = data_types.OssFuzzProject(name='my-project-no-version')
-    mock_get_jobs.return_value = [job5]
-    mock_query_project.return_value.get.return_value = project_no_version
+    mock_get_all_from_query.return_value = [job5]
+    mock_oss_fuzz_project_query.return_value.get.return_value = project_no_version
     config_map = batch._get_config_names(
         [batch.BatchTask('fuzz', 'job5', None)])
     self.assertIsNone(config_map[('fuzz', 'job5')][2])


### PR DESCRIPTION
Moves the logic to set the task base_os_version from add_task to bulk_add_tasks, because add_task is not the final place where tasks are added to the queue. add_task calls bulk_add_tasks, and bulk_add_tasks is called from other places, for instance, the schedule fuzz.

Without this fix, the tasks cannot be routed properly to the right bots, as the base_os_version is omitted by the tasks scheduled by the schedule fuzz cronjob.