### PR TITLE
Upgrade OpenJDK from 11 to 17

### DIFF
--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -115,7 +115,7 @@ sudo apt-get update
 sudo apt-get install -y \
     docker-ce \
     google-cloud-cli \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
     liblzma-dev
 
 # Install patchelf - latest version not available on some older distros so we


### PR DESCRIPTION
Running `./local/install_deps.bash` is now broken due to the fact that `openjdk-11-jdk` is no longer present in default `apt` repositories.