### PR TITLE
Embed links to issues in `Triage:` messages

### DIFF
--- a/src/appengine/private/components/testcase-detail/testcase-detail.html
+++ b/src/appengine/private/components/testcase-detail/testcase-detail.html
@@ -463,7 +463,7 @@
                     <span class="help" title="A message related to bug triage and filing.">Triage:</span>
                   </td>
                   <td colspan="5" class="value">
-                    [[info.metadata.triage_message]]
+                    <span inner-h-t-m-l="[[info.metadata.triage_message]]"></span>
                   </td>
                 </tr>
               </template>

--- a/src/clusterfuzz/_internal/cron/triage.py
+++ b/src/clusterfuzz/_internal/cron/triage.py
@@ -259,21 +259,27 @@ def _check_and_update_similar_bug(testcase, issue_tracker):
     if not issue:
       continue
 
+    similar_testcase_id = similar_testcase.key.id()
+    testcase_url = data_handler.TESTCASE_REPORT_URL.format(
+        domain=data_handler.get_domain(), testcase_id=similar_testcase_id)
+    issue_url = issue_tracker.issue_url(issue.id)
+    testcase_link = f'<a href="{testcase_url}">{similar_testcase_id}</a>'
+    issue_link = f'<a href="{issue_url}">{issue.id}</a>'
+
     # If the reproducible issue is not verified yet, bug is still valid and
     # might be caused by non-availability of latest builds. In that case,
     # don't file a new bug yet.
     if similar_testcase.open and not similar_testcase.one_time_crasher_flag:
       _add_triage_message(
           testcase, 'Delaying filing a bug since similar reproducible testcase '
-          f'({similar_testcase.key.id()} in issue {issue.id}) is not verified '
-          'yet.')
+          f'({testcase_link} in issue {issue_link}) is not verified yet.')
       return True
 
     # If the issue is still open, no need to file a duplicate bug.
     if issue.is_open:
       _add_triage_message(
           testcase, f'Skipping filing a bug since similar testcase '
-          f'({similar_testcase.key.id()}) has an open issue ({issue.id}).')
+          f'({testcase_link}) has an open issue ({issue_link}).')
       return True
 
     # If the issue indicates that this crash needs to be ignored, no need to
@@ -283,12 +289,9 @@ def _check_and_update_similar_bug(testcase, issue_tracker):
     if ignore_label in issue.labels:
       _add_triage_message(
           testcase,
-          ('Skipping filing a bug since similar testcase ({testcase_id}) in '
-           'issue ({issue_id}) is blacklisted with {ignore_label} label.'
-          ).format(
-              testcase_id=similar_testcase.key.id(),
-              issue_id=issue.id,
-              ignore_label=ignore_label))
+          f'Skipping filing a bug since similar testcase '
+          f'({testcase_link}) in issue ({issue_link}) is blacklisted with '
+          f'{ignore_label} label.')
       return True
 
     # If this testcase is not reproducible, and a previous similar
@@ -299,7 +302,7 @@ def _check_and_update_similar_bug(testcase, issue_tracker):
       _add_triage_message(
           testcase,
           'Skipping filing unreproducible bug since one was already filed '
-          f'({similar_testcase.key.id()} in issue {issue.id}).')
+          f'({testcase_link} in issue {issue_link}).')
       return True
 
     # If the issue is recently closed, wait certain time period to make sure
@@ -308,9 +311,8 @@ def _check_and_update_similar_bug(testcase, issue_tracker):
         issue.closed_time, hours=data_types.MIN_ELAPSED_TIME_SINCE_FIXED)):
       _add_triage_message(
           testcase,
-          ('Delaying filing a bug since similar testcase '
-           '({testcase_id}) in issue ({issue_id}) was just fixed.').format(
-               testcase_id=similar_testcase.key.id(), issue_id=issue.id))
+          f'Delaying filing a bug since similar testcase '
+          f'({testcase_link}) in issue ({issue_link}) was just fixed.')
       return True
 
   return False

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/triage_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/triage_test.py
@@ -386,8 +386,11 @@ class CheckAndUpdateSimilarBug(unittest.TestCase):
 
     testcase = data_handler.get_testcase_by_id(self.testcase.key.id())
     self.assertEqual(
-        'Skipping filing a bug since similar testcase (2) in issue (1) '
-        'is blacklisted with ClusterFuzz-Ignore label.',
+        'Skipping filing a bug since similar testcase '
+        '(<a href="https://test-clusterfuzz.appspot.com/testcase?key=2">2</a>)'
+        ' in issue '
+        '(<a href="https://bugs.chromium.org/p/test-project/issues/detail?'
+        'id=1">1</a>) is blacklisted with ClusterFuzz-Ignore label.',
         testcase.get_metadata(triage.TRIAGE_MESSAGE_KEY))
 
   def test_similar_testcase_with_issue_recently_closed(self):
@@ -412,8 +415,12 @@ class CheckAndUpdateSimilarBug(unittest.TestCase):
 
     testcase = data_handler.get_testcase_by_id(self.testcase.key.id())
     self.assertEqual(
-        'Delaying filing a bug since similar testcase (2) in issue (1) '
-        'was just fixed.', testcase.get_metadata(triage.TRIAGE_MESSAGE_KEY))
+        'Delaying filing a bug since similar testcase '
+        '(<a href="https://test-clusterfuzz.appspot.com/testcase?key=2">2</a>)'
+        ' in issue '
+        '(<a href="https://bugs.chromium.org/p/test-project/issues/detail?'
+        'id=1">1</a>) was just fixed.',
+        testcase.get_metadata(triage.TRIAGE_MESSAGE_KEY))
 
 
 @test_utils.with_cloud_emulators('datastore')


### PR DESCRIPTION
Working on https://oss-fuzz.com/testcase-detail/4819102282874880 today I would find it quite helpful to be able to jump straight to the duplicate/issue.