### PR TITLE
Support distinct handling and configuration for DCHECK failures

### DIFF
--- a/src/clusterfuzz/_internal/crash_analysis/crash_analyzer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/crash_analyzer.py
@@ -320,15 +320,20 @@ def is_security_issue(crash_stacktrace, crash_type, crash_address):
     return True
 
   if crash_type == 'CHECK failure':
-    # TODO(ochang): Remove this once we pick up newer builds that distinguish
-    # DCHECKs from CHECKs.
     checks_have_security_implication = environment.get_value(
         'CHECKS_HAVE_SECURITY_IMPLICATION', False)
     return checks_have_security_implication
 
-  # Debug CHECK failure should be marked with security implications.
-  if crash_type in ('Security DCHECK failure', 'DCHECK failure'):
+  # Security DCHECKs are always security issues.
+  if crash_type == 'Security DCHECK failure':
     return True
+
+  # For regular DCHECKs, projects can choose whether or not a particular fuzzer
+  # job treats them as security issues.
+  if crash_type == 'DCHECK failure':
+    dchecks_have_security_implication = environment.get_value(
+        'DCHECKS_HAVE_SECURITY_IMPLICATION', True)
+    return dchecks_have_security_implication
 
   # Hard crash, explicitly enforced in code.
   if (crash_type == 'Fatal error' or crash_type == 'Unreachable code' or

--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -323,7 +323,9 @@ def file_issue(testcase,
   is_crash = not utils.sub_string_exists_in(NON_CRASH_TYPES,
                                             testcase.crash_type)
   properties = policy.get_new_issue_properties(
-      is_security=testcase.security_flag, is_crash=is_crash)
+      is_security=testcase.security_flag,
+      is_crash=is_crash,
+      crash_type=testcase.crash_type)
 
   issue = issue_tracker.new_issue()
   issue.title = data_handler.get_issue_summary(testcase)

--- a/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/issue_filer_test.py
@@ -49,12 +49,28 @@ CHROMIUM_POLICY = issue_tracker_policy.IssueTrackerPolicy({
     },
     'all': {
         'status': 'new',
-        'labels': ['ClusterFuzz', 'Stability-%SANITIZER%']
-    },
-    'non_security': {
-        'labels': ['Type-Bug'],
-        'crash_labels': ['Stability-Crash', 'Pri-1'],
-        'non_crash_labels': ['Pri-2']
+        'labels': ['ClusterFuzz', 'Stability-%SANITIZER%'],
+        'non_security': {
+            'labels': ['Type-Bug'],
+            'non_crash': {
+                'labels': ['Pri-2'],
+            },
+            'crash': {
+                'labels': ['Stability-Crash', 'Pri-1'],
+                'dcheck': {
+                    '_ext_issue_access_limit': {
+                        'access_limit': IssueAccessLevel.LIMIT_VIEW_TRUSTED
+                    }
+                },
+            },
+        },
+        'security': {
+            'labels': ['Type-Bug-Security'],
+            '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
+            '_ext_issue_access_limit': {
+                'access_limit': IssueAccessLevel.LIMIT_VIEW
+            }
+        },
     },
     'labels': {
         'ignore': 'ClusterFuzz-Ignore',
@@ -70,13 +86,6 @@ CHROMIUM_POLICY = issue_tracker_policy.IssueTrackerPolicy({
         'os': 'OS-%PLATFORM%',
         'unreproducible': 'Unreproducible',
         'restrict_view': 'Restrict-View-SecurityTeam'
-    },
-    'security': {
-        'labels': ['Type-Bug-Security'],
-        '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
-        '_ext_issue_access_limit': {
-            'access_limit': IssueAccessLevel.LIMIT_VIEW
-        }
     },
     'existing': {
         'labels': ['Stability-%SANITIZER%']
@@ -95,12 +104,19 @@ CHROMIUM_POLICY_FALLBACK = issue_tracker_policy.IssueTrackerPolicy({
     },
     'all': {
         'status': 'new',
-        'labels': ['ClusterFuzz', 'Stability-%SANITIZER%']
-    },
-    'non_security': {
-        'labels': ['Type-Bug'],
-        'crash_labels': ['Stability-Crash', 'Pri-1'],
-        'non_crash_labels': ['Pri-2']
+        'labels': ['ClusterFuzz', 'Stability-%SANITIZER%'],
+        'non_security': {
+            'labels': ['Type-Bug'],
+            'crash_labels': ['Stability-Crash', 'Pri-1'],
+            'non_crash_labels': ['Pri-2']
+        },
+        'security': {
+            'labels': ['Type-Bug-Security'],
+            '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
+            '_ext_issue_access_limit': {
+                'access_limit': IssueAccessLevel.LIMIT_VIEW
+            }
+        },
     },
     'labels': {
         'ignore': 'ClusterFuzz-Ignore',
@@ -116,13 +132,6 @@ CHROMIUM_POLICY_FALLBACK = issue_tracker_policy.IssueTrackerPolicy({
         'os': 'OS-%PLATFORM%',
         'unreproducible': 'Unreproducible',
         'restrict_view': 'Restrict-View-SecurityTeam'
-    },
-    'security': {
-        'labels': ['Type-Bug-Security'],
-        '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
-        '_ext_issue_access_limit': {
-            'access_limit': IssueAccessLevel.LIMIT_VIEW
-        }
     },
     'existing': {
         'labels': ['Stability-%SANITIZER%']
@@ -145,12 +154,23 @@ CHROMIUM_GIT_POLICY = issue_tracker_policy.IssueTrackerPolicy({
     },
     'all': {
         'status': 'new',
-        'labels': ['1679217', 'Stability-%SANITIZER%']
-    },
-    'non_security': {
-        'labels': ['Type-Bug'],
-        'crash_labels': ['Stability-Crash', 'Pri-1'],
-        'non_crash_labels': ['Pri-2']
+        'labels': ['1679217', 'Stability-%SANITIZER%'],
+        'non_security': {
+            'labels': ['Type-Bug'],
+            'non_crash': {
+                'labels': ['Pri-2'],
+            },
+            'crash': {
+                'labels': ['Stability-Crash', 'Pri-1'],
+            }
+        },
+        'security': {
+            'labels': ['Type-Bug-Security'],
+            '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
+            '_ext_issue_access_limit': {
+                'access_limit': IssueAccessLevel.LIMIT_VIEW
+            }
+        },
     },
     'labels': {
         'ignore': '1',
@@ -166,13 +186,6 @@ CHROMIUM_GIT_POLICY = issue_tracker_policy.IssueTrackerPolicy({
         'os': '10',
         'unreproducible': '11',
         'restrict_view': '12'
-    },
-    'security': {
-        'labels': ['Type-Bug-Security'],
-        '_ext_collaborators': ['superman@krypton.com', 'batman@gotham.com'],
-        '_ext_issue_access_limit': {
-            'access_limit': IssueAccessLevel.LIMIT_VIEW
-        }
     },
     'existing': {
         'labels': ['Stability-%SANITIZER%'],
@@ -315,10 +328,13 @@ OSS_FUZZ_POLICY = issue_tracker_policy.IssueTrackerPolicy({
             'This information can help downstream consumers.\n\n'
             'If you need to contact the OSS-Fuzz team with a question, '
             'concern, or any other feedback, please file an issue at '
-            'https://github.com/google/oss-fuzz/issues.'
-    },
-    'non_security': {
-        'labels': ['Type-Bug']
+            'https://github.com/google/oss-fuzz/issues.',
+        'non_security': {
+            'labels': ['Type-Bug']
+        },
+        'security': {
+            'labels': ['Type-Bug-Security']
+        },
     },
     'labels': {
         'ignore': 'ClusterFuzz-Ignore',
@@ -334,9 +350,6 @@ OSS_FUZZ_POLICY = issue_tracker_policy.IssueTrackerPolicy({
         'os': 'OS-%PLATFORM%',
         'unreproducible': 'Unreproducible',
         'restrict_view': 'Restrict-View-Commit'
-    },
-    'security': {
-        'labels': ['Type-Bug-Security']
     },
     'deadline_policy_message':
         'This bug is subject to a 90 day disclosure deadline. If 90 days '
@@ -962,6 +975,117 @@ class IssueFilerTests(unittest.TestCase):
     issue_filer.file_issue(self.testcase8, issue_tracker)
     self.assertIn('Fuzzer-exit', issue_tracker._itm.last_issue.labels)
     self.assertNotIn('Resource Exhaustion',
+                     issue_tracker._itm.last_issue.labels)
+
+  def test_filed_issues_nesting(self):
+    """Tests issue filing for dchecks."""
+    self.mock.get.return_value = issue_tracker_policy.IssueTrackerPolicy({
+        'all': {
+            'status': 'new',
+            'labels': ['ClusterFuzz'],
+            'dcheck': {
+                'labels': ['Is-DCHECK'],
+                'security': {
+                    'labels': ['Is-Security-DCHECK'],
+                },
+                'non_security': {
+                    'labels': ['Is-Non-Security-DCHECK'],
+                }
+            },
+            'non_dcheck': {
+                'labels': ['Is-Non-DCHECK'],
+                'security': {
+                    'labels': ['Is-Security-Non-DCHECK'],
+                },
+                'non_security': {
+                    'labels': ['Is-Non-Security-Non-DCHECK'],
+                }
+            }
+        },
+        'status': {
+            'assigned': 'Assigned',
+            'duplicate': 'Duplicate',
+            'verified': 'Verified',
+            'new': 'Untriaged',
+            'wontfix': 'WontFix',
+            'fixed': 'Fixed'
+        },
+        'labels': {
+            'ignore': 'ClusterFuzz-Ignore',
+            'verified': 'ClusterFuzz-Verified',
+            'security_severity': 'Security_Severity-%SEVERITY%',
+            'needs_feedback': 'Needs-Feedback',
+            'invalid_fuzzer': 'ClusterFuzz-Invalid-Fuzzer',
+            'reported': None,
+            'wrong': 'ClusterFuzz-Wrong',
+            'fuzz_blocker': 'Fuzz-Blocker',
+            'reproducible': 'Reproducible',
+            'auto_cc_from_owners': 'ClusterFuzz-Auto-CC',
+            'os': 'OS-%PLATFORM%',
+            'unreproducible': 'Unreproducible',
+            'restrict_view': 'Restrict-View-SecurityTeam'
+        },
+    })
+    issue_tracker = monorail.IssueTracker(IssueTrackerManager('chromium'))
+
+    # +DCHECK +SECURITY
+    self.testcase1.crash_type = 'DCHECK failure'
+    self.testcase1.security_flag = True
+    self.testcase1.put()
+    issue_filer.file_issue(self.testcase1, issue_tracker)
+    self.assertIn('Is-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Non-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertIn('Is-Security-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Security-Non-DCHECK',
+                     issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Non-Security-DCHECK',
+                     issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Non-Security-Non-DCHECK',
+                     issue_tracker._itm.last_issue.labels)
+
+    # +DCHECK -SECURITY
+    self.testcase1.crash_type = 'DCHECK failure'
+    self.testcase1.security_flag = False
+    self.testcase1.put()
+    issue_filer.file_issue(self.testcase1, issue_tracker)
+    self.assertIn('Is-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Non-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Security-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Security-Non-DCHECK',
+                     issue_tracker._itm.last_issue.labels)
+    self.assertIn('Is-Non-Security-DCHECK',
+                  issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Non-Security-Non-DCHECK',
+                     issue_tracker._itm.last_issue.labels)
+
+    # -DCHECK +SECURITY
+    self.testcase1.crash_type = 'Heap-use-after-free'
+    self.testcase1.security_flag = True
+    self.testcase1.put()
+    issue_filer.file_issue(self.testcase1, issue_tracker)
+    self.assertNotIn('Is-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertIn('Is-Non-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertIn('Is-Security-Non-DCHECK',
+                  issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Security-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Non-Security-DCHECK',
+                     issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Non-Security-Non-DCHECK',
+                     issue_tracker._itm.last_issue.labels)
+
+    # -DCHECK -SECURITY
+    self.testcase1.crash_type = 'Heap-use-after-free'
+    self.testcase1.security_flag = False
+    self.testcase1.put()
+    issue_filer.file_issue(self.testcase1, issue_tracker)
+    self.assertNotIn('Is-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertIn('Is-Non-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Security-DCHECK', issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Security-Non-DCHECK',
+                     issue_tracker._itm.last_issue.labels)
+    self.assertIn('Is-Non-Security-Non-DCHECK',
+                  issue_tracker._itm.last_issue.labels)
+    self.assertNotIn('Is-Non-Security-DCHECK',
                      issue_tracker._itm.last_issue.labels)
 
 

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2325,14 +2325,23 @@ class StackAnalyzerTestcase(unittest.TestCase):
   def test_dcheck_failure_chrome(self):
     """Test a DCHECK failure with a Chrome symbolized stacktrace."""
     data = self._read_test_data('dcheck_failure_chrome.txt')
-    expected_type = 'CHECK failure'
+    expected_type = 'DCHECK failure'
     expected_address = ''
     expected_state = ('!terminated_ in latency_info.cc\n'
                       'ui::LatencyInfo::AddLatencyNumberWithTimestampImpl\n'
                       'ui::LatencyInfo::AddLatencyNumberWithTimestamp\n')
     expected_stacktrace = data
-    expected_security_flag = False
 
+    # Test with DCHECKS_HAVE_SECURITY_IMPLICATION unset.
+    environment.set_value('DCHECKS_HAVE_SECURITY_IMPLICATION', False)
+    expected_security_flag = False
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+    # Test with DCHECKS_HAVE_SECURITY_IMPLICATION set.
+    environment.set_value('DCHECKS_HAVE_SECURITY_IMPLICATION', True)
+    expected_security_flag = True
     self._validate_get_crash_data(data, expected_type, expected_address,
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -1033,8 +1033,14 @@ class StackParser:
         # Check failures.
         self.update_state_on_check_failure(state, line, GOOGLE_LOG_FATAL_REGEX,
                                            'Fatal error')
+
+        # Chrome
         self.update_state_on_check_failure(
             state, line, CHROME_CHECK_FAILURE_REGEX, 'CHECK failure')
+        self.update_state_on_check_failure(
+            state, line, CHROME_DCHECK_FAILURE_REGEX, 'DCHECK failure')
+
+        # Google
         self.update_state_on_check_failure(
             state, line, GOOGLE_CHECK_FAILURE_REGEX, 'CHECK failure')
 

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -87,7 +87,10 @@ CFI_FUNC_DEFINED_HERE_REGEX = re.compile(r'.*note: .* defined here$')
 CFI_NODEBUG_ERROR_MARKER_REGEX = re.compile(
     r'CFI: Most likely a control flow integrity violation;.*')
 CHROME_CHECK_FAILURE_REGEX = re.compile(
-    r'\s*\[[^\]]*[:]([^\](]*\([0-9]+\)|[^\]:]*[:][0-9]+).*\].*(?:Check failed:|DCHECK failed:|NOTREACHED hit.)\s*(.*)'  # pylint: disable=line-too-long
+    r'\s*\[[^\]]*[:]([^\](]*\([0-9]+\)|[^\]:]*[:][0-9]+).*\].*(?:Check failed:|NOTREACHED hit.)\s*(.*)'  # pylint: disable=line-too-long
+)
+CHROME_DCHECK_FAILURE_REGEX = re.compile(
+    r'\s*\[[^\]]*[:]([^\](]*\([0-9]+\)|[^\]:]*[:][0-9]+).*\].*(?:DCHECK failed:)\s*(.*)'  # pylint: disable=line-too-long
 )
 CHROME_STACK_FRAME_REGEX = re.compile(
     r'[ ]*(#(?P<frame_id>[0-9]+)[ ]'  # frame id (2)


### PR DESCRIPTION
Separates `DCHECK` failures from standard `CHECK` failures to enable granular severity assessment and issue tracking policies.

In Chromium, `DCHECK` failures often carry different security and priority implications than production `CHECK` failures. While they may not always be treated as immediate security vulnerabilities, they present information disclosure risks if filed publicly. Current logic groups them together, preventing distinct visibility rules.

Detailed changes:
- **Stack Parsing:** Updates `stacktraces` regex constants to explicitly distinguish "DCHECK failed" from "Check failed/NOTREACHED", assigning the distinct crash type `DCHECK failure`.
- **Security Implications:** Introduces the `DCHECKS_HAVE_SECURITY_IMPLICATION` environment variable to control whether DCHECKs are flagged as security issues per-fuzzer.
- **Policy Engine:** Refactors `IssueTrackerPolicy` to support recursive configuration application. This allows nested conditions (e.g., `all` -> `non_security` -> `dcheck`) to apply specific labels, access limits, or priority levels based on the intersection of crash traits. This decouple the configuration depth from the code, enabling arbitrary nesting or rules and simplifying the addition of future condition types.

Bug: https://issues.chromium.org/issues/406667202