### PR TITLE
Fix legacy Datastore access in data_handler.py for UWORKERs

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1078,6 +1078,10 @@ def get_value_from_fuzzer_environment_string(fuzzer_name,
                                              variable_pattern,
                                              default=None):
   """Get a specific environment variable's value for a fuzzer."""
+  # Short-circuit: UWORKERs do not have Datastore access.
+  if environment.is_uworker():
+    return environment.get_value(variable_pattern, default)
+
   fuzzer = data_types.Fuzzer.query(data_types.Fuzzer.name == fuzzer_name).get()
   if not fuzzer or not fuzzer.additional_environment_string:
     return default
@@ -1235,6 +1239,10 @@ def get_component_name(job_type):
 @memoize.wrap(memoize.Memcache(MEMCACHE_TTL_IN_SECONDS))
 def get_repository_for_component(component):
   """Get the repository based on component."""
+  # Short-circuit: UWORKERs do not have Datastore access.
+  if environment.is_uworker():
+    return ''
+
   default_repository = ''
   repository = ''
   repository_mappings = db_config.get_value('component_repository_mappings')

--- a/src/clusterfuzz/_internal/datastore/data_handler.py
+++ b/src/clusterfuzz/_internal/datastore/data_handler.py
@@ -1214,6 +1214,11 @@ def bot_run_timed_out():
 @memoize.wrap(memoize.Memcache(MEMCACHE_TTL_IN_SECONDS))
 def get_component_name(job_type):
   """Gets component name for a job type."""
+  # Short-circuit: UWORKERs do not have Datastore access. The TWORKER has
+  # already injected all job variables into the local environment.
+  if environment.is_uworker():
+    return environment.get_value('COMPONENT_NAME', '')
+
   job = data_types.Job.query(data_types.Job.name == job_type).get()
   if not job:
     return ''
@@ -1261,6 +1266,11 @@ def get_value_from_job_definition(job_type, variable_pattern, default=None):
   """Get a specific environment variable's value from a job definition."""
   if not job_type:
     return default
+
+  # Short-circuit: UWORKERs do not have Datastore access. The TWORKER has
+  # already injected all job variables into the local environment.
+  if environment.is_uworker():
+    return environment.get_value(variable_pattern, default)
 
   job = data_types.Job.query(data_types.Job.name == job_type).get()
   if not job:

--- a/src/clusterfuzz/_internal/tests/core/datastore/data_handler_test.py
+++ b/src/clusterfuzz/_internal/tests/core/datastore/data_handler_test.py
@@ -1261,12 +1261,12 @@ class GetComponentNameTest(unittest.TestCase):
   def test_uworker_bypass(self):
     """Test that uworker environment skips Datastore and uses environment."""
     self.mock.is_uworker.return_value = True
-    
+
     def _mock_get_value(key, default=None):
-        if key == 'COMPONENT_NAME':
-            return 'custom_component'
-        return default
-        
+      if key == 'COMPONENT_NAME':
+        return 'custom_component'
+      return default
+
     self.mock.get_value.side_effect = _mock_get_value
 
     result = data_handler.get_component_name('job_name')

--- a/src/clusterfuzz/_internal/tests/core/datastore/data_handler_test.py
+++ b/src/clusterfuzz/_internal/tests/core/datastore/data_handler_test.py
@@ -1246,3 +1246,72 @@ class GetValueFromJobDefinitionTest(unittest.TestCase):
     self.assertEqual(result, 'env_value')
     self.mock.get_value.assert_called_once_with('VAR_PATTERN', 'default_val')
     self.mock.query.assert_not_called()
+
+
+class GetComponentNameTest(unittest.TestCase):
+  """Tests for get_component_name."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_uworker',
+        'clusterfuzz._internal.system.environment.get_value',
+        'clusterfuzz._internal.datastore.data_types.Job.query',
+    ])
+
+  def test_uworker_bypass(self):
+    """Test that uworker environment skips Datastore and uses environment."""
+    self.mock.is_uworker.return_value = True
+    
+    def _mock_get_value(key, default=None):
+        if key == 'COMPONENT_NAME':
+            return 'custom_component'
+        return default
+        
+    self.mock.get_value.side_effect = _mock_get_value
+
+    result = data_handler.get_component_name('job_name')
+
+    self.assertEqual(result, 'custom_component')
+    self.mock.query.assert_not_called()
+
+
+class GetRepositoryForComponentTest(unittest.TestCase):
+  """Tests for get_repository_for_component."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_uworker',
+        'clusterfuzz._internal.config.db_config.get_value',
+    ])
+
+  def test_uworker_bypass(self):
+    """Test that uworker environment skips Datastore and returns empty string."""
+    self.mock.is_uworker.return_value = True
+
+    result = data_handler.get_repository_for_component('component_name')
+
+    self.assertEqual(result, '')
+    self.mock.get_value.assert_not_called()
+
+
+class GetValueFromFuzzerEnvironmentStringTest(unittest.TestCase):
+  """Tests for get_value_from_fuzzer_environment_string."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_uworker',
+        'clusterfuzz._internal.system.environment.get_value',
+        'clusterfuzz._internal.datastore.data_types.Fuzzer.query',
+    ])
+
+  def test_uworker_bypass(self):
+    """Test that uworker environment skips Datastore and uses environment."""
+    self.mock.is_uworker.return_value = True
+    self.mock.get_value.return_value = 'fuzzer_env_value'
+
+    result = data_handler.get_value_from_fuzzer_environment_string(
+        'fuzzer_name', 'VAR_PATTERN', default='default_val')
+
+    self.assertEqual(result, 'fuzzer_env_value')
+    self.mock.get_value.assert_called_once_with('VAR_PATTERN', 'default_val')
+    self.mock.query.assert_not_called()


### PR DESCRIPTION
### Background

As part of the migration of ClusterFuzz to a scalable, isolated LUCI Swarming architecture, untrusted execution logic is handled by the UWORKER. The UWORKER operates within a highly sandboxed Docker container using a restricted IAM service account (untrusted-worker@...) that explicitly lacks Google Cloud Datastore read/write permissions.

During the teardown and log-upload phases of native Android fuzzing tasks (and potentially others), the UWORKER frequently crashed with google.api_core.exceptions.PermissionDenied (403) exceptions. Investigation revealed that several legacy monolithic utility functions in data_handler.py were still attempting raw Datastore queries (e.g.,
data_types.Job.query(...).get()) to fetch metadata about the fuzzing environment.

### Proposal

This PR comprehensively patches data_handler.py to enforce the UWORKER security boundary. We implement short-circuit checks (if environment.is_uworker():) at the top of the following functions:
  1. get_value_from_job_definition
  2. get_component_name
  3. get_repository_for_component
  4. get_value_from_fuzzer_environment_string

Instead of hitting the database, these functions now pull the requested metadata directly from the UWORKER's local environment variables (which are securely pre-injected by the Trusted Worker (TWORKER) before the container boots).

### Testing
  * Unit Tests: Added tests to explicitly mock is_uworker and assert that Datastore queries (ndb.query) are never invoked when executing in an untrusted context
  * End-to-End Validation: Fully verified on a live chrome-development instance. Successfully executed an end-to-end Swarming task (android_content_shell_native_job), confirming the UWORKER correctly detects a timeout, packages its logs, bypasses the Datastore traps, and exits cleanly with Code: 0.