### PR TITLE
[BlackboxBenchmarking] Replace INTERVAL duration fields with DOUBLE duration_seconds

### DIFF
--- a/src/clusterfuzz/_internal/cron/aggregate_fuzzer_stats.py
+++ b/src/clusterfuzz/_internal/cron/aggregate_fuzzer_stats.py
@@ -55,20 +55,20 @@ DAILY_STATS_SCHEMA = {
         'type': 'INTEGER',
         'mode': 'NULLABLE'
     }, {
-        'name': 'testcase_execution_duration',
-        'type': 'INTERVAL',
+        'name': 'testcase_execution_duration_seconds',
+        'type': 'FLOAT',
         'mode': 'NULLABLE'
     }, {
         'name': 'testcases_generated',
         'type': 'INTEGER',
         'mode': 'NULLABLE'
     }, {
-        'name': 'testcase_generation_duration',
-        'type': 'INTERVAL',
+        'name': 'testcase_generation_duration_seconds',
+        'type': 'FLOAT',
         'mode': 'NULLABLE'
     }, {
-        'name': 'fuzzing_duration',
-        'type': 'INTERVAL',
+        'name': 'fuzzing_duration_seconds',
+        'type': 'FLOAT',
         'mode': 'NULLABLE'
     }]
 }
@@ -151,33 +151,23 @@ def _query_fuzzer_stats(fuzzer_name, project_id, target_date_str):
 
   query = f"""
   SELECT
-    '{fuzzer_name}' as fuzzer_name,
-    CAST(DATE(TIMESTAMP_SECONDS(CAST(timestamp AS INT64))) AS STRING) as date,
-    SUM(testcases_executed) as testcases_executed,
-    CONCAT(
-      'P',
-      CAST(EXTRACT(DAY FROM SUM(testcase_execution_duration)) AS STRING), 'DT',
-      CAST(EXTRACT(HOUR FROM SUM(testcase_execution_duration)) AS STRING), 'H',
-      CAST(EXTRACT(MINUTE FROM SUM(testcase_execution_duration)) AS STRING), 'M',
-      CAST(EXTRACT(SECOND FROM SUM(testcase_execution_duration)) AS STRING), 'S'
-    ) as testcase_execution_duration,
-    SUM(testcases_generated) as testcases_generated,
-    CONCAT(
-      'P',
-      CAST(EXTRACT(DAY FROM SUM(testcase_generation_duration)) AS STRING), 'DT',
-      CAST(EXTRACT(HOUR FROM SUM(testcase_generation_duration)) AS STRING), 'H',
-      CAST(EXTRACT(MINUTE FROM SUM(testcase_generation_duration)) AS STRING), 'M',
-      CAST(EXTRACT(SECOND FROM SUM(testcase_generation_duration)) AS STRING), 'S'
-    ) as testcase_generation_duration,
-    CONCAT(
-      'P',
-      CAST(EXTRACT(DAY FROM SUM(fuzzing_duration)) AS STRING), 'DT',
-      CAST(EXTRACT(HOUR FROM SUM(fuzzing_duration)) AS STRING), 'H',
-      CAST(EXTRACT(MINUTE FROM SUM(fuzzing_duration)) AS STRING), 'M',
-      CAST(EXTRACT(SECOND FROM SUM(fuzzing_duration)) AS STRING), 'S'
-    ) as fuzzing_duration
-  FROM
-    `{project_id}.{dataset_id}.{table_id}`
+  '{fuzzer_name}' as fuzzer_name,
+  CAST(DATE(TIMESTAMP_SECONDS(CAST(timestamp AS INT64))) AS STRING) as date,
+  SUM(testcases_executed) as testcases_executed,
+  (EXTRACT(DAY FROM SUM(testcase_execution_duration)) * 86400 +
+   EXTRACT(HOUR FROM SUM(testcase_execution_duration)) * 3600 +
+   EXTRACT(MINUTE FROM SUM(testcase_execution_duration)) * 60 +
+   EXTRACT(SECOND FROM SUM(testcase_execution_duration))) AS testcase_execution_duration_seconds,
+  SUM(testcases_generated) as testcases_generated,
+  (EXTRACT(DAY FROM SUM(testcase_generation_duration)) * 86400 +
+   EXTRACT(HOUR FROM SUM(testcase_generation_duration)) * 3600 +
+   EXTRACT(MINUTE FROM SUM(testcase_generation_duration)) * 60 +
+   EXTRACT(SECOND FROM SUM(testcase_generation_duration))) AS testcase_generation_duration_seconds,
+  (EXTRACT(DAY FROM SUM(fuzzing_duration)) * 86400 +
+   EXTRACT(HOUR FROM SUM(fuzzing_duration)) * 3600 +
+   EXTRACT(MINUTE FROM SUM(fuzzing_duration)) * 60 +
+   EXTRACT(SECOND FROM SUM(fuzzing_duration))) AS fuzzing_duration_seconds
+  FROM    `{project_id}.{dataset_id}.{table_id}`
   WHERE
     DATE(TIMESTAMP_SECONDS(CAST(timestamp AS INT64))) = '{target_date_str}'
   GROUP BY

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/aggregate_fuzzer_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/aggregate_fuzzer_stats_test.py
@@ -65,10 +65,10 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
             'fuzzer_name': 'ochang_js_fuzzer',
             'date': '2026-04-30',
             'testcases_executed': 10495,
-            'testcase_execution_duration': 'P0DT11H12M11S',
+            'testcase_execution_duration_seconds': 40331.0,
             'testcases_generated': 10495,
-            'testcase_generation_duration': 'P0DT1H15M33S',
-            'fuzzing_duration': 'P0DT12H49M49S'
+            'testcase_generation_duration_seconds': 4533.0,
+            'fuzzing_duration_seconds': 46189.0
         }],
         total_count=1)
 
@@ -128,12 +128,12 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
     self.assertEqual(uploaded_dict['fuzzer_name'], 'ochang_js_fuzzer')
     self.assertEqual(uploaded_dict['date'], '2026-04-30')
     self.assertEqual(uploaded_dict['testcases_executed'], 10495)
-    self.assertEqual(uploaded_dict['testcase_execution_duration'],
-                     'P0DT11H12M11S')
+    self.assertEqual(uploaded_dict['testcase_execution_duration_seconds'],
+                     40331.0)
     self.assertEqual(uploaded_dict['testcases_generated'], 10495)
-    self.assertEqual(uploaded_dict['testcase_generation_duration'],
-                     'P0DT1H15M33S')
-    self.assertEqual(uploaded_dict['fuzzing_duration'], 'P0DT12H49M49S')
+    self.assertEqual(uploaded_dict['testcase_generation_duration_seconds'],
+                     4533.0)
+    self.assertEqual(uploaded_dict['fuzzing_duration_seconds'], 46189.0)
 
   def test_aggregate_fuzzer_stats_ignoring_409(self):
     """Tests that execution successfully proceeds when the table already exists."""
@@ -146,10 +146,10 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
             'fuzzer_name': 'ochang_js_fuzzer',
             'date': '2026-04-30',
             'testcases_executed': 10495,
-            'testcase_execution_duration': 'P0DT11H12M11S',
+            'testcase_execution_duration_seconds': 40331.0,
             'testcases_generated': 10495,
-            'testcase_generation_duration': 'P0DT1H15M33S',
-            'fuzzing_duration': 'P0DT12H49M49S'
+            'testcase_generation_duration_seconds': 4533.0,
+            'fuzzing_duration_seconds': 46189.0
         }],
         total_count=1)
 
@@ -173,10 +173,10 @@ class AggregateFuzzerStatsTest(unittest.TestCase):
             'fuzzer_name': 'ochang_js_fuzzer',
             'date': '2026-04-30',
             'testcases_executed': 100,
-            'testcase_execution_duration': 'P0DT1H0M0S',
+            'testcase_execution_duration_seconds': 3600.0,
             'testcases_generated': 100,
-            'testcase_generation_duration': 'P0DT0H10M0S',
-            'fuzzing_duration': 'P0DT1H10M0S'
+            'testcase_generation_duration_seconds': 600.0,
+            'fuzzing_duration_seconds': 4200.0
         }],
         total_count=1)
 


### PR DESCRIPTION
F1 doesn't support INTERVAL types natively (b/213368390). This PR replaces the `INTERVAL` duration fields in `cluster-fuzz.fuzzer_stats.daily_stats` with `DOUBLE` duration_seconds.

### Rollout
I plan to just drop the existing `cluster-fuzz.fuzzer_stats.daily_stats` table after this is deployed and rerun the job to backfill the data. Since there are no consumers of this data yet, this seems simpler than doing a dual write + alter table drop column, then changing the job load to stop including the old rows.

The concern I had is that a BigQuery load without the old rows would fail, so dropping the table after this is deployed and then backfilling seems like a simpler approach.

### Testing
I verified the SQL query by running it in BigQuery against the `cluster-fuzz.fuzzer_stats.daily_stats` table.

I dropped the table in dev and ran the  cron with the new fields.  https://paste.googleplex.com/5110869211086848
https://screenshot.googleplex.com/7iTMbm3Ry6J22ZQ