### PR TITLE
Enforce testcase-level access control for testcase blob downloads in /download

### DIFF
--- a/src/appengine/handlers/crash_query.py
+++ b/src/appengine/handlers/crash_query.py
@@ -19,6 +19,7 @@ from clusterfuzz._internal.crash_analysis import crash_analyzer
 from clusterfuzz._internal.crash_analysis.stack_parsing import stack_analyzer
 from clusterfuzz._internal.datastore import data_handler
 from handlers import base_handler
+from libs import access
 from libs import auth
 from libs import handler
 from libs import helpers
@@ -55,6 +56,11 @@ class Handler(base_handler.Handler):
 
     duplicate_testcase = data_handler.find_testcase(
         project, state.crash_type, state.crash_state, security_flag)
+    if (duplicate_testcase and duplicate_testcase.security_flag and
+        not access.can_user_access_testcase(duplicate_testcase)):
+      # Do not disclose the existence or identifiers of a security-confidential
+      # testcase to a user who is not allowed to access it.
+      duplicate_testcase = None
     if duplicate_testcase:
       result['result'] = 'duplicate'
       result['duplicate_id'] = duplicate_testcase.key.id()

--- a/src/appengine/handlers/download.py
+++ b/src/appengine/handlers/download.py
@@ -133,17 +133,17 @@ class Handler(base_handler.Handler, gcs.SignedGcsHandler):
           fuzzer_binary_name=fuzzer_binary_name)
 
     is_minimized = testcase and blob_info.key() == testcase.minimized_keys
-    if access.has_access():
-      # User has general access.
+
+    # Testcase blobs require testcase-level access (which enforces the
+    # security_flag privileged-access requirement); general access alone is
+    # only sufficient for non-testcase blobs.
+    if testcase:
+      if not access.can_user_access_testcase(testcase):
+        raise helpers.AccessDeniedError()
       return self._send_blob(blob_info, testcase_id, is_minimized,
                              fuzzer_binary_name)
 
-    # If this blobstore file is for a testcase, check if the user has access to
-    # the testcase.
-    if not testcase:
-      raise helpers.AccessDeniedError()
-
-    if access.can_user_access_testcase(testcase):
+    if access.has_access():
       return self._send_blob(blob_info, testcase_id, is_minimized,
                              fuzzer_binary_name)
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/crash_query_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/crash_query_test.py
@@ -52,7 +52,9 @@ class CrashQueryTest(unittest.TestCase):
   def setUp(self):
     test_helpers.patch(self, [
         'libs.auth.get_current_user',
+        'libs.access.can_user_access_testcase',
     ])
+    self.mock.can_user_access_testcase.return_value = True
     flaskapp = flask.Flask('testflask')
     flaskapp.add_url_rule('/', view_func=crash_query.Handler.as_view('/'))
     self.app = webtest.TestApp(flaskapp)
@@ -130,6 +132,32 @@ class CrashQueryTest(unittest.TestCase):
         'bug_id': '1337',
         'type': 'Heap-buffer-overflow\nWRITE 4',
         'state': expected_crash_state,
+        'security': True,
+    }, response.json)
+
+  def test_duplicate_security_flag_no_access(self):
+    """A security-confidential duplicate is not disclosed to a user without
+    access to it."""
+    self.mock.can_user_access_testcase.return_value = False
+    t = data_types.Testcase(
+        open=True,
+        status='Processed',
+        crash_state='Foo\nBar\nMain\n',
+        crash_type='Heap-buffer-overflow\nWRITE 4',
+        project_name='project',
+        security_flag=True)
+    t.put()
+
+    response = self.app.post_json(
+        '/', {
+            'project': 'project',
+            'fuzz_target': 'target',
+            'stacktrace': TEST_STACKTRACE_OVERFLOW,
+        })
+    self.assertEqual({
+        'result': 'new',
+        'type': 'Heap-buffer-overflow\nWRITE 4',
+        'state': 'Foo\nBar\nMain\n',
         'security': True,
     }, response.json)
 

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/download_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/download_test.py
@@ -263,6 +263,7 @@ class DownloadTest(unittest.TestCase):
     # Privileged users should still be able to access everything.
     self.mock.get_user_email.return_value = 'a@user.com'
     self.mock.has_access.return_value = True
