### PR TITLE
Use google groups for CCs in OSS-Fuzz issue tracker

### DIFF
--- a/src/clusterfuzz/_internal/base/external_users.py
+++ b/src/clusterfuzz/_internal/base/external_users.py
@@ -24,7 +24,6 @@ MEMCACHE_TTL_IN_SECONDS = 15 * 60
 
 # OSS-Fuzz issue tracker CC group
 OSS_FUZZ_CC_GROUP_SUFFIX = '-ccs@oss-fuzz.com'
-OSS_FUZZ_CC_GROUP_DESC = 'External CCs in OSS-Fuzz issue tracker for project'
 
 
 def _fuzzers_for_job(job_type, include_parents):
@@ -376,14 +375,9 @@ def cc_users_for_job(job_type, security_flag, allow_cc_group=True):
 def get_cc_group_from_job(job_type: str) -> str:
   """Docstring for get_cc_group_from_entity"""
   project_name = data_handler.get_project_name(job_type)
-  return get_project_cc_group_name(project_name)
+  return get_oss_fuzz_project_cc_group(project_name)
 
 
-def get_project_cc_group_name(project_name: str) -> str:
+def get_oss_fuzz_project_cc_group(project_name: str) -> str | None:
   """Return oss-fuzz issue tracker CC group email for a project."""
   return f'{project_name}{OSS_FUZZ_CC_GROUP_SUFFIX}'
-
-
-def get_project_cc_group_description(project_name: str) -> str:
-  """Return oss-fuzz issue tracker CC group description for a project."""
-  return f'{OSS_FUZZ_CC_GROUP_DESC}: {project_name}'

--- a/src/clusterfuzz/_internal/base/external_users.py
+++ b/src/clusterfuzz/_internal/base/external_users.py
@@ -23,7 +23,7 @@ from clusterfuzz._internal.datastore import ndb_utils
 
 MEMCACHE_TTL_IN_SECONDS = 15 * 60
 
-# Issue tracker CC group
+# Issue tracker CC group suffix
 CC_GROUP_SUFFIX = '-ccs'
 
 
@@ -374,7 +374,7 @@ def cc_users_for_job(job_type, security_flag, allow_cc_group=True):
 
 
 def get_cc_group_from_job(job_type: str) -> str | None:
-  """Docstring for get_cc_group_from_job"""
+  """Retrieve the job's project issue cc google group."""
   project_name = data_handler.get_project_name(job_type)
   if not project_name:
     return None

--- a/src/clusterfuzz/_internal/base/external_users.py
+++ b/src/clusterfuzz/_internal/base/external_users.py
@@ -15,6 +15,7 @@
 
 from clusterfuzz._internal.base import memoize
 from clusterfuzz._internal.base import utils
+from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.datastore import fuzz_target_utils
@@ -22,8 +23,8 @@ from clusterfuzz._internal.datastore import ndb_utils
 
 MEMCACHE_TTL_IN_SECONDS = 15 * 60
 
-# OSS-Fuzz issue tracker CC group
-OSS_FUZZ_CC_GROUP_SUFFIX = '-ccs@oss-fuzz.com'
+# Issue tracker CC group
+CC_GROUP_SUFFIX = '-ccs'
 
 
 def _fuzzers_for_job(job_type, include_parents):
@@ -372,12 +373,17 @@ def cc_users_for_job(job_type, security_flag, allow_cc_group=True):
                               security_flag, allow_cc_group)
 
 
-def get_cc_group_from_job(job_type: str) -> str:
-  """Docstring for get_cc_group_from_entity"""
+def get_cc_group_from_job(job_type: str) -> str | None:
+  """Docstring for get_cc_group_from_job"""
   project_name = data_handler.get_project_name(job_type)
