### PR TITLE
Adds option to override the default queue for tworkers

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -24,6 +24,7 @@ from typing import List
 from typing import Optional
 
 from google.cloud import monitoring_v3
+from requests import exceptions
 
 from clusterfuzz._internal.base import external_tasks
 from clusterfuzz._internal.base import memoize
@@ -34,6 +35,7 @@ from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.datastore import ndb_utils
 from clusterfuzz._internal.fuzzing import fuzzer_selection
+from clusterfuzz._internal.google_cloud_utils import compute_metadata
 from clusterfuzz._internal.google_cloud_utils import credentials
 from clusterfuzz._internal.google_cloud_utils import pubsub
 from clusterfuzz._internal.google_cloud_utils import storage
@@ -364,6 +366,28 @@ def get_preprocess_task():
   return task
 
 
+@memoize.wrap(memoize.FifoInMemory(1))
+def _get_tworker_queue_override() -> str:
+  """Gets the tworker queue override from environment or metadata."""
+  queue_override = environment.get_value('OVERRIDE_QUEUE')
+  if queue_override:
+    return queue_override
+
+  if not compute_metadata.is_gce():
+    return ""
+
+  try:
+    queue_override = compute_metadata.get('instance/attributes/override_queue')
+    if queue_override:
+      return queue_override.strip()
+  except exceptions.RequestException as e:
+    if not (isinstance(e, exceptions.HTTPError) and
+            e.response.status_code == 404):
+      logs.warning(f'Error fetching override_queue metadata: {e}')
+
+  return ""
+
+
 def tworker_get_task():
   """Gets a task for a tworker to do."""
   assert environment.is_tworker()
@@ -372,8 +396,9 @@ def tworker_get_task():
   # queue that is probably empty) to do a single preprocess. Investigate
   # combining preprocess and postprocess queues and allowing pulling of
   # multiple messages.
-  queue_override = environment.get_value('OVERRIDE_QUEUE')
+  queue_override = _get_tworker_queue_override()
   if queue_override:
+    logs.info(f'Overriding default queue to {queue_override}')
     return get_regular_task(queue=queue_override)
 
   if random.random() < .5:

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -24,7 +24,6 @@ from typing import List
 from typing import Optional
 
 from google.cloud import monitoring_v3
-from requests import exceptions
 
 from clusterfuzz._internal.base import external_tasks
 from clusterfuzz._internal.base import memoize

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -372,6 +372,10 @@ def tworker_get_task():
   # queue that is probably empty) to do a single preprocess. Investigate
   # combining preprocess and postprocess queues and allowing pulling of
   # multiple messages.
+  queue_override = environment.get_value('OVERRIDE_QUEUE')
+  if queue_override:
+    return get_regular_task(queue=queue_override)
+
   if random.random() < .5:
     # Pick either one with equal probability so we don't hurt the
     # throughput of one compared to the other.

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -366,29 +366,7 @@ def get_preprocess_task():
   return task
 
 
-@memoize.wrap(memoize.FifoInMemory(1))
-def _get_tworker_queue_override() -> str:
-  """Gets the tworker queue override from environment or metadata."""
-  queue_override = environment.get_value('OVERRIDE_QUEUE')
-  if queue_override:
-    return queue_override
-
-  if not compute_metadata.is_gce():
-    return ""
-
-  try:
-    queue_override = compute_metadata.get('instance/attributes/override_queue')
-    if queue_override:
-      return queue_override.strip()
-  except exceptions.RequestException as e:
-    if not (isinstance(e, exceptions.HTTPError) and
-            e.response.status_code == 404):
-      logs.warning(f'Error fetching override_queue metadata: {e}')
-
-  return ""
-
-
-def tworker_get_task():
+def tworker_get_task(override_queue: str = None):
   """Gets a task for a tworker to do."""
   assert environment.is_tworker()
   # TODO(metzman): Pulling tasks is relatively expensive compared to
@@ -396,10 +374,9 @@ def tworker_get_task():
   # queue that is probably empty) to do a single preprocess. Investigate
   # combining preprocess and postprocess queues and allowing pulling of
   # multiple messages.
-  queue_override = _get_tworker_queue_override()
-  if queue_override:
-    logs.info(f'Overriding default queue to {queue_override}')
-    return get_regular_task(queue=queue_override)
+  if override_queue:
+    logs.info(f'Overriding default queue to {override_queue}')
+    return get_regular_task(queue=override_queue)
 
   if random.random() < .5:
     # Pick either one with equal probability so we don't hurt the

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
@@ -17,6 +17,7 @@ from unittest import mock
 
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 
 
