### PR TITLE
Swarming: Avoids mounting directories at startup

### DIFF
--- a/src/clusterfuzz/_internal/swarming/__init__.py
+++ b/src/clusterfuzz/_internal/swarming/__init__.py
@@ -147,6 +147,7 @@ def _get_env_vars(logs_project_id: str,
       swarming_pb2.StringPair(key='SWARMING_BOT', value='True'),  # pylint: disable=no-member
       swarming_pb2.StringPair(key='LOG_TO_GCP', value='True'),  # pylint: disable=no-member
       swarming_pb2.StringPair(key='IS_K8S_ENV', value='True'),  # pylint: disable=no-member
+      swarming_pb2.StringPair(key='DISABLE_MOUNTS', value='True'),  # pylint: disable=no-member
       swarming_pb2.StringPair(  # pylint: disable=no-member
           key='LOGGING_CLOUD_PROJECT_ID',
           value=logs_project_id or ''),
@@ -159,20 +160,21 @@ def _get_env_vars(logs_project_id: str,
   _append_metadata_env_var(default_task_environment, 'DEPLOYMENT_ZIP',
                            'project/attributes/deployment-zip')
 
-  env_vars = []
-  env_vars.append(
+  swarming_bot_env = []
+  swarming_bot_env.append(
       swarming_pb2.StringPair(  # pylint: disable=no-member
           key='DOCKER_IMAGE',
           value=instance_spec.get('docker_image', '')))
 
   platform_specific_env = instance_spec.get('env', [])
   for var in platform_specific_env:
-    env_vars.append(swarming_pb2.StringPair(key=var['key'], value=var['value']))  # pylint: disable=no-member
+    swarming_bot_env.append(
+        swarming_pb2.StringPair(key=var['key'], value=var['value']))  # pylint: disable=no-member
 
-  env_vars.append(_env_vars_to_json(default_task_environment))
-  env_vars.extend(default_task_environment)
+  swarming_bot_env.extend(default_task_environment)
+  swarming_bot_env.append(_env_vars_to_json(swarming_bot_env))
 
-  return env_vars
+  return swarming_bot_env
 
 
 def _env_vars_to_json(

--- a/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
+++ b/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
@@ -88,18 +88,20 @@ class SwarmingTest(unittest.TestCase):
                             value=
                             'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
                         ),
-                        swarming_pb2.StringPair(
-                            key='DOCKER_ENV_VARS',
-                            value=
-                            '{"UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
-                        ),
                         swarming_pb2.StringPair(key='UWORKER', value='True'),
                         swarming_pb2.StringPair(
                             key='SWARMING_BOT', value='True'),
                         swarming_pb2.StringPair(key='LOG_TO_GCP', value='True'),
                         swarming_pb2.StringPair(key='IS_K8S_ENV', value='True'),
                         swarming_pb2.StringPair(
+                            key='DISABLE_MOUNTS', value='True'),
+                        swarming_pb2.StringPair(
                             key='LOGGING_CLOUD_PROJECT_ID', value='project_id'),
+                        swarming_pb2.StringPair(
+                            key='DOCKER_ENV_VARS',
+                            value=
+                            '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
+                        ),
                     ],
                     secret_bytes=base64.b64encode(
                         'https://download_url'.encode('utf-8'))))
@@ -160,18 +162,20 @@ class SwarmingTest(unittest.TestCase):
                         swarming_pb2.StringPair(key='DOCKER_IMAGE', value=''),
                         swarming_pb2.StringPair(key='ENV_VAR1', value='VALUE1'),
                         swarming_pb2.StringPair(key='ENV_VAR2', value='VALUE2'),
-                        swarming_pb2.StringPair(
-                            key='DOCKER_ENV_VARS',
-                            value=
-                            '{"UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
-                        ),
                         swarming_pb2.StringPair(key='UWORKER', value='True'),
                         swarming_pb2.StringPair(
                             key='SWARMING_BOT', value='True'),
                         swarming_pb2.StringPair(key='LOG_TO_GCP', value='True'),
                         swarming_pb2.StringPair(key='IS_K8S_ENV', value='True'),
                         swarming_pb2.StringPair(
+                            key='DISABLE_MOUNTS', value='True'),
+                        swarming_pb2.StringPair(
                             key='LOGGING_CLOUD_PROJECT_ID', value='project_id'),
