### PR TITLE
Ignore rows which are missing stats during daily aggregation

### DIFF
--- a/src/clusterfuzz/_internal/cron/aggregate_fuzzer_stats.py
+++ b/src/clusterfuzz/_internal/cron/aggregate_fuzzer_stats.py
@@ -149,6 +149,8 @@ def _query_fuzzer_stats(fuzzer_name, project_id, target_date_str):
   dataset_id = fuzzer_stats.dataset_name(fuzzer_name)
   table_id = 'JobRun'
 
+  # We ignore rows where testcases_generated is NULL because those are rows
+  # created by an old revision of Clusterfuzz which are missing the durations.
   query = f"""
   SELECT
   '{fuzzer_name}' as fuzzer_name,
@@ -170,6 +172,7 @@ def _query_fuzzer_stats(fuzzer_name, project_id, target_date_str):
   FROM    `{project_id}.{dataset_id}.{table_id}`
   WHERE
     DATE(TIMESTAMP_SECONDS(CAST(timestamp AS INT64))) = '{target_date_str}'
+    AND testcases_generated IS NOT NULL
   GROUP BY
     date
   """


### PR DESCRIPTION
There were a couple old versions of CF running in the clusterfuzz-candidate2 bots. This PR ignores the stats which were generated by those bots. It's unfortunate that the stats are missing these, but IMO it's better to completely ignore these rows rather than writing partial data. There were 10 of these instances running, which resulted in some fuzzers having a fuzzing session unaccounted for.

Testing: Ran this SQL against the BigQuery table and verified it correctly filters out the rows and resulted in the `testcases_generated == testcases_executed`

### Rollout

we will have to rerun the cron job for the past month again after this deploys to properly ignore those rows.