### PR TITLE
Fix empty testcase upload.

### DIFF
--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -437,6 +437,9 @@ def upload_testcase(testcase_path, testcase_data, log_time):
     with open(testcase_path, 'rb') as file_handle:
       testcase_data = file_handle.read()
 
+  if not testcase_data:
+    return
+
   fuzzer_logs.upload_to_logs(
       fuzz_logs_bucket,
       testcase_data,


### PR DESCRIPTION
If you look at the fuzzer logs linked to from stats. There is a testcase uploaded after every fuzzer run. This is a mistake.