+                        swarming_pb2.StringPair(
+                            key='DOCKER_ENV_VARS',
+                            value=
+                            '{"DOCKER_IMAGE": "", "ENV_VAR1": "VALUE1", "ENV_VAR2": "VALUE2", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
+                        ),
                     ],
                     env_prefixes=[
                         swarming_pb2.StringListPair(
@@ -223,18 +227,20 @@ class SwarmingTest(unittest.TestCase):
                             value=
                             'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
                         ),
-                        swarming_pb2.StringPair(
-                            key='DOCKER_ENV_VARS',
-                            value=
-                            '{"UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
-                        ),
                         swarming_pb2.StringPair(key='UWORKER', value='True'),
                         swarming_pb2.StringPair(
                             key='SWARMING_BOT', value='True'),
                         swarming_pb2.StringPair(key='LOG_TO_GCP', value='True'),
                         swarming_pb2.StringPair(key='IS_K8S_ENV', value='True'),
                         swarming_pb2.StringPair(
+                            key='DISABLE_MOUNTS', value='True'),
+                        swarming_pb2.StringPair(
                             key='LOGGING_CLOUD_PROJECT_ID', value='project_id'),
+                        swarming_pb2.StringPair(
+                            key='DOCKER_ENV_VARS',
+                            value=
+                            '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
+                        ),
                     ],
                     secret_bytes=base64.b64encode(
                         'https://download_url'.encode('utf-8'))))
@@ -284,18 +290,20 @@ class SwarmingTest(unittest.TestCase):
                             value=
                             'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
                         ),
-                        swarming_pb2.StringPair(
-                            key='DOCKER_ENV_VARS',
-                            value=
-                            '{"UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
-                        ),
                         swarming_pb2.StringPair(key='UWORKER', value='True'),
                         swarming_pb2.StringPair(
                             key='SWARMING_BOT', value='True'),
                         swarming_pb2.StringPair(key='LOG_TO_GCP', value='True'),
                         swarming_pb2.StringPair(key='IS_K8S_ENV', value='True'),
                         swarming_pb2.StringPair(
+                            key='DISABLE_MOUNTS', value='True'),
+                        swarming_pb2.StringPair(
                             key='LOGGING_CLOUD_PROJECT_ID', value='project_id'),
+                        swarming_pb2.StringPair(
+                            key='DOCKER_ENV_VARS',
+                            value=
+                            '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
+                        ),
                     ],
                     secret_bytes=base64.b64encode(
                         'https://download_url'.encode('utf-8'))))
@@ -456,18 +464,19 @@ class SwarmingTest(unittest.TestCase):
         swarming_pb2.StringPair(
             key='DOCKER_IMAGE',
             value='gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'),
-        swarming_pb2.StringPair(
-            key='DOCKER_ENV_VARS',
-            value=
-            '{"UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id", "DEPLOYMENT_BUCKET": "test-bucket-from-metadata"}'
-        ),
         swarming_pb2.StringPair(key='UWORKER', value='True'),
         swarming_pb2.StringPair(key='SWARMING_BOT', value='True'),
         swarming_pb2.StringPair(key='LOG_TO_GCP', value='True'),
         swarming_pb2.StringPair(key='IS_K8S_ENV', value='True'),
+        swarming_pb2.StringPair(key='DISABLE_MOUNTS', value='True'),
         swarming_pb2.StringPair(
             key='LOGGING_CLOUD_PROJECT_ID', value='project_id'),
         swarming_pb2.StringPair(
             key='DEPLOYMENT_BUCKET', value='test-bucket-from-metadata'),
+        swarming_pb2.StringPair(
+            key='DOCKER_ENV_VARS',
+            value=
+            '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id", "DEPLOYMENT_BUCKET": "test-bucket-from-metadata"}'
+        ),
     ]
     self.assertEqual(env, expected_env)

--- a/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
+++ b/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
@@ -100,8 +100,11 @@ class SwarmingTest(unittest.TestCase):
                         swarming_pb2.StringPair(
                             key='DOCKER_ENV_VARS',
                             value=
-                            '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
-                        ),
+                            ('{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/'
+                             'base:a2f4dd6-202202070654", "UWORKER": "True", '
+                             '"SWARMING_BOT": "True", "LOG_TO_GCP": "True", '
+                             '"IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", '
+                             '"LOGGING_CLOUD_PROJECT_ID": "project_id"}')),
                     ],
                     secret_bytes=base64.b64encode(
                         'https://download_url'.encode('utf-8'))))
