### PR TITLE
Fix handle of missing customer id in oss-fuzz groups

### DIFF
--- a/src/clusterfuzz/_internal/cron/oss_fuzz_cc_groups.py
+++ b/src/clusterfuzz/_internal/cron/oss_fuzz_cc_groups.py
@@ -72,6 +72,7 @@ def sync_project_cc_group(project_name, info):
 
 def main():
   """Sync OSS-Fuzz projects groups used to CC owners in the issue tracker."""
+  logs.info('OSS-Fuzz CC groups sync started.')
   projects = project_setup.get_oss_fuzz_projects()
 
   for project, info in projects:

--- a/src/clusterfuzz/_internal/google_cloud_utils/google_groups.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/google_groups.py
@@ -117,8 +117,8 @@ def create_google_group(group_name: str,
   """Create a google group."""
   identity_service = get_identity_api()
 
-  customer_id = customer_id or str(
-      local_config.ProjectConfig().get('groups_customer_id'))
+  customer_id = customer_id or local_config.ProjectConfig().get(
+      'groups_customer_id')
   if not customer_id:
     logs.error('No customer ID set. Unable to create a new google group.')
     return None


### PR DESCRIPTION
Doing `str()` for the value of customer ID from config was preventing the code from checking if it is missing, hindering our debug capability.

Also, added a log for the start of the cronjob.