### PR TITLE
[test-syncer] Add Fuzzilli-import archives

### DIFF
--- a/src/clusterfuzz/_internal/cron/chrome_tests_syncer.py
+++ b/src/clusterfuzz/_internal/cron/chrome_tests_syncer.py
@@ -44,6 +44,7 @@ TESTCASES_REPORT_INTERVAL = 2500
 STORED_TESTCASES_LIST = []
 
 NUMBER_OF_FUZZILLI_ARCHIVES = 9
+NUMBER_OF_FUZZILLI_IMPORT_ARCHIVES = 9
 NUMBER_OF_FUZZILLI_DIFF_FUZZ_ARCHIVES = 5
 
 
@@ -220,6 +221,8 @@ def create_fuzzilli_tests_directory(tests_directory):
 
   for i in range(1, NUMBER_OF_FUZZILLI_ARCHIVES + 1):
     process_fuzzilli_archive(fuzzilli_tests_directory, i)
+  for i in range(1, NUMBER_OF_FUZZILLI_IMPORT_ARCHIVES + 1):
+    process_fuzzilli_archive(fuzzilli_tests_directory, f'x64-importing-{i}')
   for i in range(1, NUMBER_OF_FUZZILLI_DIFF_FUZZ_ARCHIVES + 1):
     process_fuzzilli_archive(fuzzilli_tests_directory, f'diff-fuzz-{i}')
 


### PR DESCRIPTION
This adds another archive folder from Fuzzilli to be used as input for other fuzzers, e.g. JS-Fuzzer.

BUG=https://crbug.com/467541204