### PR TITLE
Increase the memory allocated to 'BOT_TMPDIR' to 1GB

### DIFF
--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -52,9 +52,9 @@ fi
 # set up mounts in this case.
 if [[ -z "$DISABLE_MOUNTS" ]]; then
   # Setup Tmpfs dirs for frequently accessed files to save disk I/O.
-  mount -t tmpfs -o size=250M,mode=777 tmpfs $INSTALL_DIRECTORY/clusterfuzz/bot/inputs/fuzzer-testcases/
+  mount -t tmpfs -o size=1280M,mode=777 tmpfs $INSTALL_DIRECTORY/clusterfuzz/bot/inputs/fuzzer-testcases/
   mount -t tmpfs -o size=10M,mode=777 tmpfs $INSTALL_DIRECTORY/clusterfuzz/bot/logs/
-  mount -t tmpfs -o size=1G,mode=777 tmpfs $BOT_TMPDIR
+  mount -t tmpfs -o size=90M,mode=777 tmpfs $BOT_TMPDIR
 
   # Setup mount to limit disk space for fuzzer testcases disk directory.
   FUZZER_TESTCASES_DISK_FILE=$INSTALL_DIRECTORY/fuzzer-testcases.mnt

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -479,7 +479,7 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
     """Syncs a corpus from GCS to disk."""
     shell.create_directory(directory, create_intermediates=True)
     if corpus.backup_url:
-      tmpdir = environment.get_value('BOT_TMPDIR')
+      tmpdir = environment.get_value('FUZZ_INPUTS')
       with tempfile.NamedTemporaryFile(
           dir=tmpdir, suffix='.zip') as temp_zipfile:
         try:


### PR DESCRIPTION
The 90MB tmpfs mount [allocated](https://github.com/google/clusterfuzz/blob/master/docker/base/setup_clusterfuzz.sh#L57) for 'BOT_TMPDIR' ('/mnt/scratch0/tmp') is insufficient for downloading large corpus backups, leading to "[OSError: \[Errno 28\] No space left on device](https://pantheon.corp.google.com/errors/detail/CMOtt_XM86fFlwE;filter=%5B%5D;locations=global?project=google.com:cluster-fuzz)".

[This error]((https://pantheon.corp.google.com/errors/detail/CMOtt_XM86fFlwE;filter=%5B%5D;locations=global?project=google.com:cluster-fuzz)) occurs during corpus synchronization, when a corpus backup zip file is downloaded to a temporary file within '/mnt/scratch0/tmp' in [_sync_corpus_to_disk()](https://github.com/google/clusterfuzz/blob/master/src/clusterfuzz/_internal/fuzzing/corpus_manager.py#L486) before being extracted. If the said corpus' zip file exceeds [90MB](https://github.com/google/clusterfuzz/blob/master/docker/base/setup_clusterfuzz.sh#L57), the download attempt fails.

This change modifies [_sync_corpus_to_disk()](https://github.com/google/clusterfuzz/blob/master/src/clusterfuzz/_internal/fuzzing/corpus_manager.py#L486) to use the ['clusterfuzz/bot/inputs/fuzzer-testcases' directory](https://github.com/google/clusterfuzz/blob/master/docker/base/setup_clusterfuzz.sh#L55) instead of ['BOT_TMPDIR'](https://github.com/google/clusterfuzz/blob/master/docker/base/setup_clusterfuzz.sh#L57), and also increases the size of ['fuzzer-testcases' tmpfs mount](https://github.com/google/clusterfuzz/blob/master/docker/base/setup_clusterfuzz.sh#L55) to 1.25GB to accommodate for a large corpus backup zip file and prevent this error.