### PR TITLE
Add devcontainer configuration with Ubuntu and Python 3.11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,6 @@
       }
     }
   },
-  "postCreateCommand": "python --version && pip install --upgrade pip && pip install pipenv",
+  "postCreateCommand": "python --version && pip install --upgrade pip && pip install pipenv && bash local/install_deps.bash",
   "remoteUser": "vscode"
 }


### PR DESCRIPTION
Devcontainers provide a consistent and reproducible development environment for all contributors. By containerizing the setup, we eliminate 'it works on my machine' issues and significantly simplify the onboarding process for new developers.

With this change, running `local/install_deps.bash` results in consistent outcomes. After this change lands, you should be able to spawn a fresh development environment where you can simply start playing around with ClusterFuzz.