### PR TITLE
Add logs in google issue tracker to facilitate debug

### DIFF
--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -361,7 +361,9 @@ def _file_issue(testcase, issue_tracker, throttler):
     file_exception = e
 
   if file_exception:
-    logs.error(f'Failed to file issue for testcase {testcase.key.id()}.')
+    logs.error(
+        f'Failed to file issue for testcase {testcase.key.id()}.',
+        file_exception=file_exception)
     monitoring_metrics.ISSUE_FILING.increment({
         'fuzzer_name': testcase.fuzzer_name,
         'status': 'failed',

--- a/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
+++ b/src/clusterfuzz/_internal/issue_management/google_issue_tracker/issue_tracker.py
@@ -809,10 +809,11 @@ class Issue(issue_tracker.Issue):
         self._data['issueComment'] = {
             'comment': self._body,
         }
+      logs.info(f'google_issue_tracker: issue body before create: {self._data}')
       result = self.issue_tracker._execute(
           self.issue_tracker.client.issues().create(
               body=self._data, templateOptions_applyTemplate=True))
-      logs.info('google_issue_tracker: result of create: %s' % result)
+      logs.info(f'google_issue_tracker: result of create: {result}')
       self._is_new = False
     else:
       logs.info('google_issue_tracker: Updating issue..')


### PR DESCRIPTION
Log the issue data before calling the issue tracker API to create a new issue to facilitate debugging. Also, log the file_exception as a structured field when it fails.