### PR TITLE
Fix leaking Cuttlefish helper process during the teardown

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/adb.py
+++ b/src/clusterfuzz/_internal/platforms/android/adb.py
@@ -53,7 +53,6 @@ GET_DEVICE_STATE_TIMEOUT = 20
 STOP_CVD_WAIT = 20
 LAUNCH_CVD_TIMEOUT = 2700
 CMD_KILL_CROSVM = 'pkill crosvm'
-CMD_KILL_RUN_CVD = 'pkill run_cvd'
 
 # Output patterns to parse "lsusb" output.
 LSUSB_BUS_RE = re.compile(r'Bus\s+(\d+)\s+Device\s+(\d+):.*')
@@ -445,15 +444,21 @@ def stop_cuttlefish_device():
   stop_cvd_cmd = os.path.join(cvd_bin_dir, 'stop_cvd')
   logs.info('stop_cvd_cmd: %s' % str(stop_cvd_cmd))
 
-  if get_device_state() == 'device':
+  # Attempt a graceful shutdown.
+  try:
     execute_command(
         stop_cvd_cmd, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
     time.sleep(STOP_CVD_WAIT)
+  except Exception as e:
+    logs.warning('Graceful stop_cvd failed or timed out: %s' % str(e))
 
+  # Forcefully kill crosvm and all CVD helper processes to prevent port leaks.
   execute_command(
       CMD_KILL_CROSVM, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
+
+  kill_helpers_cmd = f'pkill -f "{cvd_bin_dir}/"'
   execute_command(
-      CMD_KILL_RUN_CVD, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
+      kill_helpers_cmd, timeout=RECOVERY_CMD_TIMEOUT, on_cuttlefish_host=True)
 
 
 def restart_cuttlefish_device():


### PR DESCRIPTION
The Cuttlefish teardown routine previously bypassed the graceful `stop_cvd` command when Cuttlefish froze, hung, or when the ADB connection goes offline, proceeding to force-kill only `crosvm` and `run_cvd`. This leaked helper processes related to telemetry and bridge processes like `tombstone_receiver` and `modem_simulator`, leaving TCP ports bound indefinitely and causing subsequent boot attempts to fail with `Address already in use` errors.

This change ensures `stop_cvd` is always attempted gracefully and force-kills all remaining CVD helper processes during the forced cleanup routine to guarantee a clean port release.