@@ -535,3 +536,53 @@ class QueueNameGenerationTest(unittest.TestCase):
     }.get(key, default)
     mock_platform.return_value = 'MAC'
     self.assertEqual(tasks.default_queue_suffix(), '-mac')
+
+
+class TworkerGetTaskTest(unittest.TestCase):
+  """Tests for tworker_get_task."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.get_value',
+        'clusterfuzz._internal.system.environment.is_tworker',
+        'clusterfuzz._internal.base.tasks.get_regular_task',
+        'clusterfuzz._internal.base.tasks.get_postprocess_task',
+        'clusterfuzz._internal.base.tasks.get_preprocess_task',
+        'clusterfuzz._internal.base.tasks.random.random',
+    ])
+    self.mock.is_tworker.return_value = True
+
+  def test_override_queue_set(self):
+    """Test that tworker_get_task returns a task from the override queue."""
+    self.mock.get_value.return_value = 'override_queue'
+    mock_task = mock.Mock()
+    self.mock.get_regular_task.return_value = mock_task
+
+    result = tasks.tworker_get_task()
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_regular_task.assert_called_once_with(queue='override_queue')
+
+  def test_override_queue_not_set(self):
+    """Test that tworker_get_task falls back to random choice when override queue is not set."""
+    self.mock.get_value.return_value = None
+    self.mock.random.return_value = 0.4
+    mock_task = mock.Mock()
+    self.mock.get_postprocess_task.return_value = mock_task
+
+    result = tasks.tworker_get_task()
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_postprocess_task.assert_called_once()
+
+  def test_override_queue_empty(self):
+    """Test that tworker_get_task falls back to random choice when override queue is empty."""
+    self.mock.get_value.return_value = ''
+    self.mock.random.return_value = 0.6
+    mock_task = mock.Mock()
+    self.mock.get_preprocess_task.return_value = mock_task
+
+    result = tasks.tworker_get_task()
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_preprocess_task.assert_called_once()

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
@@ -549,12 +549,16 @@ class TworkerGetTaskTest(unittest.TestCase):
         'clusterfuzz._internal.base.tasks.get_postprocess_task',
         'clusterfuzz._internal.base.tasks.get_preprocess_task',
         'clusterfuzz._internal.base.tasks.random.random',
+        'clusterfuzz._internal.google_cloud_utils.compute_metadata.is_gce',
+        'clusterfuzz._internal.google_cloud_utils.compute_metadata.get',
     ])
     self.mock.is_tworker.return_value = True
+    self.mock.is_gce.return_value = False
 
   def test_override_queue_set(self):
     """Test that tworker_get_task returns a task from the override queue."""
     self.mock.get_value.return_value = 'override_queue'
+    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
     mock_task = mock.Mock()
     self.mock.get_regular_task.return_value = mock_task
 
@@ -566,6 +570,7 @@ class TworkerGetTaskTest(unittest.TestCase):
   def test_override_queue_not_set(self):
     """Test that tworker_get_task falls back to random choice when override queue is not set."""
     self.mock.get_value.return_value = None
+    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
     self.mock.random.return_value = 0.4
     mock_task = mock.Mock()
     self.mock.get_postprocess_task.return_value = mock_task
@@ -578,6 +583,7 @@ class TworkerGetTaskTest(unittest.TestCase):
   def test_override_queue_empty(self):
     """Test that tworker_get_task falls back to random choice when override queue is empty."""
     self.mock.get_value.return_value = ''
+    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
     self.mock.random.return_value = 0.6
     mock_task = mock.Mock()
     self.mock.get_preprocess_task.return_value = mock_task
@@ -586,3 +592,34 @@ class TworkerGetTaskTest(unittest.TestCase):
 
     self.assertEqual(result, mock_task)
     self.mock.get_preprocess_task.assert_called_once()
+
+  def test_override_queue_from_metadata_success(self):
+    """Test that tworker_get_task returns a task from the override queue in metadata."""
+    self.mock.get_value.return_value = None
+    self.mock.is_gce.return_value = True
+    self.mock.get.return_value = ' metadata_override '
+    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
+    mock_task = mock.Mock()
+    self.mock.get_regular_task.return_value = mock_task
+
+    result = tasks.tworker_get_task()
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_regular_task.assert_called_once_with(
+        queue='metadata_override')
+
+  def test_override_queue_from_metadata_exception(self):
+    """Test that tworker_get_task falls back when metadata fetch fails."""
+    from requests import exceptions
+    self.mock.get_value.return_value = None
+    self.mock.is_gce.return_value = True
+    self.mock.get.side_effect = exceptions.RequestException("Failed")
+    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
+    self.mock.random.return_value = 0.4
+    mock_task = mock.Mock()
+    self.mock.get_postprocess_task.return_value = mock_task
+
+    result = tasks.tworker_get_task()
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_postprocess_task.assert_called_once()

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
@@ -17,7 +17,6 @@ from unittest import mock
 
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.datastore import data_types
-from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 
 
@@ -536,90 +535,3 @@ class QueueNameGenerationTest(unittest.TestCase):
     }.get(key, default)
     mock_platform.return_value = 'MAC'
     self.assertEqual(tasks.default_queue_suffix(), '-mac')
-
-
-class TworkerGetTaskTest(unittest.TestCase):
-  """Tests for tworker_get_task."""
-
-  def setUp(self):
-    helpers.patch(self, [
-        'clusterfuzz._internal.system.environment.get_value',
-        'clusterfuzz._internal.system.environment.is_tworker',
-        'clusterfuzz._internal.base.tasks.get_regular_task',
-        'clusterfuzz._internal.base.tasks.get_postprocess_task',
-        'clusterfuzz._internal.base.tasks.get_preprocess_task',
-        'clusterfuzz._internal.base.tasks.random.random',
-        'clusterfuzz._internal.google_cloud_utils.compute_metadata.is_gce',
-        'clusterfuzz._internal.google_cloud_utils.compute_metadata.get',
-    ])
-    self.mock.is_tworker.return_value = True
-    self.mock.is_gce.return_value = False
-
-  def test_override_queue_set(self):
-    """Test that tworker_get_task returns a task from the override queue."""
-    self.mock.get_value.return_value = 'override_queue'
-    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
-    mock_task = mock.Mock()
-    self.mock.get_regular_task.return_value = mock_task
-
-    result = tasks.tworker_get_task()
-
-    self.assertEqual(result, mock_task)
-    self.mock.get_regular_task.assert_called_once_with(queue='override_queue')
-
-  def test_override_queue_not_set(self):
-    """Test that tworker_get_task falls back to random choice when override queue is not set."""
-    self.mock.get_value.return_value = None
-    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
-    self.mock.random.return_value = 0.4
-    mock_task = mock.Mock()
-    self.mock.get_postprocess_task.return_value = mock_task
-
-    result = tasks.tworker_get_task()
-
-    self.assertEqual(result, mock_task)
-    self.mock.get_postprocess_task.assert_called_once()
-
-  def test_override_queue_empty(self):
-    """Test that tworker_get_task falls back to random choice when override queue is empty."""
-    self.mock.get_value.return_value = ''
-    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
-    self.mock.random.return_value = 0.6
-    mock_task = mock.Mock()
-    self.mock.get_preprocess_task.return_value = mock_task
-
-    result = tasks.tworker_get_task()
-
-    self.assertEqual(result, mock_task)
-    self.mock.get_preprocess_task.assert_called_once()
-
-  def test_override_queue_from_metadata_success(self):
-    """Test that tworker_get_task returns a task from the override queue in metadata."""
-    self.mock.get_value.return_value = None
-    self.mock.is_gce.return_value = True
-    self.mock.get.return_value = ' metadata_override '
-    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
-    mock_task = mock.Mock()
-    self.mock.get_regular_task.return_value = mock_task
-
-    result = tasks.tworker_get_task()
-
-    self.assertEqual(result, mock_task)
-    self.mock.get_regular_task.assert_called_once_with(
-        queue='metadata_override')
-
-  def test_override_queue_from_metadata_exception(self):
-    """Test that tworker_get_task falls back when metadata fetch fails."""
-    from requests import exceptions
-    self.mock.get_value.return_value = None
-    self.mock.is_gce.return_value = True
-    self.mock.get.side_effect = exceptions.RequestException("Failed")
-    tasks._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
-    self.mock.random.return_value = 0.4
-    mock_task = mock.Mock()
-    self.mock.get_postprocess_task.return_value = mock_task
-
-    result = tasks.tworker_get_task()
-
-    self.assertEqual(result, mock_task)
-    self.mock.get_postprocess_task.assert_called_once()

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
@@ -17,6 +17,7 @@ from unittest import mock
 
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 
 
@@ -535,3 +536,40 @@ class QueueNameGenerationTest(unittest.TestCase):
     }.get(key, default)
     mock_platform.return_value = 'MAC'
     self.assertEqual(tasks.default_queue_suffix(), '-mac')
+
+
+class TworkerGetTaskTest(unittest.TestCase):
+  """Tests for tworker_get_task."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_tworker',
+        'clusterfuzz._internal.base.tasks.get_regular_task',
+        'clusterfuzz._internal.base.tasks.get_postprocess_task',
+        'clusterfuzz._internal.base.tasks.get_preprocess_task',
+        'random.random',
+    ])
+    self.mock.is_tworker.return_value = True
+
+  def test_not_tworker(self):
+    """Test that assertion fails if not a tworker."""
+    self.mock.is_tworker.return_value = False
+    with self.assertRaises(AssertionError):
+      tasks.tworker_get_task()
+
+  def test_fallback_to_random_choice(self):
+    """Test that tworker_get_task falls back to random choice when override_queue is None or empty."""
+    self.mock.random.return_value = 0.4
+    self.mock.get_postprocess_task.return_value = 'task2'
+
+    # Test with None
+    self.assertEqual(tasks.tworker_get_task(override_queue=None), 'task2')
+    self.mock.get_postprocess_task.assert_called_once()
+    self.mock.get_preprocess_task.assert_not_called()
+
+    self.mock.get_postprocess_task.reset_mock()
+
+    # Test with empty string
+    self.assertEqual(tasks.tworker_get_task(override_queue=''), 'task2')
+    self.mock.get_postprocess_task.assert_called_once()
+    self.mock.get_preprocess_task.assert_not_called()