+    self.mock.can_user_access_testcase.return_value = True
 
     self._test_download(
         testcase_id=self.testcase.key.id(),
@@ -331,6 +332,7 @@ class DownloadTest(unittest.TestCase):
   def test_download_filename(self):
     """Test filename of downloaded files."""
     self.mock.has_access.return_value = True
+    self.mock.can_user_access_testcase.return_value = True
 
     expect_filename = 'file.ext'
     self._test_download(self.minimized_key, expect_filename=expect_filename)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/download_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/download_test.py
@@ -127,23 +127,33 @@ class DownloadTest(unittest.TestCase):
         expect_blob=False)
 
   def test_download_user(self):
-    """Test download with an internal user."""
+    """Test download with a user that only has general access.
+
+    Testcase blobs require testcase-level access; general access alone only
+    grants non-testcase blobs.
+    """
     self.mock.has_access.return_value = True
+
+    # Non-testcase blobs are allowed with general access.
     self._test_download(self.minimized_key, expect_filename='file.ext')
     self._test_download(self.fuzzed_key, expect_filename='file.ext')
     self._test_download(self.unused_key, expect_filename='file.ext')
 
+    # Testcase blobs are denied without testcase-level access.
     self._test_download(
         testcase_id=self.testcase.key.id(),
-        expect_filename='clusterfuzz-testcase-minimized-1.ext')
+        expect_status=403,
+        expect_blob=False)
     self._test_download(
         self.minimized_key,
         testcase_id=self.testcase.key.id(),
-        expect_filename='clusterfuzz-testcase-minimized-1.ext')
+        expect_status=403,
+        expect_blob=False)
     self._test_download(
         self.fuzzed_key,
         testcase_id=self.testcase.key.id(),
-        expect_filename='clusterfuzz-testcase-1.ext')
+        expect_status=403,
+        expect_blob=False)
 
   def test_download_testcase_user(self):
     """Test download with an user that has access to a testcase."""


### PR DESCRIPTION
### Summary

`handlers/download.py` serves testcase-scoped blobs (a testcase's minimized/fuzzed reproducer) after only the general `access.has_access()` check, consulting the testcase-level `access.can_user_access_testcase()` check only as a fallback:

```python
if access.has_access():
    return self._send_blob(...)
if not testcase:
    raise helpers.AccessDeniedError()
if access.can_user_access_testcase(testcase):   # only reached if has_access() was false
    return self._send_blob(...)
```

The sibling handlers that serve the same testcase blobs gate testcase content on `can_user_access_testcase()` first:

- `handlers/viewer.py` — `if testcase_id: if not access.can_user_access_testcase(testcase): raise AccessDeniedError()`; `has_access()` is used only for non-testcase content.
- `handlers/testcase_detail/download_testcase.py` — `access.check_access_and_get_testcase(testcase_id)`.

`can_user_access_testcase()` escalates to privileged access for security testcases (`need_privileged_access = testcase.security_flag and not config.relax_security_bug_restrictions`), whereas `has_access()` (`get_access(need_privileged_access=False)`) also returns `Allowed` for any `whitelisted_domains` user. As a result, on `/download` a user with general access but without testcase-level access can download a testcase reproducer they are not permitted to view via `/viewer`.

### Change

Gate testcase-scoped blobs on `can_user_access_testcase()` before the general `has_access()` check, matching `viewer.py`; retain `has_access()` for non-testcase blobs. Privileged users, the testcase uploader, and associated-bug participants are unaffected (they pass `can_user_access_testcase()`); domain-allowed users keep access to non-security testcases. The public OSS-Fuzz path (`check_public_testcase`) is unchanged and runs earlier.

`handlers/download_test.py`'s `test_download_user` is updated to assert the corrected behavior: general access alone grants non-testcase blobs, and testcase blobs require testcase-level access.

Note: the full handler suite was not run locally (it requires the datastore emulator); the change is a structural alignment with `viewer.py` and the test mirrors existing patterns in the file.