### PR TITLE
[Swarming] Crash service on startup 

### DIFF
--- a/src/clusterfuzz/_internal/remote_task/remote_task_gate.py
+++ b/src/clusterfuzz/_internal/remote_task/remote_task_gate.py
@@ -43,6 +43,7 @@ class RemoteTaskGate(remote_task_types.RemoteTaskInterface):
     self._service_map = {
         adapter.id: adapter.service()
         for adapter in remote_task_adapters.RemoteTaskAdapters
+        if adapter.feature_flag.enabled
     }
     self._adapters = remote_task_adapters.RemoteTaskAdapters
 

--- a/src/clusterfuzz/_internal/swarming/service.py
+++ b/src/clusterfuzz/_internal/swarming/service.py
@@ -32,10 +32,13 @@ SWARMING_MAIN_QUEUE_LIMIT_DEFAULT = 25
 class SwarmingService(remote_task_types.RemoteTaskInterface):
   """Remote task service implementation for Swarming."""
 
-  _api: SwarmingApi | None = None
+  _api: SwarmingApi
 
   def __init__(self):
     self._api = SwarmingApi.create()
+    if self._api is None:
+      raise ValueError(
+          'Failed to instantiate SwarmingApi. Swarming config not available.')
 
   # pylint: disable=no-member
   def _get_dimension(self, request: swarming_pb2.NewTaskRequest,

--- a/src/clusterfuzz/_internal/tests/core/remote_task/remote_task_gate_test.py
+++ b/src/clusterfuzz/_internal/tests/core/remote_task/remote_task_gate_test.py
@@ -46,19 +46,19 @@ class RemoteTaskGateTest(unittest.TestCase):
                 mock.Mock(
                     id='kubernetes',
                     service=mock.Mock(return_value=self.mock_k8s_service),
-                    feature_flag=None,
+                    feature_flag=mock.Mock(enabled=True),
                     default_weight=0.0),
             'GCP_BATCH':
                 mock.Mock(
                     id='gcp_batch',
                     service=mock.Mock(return_value=self.mock_gcp_batch_service),
-                    feature_flag=None,
+                    feature_flag=mock.Mock(enabled=True),
                     default_weight=1.0),
             'SWARMING':
                 mock.Mock(
                     id='swarming',
                     service=mock.Mock(return_value=self.mock_swarming_service),
-                    feature_flag=None,
+                    feature_flag=mock.Mock(enabled=True),
                     default_weight=0.0),
         })
     self.patcher.start()
@@ -488,19 +488,19 @@ class RemoteTaskGateProcessingTest(unittest.TestCase):
                 mock.Mock(
                     id='kubernetes',
                     service=mock.Mock(),
-                    feature_flag=None,
+                    feature_flag=mock.Mock(enabled=True),
                     default_weight=0.0),
             'GCP_BATCH':
                 mock.Mock(
                     id='gcp_batch',
                     service=mock.Mock(),
-                    feature_flag=None,
+                    feature_flag=mock.Mock(enabled=True),
                     default_weight=1.0),
             'SWARMING':
                 mock.Mock(
                     id='swarming',
                     service=mock.Mock(return_value=self.mock_swarming_service),
-                    feature_flag=None,
+                    feature_flag=mock.Mock(enabled=True),
                     default_weight=0.0),
         })
     self.patcher.start()

--- a/src/clusterfuzz/_internal/tests/core/remote_task/remote_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/remote_task/remote_task_test.py
@@ -16,7 +16,9 @@
 import unittest
 from unittest import mock
 
+from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.k8s import service as k8s_service
+from clusterfuzz._internal.remote_task import remote_task_adapters
 from clusterfuzz._internal.remote_task import remote_task_gate
 from clusterfuzz._internal.remote_task import remote_task_types
 from clusterfuzz._internal.tests.test_libs import test_utils
@@ -46,6 +48,17 @@ class RemoteTaskGateTest(unittest.TestCase):
                                 '_load_gke_credentials')
     self.addCleanup(patcher.stop)
     patcher.start()
+
+    data_types.FeatureFlag(
+        id=remote_task_adapters.RemoteTaskAdapters.KUBERNETES.feature_flag.
+        value,
+        enabled=True).put()
+    data_types.FeatureFlag(
+        id=remote_task_adapters.RemoteTaskAdapters.GCP_BATCH.feature_flag.value,
+        enabled=True).put()
+    data_types.FeatureFlag(
+        id=remote_task_adapters.RemoteTaskAdapters.SWARMING.feature_flag.value,
+        enabled=True).put()
 
     self.gate = remote_task_gate.RemoteTaskGate()
 
@@ -98,3 +111,17 @@ class RemoteTaskGateTest(unittest.TestCase):
     self.gate.create_utask_main_jobs([task])
 
     self.assertTrue(mock_k8s_create.called)
+
+  def test_service_map_filtering(self):
+    """Test that RemoteTaskGate only constructs services for enabled flags."""
+    # pylint: disable=protected-access
+    data_types.FeatureFlag(
+        id=remote_task_adapters.RemoteTaskAdapters.SWARMING.feature_flag.value,
+        enabled=False).put()
+
+    # Create a new gate instance to trigger __init__ again.
+    gate = remote_task_gate.RemoteTaskGate()
+
+    self.assertNotIn('swarming', gate._service_map)
+    self.assertIn('kubernetes', gate._service_map)
+    self.assertIn('gcp_batch', gate._service_map)

--- a/src/clusterfuzz/_internal/tests/core/swarming/service_test.py
+++ b/src/clusterfuzz/_internal/tests/core/swarming/service_test.py
@@ -138,6 +138,12 @@ class SwarmingServiceTest(unittest.TestCase):
     self.assertEqual(unscheduled, [])
     self.mock_api.push_task.assert_not_called()
 
+  def test_init_no_config(self):
+    """Test that __init__ raises ValueError when config is missing."""
+    self.mock.create.return_value = None
+    with self.assertRaises(ValueError):
+      service.SwarmingService()
+
   def test_create_utask_main_jobs_exception(self):
     """Test creating tasks when push_swarming_task raises an exception."""
     tasks = [


### PR DESCRIPTION
## Overview
`SwarmingService` and other remote task services will now be instantiated in `RemoteTaskGate` based on the their feature flag. 

Now the `SwarmingService` will crash horribly at startup, this is done to avoid happing an api instances that does nothing, and a swarming service that just fails when called, with this new logic we make sure that all parts work as expected and if they dont.... well we just wont be able to fully schedule on envs where swarming is enabled.

### Background
This PR comes from a discussion & agreement to a required change from [this review](https://github.com/google/clusterfuzz/pull/5277#discussion_r3266259807)

## Changes
- Raises an exception at `SwarmingService` constructor if the swarming config was not found
- Updated `RemoteTaskGate` to conditionally instantiate services based on the linked feature flag.
  - This safeguards envs where the swarming feature flag is not enabled.
- Added unit tests & updated a lot of them for the remote task gate changes.
