### PR TITLE
[BlackboxAudit] Add butler script to download a fuzzer config

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -351,6 +351,20 @@ class Fuzzer(Model):
   # on disk |FUZZ_INPUTS_DISK|, rather than smaller tmpfs one (FUZZ_INPUTS).
   has_large_testcases = ndb.BooleanProperty(default=False)
 
+  def get_config_dict(self):
+    """Returns a dict containing the required config to upload a fuzzer."""
+
+    return {
+        'jobs': self.jobs,
+        'data_bundle_name': self.data_bundle_name,
+        'timeout': self.timeout,
+        'max_testcases': self.max_testcases,
+        'external_contribution': self.external_contribution,
+        'additional_environment_string': self.additional_environment_string,
+        'executable_path': self.executable_path,
+        'launcher_script': self.launcher_script,
+    }
+
 
 class BuildCrashStatsJobHistory(Model):
   """Represents the record of build_crash_stats run."""

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -261,6 +261,27 @@ class Blacklist(Model):
 class Fuzzer(Model):
   """Represents a fuzzer."""
 
+  _EXCLUDED_FIELDS_FOR_CONFIG = (
+      'created_at',
+      'timestamp',
+      'name',
+      'filename',
+      'blobstore_key',
+      'file_size',
+      'supported_platforms',
+      'result',
+      'result_timestamp',
+      'console_output',
+      'return_code',
+      'sample_testcase',
+      'untrusted_content',
+      'stats_columns',
+      'stats_column_descriptions',
+      'builtin',
+      'differential',
+      'has_large_testcases',
+  )
+
   # Created at timestamp. Not set for fuzzers created before this field was
   # added.
   created_at = ndb.DateTimeProperty()
@@ -354,16 +375,7 @@ class Fuzzer(Model):
   def get_config_dict(self):
     """Returns a dict containing the required config to upload a fuzzer."""
 
-    return {
-        'jobs': self.jobs,
-        'data_bundle_name': self.data_bundle_name,
-        'timeout': self.timeout,
-        'max_testcases': self.max_testcases,
-        'external_contribution': self.external_contribution,
-        'additional_environment_string': self.additional_environment_string,
-        'executable_path': self.executable_path,
-        'launcher_script': self.launcher_script,
-    }
+    return self.to_dict(exclude=self._EXCLUDED_FIELDS_FOR_CONFIG)
 
 
 class BuildCrashStatsJobHistory(Model):

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/fuzzers_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/fuzzers_test.py
@@ -21,6 +21,7 @@ import flask
 import webtest
 
 from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.tests.test_libs import helpers as test_helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 from handlers import fuzzers
@@ -107,3 +108,79 @@ class CreateHandlerTest(unittest.TestCase):
     self.assertEqual(fuzzer.name, fuzzer_name)
     self.assertEqual(fuzzer.revision, 0)
     self.assertEqual(fuzzer.created_at, self.mock_time)
+
+
+@test_utils.with_cloud_emulators('datastore')
+class EditHandlerTest(unittest.TestCase):
+  """Tests EditHandler updates an existing Fuzzer"""
+
+  def setUp(self):
+    test_helpers.patch(self, [
+        'libs.access.has_access',
+        'libs.auth.get_current_user',
+        'libs.helpers.get_user_email',
+        'handlers.fuzzers.datetime',
+        'handlers.fuzzers.EditHandler.get_upload',
+        'handlers.fuzzers.EditHandler._get_executable_path',
+        'handlers.fuzzers.EditHandler._get_launcher_script',
+    ])
+    self.mock.has_access.return_value = True
+    self.mock.get_current_user().email = 'test@user.com'
+    self.mock.get_user_email.return_value = 'test@user.com'
+    self.mock.get_upload.return_value = storage.GcsBlobInfo(
+        bucket='test-bucket', object_path='key', filename='file.zip', size=123)
+
+    self.mock._get_executable_path.return_value = 'executable'
+    self.mock._get_launcher_script.return_value = 'launcher'
+
+    self.mock_time = datetime.datetime(2026, 1, 1, tzinfo=None)
+    self.mock.datetime.datetime.now.return_value = self.mock_time
+    self.mock.datetime.timezone = datetime.timezone
+
+    flaskapp = flask.Flask('testflask')
+    flaskapp.add_url_rule(
+        '/fuzzers/edit', view_func=fuzzers.EditHandler.as_view('/fuzzers/edit'))
+    self.app = webtest.TestApp(flaskapp)
+
+  def test_update_fuzzer(self):
+    """Test fuzzers/edit updates the fuzzer"""
+
+    fuzzer_name = 'test_fuzzer'
+    fuzzer = data_types.Fuzzer(
+        name=fuzzer_name,
+        jobs=[],
+        revision=1,
+        timeout=10,
+    )
+    fuzzer.put()
+
+    request_payload = {
+        'additional_environment_string': 'args=123',
+        'csrf_token': form.generate_csrf_token(),
+        'data_bundle_name': 'test_bundle',
+        'external_contribution': True,
+        'jobs': [],
+        'key': fuzzer.key.id(),
+        'max_testcases': 100,
+        'name': fuzzer_name,
+        'timeout': 30,
+    }
+
+    self.app.post_json('/fuzzers/edit', request_payload)
+
+    fuzzer = data_types.Fuzzer.query(
+        data_types.Fuzzer.name == fuzzer_name).get()
+
+    self.assertEqual(
+        fuzzer.get_config_dict(), {
+            'additional_environment_string': 'args=123',
+            'data_bundle_name': 'test_bundle',
+            'external_contribution': True,
+            'executable_path': 'executable',
+            'launcher_script': 'launcher',
+            'jobs': [],
+            'max_testcases': 100,
+            'revision': 2,
+            'source': 'test@user.com',
+            'timeout': 30,
+        })

