### PR TITLE
docker: Add luarocks to OSS-Fuzz base images.

### DIFF
--- a/docker/oss-fuzz/base/Dockerfile
+++ b/docker/oss-fuzz/base/Dockerfile
@@ -13,6 +13,8 @@
 # limitations under the License.
 FROM gcr.io/clusterfuzz-images/base
 
+RUN apt-get update && apt-get install -y luarocks
+
 ENV UPDATE_WEB_TESTS False
 
 COPY start.sh /data/

--- a/docker/oss-fuzz/base/ubuntu-20-04.Dockerfile
+++ b/docker/oss-fuzz/base/ubuntu-20-04.Dockerfile
@@ -13,6 +13,8 @@
 # limitations under the License.
 FROM gcr.io/clusterfuzz-images/base:ubuntu-20-04
 
+RUN apt-get update && apt-get install -y luarocks
+
 ENV UPDATE_WEB_TESTS False
 
 COPY start.sh /data/

--- a/docker/oss-fuzz/base/ubuntu-24-04.Dockerfile
+++ b/docker/oss-fuzz/base/ubuntu-24-04.Dockerfile
@@ -13,6 +13,8 @@
 # limitations under the License.
 FROM gcr.io/clusterfuzz-images/base:ubuntu-24-04
 
+RUN apt-get update && apt-get install -y luarocks
+
 ENV UPDATE_WEB_TESTS False
 
 COPY start.sh /data/


### PR DESCRIPTION
This adds luarocks to the apt-get install list in:
- docker/oss-fuzz/base/Dockerfile
- docker/oss-fuzz/base/ubuntu-20-04.Dockerfile
- docker/oss-fuzz/base/ubuntu-24-04.Dockerfile

Unblocks: https://github.com/google/oss-fuzz/pull/13929