### PR TITLE
fix python sdk version

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -128,7 +128,6 @@ RUN ln -s /usr/local/bin/python3.11 /usr/bin/python3.11
 COPY setup_19.x /data
 RUN bash setup_19.x && apt-get update -y && apt-get install -y nodejs
 
-
 ENV CLOUDSDK_PYTHON=python3.11
 
 RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \

--- a/docker/base/ubuntu-20-04.Dockerfile
+++ b/docker/base/ubuntu-20-04.Dockerfile
@@ -128,8 +128,9 @@ RUN ln -s /usr/local/bin/python3.11 /usr/bin/python3.11
 COPY setup_19.x /data
 RUN bash setup_19.x && apt-get update -y && apt-get install -y nodejs
 
-RUN export CLOUDSDK_PYTHON=python3.11 && \
-    echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \
+ENV CLOUDSDK_PYTHON=python3.11
+
+RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | apt-key add - && \

--- a/docker/base/ubuntu-24-04.Dockerfile
+++ b/docker/base/ubuntu-24-04.Dockerfile
@@ -110,8 +110,9 @@ RUN cd /tmp && \
     rm node.tar.xz
 ENV PATH="/usr/local/node/bin:${PATH}"
 
-RUN export CLOUDSDK_PYTHON=python3.11 && \
-    echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \
+ENV CLOUDSDK_PYTHON=python3.11
+
+RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | apt-key add - && \


### PR DESCRIPTION
The base image is not setting the python3.11 and the CLOUD_SDK version because it's doing it by using `export` in a RUN command and not using the `ENV`. 


It fix it by moving the CLOUD_SDK to ENV. 
<img width="1096" height="384" alt="image" src="https://github.com/user-attachments/assets/af7d309b-268c-4aaa-9f67-cebd44ee1492" />