-  return get_oss_fuzz_project_cc_group(project_name)
+  if not project_name:
+    return None
+  return get_project_cc_group(project_name)
 
 
-def get_oss_fuzz_project_cc_group(project_name: str) -> str | None:
-  """Return oss-fuzz issue tracker CC group email for a project."""
-  return f'{project_name}{OSS_FUZZ_CC_GROUP_SUFFIX}'
+def get_project_cc_group(project_name: str) -> str:
+  """Return issue tracker CC group email for a project."""
+  group_domain = local_config.ProjectConfig().get('issue_cc_groups.domain')
+  if not group_domain:
+    group_domain = 'google.com'
+  return f'{project_name}{CC_GROUP_SUFFIX}@{group_domain}'

--- a/src/clusterfuzz/_internal/base/feature_flags.py
+++ b/src/clusterfuzz/_internal/base/feature_flags.py
@@ -35,6 +35,8 @@ class FeatureFlags(Enum):
 
   PREPROCESS_QUEUE_SIZE_LIMIT = 'preprocess_queue_size_limit'
 
+  UPDATE_OSS_FUZZ_USERS_AUTO_CC = 'update_oss_fuzz_users_auto_cc'
+
   @property
   def flag(self):
     """Get the feature flag."""

--- a/src/clusterfuzz/_internal/cron/oss_fuzz_cc_groups.py
+++ b/src/clusterfuzz/_internal/cron/oss_fuzz_cc_groups.py
@@ -13,24 +13,28 @@
 # limitations under the License.
 """Cron to sync OSS-Fuzz projects groups used as CC in the issue tracker."""
 
+from clusterfuzz._internal.base import external_users
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.cron import project_setup
 from clusterfuzz._internal.google_cloud_utils import google_groups
 from clusterfuzz._internal.metrics import logs
 
-_CC_GROUP_SUFFIX = '-ccs@oss-fuzz.com'
-_CC_GROUP_DESC = 'External CCs in OSS-Fuzz issue tracker for project'
+
+def get_project_cc_group_description(project_name: str) -> str:
+  """Return oss-fuzz issue tracker CC group description for a project."""
+  oss_fuzz_cc_desc = 'External CCs in OSS-Fuzz issue tracker for project'
+  return f'{oss_fuzz_cc_desc}: {project_name}'
 
 
 def sync_project_cc_group(project_name, info):
   """Sync the project's google group used for CCing in the issue tracker."""
-  group_name = f'{project_name}{_CC_GROUP_SUFFIX}'
+  group_name = external_users.get_oss_fuzz_project_cc_group(project_name)
 
   group_id = google_groups.get_group_id(group_name)
   # Create the group and bail out since the CIG API might delay to create a
   # new group. Add members will be done in the next cron run.
   if not group_id:
-    group_description = f'{_CC_GROUP_DESC}: {project_name}'
+    group_description = get_project_cc_group_description(project_name)
     created = google_groups.create_google_group(
         group_name, group_description=group_description)
     if not created:

--- a/src/clusterfuzz/_internal/cron/oss_fuzz_cc_groups.py
+++ b/src/clusterfuzz/_internal/cron/oss_fuzz_cc_groups.py
@@ -16,7 +16,6 @@
 from clusterfuzz._internal.base import external_users
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.config import local_config
-from clusterfuzz._internal.cron import project_setup
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.google_cloud_utils import google_groups
@@ -29,7 +28,7 @@ def get_project_cc_group_description(project_name: str) -> str:
   return f'{oss_fuzz_cc_desc}: {project_name}'
 
 
-def sync_project_cc_group(project_name, info):
+def sync_project_cc_group(project_name: str, ccs: list[str]):
   """Sync the oss-fuzz project's group used for CCing in the issue tracker."""
   group_name = external_users.get_project_cc_group(project_name)
 

--- a/src/clusterfuzz/_internal/cron/project_setup.py
+++ b/src/clusterfuzz/_internal/cron/project_setup.py
@@ -23,6 +23,7 @@ from google.cloud import ndb
 import requests
 import yaml
 
+from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import untrusted
 from clusterfuzz._internal.base import utils
