### PR TITLE
Update CHROME_CHECK_FAILURE_REGEX to match new format.

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/chrome_check_semicolon.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/chrome_check_semicolon.txt
@@ -1,0 +1,104 @@
+[Environment] ASAN_OPTIONS=detect_odr_violation=0:exitcode=77
++----------------------------------------Release Build Stacktrace----------------------------------------+
+Command: /mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer -rss_limit_mb=0 -timeout=60 -runs=100 /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/46a14d577878522b8fbed914037174bdccef013ffc168142f4310692fe001cdb
+Time ran: 1.51155686378479
+
+INFO: found LLVMFuzzerCustomMutator (0x5c6c944c6c70). Disabling -len_control by default.
+INFO: Running with entropic power schedule (0xFF, 100).
+INFO: Seed: 3261236845
+INFO: Loaded 322 modules   (8215393 inline 8-bit counters): 26419 [0x7ca64cb54910, 0x7ca64cb5b043), 685 [0x7ca6658f8930, 0x7ca6658f8bdd), 28129 [0x7ca6b5aa5de0, 0x7ca6b5aacbc1), 1299 [0x7ca6b74d5930, 0x7ca6b74d5e43), 6971 [0x7ca6b7480eb0, 0x7ca6b74829eb), 1 [0x7ca6b7383700, 0x7ca6b7383701), 13 [0x7ca6b74e1130, 0x7ca6b74e113d), 58686 [0x7ca6b25ba390, 0x7ca6b25c88ce), 2894 [0x7ca6af6d8250, 0x7ca6af6d8d9e), 118048 [0x7ca6b17e8ce0, 0x7ca6b1805a00), 41573 [0x7ca6a642c830, 0x7ca6a6436a95), 62281 [0x7ca6a723bfa0, 0x7ca6a724b2e9), 120715 [0x7ca6b4fd26e0, 0x7ca6b4fefe6b), 3749 [0x7ca6347eef90, 0x7ca6347efe35), 712 [0x7ca630c59890, 0x7ca630c59b58), 2916 [0x7ca630cffa00, 0x7ca630d00564), 3426 [0x7ca630df0ab0, 0x7ca630df1812), 49 [0x7ca6b737a190, 0x7ca6b737a1c1), 2245 [0x7ca665983890, 0x7ca665984155), 4094 [0x7ca6af7edde0, 0x7ca6af7eedde), 4733 [0x7ca6a75eae60, 0x7ca6a75ec0dd), 5823 [0x7ca6af1e6420, 0x7ca6af1e7adf), 360 [0x7ca6b5bd5400, 0x7ca6b5bd5568), 64 [0x7ca6b5e15b50, 0x7ca6b5e15b90), 106476 [0x7ca6a90037c0, 0x7ca6a901d7ac), 7699 [0x7ca6975e0560, 0x7ca6975e2373), 42855 [0x7ca648924340, 0x7ca64892eaa7), 7271 [0x7ca67dfdfe10, 0x7ca67dfe1a77), 2351 [0x7ca65ffaa560, 0x7ca65ffaae8f), 333507 [0x7ca6ae26a5c0, 0x7ca6ae2bbc83), 1058 [0x7ca6b5efa3e0, 0x7ca6b5efa802), 5128 [0x7ca6b27e8880, 0x7ca6b27e9c88), 35450 [0x7ca6aefc4c40, 0x7ca6aefcd6ba), 340 [0x7ca6b736d7b0, 0x7ca6b736d904), 17697 [0x7ca6af5c3a40, 0x7ca6af5c7f61), 4964 [0x7ca6b53e9da0, 0x7ca6b53eb104), 3724 [0x7ca6b5feeff0, 0x7ca6b5fefe7c), 627 [0x7ca6b5eb12f0, 0x7ca6b5eb1563), 683 [0x7ca6b5bfcdd0, 0x7ca6b5bfd07b), 1672 [0x7ca6b5e7e5b0, 0x7ca6b5e7ec38), 12827 [0x7ca6afb190a0, 0x7ca6afb1c2bb), 1045 [0x7ca6b5ba7030, 0x7ca6b5ba7445), 725 [0x7ca6a91fc7b0, 0x7ca6a91fca85), 1224 [0x7ca6a5bf9af0, 0x7ca6a5bf9fb8), 532 [0x7ca6b5b4eb80, 0x7ca6b5b4ed94), 3157 [0x7ca6a65f21f0, 0x7ca6a65f2e45), 414 [0x7ca6af07c0c0, 0x7ca6af07c25e), 218 [0x7ca6a5a5d3b0, 0x7ca6a5a5d48a), 785 [0x7ca6995fbff0, 0x7ca6995fc301), 7282 [0x7ca69d1e0060, 0x7ca69d1e1cd2), 1820 [0x7ca6991862b0, 0x7ca6991869cc), 1289 [0x7ca69910e620, 0x7ca69910eb29), 7726 [0x7ca6977de630, 0x7ca6977e045e), 41 [0x7ca6b74ecd40, 0x7ca6b74ecd69), 58340 [0x7ca6b7255c70, 0x7ca6b7264054), 14895 [0x7ca697d23a40, 0x7ca697d2746f), 6659 [0x7ca697fe2d20, 0x7ca697fe4723), 41 [0x7ca6a43aa910, 0x7ca6a43aa939), 163 [0x7ca6a037a6d0, 0x7ca6a037a773), 3659 [0x7ca6989eecd0, 0x7ca6989efb1b), 29104 [0x7ca6a0175d60, 0x7ca6a017cf10), 1 [0x7ca65ff02360, 0x7ca65ff02361), 81289 [0x7ca64a8c8910, 0x7ca64a8dc699), 16977 [0x7ca64972dce0, 0x7ca649731f31), 349338 [0x7ca68a0b11a0, 0x7ca68a10663a), 1742 [0x7ca6988de810, 0x7ca6988deede), 1047 [0x7ca69892efa0, 0x7ca69892f3b7), 239 [0x7ca69e7fe320, 0x7ca69e7fe40f), 48 [0x7ca6a438caf0, 0x7ca6a438cb20), 3359 [0x7ca69740fbe0, 0x7ca6974108ff), 778 [0x7ca68092eca0, 0x7ca68092efaa), 4975 [0x7ca681c794c0, 0x7ca681c7a82f), 19 [0x7ca69e7e8290, 0x7ca69e7e82a3), 2764 [0x7ca66f806bc0, 0x7ca66f80768c), 1105 [0x7ca65cd55f40, 0x7ca65cd56391), 1686 [0x7ca697e40450, 0x7ca697e40ae6), 1208 [0x7ca697dd2140, 0x7ca697dd25f8), 260 [0x7ca69e7dd6e0, 0x7ca69e7dd7e4), 4334 [0x7ca68a9ec1f0, 0x7ca68a9ed2de), 433 [0x7ca69df1dae0, 0x7ca69df1dc91), 2952 [0x7ca680c0bd90, 0x7ca680c0c918), 205 [0x7ca680c2f230, 0x7ca680c2f2fd), 42835 [0x7ca6818f8d70, 0x7ca6819034c3), 2030 [0x7ca698cec020, 0x7ca698cec80e), 30279 [0x7ca682646320, 0x7ca68264d967), 719 [0x7ca696ffc460, 0x7ca696ffc72f), 6 [0x7ca69def2770, 0x7ca69def2776), 170 [0x7ca6972c28d0, 0x7ca6972c297a), 777 [0x7ca68b1852a0, 0x7ca68b1855a9), 3552 [0x7ca681d96560, 0x7ca681d97340), 461 [0x7ca681cb9d50, 0x7ca681cb9f1d), 5110 [0x7ca67dc67cd0, 0x7ca67dc690c6), 134 [0x7ca67e5feb40, 0x7ca67e5febc6), 1057 [0x7ca666fface0, 0x7ca666ffb101), 2174 [0x7ca65f7f6880, 0x7ca65f7f70fe), 38765 [0x7ca6493522e0, 0x7ca64935ba4d), 78 [0x7ca68a89ed30, 0x7ca68a89ed7e), 1229 [0x7ca658df99b0, 0x7ca658df9e7d), 1800 [0x7ca6497f74b0, 0x7ca6497f7bb8), 8528 [0x7ca66fbdb9b0, 0x7ca66fbddb00), 1468 [0x7ca696bf95c0, 0x7ca696bf9b7c), 1461 [0x7ca697338f10, 0x7ca6973394c5), 5633 [0x7ca63d1e78f0, 0x7ca63d1e8ef1), 820 [0x7ca6436ad0e0, 0x7ca6436ad414), 
+INFO: Loaded 322 PC tables (8215393 PCs): 26419 [0x7ca64cb5b048,0x7ca64cbc2378), 685 [0x7ca6658f8be0,0x7ca6658fb6b0), 28129 [0x7ca6b5aacbc8,0x7ca6b5b1a9d8), 1299 [0x7ca6b74d5e48,0x7ca6b74daf78), 6971 [0x7ca6b74829f0,0x7ca6b749dda0), 1 [0x7ca6b7383708,0x7ca6b7383718), 13 [0x7ca6b74e1140,0x7ca6b74e1210), 58686 [0x7ca6b25c88d0,0x7ca6b26adcb0), 2894 [0x7ca6af6d8da0,0x7ca6af6e4280), 118048 [0x7ca6b1805a00,0x7ca6b19d2c00), 41573 [0x7ca6a6436a98,0x7ca6a64d90e8), 62281 [0x7ca6a724b2f0,0x7ca6a733e780), 120715 [0x7ca6b4fefe70,0x7ca6b51c7720), 3749 [0x7ca6347efe38,0x7ca6347fe888), 712 [0x7ca630c59b58,0x7ca630c5c7d8), 2916 [0x7ca630d00568,0x7ca630d0bba8), 3426 [0x7ca630df1818,0x7ca630dfee38), 49 [0x7ca6b737a1c8,0x7ca6b737a4d8), 2245 [0x7ca665984158,0x7ca66598cda8), 4094 [0x7ca6af7eede0,0x7ca6af7fedc0), 4733 [0x7ca6a75ec0e0,0x7ca6a75fe8b0), 5823 [0x7ca6af1e7ae0,0x7ca6af1fe6d0), 360 [0x7ca6b5bd5568,0x7ca6b5bd6be8), 64 [0x7ca6b5e15b90,0x7ca6b5e15f90), 106476 [0x7ca6a901d7b0,0x7ca6a91bd670), 7699 [0x7ca6975e2378,0x7ca6976004a8), 42855 [0x7ca64892eaa8,0x7ca6489d6118), 7271 [0x7ca67dfe1a78,0x7ca67dffe0e8), 2351 [0x7ca65ffaae90,0x7ca65ffb4180), 333507 [0x7ca6ae2bbc88,0x7ca6ae7d28b8), 1058 [0x7ca6b5efa808,0x7ca6b5efea28), 5128 [0x7ca6b27e9c88,0x7ca6b27fdd08), 35450 [0x7ca6aefcd6c0,0x7ca6af057e60), 340 [0x7ca6b736d908,0x7ca6b736ee48), 17697 [0x7ca6af5c7f68,0x7ca6af60d178), 4964 [0x7ca6b53eb108,0x7ca6b53fe748), 3724 [0x7ca6b5fefe80,0x7ca6b5ffe740), 627 [0x7ca6b5eb1568,0x7ca6b5eb3c98), 683 [0x7ca6b5bfd080,0x7ca6b5bffb30), 1672 [0x7ca6b5e7ec38,0x7ca6b5e854b8), 12827 [0x7ca6afb1c2c0,0x7ca6afb4e470), 1045 [0x7ca6b5ba7448,0x7ca6b5bab598), 725 [0x7ca6a91fca88,0x7ca6a91ff7d8), 1224 [0x7ca6a5bf9fb8,0x7ca6a5bfec38), 532 [0x7ca6b5b4ed98,0x7ca6b5b50ed8), 3157 [0x7ca6a65f2e48,0x7ca6a65ff398), 414 [0x7ca6af07c260,0x7ca6af07dc40), 218 [0x7ca6a5a5d490,0x7ca6a5a5e230), 785 [0x7ca6995fc308,0x7ca6995ff418), 7282 [0x7ca69d1e1cd8,0x7ca69d1fe3f8), 1820 [0x7ca6991869d0,0x7ca69918db90), 1289 [0x7ca69910eb30,0x7ca699113bc0), 7726 [0x7ca6977e0460,0x7ca6977fe740), 41 [0x7ca6b74ecd70,0x7ca6b74ed000), 58340 [0x7ca6b7264058,0x7ca6b7347e98), 14895 [0x7ca697d27470,0x7ca697d61760), 6659 [0x7ca697fe4728,0x7ca697ffe758), 41 [0x7ca6a43aa940,0x7ca6a43aabd0), 163 [0x7ca6a037a778,0x7ca6a037b1a8), 3659 [0x7ca6989efb20,0x7ca6989fdfd0), 29104 [0x7ca6a017cf10,0x7ca6a01eea10), 1 [0x7ca65ff02368,0x7ca65ff02378), 81289 [0x7ca64a8dc6a0,0x7ca64aa19f30), 16977 [0x7ca649731f38,0x7ca649774448), 349338 [0x7ca68a106640,0x7ca68a65afe0), 1742 [0x7ca6988deee0,0x7ca6988e5bc0), 1047 [0x7ca69892f3b8,0x7ca698933528), 239 [0x7ca69e7fe410,0x7ca69e7ff300), 48 [0x7ca6a438cb20,0x7ca6a438ce20), 3359 [0x7ca697410900,0x7ca69741daf0), 778 [0x7ca68092efb0,0x7ca680932050), 4975 [0x7ca681c7a830,0x7ca681c8df20), 19 [0x7ca69e7e82a8,0x7ca69e7e83d8), 2764 [0x7ca66f807690,0x7ca66f812350), 1105 [0x7ca65cd56398,0x7ca65cd5a8a8), 1686 [0x7ca697e40ae8,0x7ca697e47448), 1208 [0x7ca697dd25f8,0x7ca697dd7178), 260 [0x7ca69e7dd7e8,0x7ca69e7de828), 4334 [0x7ca68a9ed2e0,0x7ca68a9fe1c0), 433 [0x7ca69df1dc98,0x7ca69df1f7a8), 2952 [0x7ca680c0c918,0x7ca680c18198), 205 [0x7ca680c2f300,0x7ca680c2ffd0), 42835 [0x7ca6819034c8,0x7ca6819aa9f8), 2030 [0x7ca698cec810,0x7ca698cf46f0), 30279 [0x7ca68264d968,0x7ca6826c3dd8), 719 [0x7ca696ffc730,0x7ca696fff420), 6 [0x7ca69def2778,0x7ca69def27d8), 170 [0x7ca6972c2980,0x7ca6972c3420), 777 [0x7ca68b1855b0,0x7ca68b188640), 3552 [0x7ca681d97340,0x7ca681da5140), 461 [0x7ca681cb9f20,0x7ca681cbbbf0), 5110 [0x7ca67dc690c8,0x7ca67dc7d028), 134 [0x7ca67e5febc8,0x7ca67e5ff428), 1057 [0x7ca666ffb108,0x7ca666fff318), 2174 [0x7ca65f7f7100,0x7ca65f7ff8e0), 38765 [0x7ca64935ba50,0x7ca6493f3120), 78 [0x7ca68a89ed80,0x7ca68a89f260), 1229 [0x7ca658df9e80,0x7ca658dfeb50), 1800 [0x7ca6497f7bb8,0x7ca6497fec38), 8528 [0x7ca66fbddb00,0x7ca66fbff000), 1468 [0x7ca696bf9b80,0x7ca696bff740), 1461 [0x7ca6973394c8,0x7ca69733f018), 5633 [0x7ca63d1e8ef8,0x7ca63d1fef08), 820 [0x7ca6436ad418,0x7ca6436b0758), 1352 [0x7ca634d9cf88,0x7ca634da2408), 5045 [0x7ca671be5908,0x7ca671bf9458), 4958 [0x7ca634f82d40,0x7ca634f96320), 2095 [0x
+/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer: Running 1 inputs 100 time(s) each.
+Running: /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/46a14d577878522b8fbed914037174bdccef013ffc168142f4310692fe001cdb
+[0424/050845.358008:FATAL:base/feature_list.cc:467] DCHECK failed: !HasAssociatedFieldTrialByFeatureName(feature_name); Feature 	 is overriden multiple times in these trials: L and L. Check the trial (study) in (1) the server config, (2) fieldtrial_testing_config.json, (3) about_flags.cc, and (4) client-side field trials.
+#0 0x5c6c94428a76 <unknown>
+#1 0x7ca6b419da5d <unknown>
+#2 0x7ca6b4071d2b <unknown>
+#3 0x7ca6b4071a61 <unknown>
+#4 0x7ca6b357b46e <unknown>
+#5 0x7ca6b357b06d <unknown>
+#6 0x7ca6b345a8e1 <unknown>
+#7 0x7ca6b345a945 <unknown>
+#8 0x7ca6b345ac3a <unknown>
+#9 0x7ca6b3458018 <unknown>
+#10 0x7ca6b3457e77 <unknown>
+#11 0x7ca6b34dd74c <unknown>
+#12 0x7ca6b668509a <unknown>
+#13 0x7ca6b66831b6 <unknown>
+#14 0x7ca6b6681e1d <unknown>
+#15 0x5c6c944c659e <unknown>
+#16 0x5c6c944c755b <unknown>
+#17 0x5c6c944c73ad <unknown>
+#18 0x5c6c9455ab0b <unknown>
+#19 0x5c6c945069bc <unknown>
+#20 0x5c6c9450c11b <unknown>
+#21 0x5c6c944d5994 <unknown>
+#22 0x7ca64c101083 <unknown>
+#23 0x5c6c943df07a <unknown>
+
+AddressSanitizer:DEADLYSIGNAL
+=================================================================
+==1328==ERROR: AddressSanitizer: ABRT on unknown address 0x053900000530 (pc 0x7ca64c12000b bp 0x7ffe20c6caa0 sp 0x7ffe20c6c6f0 T0)
+==1328==WARNING: invalid path to external symbolizer!
+==1328==WARNING: Failed to use and restart external symbolizer!
+    #0 0x7ca64c12000b in raise /build/glibc-LcI20x/glibc-2.31/sysdeps/unix/sysv/linux/raise.c:51:1
+    #1 0x7ca6b35a1186 in logging::LogMessage::Flush()::$_0::operator()() const ../../base/logging.cc:743:7
+    #2 0x7ca6b35a0f28 in absl::cleanup_internal::Storage<logging::LogMessage::Flush()::$_0>::InvokeCallback() ../../third_party/abseil-cpp/absl/cleanup/internal/cleanup.h:86:5
+    #3 0x7ca6b357cc9f in absl::Cleanup<absl::cleanup_internal::Tag, logging::LogMessage::Flush()::$_0>::~Cleanup() ../../third_party/abseil-cpp/absl/cleanup/cleanup.h:110:16
+    #4 0x7ca6b357bd0f in logging::LogMessage::Flush() ../../base/logging.cc:926:1
+    #5 0x7ca6b357b06c in logging::LogMessage::~LogMessage() ../../base/logging.cc:697:3
+    #6 0x7ca6b345a8e0 in logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() ../../base/check.cc:182:3
+    #7 0x7ca6b345a944 in logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() ../../base/check.cc:178:32
+    #8 0x7ca6b345ac39 in std::__Cr::default_delete<logging::LogMessage>::operator()(logging::LogMessage*) const gen/third_party/libc++/src/include/__memory/unique_ptr.h:74:5
+    #9 0x7ca6b3458017 in std::__Cr::unique_ptr<logging::LogMessage, std::__Cr::default_delete<logging::LogMessage>>::reset(logging::LogMessage*) gen/third_party/libc++/src/include/__memory/unique_ptr.h:288:7
+    #10 0x7ca6b3457e76 in logging::CheckError::~CheckError() ../../base/check.cc:349:16
+    #11 0x7ca6b34dd74b in base::FeatureList::RegisterFieldTrialOverride(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&, base::FeatureList::OverrideState, base::FieldTrial*) ../../base/feature_list.cc:467:3
+    #12 0x7ca6b6685099 in variations::(anonymous namespace)::RegisterFeatureOverrides(variations::Study const&, variations::Study_Experiment const&, base::FieldTrial*, base::FeatureList*) ../../components/variations/variations_seed_processor.cc:261:19
+    #13 0x7ca6b66831b5 in variations::VariationsSeedProcessor::CreateTrialFromStudy(variations::ProcessedStudy const&, variations::EntropyProviders const&, variations::VariationsLayers const&, base::FeatureList*) ../../components/variations/variations_seed_processor.cc:494:9
+    #14 0x7ca6b6681e1c in variations::VariationsSeedProcessor::CreateTrialsFromSeed(variations::VariationsSeed const&, variations::ClientFilterableState const&, variations::EntropyProviders const&, variations::VariationsLayers const&, base::FeatureList*) ../../components/variations/variations_seed_processor.cc:347:5
+    #15 0x5c6c944c659d in variations::CreateTrialsFromStudyFuzzer(variations::VariationsSeed const&) ../../components/variations/fuzzers/create_trials_from_seed_fuzzer.cc:54:8
+    #16 0x5c6c944c755a in variations::TestOneProtoInput(variations::VariationsSeed const&) ../../components/variations/fuzzers/create_trials_from_seed_fuzzer.cc:60:3
+    #17 0x5c6c944c73ac in LLVMFuzzerTestOneInput ../../components/variations/fuzzers/create_trials_from_seed_fuzzer.cc:58:1
+    #18 0x5c6c9455ab0a in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) ../../third_party/libFuzzer/src/FuzzerLoop.cpp:619:13
+    #19 0x5c6c945069bb in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) ../../third_party/libFuzzer/src/FuzzerDriver.cpp:329:6
+    #20 0x5c6c9450c11a in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) ../../third_party/libFuzzer/src/FuzzerDriver.cpp:864:9
+    #21 0x5c6c944d5993 in main ../../third_party/libFuzzer/src/FuzzerMain.cpp:20:10
+    #22 0x7ca64c101082 in __libc_start_main /build/glibc-LcI20x/glibc-2.31/csu/libc-start.c:308:16
+
+==1328==Register values:
+rax = 0x0000000000000000  rbx = 0x00007ca634368940  rcx = 0x00007ca64c12000b  rdx = 0x0000000000000000
+rdi = 0x0000000000000002  rsi = 0x00007ffe20c6c6f0  rbp = 0x00007ffe20c6caa0  rsp = 0x00007ffe20c6c6f0
+ r8 = 0x0000000000000000   r9 = 0x00007ffe20c6c6f0  r10 = 0x0000000000000008  r11 = 0x0000000000000246
+r12 = 0x00005c6c943df050  r13 = 0x00007ffe20c6dec0  r14 = 0x0000000000000000  r15 = 0x0000000000000000
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: ABRT (/lib/x86_64-linux-gnu/libc.so.6+0x4300b) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
+==1328==ABORTING
+
+
++----------------------------------------Release Build Unsymbolized Stacktrace (diff)----------------------------------------+
+
+==1328==WARNING: invalid path to external symbolizer!
+==1328==WARNING: Failed to use and restart external symbolizer!
+    #0 0x7ca64c12000b  (/lib/x86_64-linux-gnu/libc.so.6+0x4300b) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
+    #1 0x7ca6b35a1186  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xda1186) (BuildId: 8ddb1d1b982a86b0)
+    #2 0x7ca6b35a0f28  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xda0f28) (BuildId: 8ddb1d1b982a86b0)
+    #3 0x7ca6b357cc9f  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xd7cc9f) (BuildId: 8ddb1d1b982a86b0)
+    #4 0x7ca6b357bd0f  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xd7bd0f) (BuildId: 8ddb1d1b982a86b0)
+    #5 0x7ca6b357b06c  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xd7b06c) (BuildId: 8ddb1d1b982a86b0)
+    #6 0x7ca6b345a8e0  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xc5a8e0) (BuildId: 8ddb1d1b982a86b0)
+    #7 0x7ca6b345a944  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xc5a944) (BuildId: 8ddb1d1b982a86b0)
+    #8 0x7ca6b345ac39  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xc5ac39) (BuildId: 8ddb1d1b982a86b0)
+    #9 0x7ca6b3458017  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xc58017) (BuildId: 8ddb1d1b982a86b0)
+    #10 0x7ca6b3457e76  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xc57e76) (BuildId: 8ddb1d1b982a86b0)
+    #11 0x7ca6b34dd74b  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libbase.so+0xcdd74b) (BuildId: 8ddb1d1b982a86b0)
+    #12 0x7ca6b6685099  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libcomponents_variations.so+0x685099) (BuildId: 0347162b358a2d0f)
+    #13 0x7ca6b66831b5  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libcomponents_variations.so+0x6831b5) (BuildId: 0347162b358a2d0f)
+    #14 0x7ca6b6681e1c  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/libcomponents_variations.so+0x681e1c) (BuildId: 0347162b358a2d0f)
+    #15 0x5c6c944c659d  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer+0x146f59d) (BuildId: 9c280e886164bb83)
+    #16 0x5c6c944c755a  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer+0x147055a) (BuildId: 9c280e886164bb83)
+    #17 0x5c6c944c73ac  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer+0x14703ac) (BuildId: 9c280e886164bb83)
+    #18 0x5c6c9455ab0a  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer+0x1503b0a) (BuildId: 9c280e886164bb83)
+    #19 0x5c6c945069bb  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer+0x14af9bb) (BuildId: 9c280e886164bb83)
+    #20 0x5c6c9450c11a  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer+0x14b511a) (BuildId: 9c280e886164bb83)
+    #21 0x5c6c944d5993  (/mnt/scratch0/clusterfuzz/bot/builds/chromium-browser-libfuzzer_linux-debug-asan_ae530a86793cd6b8b56ce9af9159ac101396e802/revisions/create_trials_from_seed_fuzzer+0x147e993) (BuildId: 9c280e886164bb83)
+    #22 0x7ca64c101082  (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2414,6 +2414,35 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_check_failure_chrome_semicolon(self):
+    """Test a CHECK failure in Chrome with the new semicolon format."""
+    data = '[123:456:file.cc(130)] Check failed: false; foo'
+    expected_type = 'CHECK failure'
+    expected_address = ''
+    expected_state = 'false in file.cc\n'
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
+  def test_check_failure_chrome_semicolon_file(self):
+    """Test a CHECK failure in Chrome using chrome_check_semicolon.txt."""
+    data = self._read_test_data('chrome_check_semicolon.txt')
+    expected_type = 'CHECK failure'
+    expected_address = ''
+    expected_state = (
+        '!HasAssociatedFieldTrialByFeatureName(feature_name) in feature_list.cc\n'
+        'base::FeatureList::RegisterFieldTrialOverride\n'
+        'variations::RegisterFeatureOverrides\n')
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_check_failure_chrome_android(self):
     """Test a CHECK failure with a Chrome on Android symbolized stacktrace."""
     data = self._read_test_data('check_failure_chrome_android.txt')

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -90,7 +90,7 @@ CFI_FUNC_DEFINED_HERE_REGEX = re.compile(r'.*note: .* defined here$')
 CFI_NODEBUG_ERROR_MARKER_REGEX = re.compile(
     r'CFI: Most likely a control flow integrity violation;.*')
 CHROME_CHECK_FAILURE_REGEX = re.compile(
-    r'\s*\[[^\]]*[:]([^\](]*\([0-9]+\)|[^\]:]*[:][0-9]+).*\].*(?:Check failed:|DCHECK failed:|NOTREACHED hit.)\s*(.*)'  # pylint: disable=line-too-long
+    r'\s*\[[^\]]*[:]([^\](]*\([0-9]+\)|[^\]:]*[:][0-9]+).*\].*(?:Check failed:|DCHECK failed:|NOTREACHED hit.)\s*([^;]*)'  # pylint: disable=line-too-long
 )
 CHROME_STACK_FRAME_REGEX = re.compile(
     r'[ ]*(#(?P<frame_id>[0-9]+)[ ]'  # frame id (2)


### PR DESCRIPTION
In fuzzing mode, Chromium now ends check failure messages with a semicolon to separate the static condition from runtime variables. This change updates the regex to ignore everything after the semicolon to calculate crash states.

Bug: crbug.com/443588668