### PR TITLE
docker: Add i386 support to ubuntu 20 and 24 base images.

### DIFF
--- a/docker/base/ubuntu-20-04.Dockerfile
+++ b/docker/base/ubuntu-20-04.Dockerfile
@@ -130,6 +130,10 @@ RUN ln -s /usr/local/bin/python3.11 /usr/bin/python3.11
 COPY setup_19.x /data
 RUN bash setup_19.x && apt-get update -y && apt-get install -y nodejs
 
+# Support i386.
+RUN dpkg --add-architecture i386
+RUN apt update && apt install libc6:i386 -y
+
 ENV CLOUDSDK_PYTHON=python3.11
 
 RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \

--- a/docker/base/ubuntu-24-04.Dockerfile
+++ b/docker/base/ubuntu-24-04.Dockerfile
@@ -112,6 +112,10 @@ RUN cd /tmp && \
     rm node.tar.xz
 ENV PATH="/usr/local/node/bin:${PATH}"
 
+# Support i386.
+RUN dpkg --add-architecture i386
+RUN apt update && apt install libc6:i386 -y
+
 ENV CLOUDSDK_PYTHON=python3.11
 
 RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \


### PR DESCRIPTION
Follow up to #4773 
Related: https://github.com/google/oss-fuzz/issues/13152