### PR TITLE
remove k8s node selector

### DIFF
--- a/src/clusterfuzz/_internal/k8s/job_template.yaml
+++ b/src/clusterfuzz/_internal/k8s/job_template.yaml
@@ -85,9 +85,5 @@ spec:
         emptyDir:
           medium: Memory
           sizeLimit: 1.9Gi
-      {% if is_kata %}
-      nodeSelector:
-        cloud.google.com/gke-nodepool: kata-enabled-pool
-      {% endif %}
       restartPolicy: "{{restart_policy}}"
   backoffLimit: 0


### PR DESCRIPTION
Remove node selector from K8s jobs template.  This node selector was necessary while we had a single cluster for running both the kata jobs and the cronjobs. 

Now we have a separate cluster for kata jobs, and removing the node selector allow us to have many different node pools able to run kata containers.