### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/configs/test/gce/windows-init.ps1
+++ b/configs/test/gce/windows-init.ps1
@@ -276,7 +276,7 @@ $fileName = "$tmp\clusterfuzz.zip"
 if ($env:USE_GCLOUD_STORAGE_CP -eq "1") {
   gcloud storage cp gs://$deploymentBucket/windows-3.zip $fileName
 } else {
-  gsutil cp gs://$deploymentBucket/windows-3.zip $fileName
+  gcloud storage cp gs://$deploymentBucket/windows-3.zip $fileName
 }
 unzip $fileName
 
@@ -313,5 +313,4 @@ cmd /c c:\python311\python -m pip install pywinauto==0.6.8
 Write-Host "Run scripts"
 c:\autologin.bat
 c:\PsExec.exe \\$hostName -accepteula -h -i 0 -username `""$domain\$username"`" -password `""$password"`" c:\startup.bat
-
 

--- a/docker/base/setup_clusterfuzz.sh
+++ b/docker/base/setup_clusterfuzz.sh
@@ -42,7 +42,7 @@ else
     if [ "$USE_GCLOUD_STORAGE_CP" = "1" ]; then
       gcloud storage cp gs://$DEPLOYMENT_BUCKET/$DEPLOYMENT_ZIP $CLUSTERFUZZ_FILE
     else
-      gsutil cp gs://$DEPLOYMENT_BUCKET/$DEPLOYMENT_ZIP $CLUSTERFUZZ_FILE
+      gcloud storage cp gs://$DEPLOYMENT_BUCKET/$DEPLOYMENT_ZIP $CLUSTERFUZZ_FILE
     fi
     unzip -q -o $CLUSTERFUZZ_FILE
   fi

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -65,16 +65,16 @@ class GcsCorpusTest(unittest.TestCase):
     self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
 
     self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil', '-m', '-o', 'GSUtil:parallel_thread_count=16',
-        '-q', 'rsync', '-r', '-d', 'gs://bucket/', '/dir'
+        '/gsutil_path/gcloud', 'storage', 'rsync', '--recursive',
+        '--delete-unmatched-destination-objects', 'gs://bucket/', '/dir'
     ])
 
     self.mock.cpu_count.return_value = 2
     corpus = corpus_manager.GcsCorpus('bucket')
     self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
     self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil', '-m', '-q', 'rsync', '-r', '-d', 'gs://bucket/',
-        '/dir'
+        '/gsutil_path/gcloud', 'storage', 'rsync', '--recursive',
+        '--delete-unmatched-destination-objects', 'gs://bucket/', '/dir'
     ])
 
   def test_rsync_from_disk(self):
@@ -84,16 +84,16 @@ class GcsCorpusTest(unittest.TestCase):
     self.assertTrue(corpus.rsync_from_disk('/dir'))
 
     self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil', '-m', '-o', 'GSUtil:parallel_thread_count=16',
-        '-q', 'rsync', '-r', '-d', '/dir', 'gs://bucket/'
+        '/gsutil_path/gcloud', 'storage', 'rsync', '--recursive',
+        '--delete-unmatched-destination-objects', '/dir', 'gs://bucket/'
     ])
 
     self.mock.cpu_count.return_value = 2
     corpus = corpus_manager.GcsCorpus('bucket')
     self.assertTrue(corpus.rsync_from_disk('/dir'))
     self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil', '-m', '-q', 'rsync', '-r', '-d', '/dir',
-        'gs://bucket/'
+        '/gsutil_path/gcloud', 'storage', 'rsync', '--recursive',
+        '--delete-unmatched-destination-objects', '/dir', 'gs://bucket/'
     ])
 
   def test_upload_files(self):
@@ -105,8 +105,8 @@ class GcsCorpusTest(unittest.TestCase):
     self.assertTrue(corpus.upload_files(['/dir/a', '/dir/b']))
 
     self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil', '-m', '-o', 'GSUtil:parallel_thread_count=16',
-        'cp', '-I', 'gs://bucket/'
+        '/gsutil_path/gcloud', 'storage', 'cp', '--read-paths-from-stdin',
+        'gs://bucket/'
     ])
 
     mock_popen.communicate.assert_called_with(b'/dir/a\n/dir/b')
@@ -115,7 +115,7 @@ class GcsCorpusTest(unittest.TestCase):
     corpus = corpus_manager.GcsCorpus('bucket')
     self.assertTrue(corpus.upload_files(['/dir/a', '/dir/b']))
     self.assertEqual(self.mock.Popen.call_args[0][0],
-                     ['/gsutil_path/gsutil', '-m', 'cp', '-I', 'gs://bucket/'])
+                     ['/gsutil_path/gcloud', 'storage', 'cp', '--read-paths-from-stdin', 'gs://bucket/'])
 
 
 class RsyncErrorHandlingTest(unittest.TestCase):
@@ -247,12 +247,11 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
     corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'fuzzer')
     self.assertTrue(corpus.rsync_to_disk('/dir', timeout=60))
     self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil',
-        '-m',
-        '-q',
+        '/gsutil_path/gcloud',
+        'storage',
         'rsync',
-        '-r',
-        '-d',
+        '--recursive',
+        '--delete-unmatched-destination-objects',
         'gs://bucket/libFuzzer/fuzzer/',
         '/dir',
     ])
@@ -267,21 +266,19 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
 
     self.assertEqual(commands, [
         [
-            '/gsutil_path/gsutil',
-            '-m',
-            '-q',
+            '/gsutil_path/gcloud',
+            'storage',
             'rsync',
-            '-r',
-            '-d',
+            '--recursive',
+            '--delete-unmatched-destination-objects',
             'gs://bucket/libFuzzer/fuzzer/',
             '/dir',
         ],
         [
-            '/gsutil_path/gsutil',
-            '-m',
-            '-q',
+            '/gsutil_path/gcloud',
+            'storage',
             'rsync',
-            '-r',
+            '--recursive',
             'gs://bucket/libFuzzer/fuzzer_regressions/',
             '/dir/regressions',
         ],
@@ -292,8 +289,8 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
     corpus = corpus_manager.FuzzTargetCorpus('libFuzzer', 'fuzzer')
     self.assertTrue(corpus.rsync_from_disk('/dir'))
     self.assertEqual(self.mock.Popen.call_args_list[0][0][0], [
-        '/gsutil_path/gsutil', '-m', '-q', 'rsync', '-r', '-d', '/dir',
-        'gs://bucket/libFuzzer/fuzzer/'
+        '/gsutil_path/gcloud', 'storage', 'rsync', '--recursive', '--delete-unmatched-destination-objects',
+        '/dir', 'gs://bucket/libFuzzer/fuzzer/'
     ])
 
   def test_upload_files(self):
@@ -305,7 +302,7 @@ class FuzzTargetCorpusTest(fake_filesystem_unittest.TestCase):
     mock_popen.communicate.assert_called_with(b'/dir/a\n/dir/b')
 
     self.assertEqual(self.mock.Popen.call_args[0][0], [
-        '/gsutil_path/gsutil', '-m', 'cp', '-I', 'gs://bucket/libFuzzer/fuzzer/'
+        '/gsutil_path/gcloud', 'storage', 'cp', '--read-paths-from-stdin', 'gs://bucket/libFuzzer/fuzzer/'
     ])
 
 


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
