### PR TITLE
[CLI]  Add google auth dependencies in casp pyproject

### DIFF
--- a/cli/casp/pyproject.toml
+++ b/cli/casp/pyproject.toml
@@ -18,7 +18,9 @@ classifiers = [
 ]
 dependencies = [
     "click",
-    "docker"
+    "docker",
+    "google",
+    "google-auth"
 ]
 
 [project.urls]


### PR DESCRIPTION
### Context 

When using the CLI locally, some dependencies were already installed, but were missing when running in a new environment.

### Changes made

This PR adds the `google` and `google-auth` dependencies to `pyproject.toml` for `casp`. These dependencies are used to validate `gcloud` user credentials.
