### PR TITLE
[BlackboxBenchmarking] Adds return True for aggregate fuzzer stats cron

### DIFF
--- a/src/clusterfuzz/_internal/cron/aggregate_fuzzer_stats.py
+++ b/src/clusterfuzz/_internal/cron/aggregate_fuzzer_stats.py
@@ -301,7 +301,7 @@ def main(argv=None):
   if environment.is_local_development():
     logs.error('BigQuery requires a cloud project to run. '
                'This cron job cannot run locally.')
-    return
+    return False
 
   bigquery_client = big_query.get_api_client()
   project_id = utils.get_application_id()
@@ -325,3 +325,4 @@ def main(argv=None):
       date_partition_str=date_partition_str)
 
   logs.info('Fuzzer stats aggregation cron complete.')
+  return True

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/aggregate_fuzzer_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/aggregate_fuzzer_stats_test.py
@@ -72,7 +72,7 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
         }],
         total_count=1)
 
-    aggregate_fuzzer_stats.main()
+    self.assertTrue(aggregate_fuzzer_stats.main())
 
     self.mock_api_client.datasets().insert.assert_called_with(
         projectId='test-clusterfuzz',
@@ -180,7 +180,7 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
         }],
         total_count=1)
 
-    aggregate_fuzzer_stats.main(['--date', '2026-04-30'])
+    self.assertTrue(aggregate_fuzzer_stats.main(['--date', '2026-04-30']))
 
     call_kwargs = self.mock_api_client.jobs().insert.call_args[1]
     load_config = call_kwargs['body']['configuration']['load']


### PR DESCRIPTION
The bots `run_cron` script expects the cron job's `main()` to return `True`, otherwise it assumes the script failed if it returns None ([code](https://github.com/google/clusterfuzz/blob/0ac00ac0508df394073ae3805363a13b85498b1a/src/python/bot/startup/run_cron.py#L68)). This was causing the job to retry multiple times in dev.

[logs](https://cloudlogging.app.goo.gl/rGCGx5Nkc251ZuVh8)