@@ -973,6 +974,11 @@ class ProjectSetup:
   def sync_user_permissions(self, project, info):
     """Sync permissions of project based on project.yaml."""
     ccs = ccs_from_info(info)
+    fflag = feature_flags.FeatureFlags.UPDATE_OSS_FUZZ_USERS_AUTO_CC
+    update_cc_to_groups = fflag.enabled
+    auto_cc_type = (
+        data_types.AutoCCType.USE_CC_GROUP
+        if update_cc_to_groups else data_types.AutoCCType.ALL)
 
     for template in get_jobs_for_project(project, info):
       job_name = template.job_name(project, self._config_suffix)
@@ -997,6 +1003,10 @@ class ProjectSetup:
 
         existing_permission = query.get()
         if existing_permission:
+          if (update_cc_to_groups and
+              existing_permission.auto_cc != auto_cc_type):
+            existing_permission.auto_cc = auto_cc_type
+            existing_permission.put()
           continue
         # For OSS-Fuzz issue tracker, use the project cc google group.
         data_types.ExternalUserPermission(
@@ -1004,7 +1014,7 @@ class ProjectSetup:
             entity_kind=data_types.PermissionEntityKind.JOB,
             entity_name=job_name,
             is_prefix=False,
-            auto_cc=data_types.AutoCCType.USE_CC_GROUP).put()
+            auto_cc=auto_cc_type).put()
 
   def set_up(self, projects):
     """Do project setup. Return a list of all the project names that were set

--- a/src/clusterfuzz/_internal/cron/project_setup.py
+++ b/src/clusterfuzz/_internal/cron/project_setup.py
@@ -998,13 +998,13 @@ class ProjectSetup:
         existing_permission = query.get()
         if existing_permission:
           continue
-
+        # OSS-Fuzz issue tracker ccs use the corresponding project cc group.
         data_types.ExternalUserPermission(
             email=cc,
             entity_kind=data_types.PermissionEntityKind.JOB,
             entity_name=job_name,
             is_prefix=False,
-            auto_cc=data_types.AutoCCType.ALL).put()
+            auto_cc=data_types.AutoCCType.USE_CC_GROUP).put()
 
   def set_up(self, projects):
     """Do project setup. Return a list of all the project names that were set

--- a/src/clusterfuzz/_internal/cron/project_setup.py
+++ b/src/clusterfuzz/_internal/cron/project_setup.py
@@ -998,7 +998,7 @@ class ProjectSetup:
         existing_permission = query.get()
         if existing_permission:
           continue
