### PR TITLE
Swarming: Fix double base64 encoding of secret_bytes in swarming tasks

### DIFF
--- a/src/clusterfuzz/_internal/swarming/__init__.py
+++ b/src/clusterfuzz/_internal/swarming/__init__.py
@@ -251,7 +251,7 @@ def create_new_task_request(command: str, job_name: str, download_url: str
                   execution_timeout_secs=execution_timeout_secs,
                   env=swarming_bot_environment,
                   env_prefixes=env_prefixes,
-                  secret_bytes=base64.b64encode(download_url.encode('utf-8'))))
+                  secret_bytes=download_url.encode('utf-8')))
       ])
 
   return new_task_request

--- a/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
+++ b/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Swarming tests."""
-import base64
 import os
 import unittest
 from unittest import mock
@@ -106,8 +105,7 @@ class SwarmingTest(unittest.TestCase):
                              '"IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", '
                              '"LOGGING_CLOUD_PROJECT_ID": "project_id"}')),
                     ],
-                    secret_bytes=base64.b64encode(
-                        'https://download_url'.encode('utf-8'))))
+                    secret_bytes='https://download_url'.encode('utf-8')))
         ])
     self.assertEqual(spec, expected_spec)
 
@@ -191,8 +189,7 @@ class SwarmingTest(unittest.TestCase):
                                 'package_install_path/bin'
                             ])
                     ],
-                    secret_bytes=base64.b64encode(
-                        'https://download_url'.encode('utf-8'))))
+                    secret_bytes='https://download_url'.encode('utf-8')))
         ])
     self.assertEqual(spec, expected_spec)
 
@@ -251,8 +248,7 @@ class SwarmingTest(unittest.TestCase):
                              '"IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", '
                              '"LOGGING_CLOUD_PROJECT_ID": "project_id"}')),
                     ],
-                    secret_bytes=base64.b64encode(
-                        'https://download_url'.encode('utf-8'))))
+                    secret_bytes='https://download_url'.encode('utf-8')))
         ])
     self.assertEqual(spec, expected_spec)
 
@@ -317,8 +313,7 @@ class SwarmingTest(unittest.TestCase):
                              '"IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", '
                              '"LOGGING_CLOUD_PROJECT_ID": "project_id"}')),
                     ],
-                    secret_bytes=base64.b64encode(
-                        'https://download_url'.encode('utf-8'))))
+                    secret_bytes='https://download_url'.encode('utf-8')))
         ])
 
     self.mock.get_scoped_service_account_credentials.assert_called_with(


### PR DESCRIPTION
This small Pr fixes a misconception we had since the beginning, we were manually encoding the `input_dowload_url` to then give it to the `secret_bytes` at the swarming request, which in paper is correct. BUT the swarming request proto implicitly encodes the given bytes, hence we were encoding them twice.

So we remove the additional encoding from the request.

## Test performed
This changes have been present in `dev` since April 16th
We are able to [successfully download the input](https://cloudlogging.app.goo.gl/n84Sk58pjRwzNssVA) using the signed url.