### PR TITLE
Add 'yapf' style parameter to butler.py yapf calls

### DIFF
--- a/src/local/butler/format.py
+++ b/src/local/butler/format.py
@@ -17,6 +17,7 @@ import os
 
 from local.butler import common
 
+
 FIRST_PARTY_MODULES = [
     'handlers',
     'libs',
@@ -24,8 +25,8 @@ FIRST_PARTY_MODULES = [
 ]
 
 ISORT_CMD = ('isort --dont-order-by-type --force-single-line-imports '
-             '--force-sort-within-sections --line-length=80 ' + ' '.join(
-                 [f'-p {mod}' for mod in FIRST_PARTY_MODULES]) + ' ')
+             '--force-sort-within-sections --line-length=80 ' +
+             ' '.join([f'-p {mod}' for mod in FIRST_PARTY_MODULES]) + ' ')
 
 
 def execute(args):
@@ -48,7 +49,7 @@ def execute(args):
       not f.endswith('_pb2.py') and not f.endswith('_pb2_grpc.py')
   ]
   if py_changed_file_paths:
-    common.execute(f'yapf -p -i {" ".join(py_changed_file_paths)}')
+    common.execute(f'yapf -p -i --style yapf {" ".join(py_changed_file_paths)}')
     common.execute(f'{ISORT_CMD} {" ".join(py_changed_file_paths)}')
   go_changed_file_paths = [f for f in file_paths if f.endswith('.go')]
 

--- a/src/local/butler/lint.py
+++ b/src/local/butler/lint.py
@@ -234,7 +234,7 @@ def execute(args):
   py_changed_file_paths = py_changed_nontests + py_changed_tests
   if py_changed_file_paths:
     joined_paths = " ".join(py_changed_file_paths)
-    _execute_command_and_track_error(f'yapf -p -d {joined_paths}')
+    _execute_command_and_track_error(f'yapf -p -d --style yapf {joined_paths}')
     _execute_command_and_track_error(f'{formatter.ISORT_CMD} -c {joined_paths}')
     if args.type_check:
       _execute_command_and_track_error(f'pyright {joined_paths}')


### PR DESCRIPTION
When using butler.py's format and lint commands it seems the default style config currently used for yapf calls is 'chromium', which has been renamed to 'yapf': https://github.com/google/yapf/blob/12005095296072751e3e4c1f33a047d41b0ce18d/CHANGELOG.md?plain=1#L168. This was giving me errors related to the 'chromium' style not being found.