### PR TITLE
Add .devcontainer config with Ubuntu 24.04 and Python 3.11

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM mcr.microsoft.com/devcontainers/base:noble
 
 # Prevent interactive prompts during package installation.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,17 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 {
 	"name": "ClusterFuzz Noble Python 3.11",
 	"build": {


### PR DESCRIPTION
I have created a `.devcontainer` directory with a `Dockerfile` and `devcontainer.json` to provide a development environment using Ubuntu 24.04 (Noble) and Python 3.11.

The `Dockerfile` uses `mcr.microsoft.com/devcontainers/base:noble` as the base image and installs Python 3.11 from the `deadsnakes/ppa`. It also installs `pipenv` and essential build tools, and sets Python 3.11 as the default system `python3`.

The `devcontainer.json` is configured with modern VS Code settings and includes recommendations for the Python and Pylance extensions. It also includes a robust `postCreateCommand` to install project dependencies if the `local/install_deps.bash` script is present.


---
*PR created automatically by Jules for task [14289153259786859003](https://jules.google.com/task/14289153259786859003) started by @jardondiego*