### PR TITLE
Enable manual job configuration setting to select OS for Swarming task execution

### DIFF
--- a/src/clusterfuzz/_internal/swarming/__init__.py
+++ b/src/clusterfuzz/_internal/swarming/__init__.py
@@ -69,7 +69,7 @@ def _get_task_dimensions(job: data_types.Job, platform_specific_dimensions: list
   unique_dimensions = {}
   unique_dimensions['os'] = job.platform
   unique_dimensions['pool'] = _get_swarming_config().get('swarming_pool')
-  
+
   os_task_dimension = job.get_environment().get('SWARMING_OS_DIMENSION')
   if os_task_dimension:
     unique_dimensions['os'] = os_task_dimension

--- a/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
+++ b/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
@@ -97,21 +97,6 @@ class SwarmingTest(unittest.TestCase):
 
     self.assertEqual(spec, expected_spec)
 
-  def test_get_spec_with_swarming_os_dimension(self):
-    """Tests that _get_new_task_spec uses SWARMING_OS_DIMENSION if present."""
-    job = data_types.Job(
-        name='libfuzzer_chrome_asan',
-        platform='LINUX',
-        environment_string='SWARMING_OS_DIMENSION = custom_os')
-    job.put()
-    spec = swarming._get_new_task_spec(  # pylint: disable=protected-access
-        'corpus_pruning', job.name, 'https://download_url')
-
-    # Verify that the 'os' dimension is 'custom_os' instead of 'LINUX'.
-    dimensions = spec.task_slices[0].properties.dimensions
-    os_dimension = [d.value for d in dimensions if d.key == 'os'][0]
-    self.assertEqual(os_dimension, 'custom_os')
-
   def test_get_spec_from_config_raises_error_on_unknown_config(self):
     """Tests that _get_new_task_spec raises error when there's no mapping for
     the config."""
@@ -389,5 +374,19 @@ class SwarmingTest(unittest.TestCase):
         swarming_pb2.StringPair(key='pool', value='pool-name'),
         swarming_pb2.StringPair(key='key1', value='job_value1'),
         swarming_pb2.StringPair(key='key2', value='value2'),
+    ]
+    self.assertCountEqual(dimensions, expected_dimensions)
+
+  def test_get_task_dimensions_with_os_env_var(self):
+    """Tests that _get_task_dimensions handles SWARMING_OS_DIMENSION env var."""
+    job = data_types.Job(
+        name='libfuzzer_chrome_asan',
+        platform='LINUX',
+        environment_string='SWARMING_OS_DIMENSION = windows')
+    dimensions = swarming._get_task_dimensions(job, [])  # pylint: disable=protected-access
+
+    expected_dimensions = [
+        swarming_pb2.StringPair(key='os', value='windows'),
+        swarming_pb2.StringPair(key='pool', value='pool-name'),
     ]
     self.assertCountEqual(dimensions, expected_dimensions)


### PR DESCRIPTION
By default, os selection for swarming tasks should be the `job.platform` field, but we should also be able to override in case it's needed since not all possible values of `job.platform` map to an OS field in swarming.

After testing the change in the development environment, there are spikes in errors and overall reliability metrics look fine as well.
Dashboard http://shortn/_dqBN6VW9hf
Logs http://shortn/_2CAdQoldae