--- a/src/clusterfuzz/_internal/tests/core/datastore/data_types_test.py
+++ b/src/clusterfuzz/_internal/tests/core/datastore/data_types_test.py
@@ -20,6 +20,42 @@ from clusterfuzz._internal.tests.test_libs import test_utils
 
 
 @test_utils.with_cloud_emulators('datastore')
+class FuzzerTest(unittest.TestCase):
+  """Test Fuzzer."""
+
+  def test_get_config_dict(self):
+    """Test get_config_dict()."""
+
+    fuzzer = data_types.Fuzzer(
+        name='fuzzer',
+        jobs=['job1', 'job2'],
+        data_bundle_name='data_bundle',
+        timeout=10,
+        max_testcases=100,
+        external_contribution=True,
+        additional_environment_string='A=1\nB=2',
+        executable_path='path/to/exec',
+        launcher_script='path/to/launcher',
+    )
+
+    config_dict = fuzzer.get_config_dict()
+
+    self.assertDictEqual(
+        {
+            'jobs': ['job1', 'job2'],
+            'data_bundle_name': 'data_bundle',
+            'timeout': 10,
+            'max_testcases': 100,
+            'external_contribution': True,
+            'additional_environment_string': 'A=1\nB=2',
+            'executable_path': 'path/to/exec',
+            'launcher_script': 'path/to/launcher',
+        },
+        config_dict,
+    )
+
+
+@test_utils.with_cloud_emulators('datastore')
 class TestcaseTest(unittest.TestCase):
   """Test Testcase."""
 

--- a/src/clusterfuzz/_internal/tests/core/datastore/data_types_test.py
+++ b/src/clusterfuzz/_internal/tests/core/datastore/data_types_test.py
@@ -36,6 +36,8 @@ class FuzzerTest(unittest.TestCase):
         additional_environment_string='A=1\nB=2',
         executable_path='path/to/exec',
         launcher_script='path/to/launcher',
+        revision=3,
+        source='author',
     )
 
     config_dict = fuzzer.get_config_dict()
@@ -50,6 +52,8 @@ class FuzzerTest(unittest.TestCase):
             'additional_environment_string': 'A=1\nB=2',
             'executable_path': 'path/to/exec',
             'launcher_script': 'path/to/launcher',
+            'revision': 3,
+            'source': 'author',
         },
         config_dict,
     )

