### PR TITLE
[ossfuzz][project_setup] Improve weighting of memory safe vs unsafe projects

### DIFF
--- a/src/clusterfuzz/_internal/cron/project_setup.py
+++ b/src/clusterfuzz/_internal/cron/project_setup.py
@@ -65,7 +65,7 @@ ALLOWED_VIEW_RESTRICTIONS = ['none', 'security', 'all']
 
 PUBSUB_PLATFORMS = ['linux']
 
-MEMORY_SAFE_LANGUAGES = {'go', 'java', 'python', 'rust'}
+MEMORY_UNSAFE_LANGUAGES = {'c++', 'c'}
 OSS_FUZZ_DEFAULT_PROJECT_CPU_WEIGHT = 1.0
 OSS_FUZZ_MEMORY_SAFE_LANGUAGE_PROJECT_WEIGHT = 0.2
 
@@ -562,10 +562,10 @@ def create_project_settings(project, info, service_account):
       oss_fuzz_project.base_os_version = base_os_version
       oss_fuzz_project.put()
   else:
-    if language in MEMORY_SAFE_LANGUAGES:
-      cpu_weight = OSS_FUZZ_MEMORY_SAFE_LANGUAGE_PROJECT_WEIGHT
-    else:
+    if language in MEMORY_UNSAFE_LANGUAGES:
       cpu_weight = OSS_FUZZ_DEFAULT_PROJECT_CPU_WEIGHT
+    else:
+      cpu_weight = OSS_FUZZ_MEMORY_SAFE_LANGUAGE_PROJECT_WEIGHT
 
     data_types.OssFuzzProject(
         id=project,

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -247,12 +247,15 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         }),
         ('lib2', {
             'homepage': 'http://example2.com',
+            'language': 'c++',
             'disabled': True,
             'fuzzing_engines': ['libfuzzer',],
         }),
         ('lib3', {
             'homepage':
                 'http://example3.com',
+            'language':
+                'c',
             'sanitizers': [
                 'address',
                 {
@@ -281,6 +284,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         }),
         ('lib5', {
             'homepage': 'http://example5.com',
+            'language': 'python',
             'sanitizers': ['address'],
             'fuzzing_engines': ['libfuzzer',],
             'experimental': True,
@@ -289,6 +293,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         }),
         ('lib6', {
             'homepage': 'http://example6.com',
+            'language': 'rust',
             'sanitizers': ['address', 'memory', 'undefined'],
             'fuzzing_engines': ['libfuzzer', 'afl'],
             'auto_ccs': 'User@example.com',
@@ -296,6 +301,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         }),
         ('lib7', {
             'homepage': 'http://example.com',
+            'language': 'jvm',
             'primary_contact': 'primary@example.com',
             'auto_ccs': ['User@example.com',],
             'fuzzing_engines': ['libfuzzer',],


### PR DESCRIPTION
Fix b/477894702

The code here is broken because it doesn’t deal with new memory safe languages and also “java” language in oss-fuzz is not called java but is called jvm. The fix changes it so that languages are down weighted if not C/C++.