--- a/src/clusterfuzz/_internal/tests/core/bot/startup/run_bot_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/startup/run_bot_test.py
@@ -204,3 +204,90 @@ class ScheduleUtaskMainsTest(unittest.TestCase):
 
     self.mock.RemoteTaskGate.return_value.create_utask_main_jobs.assert_called_once(
     )
+
+
+class TworkerGetTaskTest(unittest.TestCase):
+  """Tests for tworker_get_task."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.get_value',
+        'clusterfuzz._internal.system.environment.is_tworker',
+        'clusterfuzz._internal.base.tasks.get_regular_task',
+        'clusterfuzz._internal.base.tasks.get_postprocess_task',
+        'clusterfuzz._internal.base.tasks.get_preprocess_task',
+        'clusterfuzz._internal.base.tasks.random.random',
+        'clusterfuzz._internal.google_cloud_utils.compute_metadata.is_gce',
+        'clusterfuzz._internal.google_cloud_utils.compute_metadata.get',
+    ])
+    self.mock.is_tworker.return_value = True
+    self.mock.is_gce.return_value = False
+
+  def test_override_queue_set(self):
+    """Test that tworker_get_task returns a task from the override queue."""
+    self.mock.get_value.return_value = 'override_queue'
+    override = run_bot._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
+    mock_task = mock.Mock()
+    self.mock.get_regular_task.return_value = mock_task
+
+    result = taskslib.tworker_get_task(override_queue=override)
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_regular_task.assert_called_once_with(queue='override_queue')
+
+  def test_override_queue_not_set(self):
+    """Test that tworker_get_task falls back to random choice when override queue is not set."""
+    self.mock.get_value.return_value = None
+    override = run_bot._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
+    self.mock.random.return_value = 0.4
+    mock_task = mock.Mock()
+    self.mock.get_postprocess_task.return_value = mock_task
+
+    result = taskslib.tworker_get_task(override_queue=override)
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_postprocess_task.assert_called_once()
+
+  def test_override_queue_empty(self):
+    """Test that tworker_get_task falls back to random choice when override queue is empty."""
+    self.mock.get_value.return_value = ''
+    override = run_bot._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
+    self.mock.random.return_value = 0.6
+    mock_task = mock.Mock()
+    self.mock.get_preprocess_task.return_value = mock_task
+
+    result = taskslib.tworker_get_task(override_queue=override)
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_preprocess_task.assert_called_once()
+
+  def test_override_queue_from_metadata_success(self):
+    """Test that tworker_get_task returns a task from the override queue in metadata."""
+    self.mock.get_value.return_value = None
+    self.mock.is_gce.return_value = True
+    self.mock.get.return_value = ' metadata_override '
+    override = run_bot._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
+    mock_task = mock.Mock()
+    self.mock.get_regular_task.return_value = mock_task
+
+    result = taskslib.tworker_get_task(override_queue=override)
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_regular_task.assert_called_once_with(
+        queue='metadata_override')
+
+  def test_override_queue_from_metadata_exception(self):
+    """Test that tworker_get_task falls back to original behavior when metadata fetch fails."""
+    from requests import exceptions
+    self.mock.get_value.return_value = None
+    self.mock.is_gce.return_value = True
+    self.mock.get.side_effect = exceptions.RequestException("Failed")
+    override = run_bot._get_tworker_queue_override(__memoize_force__=True)  # pylint: disable=protected-access
+    self.mock.random.return_value = 0.4
+    mock_task = mock.Mock()
+    self.mock.get_postprocess_task.return_value = mock_task
+
+    result = taskslib.tworker_get_task(override_queue=override)
+
+    self.assertEqual(result, mock_task)
+    self.mock.get_postprocess_task.assert_called_once()

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -28,9 +28,11 @@ import time
 import traceback
 
 import requests
+from requests import exceptions
 
 from clusterfuzz._internal.base import dates
 from clusterfuzz._internal.base import errors
+from clusterfuzz._internal.base import memoize
 from clusterfuzz._internal.base import tasks
 from clusterfuzz._internal.base import untrusted
 from clusterfuzz._internal.base import utils
@@ -40,6 +42,7 @@ from clusterfuzz._internal.bot.tasks import update_task
 from clusterfuzz._internal.bot.tasks import utasks
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import ndb_init
+from clusterfuzz._internal.google_cloud_utils import compute_metadata
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.metrics import monitor
 from clusterfuzz._internal.metrics import monitoring_metrics
@@ -126,6 +129,29 @@ def _get_max_task_executions():  # pylint: disable=inconsistent-return-statement
     logs.log_fatal_and_exit(f'Invalid value for MAX_TASK_EXECUTIONS: {val}')
 
 
+@memoize.wrap(memoize.FifoInMemory(1))
+def _get_tworker_queue_override() -> str:
+  """Gets the tworker queue override from environment or metadata."""
+  queue_override = environment.get_value('OVERRIDE_TWORKER_QUEUE')
+  if queue_override:
+    return queue_override
+
+  if not compute_metadata.is_gce():
+    return ""
+
+  try:
+    queue_override = compute_metadata.get(
+        'instance/attributes/override_tworker_queue')
+    if queue_override:
+      return queue_override.strip()
+  except exceptions.RequestException as e:
+    if not (isinstance(e, exceptions.HTTPError) and
+            e.response.status_code == 404):
+      logs.warning(f'Error fetching override_tworker_queue metadata: {e}')
+
+  return ""
+
+
 def task_loop():
   """Executes tasks indefinitely."""
   # Defer heavy task imports to prevent issues with multiprocessing.Process
@@ -170,7 +196,8 @@ def task_loop():
         continue
 
       if environment.is_tworker():
-        task = tasks.tworker_get_task()
+        task = tasks.tworker_get_task(
+            override_queue=_get_tworker_queue_override())
       else:
         task = tasks.get_task()
 


### PR DESCRIPTION

We needed a way of making some tworker bots to always pull from the same queue, so this way we can boot up some tworkers that will only pull from swarming's preprocess queue, to achieve this we added a way to override the tworkers default behavior by forcing it to always pull from the given queue.

## Changes
- Adds an option at `tworker_get_task()` of always selecting a queue when:
  - the `OVERRIDE_TWORKER_QUEUE` env var is set for the given bot.
  - the metadata key 'override_tworker_queue' is present in this instance metadata
  - the new method is memoized because we don't expect this value to change mid flight, it must change trough terraform config files
- Create some unit tests for this new behavior

## Tests performed
Currently theres one tworker in `dev` that its running with this new code, and it works perfectly fine its readding tasks from the given queue
<img width="1574" height="205" alt="image" src="https://github.com/user-attachments/assets/aac9092c-1a2e-44c5-ac0e-c369513d444e" />

Note: the error you see comes from the fact that the `utask_main` queue is currently full in dev which is an expected behavior right now.

Heres a log of what happens when the `utask_main` queue is not full:
<img width="1472" height="383" alt="image" src="https://github.com/user-attachments/assets/6e5f7f44-e05c-4187-9eb0-cae53911d737" />
