### PR TITLE
Revert "feat: Add USE_GCLOUD_STORAGE_RSYNC=1 to Cloud Batch Jobs"

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/batch.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/batch.py
@@ -133,7 +133,6 @@ def _get_task_spec(batch_workload_spec):
       '-e HOST_UID=1337 -P --privileged --cap-add=all '
       f'-e CLUSTERFUZZ_RELEASE={clusterfuzz_release} '
       '--name=clusterfuzz -e UNTRUSTED_WORKER=False -e UWORKER=True '
-      '-e USE_GCLOUD_STORAGE_RSYNC=1 '
       '-e UWORKER_INPUT_DOWNLOAD_URL')
   runnable.container.volumes = ['/var/scratch0:/mnt/scratch0']
   task_spec = batch.TaskSpec()


### PR DESCRIPTION
Reverts google/clusterfuzz#5017

The original change aimed to migrate storage synchronization by enabling `gcloud storage rsync`. However, post-deployment monitoring revealed an issue: while `gsutil` rsync usage decreased as expected, there was no corresponding increase in `gcloud storage` rsync operations.

Following a "rollback first" policy to ensure system stability, this change reverts the feature enablement to allow for a more detailed investigation into the root cause of this discrepancy. The feature will be re-evaluated and potentially re-introduced after a thorough analysis