-        # OSS-Fuzz issue tracker ccs use the corresponding project cc group.
+        # For OSS-Fuzz issue tracker, use the project cc google group.
         data_types.ExternalUserPermission(
             email=cc,
             entity_kind=data_types.PermissionEntityKind.JOB,

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -208,7 +208,7 @@ class AutoCCType:
   ALL = 1
   # Auto-CC only for security issues.
   SECURITY = 2
-  # Use cc google group for all issues - oss-fuzz specific.
+  # OSS-Fuzz specific - Auto-CC the user's project google group in all issues.
   USE_CC_GROUP = 3
 
 

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -208,6 +208,8 @@ class AutoCCType:
   ALL = 1
   # Auto-CC only for security issues.
   SECURITY = 2
+  # Use cc google group for all issues - oss-fuzz specific.
+  USE_CC_GROUP = 3
 
 
 # Type of permission. Used by ExternalUserPermision.

--- a/src/clusterfuzz/_internal/google_cloud_utils/google_groups.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/google_groups.py
@@ -118,8 +118,7 @@ def create_google_group(group_name: str,
   """Create a google group."""
   identity_service = get_identity_api()
 
-  customer_id = customer_id or local_config.ProjectConfig().get(
-      'groups_customer_id')
+  customer_id = customer_id or local_config.ProjectConfig().get('customer_id')
   if not customer_id:
     logs.error('No customer ID set. Unable to create a new google group.')
     return None

--- a/src/clusterfuzz/_internal/google_cloud_utils/google_groups.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/google_groups.py
@@ -118,7 +118,8 @@ def create_google_group(group_name: str,
   """Create a google group."""
   identity_service = get_identity_api()
 
-  customer_id = customer_id or local_config.ProjectConfig().get('customer_id')
+  customer_id = customer_id or local_config.ProjectConfig().get(
+      'groups_customer_id')
   if not customer_id:
     logs.error('No customer ID set. Unable to create a new google group.')
     return None

--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -315,7 +315,8 @@ def file_issue(testcase,
                issue_tracker,
                security_severity=None,
                user_email=None,
-               additional_ccs=None):
+               additional_ccs=None,
+               allow_project_cc_group=True):
   """File an issue for the given test case."""
   logs.info(f'Filing new issue for testcase: {testcase.key.id()}.')
 
@@ -406,8 +407,10 @@ def file_issue(testcase,
       testcase.overridden_fuzzer_name or testcase.fuzzer_name)
   ccs += external_users.cc_users_for_fuzzer(fully_qualified_fuzzer_name,
                                             testcase.security_flag)
-  ccs += external_users.cc_users_for_job(testcase.job_type,
-                                         testcase.security_flag)
+  ccs += external_users.cc_users_for_job(
+      testcase.job_type,
+      testcase.security_flag,
+      allow_cc_group=allow_project_cc_group)
 
   # Add the user as a cc if requested, and any default ccs for this job.
   # Check for additional ccs or labels from the job definition.

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/oss_fuzz_build_status_test.py
@@ -125,10 +125,13 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         ('policy_get',
          'clusterfuzz._internal.issue_management.issue_tracker_policy.get'),
         'clusterfuzz._internal.issue_management.issue_tracker_utils.get_issue_tracker',
-        'clusterfuzz._internal.metrics.logs.error',
-        'requests.get',
+        'clusterfuzz._internal.metrics.logs.error', 'requests.get',
+        'clusterfuzz._internal.config.local_config.ProjectConfig'
     ])
 
+    self.mock.ProjectConfig.return_value = {
+        'issue_cc_groups.domain': 'oss-fuzz.com'
+    }
     self.mock.utcnow.return_value = datetime.datetime(2018, 2, 1)
     self.mock.is_cron.return_value = True
 
