### PR TITLE
handlers: reject protocol-relative URLs in redirect validation

### DIFF
--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -45,7 +45,7 @@ from libs import helpers
 # https://github.com/google/closure-library/blob/
 # 3037e09cc471bfe99cb8f0ee22d9366583a20c28/closure/goog/html/safeurl.js
 _SAFE_URL_PATTERN = re.compile(
-    r'^(?:(?:https?|mailto|ftp):|[^:/?#]*(?:[/?#]|$))', flags=re.IGNORECASE)
+    r'^(?:(?:https?|mailto|ftp):|(?!//)[^:/?#]*(?:[/?#]|$))', flags=re.IGNORECASE)
 
 
 def add_jinja2_filter(name, fn):

--- a/src/appengine/handlers/base_handler.py
+++ b/src/appengine/handlers/base_handler.py
@@ -130,6 +130,15 @@ def make_logout_url(dest_url):
 
 def check_redirect_url(url):
   """Check redirect URL is safe."""
+  # Browsers strip ASCII tab/newline and leading control/whitespace characters
+  # from URLs and normalize backslashes to forward slashes, so inputs such as
+  # `/\\evil.com`, ` //evil.com` or `\r\n//evil.com` would otherwise pass the
+  # scheme-relative check below and then navigate to an external host. Reject
+  # any input with a backslash, a control character, or leading/trailing
+  # whitespace before validating.
+  if (not url or url != url.strip() or '\\' in url
+      or any(ord(char) < 0x20 for char in url)):
+    raise helpers.EarlyExitError('Invalid redirect.', 403)
   if not _SAFE_URL_PATTERN.match(url):
     raise helpers.EarlyExitError('Invalid redirect.', 403)
 


### PR DESCRIPTION
## Summary

`check_redirect_url` in `src/appengine/handlers/base_handler.py` uses
`_SAFE_URL_PATTERN` (based on the Closure Library `SafeUrl` pattern) to
validate redirect targets.  The relative-URL branch of that pattern is:

```
[^:/?#]*(?:[/?#]|$)
```

`[^:/?#]*` can match zero characters, after which `(?:[/?#]|$)` matches
the leading `/` of `//evil.com`.  This means the pattern accepts any
protocol-relative URL such as `//attacker.example.com/steal` as safe.

Browsers interpret `//evil.com/path` as scheme-relative (same scheme as
the current page), so a `next=//evil.com/login` parameter causes a
post-login redirect to the attacker's host.

## Fix

Add a negative lookahead `(?!//)` to the relative-URL branch:

```python
# Before
r'^(?:(?:https?|mailto|ftp):|[^:/?#]*(?:[/?#]|$))'

# After
r'^(?:(?:https?|mailto|ftp):|(?!//)[^:/?#]*(?:[/?#]|$))'
```

This rejects any URL that the relative branch would match but that begins
with `//`, while continuing to accept ordinary relative paths (`/login`,
`relative/path`) and absolute URLs with safe schemes.

## Verification

```python
>>> import re
>>> p = re.compile(r'^(?:(?:https?|mailto|ftp):|(?!//)[^:/?#]*(?:[/?#]|$))', re.I)
>>> bool(p.match('//evil.com/path'))
False
>>> bool(p.match('/login'))
True
>>> bool(p.match('https://clusterfuzz.com/'))
True
```