### PR TITLE
Fix credentials for groups settings api

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/google_groups.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/google_groups.py
@@ -43,7 +43,8 @@ def get_identity_api() -> discovery.Resource | None:
 def get_group_settings_api() -> discovery.Resource | None:
   """Return the groups settings api client."""
   if not hasattr(_local, 'groups_settings_service'):
-    creds, _ = credentials.get_default()
+    scopes = ['https://www.googleapis.com/auth/apps.groups.settings']
+    creds = credentials.get_scoped_service_account_credentials(scopes)
     _local.groups_settings_service = discovery.build(
         'groupssettings', 'v1', credentials=creds, cache_discovery=False)
 


### PR DESCRIPTION
#### Motivation
 In order to call the groups settings API to allow adding external members to groups, the service account credentials need to contain the correct scope `'https://www.googleapis.com/auth/apps.groups.settings'` to verify its admin role in the correspondent Google Workspace (oss-fuzz.com in this case).

#### Rationale
Calling the get default creds with this scope does not work correctly. My guess is that the GKE/GCE gets the Application Default Credentials via its metadata server, which is configured by default to issue tokens within a limited set of defined scopes (e.g., `cloud-platform`).

An alternative is self-impersonating the service account to generate new Credentials with the right scopes. This avoids having to deal with creating a secret containing a new key for the default service account and then generating the credentials based on this key.

Note: For this to work, the SA must have the `Service Account Token Creator` role. This is already set for the Compute Engine default account in all prod environments.

#### Tests
Tested in dev by running the oss_fuzz_cc_groups cronjob with test groups. logs: https://screenshot.googleplex.com/76a7vJjjKC4NhCe.png

Check complete investigation on: b/477964128