@@ -374,7 +377,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
     data_types.OssFuzzProject(
         id='proj2', name='proj2', ccs=['a@user.com']).put()
     data_types.OssFuzzProject(
-        id='proj6', name='proj7', ccs=['b@user.com']).put()
+        id='proj6', name='proj6', ccs=['b@user.com']).put()
 
     oss_fuzz_build_status.main()
     self.assertCountEqual([
@@ -426,7 +429,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
 
     self.assertEqual(2, len(self.itm.issues))
     issue = self.itm.issues[1]
-    self.assertCountEqual(['a@user.com'], issue.cc)
+    self.assertCountEqual(['proj2-ccs@oss-fuzz.com'], issue.cc)
     self.assertEqual('New', issue.status)
     self.assertEqual('proj2: Fuzzing build failure', issue.summary)
     self.assertEqual(
@@ -445,7 +448,7 @@ class OssFuzzBuildStatusTest(unittest.TestCase):
         'day once it is fixed.**', issue.body)
 
     issue = self.itm.issues[2]
-    self.assertCountEqual(['b@user.com'], issue.cc)
+    self.assertCountEqual(['proj6-ccs@oss-fuzz.com'], issue.cc)
     self.assertEqual('New', issue.status)
     self.assertEqual('proj6: Coverage build failure', issue.summary)
     self.assertEqual(

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/oss_fuzz_cc_groups_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/oss_fuzz_cc_groups_test.py
@@ -34,7 +34,12 @@ class OssFuzzCcGroupsTest(unittest.TestCase):
         'clusterfuzz._internal.google_cloud_utils.google_groups.delete_google_group_membership',
         'clusterfuzz._internal.google_cloud_utils.google_groups.set_oss_fuzz_access_settings',
         'clusterfuzz._internal.base.utils.is_service_account',
+        'clusterfuzz._internal.config.local_config.ProjectConfig'
     ])
+    self.mock.ProjectConfig.return_value = {
+        'issue_cc_groups.customer_id': 'C10101010',
+        'issue_cc_groups.domain': 'oss-fuzz.com'
+    }
 
   def test_main(self):
     """Test main execution for creating groups and syncing project ccs."""
@@ -62,7 +67,8 @@ class OssFuzzCcGroupsTest(unittest.TestCase):
     self.mock.create_google_group.assert_called_with(
         'project1-ccs@oss-fuzz.com',
         group_description=(
-            'External CCs in OSS-Fuzz issue tracker for project: project1'))
+            'External CCs in OSS-Fuzz issue tracker for project: project1'),
+        customer_id='C10101010')
 
     # project2 check
     self.mock.add_member_to_group.assert_called_with('group2_id',

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -23,6 +23,7 @@ from unittest import mock
 from google.cloud import ndb
 import googleapiclient
 
+from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.cron import project_setup
 from clusterfuzz._internal.datastore import data_types
@@ -234,6 +235,10 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     pubsub_client.create_topic(old_topic_name)
     pubsub_client.create_topic(other_topic_name)
     pubsub_client.create_subscription(old_subscription_name, old_topic_name)
+
+    data_types.FeatureFlag(
+        id=feature_flags.FeatureFlags.UPDATE_OSS_FUZZ_USERS_AUTO_CC.value,
+        enabled=True).put()
 
     self.mock.get_oss_fuzz_projects.return_value = [
         ('lib1', {

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/project_setup_test.py
@@ -140,7 +140,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     data_types.ExternalUserPermission(
         entity_kind=data_types.PermissionEntityKind.JOB,
         is_prefix=False,
-        auto_cc=data_types.AutoCCType.ALL,
+        auto_cc=data_types.AutoCCType.USE_CC_GROUP,
         entity_name='libfuzzer_asan_lib1',
         email='willberemoved@example.com').put()
 
@@ -148,7 +148,7 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
     data_types.ExternalUserPermission(
         entity_kind=data_types.PermissionEntityKind.JOB,
         is_prefix=False,
-        auto_cc=data_types.AutoCCType.ALL,
+        auto_cc=data_types.AutoCCType.USE_CC_GROUP,
         entity_name='libfuzzer_asan_lib1',
         email='primary@example.com').put()
 
@@ -1353,91 +1353,91 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_asan_lib1',
             'email': 'primary@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_ubsan_lib1',
             'email': 'primary@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_ubsan_lib1',
             'email': 'user@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_ubsan_lib1',
             'email': 'user2@googlemail.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_asan_lib1',
             'email': 'user@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_asan_lib1',
             'email': 'user2@googlemail.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'afl_asan_lib1',
             'email': 'primary@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'afl_asan_lib1',
             'email': 'user@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'afl_asan_lib1',
             'email': 'user2@googlemail.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_msan_lib3',
             'email': 'user@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_ubsan_lib3',
             'email': 'user@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'libfuzzer_asan_lib3',
             'email': 'user@example.com'
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
-            'auto_cc': 1,
+            'auto_cc': 3,
             'entity_name': 'asan_lib4',
             'email': 'user@example.com'
         },
@@ -1446,168 +1446,168 @@ class OssFuzzProjectSetupTest(unittest.TestCase):
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'libfuzzer_asan_i386_lib3',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'libfuzzer_msan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'libfuzzer_ubsan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'libfuzzer_asan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'afl_asan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'vendor1@example.com',
             'entity_name': 'libfuzzer_msan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'vendor1@example.com',
             'entity_name': 'libfuzzer_ubsan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'vendor1@example.com',
             'entity_name': 'libfuzzer_asan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'vendor1@example.com',
             'entity_name': 'afl_asan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'vendor2@example.com',
             'entity_name': 'libfuzzer_msan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'vendor2@example.com',
             'entity_name': 'libfuzzer_ubsan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'vendor2@example.com',
             'entity_name': 'libfuzzer_asan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'vendor2@example.com',
             'entity_name': 'afl_asan_lib6',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'primary@example.com',
             'entity_name': 'honggfuzz_asan_lib1',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'honggfuzz_asan_lib1',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user2@googlemail.com',
             'entity_name': 'honggfuzz_asan_lib1',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'primary@example.com',
             'entity_name': 'libfuzzer_asan_lib7',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'libfuzzer_asan_lib7',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'libfuzzer_nosanitizer_lib8',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'primary@example.com',
             'entity_name': 'libfuzzer_nosanitizer_lib8',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'primary@example.com',
             'entity_name': 'libfuzzer_nosanitizer_i386_lib8',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'user@example.com',
             'entity_name': 'centipede_asan_lib9',
-            'auto_cc': 1
+            'auto_cc': 3
         },
         {
             'entity_kind': 1,
             'is_prefix': False,
             'email': 'primary@example.com',
             'entity_name': 'centipede_asan_lib9',
-            'auto_cc': 1
+            'auto_cc': 3
         },
     ])
 

