### PR TITLE
Handle broken symlinks in devcontainer set up

### DIFF
--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -351,7 +351,7 @@ def install_dependencies(platform_name=None):
 
 def remove_symlink(target):
   """Removes a symlink."""
-  if not os.path.exists(target):
+  if not os.path.lexists(target):
     return
 
   if os.path.isdir(target) and get_platform() == 'windows':
@@ -372,7 +372,8 @@ def symlink(src, target):
   else:
     os.symlink(src, target)
 
-  assert os.path.exists(target), f'Failed to create {target} symlink for {src}.'
+  assert os.path.lexists(
+      target), f'Failed to create {target} symlink for {src}.'
 
   print(f'Created symlink: source: {src}, target {target}.')
 

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -93,7 +93,7 @@ def _get_clusterfuzz_config_commit_sha():
 
 def _compute_revision(timestamp, is_staging=False):
   """Return a source code revision.
-   
+
   This revision contains the timestamp, git-sha, user, config git-sha, and
   appengine release (prod or staging). The ordinality of revision is crucial
   for updating source code. Later revision *must* be greater than earlier
@@ -372,8 +372,7 @@ def symlink(src, target):
   else:
     os.symlink(src, target)
 
-  assert os.path.lexists(
-      target), f'Failed to create {target} symlink for {src}.'
+  assert os.path.exists(target), f'Failed to create {target} symlink for {src}.'
 
   print(f'Created symlink: source: {src}, target {target}.')
 


### PR DESCRIPTION
I was running into an issue running the server in the devcontainer when I had initialized the config on my host machine.

This PR checks and cleans up broken symlinks correctly

After this change I can run the server in the devcontainer and the symlink is fixed