### PR TITLE
[build_manager] Skip unzipping during fuzz task target discovery

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -729,6 +729,23 @@ class RegularBuild(Build):
     self._pre_setup()
     environment.set_value(self.env_prefix + 'BUILD_URL', self.build_url)
 
+    # Check for target discovery run
+    # (fuzz task with no selected target for an engine job).
+    if (not self.fuzz_target and not self._unpack_everything and
+        environment.is_engine_fuzzer_job() and
+        environment.get_value('TASK_NAME') == 'fuzz'):
+      logs.info('[Target Discovery] Fuzz task engine job target discovery.'
+                ' Listing targets from archive.')
+      try:
+        with self._open_build_archive(self.base_build_dir, self.build_dir,
+                                      self.build_url,
+                                      self.http_build_url) as build:
+          self._fuzz_targets = list(build.list_fuzz_targets())
+        return True
+      except Exception as e:
+        logs.error(f'Failed to open build archive to list targets: {e}')
+        return False
+
     logs.info(f'Retrieving build r{self.revision} from {self.build_url}.')
     build_update = not self.exists()
     if build_update:

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -733,7 +733,7 @@ class RegularBuild(Build):
     # (fuzz task with no selected target for an engine job).
     if (not self.fuzz_target and not self._unpack_everything and
         environment.is_engine_fuzzer_job() and
-        environment.get_value('TASK_NAME') == 'fuzz'):
+        environment.get_value('TASK_NAME') == 'fuzz' and not self.build_prefix):
       logs.info('[Target Discovery] Fuzz task engine job target discovery.'
                 ' Listing targets from archive.')
       try:

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -741,7 +741,9 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     os.environ['ALLOW_UNPACK_OVER_HTTP'] = "True"
     self.mock.unzip_over_http_compatible.return_value = True
     self.mock.time.return_value = 1000.0
-    build = build_manager.setup_regular_build(2)
+    fuzz_target = build_manager.pick_random_fuzz_target(
+        target_weights=self.target_weights)
+    build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
     self.assertIsInstance(build, build_manager.RegularBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
 
@@ -756,7 +758,9 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
     # Test setting up build again.
     self.mock.time.return_value = 1005.0
-    build = build_manager.setup_regular_build(2)
+    fuzz_target = build_manager.pick_random_fuzz_target(
+        target_weights=self.target_weights)
+    build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
 
     self.assertIsInstance(build, build_manager.RegularBuild)
 
@@ -778,7 +782,9 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         'https://example.com/path/file-release-([0-9]+).zip')
     self.mock.unzip_over_http_compatible.return_value = True
     self.mock.time.return_value = 1000.0
-    build = build_manager.setup_regular_build(2)
+    fuzz_target = build_manager.pick_random_fuzz_target(
+        target_weights=self.target_weights)
+    build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
     self.assertIsInstance(build, build_manager.RegularBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
 
@@ -791,7 +797,9 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     # Test setting up build again.
     os.environ['FUZZ_TARGET'] = ''
     self.mock.time.return_value = 1005.0
-    build = build_manager.setup_regular_build(2)
+    fuzz_target = build_manager.pick_random_fuzz_target(
+        target_weights=self.target_weights)
+    build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
 
     self.assertIsInstance(build, build_manager.RegularBuild)
 
@@ -802,6 +810,31 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         1, self.mock.open.return_value.__enter__.return_value.unpack.call_count)
 
     self.assertCountEqual(['target1', 'target2', 'target3'], build.fuzz_targets)
+
+  def test_setup_fuzz_target_discovery(self):
+    """Tests that setup for engine jobs in target discovery phase skips unzipping/unpacking."""
+    os.environ['TASK_NAME'] = 'fuzz'
+    os.environ['OS_OVERRIDE'] = 'WINDOWS'
+    os.environ['RELEASE_BUILD_URL_PATTERN'] = (
+        'https://example.com/path/file-release-([0-9]+).zip')
+    self.mock.time.return_value = 1000.0
+    # Set fuzz_target=None (discovery run).
+    build = build_manager.setup_regular_build(2, fuzz_target=None)
+    self.assertIsInstance(build, build_manager.RegularBuild)
+
+    # Target list should still be discovered successfully from the zip directory catalog.
+    self.assertCountEqual(['target1', 'target2', 'target3'], build.fuzz_targets)
+
+    # Assert that NO unpacking occurred.
+    self.assertEqual(
+        0, self.mock.open.return_value.__enter__.return_value.unpack.call_count)
+    self.assertEqual(
+        0,
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
+    )
+
+    # Assert that no timestamp file was written.
+    self.assertIsNone(_get_timestamp(build.base_build_dir))
 
   def test_delete(self):
     """Test deleting this build."""


### PR DESCRIPTION
Context **b/500991018** and **b/509600495**.

### The Problem
During the very first target discovery run of a new engine fuzzer job (or after mappings are reset), no target is selected yet (`fuzz_target=None` / `"unknown"`). 

The build manager was currently attempting to download and uncompress the entire build archive (which are massive: 123 GB on Linux, and up to 397 GB on Windows) just to list fuzzer target names and exit. 

This causes space allocation checks (`_make_space`) to fail on standard GCE bot disks (75GB - 200GB), leaving the job stuck in an infinite crash loop.

### The Fix
During fuzz task target discovery runs (where `fuzz_target` is `None` for engine jobs with selective unzipping), we bypass zip file extraction entirely. We only open the archive, read fuzzer target names in memory from the catalog index (which takes milliseconds over HTTP without disk allocation), save them to Datastore, and exit early. 

Once saved, subsequent runs select a target and run selective unzipping (only ~500 MB), which fits comfortably.

### Impact in other workflows 
To ensure this optimization has zero impact on other active workflows, the bypass is protected by five guards:
1. `not self.fuzz_target`: Restricts only to target-discovery runs (where no target is selected yet).
2. `not self._unpack_everything`: Restricts only when selective target unzipping is enabled (if a job disables selective unzipping, it requires a full unpack of all targets, so we must not bypass).
3. `environment.is_engine_fuzzer_job()`: Restricts only to engine fuzzers (blackbox fuzzer jobs don't selective-unpack and always need to fully unzip their application binaries).
4. `environment.get_value('TASK_NAME') == 'fuzz'`: Restricts only to fuzzing tasks (progression/regression tasks working on crashes always need their target build unpacked to disk to run reproductions).
5. `not self.build_prefix`: Restricts only to the primary target build and not supporting extra engine binary packages (which must always be fully unpacked to disk).
6. `environment.platform() == 'WINDOWS'`: Restricts this bypass strictly to Windows bots. This limits the production rollout blast radius exclusively to the Windows platform to resolve the Windows bot crash block (b/509600495) with absolute safety.

### Note on Testing
Unit tests were updated and a new discovery test was added. All tests are passing. Note that this cannot be easily tested in dev because we don't have working local Windows bots running right now, but the logic is fully covered by unit tests.