--- a/src/clusterfuzz/_internal/tests/core/base/external_users_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/external_users_test.py
@@ -127,6 +127,13 @@ class ExternalUsersTest(unittest.TestCase):
         auto_cc=data_types.AutoCCType.NONE).put()
 
     data_types.ExternalUserPermission(
+        email='user11@example.com',
+        entity_name='job',
+        entity_kind=data_types.PermissionEntityKind.JOB,
+        is_prefix=False,
+        auto_cc=data_types.AutoCCType.USE_CC_GROUP).put()
+
+    data_types.ExternalUserPermission(
         email='uploader1@example.com',
         entity_name=None,
         entity_kind=data_types.PermissionEntityKind.UPLOADER,
@@ -137,7 +144,7 @@ class ExternalUsersTest(unittest.TestCase):
     data_types.Fuzzer(name='fuzzer').put()
     data_types.Fuzzer(name='parent', jobs=['job', 'job2', 'job3']).put()
 
-    data_types.Job(name='job').put()
+    data_types.Job(name='job', environment_string='PROJECT_NAME=project1').put()
     data_types.Job(name='job2').put()
     data_types.Job(name='job3').put()
 
@@ -311,9 +318,12 @@ class ExternalUsersTest(unittest.TestCase):
   def test_cc_users_for_job(self):
     """cc_users_for_job tests."""
     result = external_users.cc_users_for_job('job', security_flag=False)
-    self.assertEqual(result, ['user2@example.com', 'user@example.com'])
+    self.assertEqual(
+        result,
+        ['project1-ccs@google.com', 'user2@example.com', 'user@example.com'])
 
-    result = external_users.cc_users_for_job('job', security_flag=True)
+    result = external_users.cc_users_for_job(
+        'job', security_flag=True, allow_cc_group=False)
     self.assertEqual(result, ['user2@example.com', 'user@example.com'])
 
     result = external_users.cc_users_for_job('job2', security_flag=False)


### PR DESCRIPTION
This PR is related to the oss-fuzz issue tracker logic in clusterfuzz. It switches from CCing individual users from oss-fuzz projects to CCing the correspondent project CC google group.

This should be merged and deployed after:
* Confirming that the cc groups are working as expected (containing all the correct members);
* Backfilled all current open issues with the project group;
* Disabled apply_ccs cronjob;
* PR in clusterfuzz-config adding the project.yaml value for issue_cc_groups customer_id and domain.
* Backfilled all oss-fuzz users' `PermissionEntityKind` in datastore to the new auto_cc type -> this will need to be done in the same PR as it depends on changes here;

Context: b/477964128