### PR TITLE
Add runtime label for crashes metrics

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -461,6 +461,7 @@ def _track_fuzzer_run_result(fuzzer_name, job_type, generated_testcase_count,
       'return_code': return_code,
       'platform': environment.platform(),
       'job': job_type,
+      'runtime': environment.get_runtime().value
   })
 
 
@@ -480,20 +481,26 @@ def _track_testcase_run_result(fuzzer, job_type, new_crash_count,
       known_crash_count, {
           'fuzzer': fuzzer,
           'platform': environment.platform(),
+          'runtime': environment.get_runtime().value
       })
   monitoring_metrics.FUZZER_NEW_CRASH_COUNT.increment_by(
       new_crash_count, {
           'fuzzer': fuzzer,
           'platform': environment.platform(),
+          'runtime': environment.get_runtime().value
       })
-  monitoring_metrics.JOB_KNOWN_CRASH_COUNT.increment_by(known_crash_count, {
-      'job': job_type,
-      'platform': environment.platform(),
-  })
-  monitoring_metrics.JOB_NEW_CRASH_COUNT.increment_by(new_crash_count, {
-      'job': job_type,
-      'platform': environment.platform()
-  })
+  monitoring_metrics.JOB_KNOWN_CRASH_COUNT.increment_by(
+      known_crash_count, {
+          'job': job_type,
+          'platform': environment.platform(),
+          'runtime': environment.get_runtime().value
+      })
+  monitoring_metrics.JOB_NEW_CRASH_COUNT.increment_by(
+      new_crash_count, {
+          'job': job_type,
+          'platform': environment.platform(),
+          'runtime': environment.get_runtime().value
+      })
 
 
 def _last_sync_time(sync_file_path):
@@ -2020,7 +2027,8 @@ class FuzzingSession:
         fuzzing_session_duration, {
             'fuzzer': self.fuzzer_name,
             'job': self.job_type,
-            'platform': environment.platform()
+            'platform': environment.platform(),
+            'runtime': environment.get_runtime().value,
         })
 
     return uworker_msg_pb2.Output(fuzz_task_output=self.fuzz_task_output)  # pylint: disable=no-member

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -97,6 +97,7 @@ FUZZER_KNOWN_CRASH_COUNT = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('fuzzer'),
         monitor.StringField('platform'),
+        monitor.StringField('runtime')
     ])
 
 FUZZER_NEW_CRASH_COUNT = monitor.CounterMetric(
@@ -106,6 +107,7 @@ FUZZER_NEW_CRASH_COUNT = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('fuzzer'),
         monitor.StringField('platform'),
+        monitor.StringField('runtime')
     ])
 
 JOB_KNOWN_CRASH_COUNT = monitor.CounterMetric(
@@ -115,6 +117,7 @@ JOB_KNOWN_CRASH_COUNT = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('job'),
         monitor.StringField('platform'),
+        monitor.StringField('runtime')
     ])
 
 JOB_NEW_CRASH_COUNT = monitor.CounterMetric(
@@ -124,6 +127,7 @@ JOB_NEW_CRASH_COUNT = monitor.CounterMetric(
     field_spec=[
         monitor.StringField('job'),
         monitor.StringField('platform'),
+        monitor.StringField('runtime')
     ])
 
 FUZZER_RETURN_CODE_COUNT = monitor.CounterMetric(
@@ -135,6 +139,7 @@ FUZZER_RETURN_CODE_COUNT = monitor.CounterMetric(
         monitor.IntegerField('return_code'),
         monitor.StringField('platform'),
         monitor.StringField('job'),
+        monitor.StringField('runtime')
     ],
 )
 
@@ -163,6 +168,7 @@ FUZZING_SESSION_DURATION = monitor.CumulativeDistributionMetric(
         monitor.StringField('fuzzer'),
         monitor.StringField('job'),
         monitor.StringField('platform'),
+        monitor.StringField('runtime')
     ],
 )
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
@@ -60,6 +60,9 @@ class TrackFuzzerRunResultTest(unittest.TestCase):
     monitor.metrics_store().reset_for_testing()
     helpers.patch(self, ['clusterfuzz._internal.system.environment.platform'])
     self.mock.platform.return_value = 'some_platform'
+    helpers.patch(self,
+                  ['clusterfuzz._internal.system.environment.get_runtime'])
+    self.mock.get_runtime.return_value = environment.UtaskMainRuntime.KATA_CONTAINER
 
   def test_fuzzer_run_result(self):
     """Ensure _track_fuzzer_run_result set the right metrics."""
@@ -77,6 +80,7 @@ class TrackFuzzerRunResultTest(unittest.TestCase):
             'return_code': 2,
             'platform': 'some_platform',
             'job': 'job',
+            'runtime': 'kata_container'
         }))
     self.assertEqual(
         1,
@@ -85,6 +89,7 @@ class TrackFuzzerRunResultTest(unittest.TestCase):
             'return_code': 0,
             'platform': 'some_platform',
             'job': 'job',
+            'runtime': 'kata_container'
         }))
     self.assertEqual(
         1,
@@ -93,6 +98,7 @@ class TrackFuzzerRunResultTest(unittest.TestCase):
             'return_code': -1,
             'platform': 'some_platform',
             'job': 'job',
+            'runtime': 'kata_container'
         }))
 
     testcase_count_ratio = (
@@ -143,6 +149,9 @@ class TrackTestcaseRunResultTest(unittest.TestCase):
     monitor.metrics_store().reset_for_testing()
     helpers.patch(self, ['clusterfuzz._internal.system.environment.platform'])
     self.mock.platform.return_value = 'some_platform'
+    helpers.patch(self,
+                  ['clusterfuzz._internal.system.environment.get_runtime'])
+    self.mock.get_runtime.return_value = environment.UtaskMainRuntime.KATA_CONTAINER
 
   def test_testcase_run_result(self):
     """Ensure _track_testcase_run_result sets the right metrics."""
@@ -154,24 +163,28 @@ class TrackTestcaseRunResultTest(unittest.TestCase):
         monitoring_metrics.JOB_NEW_CRASH_COUNT.get({
             'job': 'job',
             'platform': 'some_platform',
+            'runtime': 'kata_container',
         }))
     self.assertEqual(
         15,
         monitoring_metrics.JOB_KNOWN_CRASH_COUNT.get({
             'job': 'job',
             'platform': 'some_platform',
+            'runtime': 'kata_container',
         }))
     self.assertEqual(
         7,
         monitoring_metrics.FUZZER_NEW_CRASH_COUNT.get({
             'fuzzer': 'fuzzer',
             'platform': 'some_platform',
+            'runtime': 'kata_container',
         }))
     self.assertEqual(
         15,
         monitoring_metrics.FUZZER_KNOWN_CRASH_COUNT.get({
             'fuzzer': 'fuzzer',
             'platform': 'some_platform',
+            'runtime': 'kata_container',
         }))
 
 


### PR DESCRIPTION
It adds the label `runtime` in the CRASHES metrics. It will help ups to validate the runtimes in its capacity to reproduce and find crashes. 