### PR TITLE
Refactoring the fuzzing hours labels by moving from is_batch to runtime

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -424,14 +424,14 @@ class _TrackFuzzTime:
             'fuzzer': self.fuzzer_name,
             'timeout': self.timeout,
             'platform': environment.platform(),
-            'is_batch': environment.is_uworker(),
+            'runtime': environment.get_runtime().value,
         })
     monitoring_metrics.JOB_TOTAL_FUZZ_TIME.increment_by(
         int(duration), {
             'job': self.job_type,
             'timeout': self.timeout,
             'platform': environment.platform(),
-            'is_batch': environment.is_uworker()
+            'runtime': environment.get_runtime().value
         })
 
 

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -146,7 +146,7 @@ FUZZER_TOTAL_FUZZ_TIME = monitor.CounterMetric(
         monitor.StringField('fuzzer'),
         monitor.BooleanField('timeout'),
         monitor.StringField('platform'),
-        monitor.StringField('is_batch')
+        monitor.StringField('runtime')
     ],
 )
 
@@ -171,7 +171,7 @@ JOB_TOTAL_FUZZ_TIME = monitor.CounterMetric(
         monitor.StringField('job'),
         monitor.BooleanField('timeout'),
         monitor.StringField('platform'),
-        monitor.StringField('is_batch')
+        monitor.StringField('runtime')
     ],
 )
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -14,6 +14,7 @@
 """Environment functions."""
 
 import ast
+import enum
 import functools
 import os
 import re
@@ -54,6 +55,13 @@ COMMON_SANITIZER_OPTIONS = {
     'print_summary': 1,
     'use_sigaltstack': 1,
 }
+
+
+class UtaskMainRuntime(enum.Enum):
+
+  BATCH = 'batch'
+  KATA_CONTAINER = 'kata_container'
+  INSTANCE_GROUP = 'instance_group'
 
 
 def _eval_value(value_string):
@@ -724,6 +732,24 @@ def is_uworker():
   """Return whether or not the current bot is a uworker. This is not the same as
   OSS-Fuzz's untrusted worker."""
   return get_value('UWORKER')
+
+
+def get_runtime() -> UtaskMainRuntime:
+  """
+  Get the current runtime for running the tasks.
+  It can be KATA_CONTAINER, BATCH or INSTANCE_GROUP.
+
+  :return: Enum UtaskMainRuntime with one of KATA_CONTAINER,
+  BATCH or INSTANCE_GROUP
+  :rtype: UtaskMainRuntime
+  """
+  if is_uworker() and is_running_on_k8s():
+    return UtaskMainRuntime.KATA_CONTAINER
+
+  if is_uworker() and not is_running_on_k8s():
+    return UtaskMainRuntime.BATCH
+
+  return UtaskMainRuntime.INSTANCE_GROUP
 
 
 def is_swarming_bot():

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
@@ -215,7 +215,7 @@ class TrackFuzzTimeTest(unittest.TestCase):
         'fuzzer': 'fuzzer',
         'timeout': timeout,
         'platform': 'some_platform',
-        'is_batch': environment.is_uworker()
+        'runtime': environment.get_runtime().value
     })
     self.assertEqual(5, fuzzer_total_time)
 


### PR DESCRIPTION
Fix b/469019068

It does update the fuzzing hours metrics to add KATA CONTAINER as a runtime.
It removes the label `is_batch` and move it to the `runtime` label as `BATCH`. 