### PR TITLE
[BlackboxBenchmarking] Remove dry run arg from aggregate_fuzzer_stats cron

### DIFF
--- a/src/clusterfuzz/_internal/cron/aggregate_fuzzer_stats.py
+++ b/src/clusterfuzz/_internal/cron/aggregate_fuzzer_stats.py
@@ -226,15 +226,10 @@ def _gather_all_stats(fuzzers, project_id, target_date_str):
 
 
 def _persist_daily_stats(all_rows, bigquery_client, project_id,
-                         date_partition_str, non_dry_run):
+                         date_partition_str):
   """Writes gathered row statistics to destination table."""
   if not all_rows:
     logs.error(f'No data to write to daily_stats on {date_partition_str}')
-    return
-
-  if not non_dry_run:
-    logs.info(f'DRY RUN: Would insert {len(all_rows)} rows across all fuzzers.')
-    logs.info(all_rows)
     return
 
   try:
@@ -282,17 +277,15 @@ def _persist_daily_stats(all_rows, bigquery_client, project_id,
     logs.error('Failed to execute batch load job in BigQuery', exception=e)
 
 
-def main(argv):
+def main(argv=None):
   """Main entry point for the aggregate_fuzzer_stats cron job."""
   parser = argparse.ArgumentParser(prog='aggregate_fuzzer_stats')
-  parser.add_argument(
-      '--non-dry-run', action='store_true', help='Whether to write to BigQuery')
   parser.add_argument(
       '--date',
       help=('Date for fuzzer stats aggregation (YYYY-MM-DD). Defaults to today '
             'UTC.'),
       type=str)
-  args = parser.parse_args(argv)
+  args = parser.parse_args(argv if argv is not None else [])
 
   logs.info('Starting fuzzer stats aggregation cron.')
 
@@ -313,10 +306,9 @@ def main(argv):
   bigquery_client = big_query.get_api_client()
   project_id = utils.get_application_id()
 
-  if args.non_dry_run:
-    _create_dataset_if_needed(bigquery_client, 'fuzzer_stats')
-    _create_table_if_needed(bigquery_client, 'fuzzer_stats', 'daily_stats',
-                            DAILY_STATS_SCHEMA)
+  _create_dataset_if_needed(bigquery_client, 'fuzzer_stats')
+  _create_table_if_needed(bigquery_client, 'fuzzer_stats', 'daily_stats',
+                          DAILY_STATS_SCHEMA)
 
   fuzzers = list(
       data_types.Fuzzer.query(ndb_utils.is_false(data_types.Fuzzer.builtin)))
@@ -330,7 +322,6 @@ def main(argv):
       all_rows=all_rows,
       bigquery_client=bigquery_client,
       project_id=project_id,
-      date_partition_str=date_partition_str,
-      non_dry_run=args.non_dry_run)
+      date_partition_str=date_partition_str)
 
   logs.info('Fuzzer stats aggregation cron complete.')

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/aggregate_fuzzer_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/aggregate_fuzzer_stats_test.py
@@ -72,7 +72,7 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
         }],
         total_count=1)
 
-    aggregate_fuzzer_stats.main(['--non-dry-run'])
+    aggregate_fuzzer_stats.main()
 
     self.mock_api_client.datasets().insert.assert_called_with(
         projectId='test-clusterfuzz',
@@ -153,7 +153,7 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
         }],
         total_count=1)
 
-    aggregate_fuzzer_stats.main(['--non-dry-run'])
+    aggregate_fuzzer_stats.main()
 
     self.mock_api_client.tables().insert.assert_called_once()
 
@@ -164,7 +164,7 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
         response, b'Internal Server Error')
 
     with self.assertRaises(HttpError):
-      aggregate_fuzzer_stats.main(['--non-dry-run'])
+      aggregate_fuzzer_stats.main()
 
   def test_aggregate_fuzzer_stats_with_date_flag(self):
     """Tests execution of the cron job with a specific --date flag."""
@@ -180,7 +180,7 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
         }],
         total_count=1)
 
-    aggregate_fuzzer_stats.main(['--non-dry-run', '--date', '2026-04-30'])
+    aggregate_fuzzer_stats.main(['--date', '2026-04-30'])
 
     call_kwargs = self.mock_api_client.jobs().insert.call_args[1]
     load_config = call_kwargs['body']['configuration']['load']
@@ -195,4 +195,4 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
   def test_aggregate_fuzzer_stats_with_invalid_date_flag(self):
     """Tests that an invalid --date format causes argument parsing error."""
     with self.assertRaises(SystemExit):
-      aggregate_fuzzer_stats.main(['--non-dry-run', '--date', 'invalid-date'])
+      aggregate_fuzzer_stats.main(['--date', 'invalid-date'])


### PR DESCRIPTION
removes dry run args and makes args optional in `aggregate_fuzzer_stats` cron job

The bot version of [run_cron.py](https://github.com/google/clusterfuzz/blob/47ed79626d0fb4fc873f3e4c4646f5fdda6a9630/src/python/bot/startup/run_cron.py#L68) does not accept any args, while the [local run_cron.py](https://github.com/google/clusterfuzz/blob/47ed79626d0fb4fc873f3e4c4646f5fdda6a9630/src/local/butler/scripts/run_cron.py#L96) does accept args.

I previously used required args and this caused the cron job to fail in dev after I pushed the helm config.

```
Unhandled exception in cron: main() missing 1 required positional argument: 'argv'
Traceback (most recent call last):
  File "/mnt/scratch0/clusterfuzz/src/python/bot/startup/run_cron.py", line 68, in main
    return 0 if task_module.main() else 1
                ^^^^^^^^^^^^^^^^^^
TypeError: main() missing 1 required positional argument: 'argv'
```