### PR TITLE
Fix missing fuzzer name in engine fuzzer logs bucket

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -2295,11 +2295,15 @@ def _add_build_metadata_to_output(
   fuzz_task_output.gn_args = data_handler.get_filtered_gn_args() or ''
 
 
-def _upload_engine_output(engine_output):
+def _upload_engine_output(engine_output, fuzzer_name):
   timestamp = uworker_io.proto_timestamp_to_timestamp(engine_output.timestamp)
-  testcase_manager.upload_log(engine_output.output.decode(),
-                              engine_output.return_code, timestamp)
-  testcase_manager.upload_testcase(None, engine_output.testcase, timestamp)
+  testcase_manager.upload_log(
+      engine_output.output.decode(),
+      engine_output.return_code,
+      timestamp,
+      fuzzer_name=fuzzer_name)
+  testcase_manager.upload_testcase(
+      None, engine_output.testcase, timestamp, fuzzer_name=fuzzer_name)
 
 
 def _utask_postprocess(output):
@@ -2316,8 +2320,9 @@ def _utask_postprocess(output):
   session.postprocess(output)
   # TODO(b/374776013): Refactor this code so the uploads happen during
   # utask_main.
+  fuzzer_name = output.fuzz_task_output.fully_qualified_fuzzer_name
   for engine_output in output.fuzz_task_output.engine_outputs:
-    _upload_engine_output(engine_output)
+    _upload_engine_output(engine_output, fuzzer_name)
 
 
 def utask_postprocess(output):

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -424,7 +424,7 @@ def _get_testcase_time(testcase_path):
   return None
 
 
-def upload_testcase(testcase_path, testcase_data, log_time):
+def upload_testcase(testcase_path, testcase_data, log_time, fuzzer_name=None):
   """Uploads testcase so that a log file can be matched with it folder."""
   fuzz_logs_bucket = environment.get_value('FUZZ_LOGS_BUCKET')
   if not fuzz_logs_bucket:
@@ -441,6 +441,7 @@ def upload_testcase(testcase_path, testcase_data, log_time):
       fuzz_logs_bucket,
       testcase_data,
       time=log_time,
+      fuzzer_name=fuzzer_name,
       file_extension='.testcase')
 
 
@@ -873,14 +874,19 @@ def _prepare_log_for_upload(symbolized_output, return_code, app_revision):
   return result.encode('utf-8')
 
 
-def upload_log(symbolized_output, return_code, log_time, app_revision=None):
+def upload_log(symbolized_output,
+               return_code,
+               log_time,
+               app_revision=None,
+               fuzzer_name=None):
   """Upload the output into corresponding GCS logs bucket."""
   log = _prepare_log_for_upload(symbolized_output, return_code, app_revision)
   fuzz_logs_bucket = environment.get_value('FUZZ_LOGS_BUCKET')
   if not fuzz_logs_bucket:
     return
 
-  fuzzer_logs.upload_to_logs(fuzz_logs_bucket, log, time=log_time)
+  fuzzer_logs.upload_to_logs(
+      fuzz_logs_bucket, log, time=log_time, fuzzer_name=fuzzer_name)
 
 
 def get_user_profile_directory(user_profile_index):


### PR DESCRIPTION
This tries to fix the issue where log uploads are being sent to buckets named with "None", for instance: https://pantheon.corp.google.com/storage/browser/_details/envoy-logs.clusterfuzz-external.appspot.com/None/libfuzzer_asan_envoy/2026-01-15/00:24:05:542930.log;tab=live_object?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&e=-13802955&mods=logs_tg_prod

Since the `FUZZER_NAME` env var is only set during the utask main, we need to explicitly pass the fuzzer name value to get the correct bucket name.