### PR TITLE
memoize queue size for utask-main and preprocess

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -26,6 +26,7 @@ from typing import Optional
 from google.cloud import monitoring_v3
 
 from clusterfuzz._internal.base import external_tasks
+from clusterfuzz._internal.base import memoize
 from clusterfuzz._internal.base import persistent_cache
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.base.tasks import task_utils
@@ -694,6 +695,7 @@ def get_utask_mains() -> List[PubSubTask]:
   return handle_multiple_utask_main_messages(messages, UTASK_MAIN_QUEUE)
 
 
+@memoize.wrap(memoize.InMemory(60))
 def get_utask_main_queue_size():
   """Returns the size of the utask main queue."""
   queue_name = UTASK_MAIN_QUEUE

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -20,6 +20,7 @@ import time
 from google.cloud import monitoring_v3
 
 from clusterfuzz._internal.base import feature_flags
+from clusterfuzz._internal.base import memoize
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.datastore import data_types
@@ -30,6 +31,7 @@ from clusterfuzz._internal.metrics import logs
 PREPROCESS_TARGET_SIZE_DEFAULT = 10000
 
 
+@memoize.wrap(memoize.InMemory(60))
 def get_queue_size(creds, project_id, subscription_id):
   """Returns the size of the queue (unacked messages)."""
   # TODO(metzman): Not all of these are fuzz_tasks. Deal with that.

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/queue_size_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/queue_size_test.py
@@ -56,7 +56,7 @@ class GetUtaskMainQueueSizeTest(unittest.TestCase):
     mock_series.points = [mock_point]
     mock_client.list_time_series.return_value = [mock_series]
 
-    size = tasks.get_utask_main_queue_size()
+    size = tasks.get_utask_main_queue_size(__memoize_force__=True)
     self.assertEqual(size, 12345)
 
     mock_client.list_time_series.assert_called_once()
@@ -77,7 +77,7 @@ class GetUtaskMainQueueSizeTest(unittest.TestCase):
     mock_series.points = [mock_point]
     mock_client.list_time_series.return_value = [mock_series]
 
-    size = tasks.get_utask_main_queue_size()
+    size = tasks.get_utask_main_queue_size(__memoize_force__=True)
     self.assertEqual(size, 10)
 
     kwargs = mock_client.list_time_series.call_args[1]
@@ -88,5 +88,5 @@ class GetUtaskMainQueueSizeTest(unittest.TestCase):
     """Test failure to retrieve queue size (returns 0)."""
     mock_client = self.mock_monitoring.return_value
     mock_client.list_time_series.side_effect = Exception("Boom")
-    size = tasks.get_utask_main_queue_size()
+    size = tasks.get_utask_main_queue_size(__memoize_force__=True)
     self.assertEqual(size, 0)


### PR DESCRIPTION
I does a memorization of 60 seconds for the functions that queries the `utask-main` and `preprocess` queues size. It's required to stop reaching the queries per minute quota. 

It intends to fix [this error group](https://pantheon.corp.google.com/errors/detail/CPWHwu6d_4SnLg;locations=global?project=clusterfuzz-external&e=-13802955&mods=logs_tg_prod)