### PR TITLE
Fix UWORKER initialization crash by bypassing Wi-Fi Datastore queries in Android

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/wifi.py
+++ b/src/clusterfuzz/_internal/platforms/android/wifi.py
@@ -49,10 +49,10 @@ def disable_airplane_mode():
 
 def configure(force_enable=False):
   """Configure airplane mode and wifi on device."""
-  # Short-circuit: UWORKERs do not have Datastore access to retrieve Wi-Fi credentials.
+  # Short-circuit: UWORKERs do not have Datastore access for Wi-Fi credentials.
   if environment.is_uworker():
     return
-  
+
   # Airplane mode should be disabled in all cases. This can get inadvertently
   # turned on via gestures.
   disable_airplane_mode()

--- a/src/clusterfuzz/_internal/platforms/android/wifi.py
+++ b/src/clusterfuzz/_internal/platforms/android/wifi.py
@@ -49,6 +49,10 @@ def disable_airplane_mode():
 
 def configure(force_enable=False):
   """Configure airplane mode and wifi on device."""
+  # Short-circuit: UWORKERs do not have Datastore access to retrieve Wi-Fi credentials.
+  if environment.is_uworker():
+    return
+  
   # Airplane mode should be disabled in all cases. This can get inadvertently
   # turned on via gestures.
   disable_airplane_mode()

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/wifi_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/wifi_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/wifi_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/wifi_test.py
@@ -1,0 +1,40 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for wifi functions."""
+
+import unittest
+
+from clusterfuzz._internal.platforms.android import wifi
+from clusterfuzz._internal.tests.test_libs import helpers
+
+
+class ConfigureTest(unittest.TestCase):
+  """Tests for wifi.configure."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_uworker',
+        'clusterfuzz._internal.platforms.android.wifi.disable_airplane_mode',
+        'clusterfuzz._internal.config.db_config.get',
+    ])
+
+  def test_uworker_bypass(self):
+    """Test that uworker environment skips wifi setup."""
+    self.mock.is_uworker.return_value = True
+
+    wifi.configure()
+
+    # Ensure none of the subsequent functions that crash/hit Datastore are called.
+    self.mock.disable_airplane_mode.assert_not_called()
+    self.mock.get.assert_not_called()


### PR DESCRIPTION
### Overview
This PR fixes a critical initialization crash that occurs when untrusted workers (UWORKERs) attempt to set up Android emulators.

### The Bug
During the Android device initialization sequence, wifi.configure() is called to ensure the device is connected to the network. This function attempts to retrieve Wi-Fi credentials (SSID/password) by calling db_config.get(), which queries Google Cloud Datastore.

However, UWORKER containers run under a restricted security boundary and are explicitly denied IAM permissions to access Datastore (to prevent malicious fuzzers from escalating privileges or stealing project secrets). When the Datastore SDK intercepts the request, it returns a 403 Missing or insufficient permissions exception. Because this exception is
unhandled, it violently crashes the entire setup process, preventing the UWORKER from ever reaching the fuzzing loop.

### The Fix
This PR introduces an environment check at the top of wifi.configure():
```
if environment.is_uworker():
   return
```
This gracefully short-circuits the function for untrusted workers, bypassing the illegal Datastore query.

### Notes
  1. Networking works without it: Android emulators executed via Swarming in this architecture share the host network namespace (--network=host). They inherit outbound internet access directly from the Swarming bot's host machine and do not require explicit Wi-Fi credentials to be injected.
  2. Established Pattern: This mirrors the exact same security bypass we already use in device.add_test_accounts_if_needed(), which also short-circuits to avoid Datastore queries in UWORKERs.