### PR TITLE
Normalize emails for oss-fuzz cc groups

### DIFF
--- a/src/clusterfuzz/_internal/cron/oss_fuzz_cc_groups.py
+++ b/src/clusterfuzz/_internal/cron/oss_fuzz_cc_groups.py
@@ -95,7 +95,7 @@ def sync_project_cc_group(project_name: str, ccs: list[str]):
     # Ignore the SA that created the group from members to delete.
     if not member or utils.is_service_account(member):
       continue
-    memebership_name = group_memberships[member]
+    memebership_name = group_memberships_norm[member]
     google_groups.delete_google_group_membership(group_id, member,
                                                  memebership_name)
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/oss_fuzz_cc_groups_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/oss_fuzz_cc_groups_test.py
@@ -43,7 +43,8 @@ class OssFuzzCcGroupsTest(unittest.TestCase):
     project1 = data_types.OssFuzzProject(
         name='project1', ccs=['member2@example.com'])
     project2 = data_types.OssFuzzProject(
-        name='project2', ccs=['member2@example.com', 'member3@example.com'])
+        name='project2',
+        ccs=['member2@example.com', 'Member3+alias@example.com'])
     project1.put()
     project2.put()
 


### PR DESCRIPTION
**Motivation**
The cronjob is hitting some errors during group membership management that are mainly related to normalizing emails to match how Cloud Identity Groups API treats them. For instance:
* User emails containing invalid character '+' (usually used for tags, but unsupported by groups API):  `"Error(1005): Entity Id must not contain the '+' character."}]}]"`
* User emails that are normalized/canonicalized when added to google groups. Thus, when the membership is retrieved to compare with the email from the project yaml, the same email is considered distinct (which creates issues with trying incorrectly add/remove members):  `"Error(4003): Cannot create membership '****' in 'groups/***' because it already exists."`

**Changes**
Added a method to normalize the emails retrived from the ccs info in project yaml and from the membership query for the google groups. The normalization consists on:
* lowercasing.
* converting googlemail to gmail.
* removing pluses aliases/tags not supported by groups.
* removing dots (only when the domain is gmail, as dots are ignored in this domain).

These were loosely based on [go/email-address-normalization](http://go/email-address-normalization)

Context: b/477964128