### PR TITLE
Allow bots with RUN_TIMEOUT flash devices

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -109,7 +109,12 @@ def flash_to_latest_build_if_needed():
     return
 
   run_timeout = environment.get_value('RUN_TIMEOUT')
-  if run_timeout:
+  force_flashing = utils.string_is_true(
+      environment.get_value('FORCE_ANDROID_FLASHING'))
+
+  if run_timeout and not force_flashing:
+    logs.info('Skipping reimage: RUN_TIMEOUT is set. '
+              'And FORCE_ANDROID_FLASHING is false')
     # If we have a run timeout, then we are already scheduled to bail out and
     # will be probably get re-imaged. E.g. using frameworks like Tradefed.
     return
@@ -121,6 +126,9 @@ def flash_to_latest_build_if_needed():
   needs_flash = last_flash_time is None or dates.time_has_expired(
       last_flash_time, seconds=FLASH_INTERVAL)
   if not needs_flash:
+    logs.info(
+        f'Skipping reimage: FLASH_INTERVAL ({FLASH_INTERVAL}s) has not expired '
+        f'since last flash ({last_flash_time:%Y-%m-%d %H:%M:%S}).')
     return
 
   is_google_device = settings.is_google_device()


### PR DESCRIPTION
## Description

There is an assumption that id `RUN_TIMEOUT` is defined then flashing android devices is not needed, however, that's not always true.

This opens the possibility to allow flashing even if `RUN_TIMEOUT` is defined

- Add log entries for future easier debugging

## Testing

- Tested in local that the code follows the expected path, didn't have a flashable device on hand to demonstrate flashing actually occurs, but that might be out of the scope of this PR
- Test on dev was not possible since there are no Android bots available