### PR TITLE
enforce python3.11 as cloudsdk_python

### DIFF
--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export CLOUDSDK_PYTHON=python3.11
+
 if [ -z "$DEPLOYMENT_BUCKET" ]; then
   # Get deployment bucket from project metadata.
   export DEPLOYMENT_BUCKET=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/attributes/deployment-bucket)


### PR DESCRIPTION
Even after setting the $CLOUDSDK_PYTHON correctly to be persisted on the image on #5039, the gsutil command continues to try to use python3.8. 

The screenshot below shows that the env var is set and the gsutil is getting the correct Python version. 

<img width="910" height="369" alt="image" src="https://github.com/user-attachments/assets/70cc8c51-3534-4091-b451-690b6b598f3a" />

But in this [Batch log](https://pantheon.corp.google.com/batch/jobsDetail/regions/us-central1/jobs/j-221811e7-1ec3-4571-8195-beb65a5b666d/logs?e=-13802955&mods=logs_tg_prod&project=clusterfuzz-development), the gsutil is still using python3.8 and failing. 

It seems that for some reason the env var is being unset or overriden before reaching the gsutil command. 

This PR explicitly set the env var in the only file that performs the gcloud/gsutil command for python3.11.
