### PR TITLE
Set rss_limit_mb to 0 by default for chromium/google centipede targets

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -24,6 +24,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.bot.fuzzers import dictionary_manager
 from clusterfuzz._internal.bot.fuzzers import engine_common
 from clusterfuzz._internal.bot.fuzzers import options as fuzzer_options
@@ -425,9 +426,12 @@ class Engine(engine.Engine):
 
     existing_runner_flags = os.environ.get('CENTIPEDE_RUNNER_FLAGS')
     if not existing_runner_flags:
-      rss_limit = constants.RSS_LIMIT_MB_DEFAULT
       if constants.RSS_LIMIT_MB_FLAGNAME in fuzzer_arguments:
         rss_limit = fuzzer_arguments[constants.RSS_LIMIT_MB_FLAGNAME]
+      elif (utils.is_chromium() or utils.default_project_name() == 'google'):
+        rss_limit = 0
+      else:
+        rss_limit = constants.RSS_LIMIT_MB_DEFAULT
       timeout = constants.TIMEOUT_PER_INPUT_REPR_DEFAULT
       if constants.TIMEOUT_PER_INPUT_FLAGNAME in fuzzer_arguments:
         timeout = fuzzer_arguments[constants.TIMEOUT_PER_INPUT_FLAGNAME]


### PR DESCRIPTION
This matches the behavior for libFuzzer targets: https://github.com/google/clusterfuzz/blob/9f0c774d414c1d9be2926ed0a8a1ef69d44dd8bd/src/clusterfuzz/_internal/bot/fuzzers/libFuzzer/fuzzer.py#L48-L51