### PR TITLE
Re-enable gcloud storage on mac and android

### DIFF
--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -1020,6 +1020,12 @@ def set_bot_environment():
   from clusterfuzz._internal.config import local_config
   local_config.ProjectConfig().set_environment()
 
+  # Tmp: set gcloud_storage flag for android/MAC bots
+  # to validate the gsutil migration on these platforms.
+  if is_android() or platform() == 'MAC':
+    os.environ['USE_GCLOUD_STORAGE_CP'] = 'True'
+    os.environ['USE_GCLOUD_STORAGE_RSYNC'] = '1'
+
   # Success.
   return True
 


### PR DESCRIPTION
Directly enables the gcloud storage flag for MAC and Android bots.

This is done because, for internal/chrome deployment, the init scripts that start ClusterFuzz are stored at chrome infra's repositories, so setting/reverting these env vars in these scripts would have a much higher overhead.

Evidence of this working after the Chrome bots were updated: https://cloudlogging.app.goo.gl/SSdQUpc82Pi2TdXr6
https://screenshot.googleplex.com/4eWX4isMooCmzsC.png