### PR TITLE
[CLI] Run command inside docker container

### DIFF
--- a/cli/casp/src/casp/tests/utils/test_docker.py
+++ b/cli/casp/src/casp/tests/utils/test_docker.py
@@ -129,7 +129,7 @@ class PullImageTest(unittest.TestCase):
         docker.models.images.ImageCollection, instance=True, spec_set=True)
     mock_client.images = mock_images_collection
 
-    result = docker_utils.pull_image()
+    result = docker_utils.pull_image(docker_utils.PROJECT_TO_IMAGE["internal"])
 
     self.assertTrue(result)
     mock_echo.assert_called_once()
@@ -149,7 +149,7 @@ class PullImageTest(unittest.TestCase):
   def test_pull_image_docker_setup_fails(self, mock_echo, mock_secho,
                                          mock_check_docker_setup):
     """Tests when check_docker_setup returns None."""
-    result = docker_utils.pull_image()
+    result = docker_utils.pull_image(docker_utils.PROJECT_TO_IMAGE["internal"])
 
     self.assertFalse(result)
     mock_check_docker_setup.assert_called_once()
@@ -172,7 +172,7 @@ class PullImageTest(unittest.TestCase):
     mock_images_collection.pull.side_effect = docker.errors.DockerException(
         "Image not found")
 
-    result = docker_utils.pull_image()
+    result = docker_utils.pull_image(docker_utils.PROJECT_TO_IMAGE["internal"])
 
     self.assertFalse(result)
     mock_echo.assert_called_once_with(

--- a/cli/casp/src/casp/utils/docker_utils.py
+++ b/cli/casp/src/casp/utils/docker_utils.py
@@ -60,7 +60,7 @@ def check_docker_setup() -> docker.client.DockerClient | None:
     return None
 
 
-def pull_image(image: str = PROJECT_TO_IMAGE['internal']) -> bool:
+def pull_image(image: str) -> bool:
   """Pulls the docker image."""
   client = check_docker_setup()
   if not client:


### PR DESCRIPTION
This PR introduces a utility function that executes a command within a Docker container. It's a crucial function for the CLI, as most of its commands run inside a container.

Here's the function's description, which can also be found in its docstring:
```
Runs a command in a docker container and streams logs.
Args:
  command: The command to run.
  volumes: A dictionary of volumes to mount.
  image: The docker image to use.
  privileged: Whether to run the container as privileged.
Returns:
  True on success, False otherwise.
```

Here are two printouts of it in action. The first one simply prints "hello" in the container, and the second one runs `reproduce` for an `internal` testcase.

* `echo hello`
<img width="1713" height="350" alt="image" src="https://github.com/user-attachments/assets/727ce923-6ac1-44ad-937b-884a6bb337b3" />

* `reproduce` (truncated)
<img width="1866" height="736" alt="image" src="https://github.com/user-attachments/assets/ab7640ee-03b8-49af-ab64-9944936f8621" />
<img width="961" height="192" alt="image" src="https://github.com/user-attachments/assets/53d9f251-a237-4645-a8c6-1e164db3d907" />