@@ -173,9 +176,12 @@ class SwarmingTest(unittest.TestCase):
                             key='LOGGING_CLOUD_PROJECT_ID', value='project_id'),
                         swarming_pb2.StringPair(
                             key='DOCKER_ENV_VARS',
-                            value=
-                            '{"DOCKER_IMAGE": "", "ENV_VAR1": "VALUE1", "ENV_VAR2": "VALUE2", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
-                        ),
+                            value=(
+                                '{"DOCKER_IMAGE": "", "ENV_VAR1": "VALUE1", '
+                                '"ENV_VAR2": "VALUE2", "UWORKER": "True", '
+                                '"SWARMING_BOT": "True", "LOG_TO_GCP": "True", '
+                                '"IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", '
+                                '"LOGGING_CLOUD_PROJECT_ID": "project_id"}')),
                     ],
                     env_prefixes=[
                         swarming_pb2.StringListPair(
@@ -239,8 +245,11 @@ class SwarmingTest(unittest.TestCase):
                         swarming_pb2.StringPair(
                             key='DOCKER_ENV_VARS',
                             value=
-                            '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
-                        ),
+                            ('{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/'
+                             'base:a2f4dd6-202202070654", "UWORKER": "True", '
+                             '"SWARMING_BOT": "True", "LOG_TO_GCP": "True", '
+                             '"IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", '
+                             '"LOGGING_CLOUD_PROJECT_ID": "project_id"}')),
                     ],
                     secret_bytes=base64.b64encode(
                         'https://download_url'.encode('utf-8'))))
@@ -302,8 +311,11 @@ class SwarmingTest(unittest.TestCase):
                         swarming_pb2.StringPair(
                             key='DOCKER_ENV_VARS',
                             value=
-                            '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id"}'
-                        ),
+                            ('{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/'
+                             'base:a2f4dd6-202202070654", "UWORKER": "True", '
+                             '"SWARMING_BOT": "True", "LOG_TO_GCP": "True", '
+                             '"IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", '
+                             '"LOGGING_CLOUD_PROJECT_ID": "project_id"}')),
                     ],
                     secret_bytes=base64.b64encode(
                         'https://download_url'.encode('utf-8'))))
@@ -475,8 +487,11 @@ class SwarmingTest(unittest.TestCase):
             key='DEPLOYMENT_BUCKET', value='test-bucket-from-metadata'),
         swarming_pb2.StringPair(
             key='DOCKER_ENV_VARS',
-            value=
-            '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654", "UWORKER": "True", "SWARMING_BOT": "True", "LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", "LOGGING_CLOUD_PROJECT_ID": "project_id", "DEPLOYMENT_BUCKET": "test-bucket-from-metadata"}'
-        ),
+            value=(
+                '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/base:a2f4dd6-'
+                '202202070654", "UWORKER": "True", "SWARMING_BOT": "True", '
+                '"LOG_TO_GCP": "True", "IS_K8S_ENV": "True", "DISABLE_MOUNTS": '
+                '"True", "LOGGING_CLOUD_PROJECT_ID": "project_id", '
+                '"DEPLOYMENT_BUCKET": "test-bucket-from-metadata"}')),
     ]
     self.assertEqual(env, expected_env)


### PR DESCRIPTION
We previously worked in avoiding mounting some directories into the docker container from swarming, [see this pr](https://github.com/google/clusterfuzz/pull/5213)

After fixing other issues related to auth, we discovered that later in the bot execution, other startup scripts [try to remount](https://github.com/google/clusterfuzz/blob/master/docker/base/setup_clusterfuzz.sh) some more directories:
```
if [[ -z "$DISABLE_MOUNTS" ]]; then
  # Setup Tmpfs dirs for frequently accessed files to save disk I/O.
  .....
```
This can't be done in swarming, so this change aims to avoid said mount at startup by adding the env variable as one of the default required env vars for a swarming task request.

Note: @javanlacerda is the e2e github CI check still failing by default?