--- a/src/clusterfuzz/_internal/tests/core/local/butler/scripts/download_fuzzer_config_test.py
+++ b/src/clusterfuzz/_internal/tests/core/local/butler/scripts/download_fuzzer_config_test.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for download_fuzzer_config."""
+
+import json
+import os
+import unittest
+
+from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.tests.test_libs import helpers
+from clusterfuzz._internal.tests.test_libs import test_utils
+from local.butler.scripts import download_fuzzer_config
+
+
+class Args:
+
+  def __init__(self, script_args, non_dry_run=True):
+    self.script_args = script_args
+    self.non_dry_run = non_dry_run
+
+
+@test_utils.with_cloud_emulators('datastore')
+class DownloadFuzzerConfigTest(unittest.TestCase):
+  """Tests for download_fuzzer_config."""
+
+  def setUp(self):
+    helpers.patch(
+        self,
+        [
+            'sys.exit',
+        ],
+    )
+
+    self.fuzzer1 = data_types.Fuzzer(
+        name='fuzzer1',
+        jobs=['job1'],
+        data_bundle_name='data_bundle1',
+        timeout=10,
+        max_testcases=100,
+        external_contribution=True,
+        additional_environment_string='A=1',
+        executable_path='path/to/exec1',
+        launcher_script='path/to/launcher1',
+    )
+    self.fuzzer1.put()
+
+    self.fuzzer2 = data_types.Fuzzer(
+        name='fuzzer2',
+        jobs=[],
+        data_bundle_name='data_bundle2',
+        timeout=20,
+        max_testcases=200,
+        external_contribution=False,
+        additional_environment_string='B=2',
+        executable_path='path/to/exec2',
+        launcher_script='path/to/launcher2',
+    )
+    self.fuzzer2.put()
+
+  def tearDown(self):
+    if os.path.exists('fuzzer1_config.json'):
+      os.remove('fuzzer1_config.json')
+    if os.path.exists('fuzzer2_config.json'):
+      os.remove('fuzzer2_config.json')
+
+  def test_execute_success(self):
+    """Test successful download."""
+    args = Args(['fuzzer1', 'fuzzer2'])
+    download_fuzzer_config.execute(args)
+
+    with open('fuzzer1_config.json') as f:
+      config1 = json.load(f)
+      self.assertEqual(['job1'], config1['jobs'])
+      self.assertEqual('data_bundle1', config1['data_bundle_name'])
+      self.assertEqual(10, config1['timeout'])
+
+    with open('fuzzer2_config.json') as f:
+      config2 = json.load(f)
+      self.assertEqual([], config2['jobs'])
+      self.assertEqual('data_bundle2', config2['data_bundle_name'])
+      self.assertEqual(20, config2['timeout'])
+
+  def test_execute_not_found(self):
+    """Test fuzzer not found."""
+    args = Args(['fuzzer1', 'fuzzer_missing'])
+    download_fuzzer_config.execute(args)
+
+    self.assertTrue(os.path.exists('fuzzer1_config.json'))
+    self.assertFalse(os.path.exists('fuzzer_missing_config.json'))

--- a/src/local/butler/scripts/download_fuzzer_config.py
+++ b/src/local/butler/scripts/download_fuzzer_config.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Download fuzzer config as a JSON file."""
+
+import json
+import sys
+
+from clusterfuzz._internal.datastore import data_types
+
+
+def execute(args):
+  """Download fuzzer config."""
+  if not args.script_args:
+    print('Please provide a list of fuzzer names as script arguments.')
+    sys.exit(1)
+
+  fuzzers = data_types.Fuzzer.query(
+      data_types.Fuzzer.name.IN(args.script_args)).fetch()
+
+  existing_fuzzer_names = {fuzzer.name for fuzzer in fuzzers}
+
+  for fuzzer_name in args.script_args:
+    if fuzzer_name not in existing_fuzzer_names:
+      print(f'Fuzzer {fuzzer_name} not found.')
+
+  if not args.non_dry_run:
+    print('Skipping writes in dry-run mode.')
+    return
+
+  for fuzzer in fuzzers:
+    config = fuzzer.get_config_dict()
+    filename = f'{fuzzer.name}_config.json'
+
+    with open(filename, 'w') as f:
+      json.dump(config, f, indent=4)
+
+    print(f'Saved config for {fuzzer.name} to {filename}.')


### PR DESCRIPTION
Adds script to download a JSON config with the parameters required to upload a fuzzer.

Along with #5236 allows us to edit configs without going through the UI.

We want to store these configs in VCS so that we have a history of the jobs that a fuzzer is enabled for

### Testing
I ran this with my local server and the  prod config with `python butler.py  run --non-dry-run -c ../clusterfuzz-config/configs/internal download_fuzzer_config --script_args ifratric-browserfuzzer-v3`
and
`python butler.py  run --non-dry-run --local -c configs/test download_fuzzer_config --script_args dylanj_test_fuzzer`

Then uploaded a test fuzzer locally with `python butler.py  run --non-dry-run -c configs/test/ --local upload_fuzzer --script_args --fuzzer-name=dylanj_test_fuzzer --fuzzer-archive-path=../dylanj_b0ring_webidl_fuzzer.zip --config-path=test_config.json`