### PR TITLE
Fix butler deploy by setting CLOUDSDK_PYTHON

### DIFF
--- a/butler.py
+++ b/butler.py
@@ -509,6 +509,7 @@ def _setup(args):
   """Set up configs and import paths."""
   os.environ['ROOT_DIR'] = os.path.abspath('.')
   os.environ['PYTHONIOENCODING'] = 'UTF-8'
+  os.environ['CLOUDSDK_PYTHON'] = sys.executable
 
   sys.path.insert(0, os.path.abspath(os.path.join('src')))
   from clusterfuzz._internal.base import modules


### PR DESCRIPTION
Recent [dev](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/cab18c8b-9e97-416d-b3c8-a082ec5cfb29?e=-13802955&mods=logs_tg_prod&project=clusterfuzz-development) and [staging](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/c481341a-26f8-4235-b5e6-e64ac94b6f4e?project=clusterfuzz-staging&e=-13802955&mods=logs_tg_prod) deployments failed with the same build error:
```
ERROR: build step 2 "gcr.io/clusterfuzz-images/base:<hash>" failed: step exited with non-zero status: 1
ERROR
Finished Step #2
| Exit.
| Return code is non-zero (1).
|   gcloud info --run-diagnostics
| To check gcloud for common problems, please run the following command:
| 
|   gcloud feedback
| If you would like to report this issue, please run the following command:
| 
| ERROR: gcloud crashed (TypeError): Metaclasses with custom tp_new are not supported.

```

Seems that this kind of error stems from incompatibility between Python versions of some dependencies that are bundled in our third_party dir.

Since `./local/install_deps.bash` installs the latest `google-cloud-cli` , it might be that the SDK default runtime was updated to use Python 3.12, while the script configures the `PYTHONPATH` to include the local third_party dir which might have libs that still not support this version.

By setting the `CLOUDSDK_PYTHON` to the runtime python version, we ensure that any gcloud command called by `butler.py` uses the same Python 3.11 interpreter that butler is running on.