### PR TITLE
[BlackboxAudit] Only update fuzzer.source when creating a fuzzer

### DIFF
--- a/src/appengine/handlers/fuzzers.py
+++ b/src/appengine/handlers/fuzzers.py
@@ -186,7 +186,7 @@ class BaseEditHandler(base_handler.GcsUploadHandler):
 
     fuzzer.jobs = jobs
     fuzzer.revision = fuzzer.revision + 1
-    fuzzer.source = helpers.get_user_email()
+    fuzzer.last_edited_by = helpers.get_user_email()
     fuzzer.timeout = timeout
     fuzzer.max_testcases = max_testcases
     fuzzer.result = None
@@ -254,6 +254,8 @@ class CreateHandler(BaseEditHandler):
     fuzzer.revision = 0
     fuzzer.created_at = datetime.datetime.now(tz=datetime.timezone.utc).replace(
         tzinfo=None)
+    fuzzer.source = helpers.get_user_email()
+
     return self.apply_fuzzer_changes(fuzzer, upload_info)
 
 

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -313,6 +313,9 @@ class Fuzzer(Model):
   # Fuzzer's source (for accountability).
   source = ndb.StringProperty()
 
+  # Last person to make changes to the Fuzzer code or configuration.
+  last_edited_by = ndb.StringProperty()
+
   # Testcase timeout.
   timeout = ndb.IntegerProperty()
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/fuzzers_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/fuzzers_test.py
@@ -78,6 +78,7 @@ class CreateHandlerTest(unittest.TestCase):
         'handlers.fuzzers.CreateHandler.get_upload',
         'handlers.fuzzers.CreateHandler.apply_fuzzer_changes',
     ])
+
     self.mock.has_access.return_value = True
     self.mock.get_current_user().email = 'test@user.com'
     self.mock.get_user_email.return_value = 'test@user.com'
@@ -108,6 +109,7 @@ class CreateHandlerTest(unittest.TestCase):
     self.assertEqual(fuzzer.name, fuzzer_name)
     self.assertEqual(fuzzer.revision, 0)
     self.assertEqual(fuzzer.created_at, self.mock_time)
+    self.assertEqual(fuzzer.source, 'test@user.com')
 
 
 @test_utils.with_cloud_emulators('datastore')
@@ -125,8 +127,8 @@ class EditHandlerTest(unittest.TestCase):
         'handlers.fuzzers.EditHandler._get_launcher_script',
     ])
     self.mock.has_access.return_value = True
-    self.mock.get_current_user().email = 'test@user.com'
-    self.mock.get_user_email.return_value = 'test@user.com'
+    self.mock.get_current_user().email = 'editor@example.com'
+    self.mock.get_user_email.return_value = 'editor@example.com'
     self.mock.get_upload.return_value = storage.GcsBlobInfo(
         bucket='test-bucket', object_path='key', filename='file.zip', size=123)
 
@@ -150,6 +152,7 @@ class EditHandlerTest(unittest.TestCase):
         name=fuzzer_name,
         jobs=[],
         revision=1,
+        source='original@example.com',
         timeout=10,
     )
     fuzzer.put()
@@ -177,10 +180,11 @@ class EditHandlerTest(unittest.TestCase):
             'data_bundle_name': 'test_bundle',
             'external_contribution': True,
             'executable_path': 'executable',
+            'last_edited_by': 'editor@example.com',
             'launcher_script': 'launcher',
             'jobs': [],
             'max_testcases': 100,
             'revision': 2,
-            'source': 'test@user.com',
+            'source': 'original@example.com',
             'timeout': 30,
         })

--- a/src/clusterfuzz/_internal/tests/core/datastore/data_types_test.py
+++ b/src/clusterfuzz/_internal/tests/core/datastore/data_types_test.py
@@ -38,6 +38,7 @@ class FuzzerTest(unittest.TestCase):
         launcher_script='path/to/launcher',
         revision=3,
         source='author',
+        last_edited_by='editor',
     )
 
     config_dict = fuzzer.get_config_dict()
@@ -54,6 +55,7 @@ class FuzzerTest(unittest.TestCase):
             'launcher_script': 'path/to/launcher',
             'revision': 3,
             'source': 'author',
+            'last_edited_by': 'editor',
         },
         config_dict,
     )


### PR DESCRIPTION
The `Fuzzer.source` is the point of contact or owner of a fuzzer. When the fuzzer is created, the source is the author who uploads the fuzzer. Currently, when we edit the jobs, configuration, or upload a new version of the fuzzer, the `Fuzzer.source` updates to the person who is making that change.

This was fine when the only one maintaining a fuzzer was the current owner of the fuzzer, but breaks down when making LSC type changes to our fuzzer suite. This PR changes the behavior to only set the source when creating a fuzzer and introduces a `last_edited_by` to capture the paper trail of changes. Now, if we want to change the owner we can do so in the datastore directly, and small edits to disable/enable a Fuzzer won't change the source, which is the Fuzzer's owner

The user who is making the edit is also logged as part of the [fuzzer_update_message](https://github.com/google/clusterfuzz/blob/0b9e68ae390d76ae9f475165b1957ca10689f50b/src/appengine/handlers/fuzzers.py#L221).


Tested this locally by creating and editing a fuzzer.