### PR TITLE
Enforce testcase access control in the crash-query endpoint

### DIFF
--- a/src/appengine/handlers/crash_query.py
+++ b/src/appengine/handlers/crash_query.py
@@ -19,6 +19,7 @@ from clusterfuzz._internal.crash_analysis import crash_analyzer
 from clusterfuzz._internal.crash_analysis.stack_parsing import stack_analyzer
 from clusterfuzz._internal.datastore import data_handler
 from handlers import base_handler
+from libs import access
 from libs import auth
 from libs import handler
 from libs import helpers
@@ -55,7 +56,13 @@ class Handler(base_handler.Handler):
 
     duplicate_testcase = data_handler.find_testcase(
         project, state.crash_type, state.crash_state, security_flag)
-    if duplicate_testcase:
+    # Only disclose the duplicate testcase id / bug id if the current user is
+    # allowed to access that testcase. Otherwise (e.g. a non-privileged user
+    # matching a restricted security testcase) behave as if no duplicate
+    # exists, consistent with how crash_access.add_scope() hides security
+    # testcases from non-privileged users on every other crash data path
+    # (testcase_list, crash_stats, commit_range).
+    if duplicate_testcase and access.can_user_access_testcase(duplicate_testcase):
       result['result'] = 'duplicate'
       result['duplicate_id'] = duplicate_testcase.key.id()
 


### PR DESCRIPTION
## Problem

The `/crash-query` endpoint (`crash_query.py`) is gated only by a logged-in check (`auth.get_current_user()`). It takes a caller-supplied stacktrace, computes the crash signature and `security_flag`, calls `data_handler.find_testcase(project, crash_type, crash_state, security_flag)` (which matches security testcases) and returns the matched testcase's `duplicate_id` and `bug_id`.

Every other crash-data path applies `crash_access.add_scope()`, which hides `security_flag=True` testcases from non-privileged users (including domain-allowed "everything-but-security" users): `testcase_list.py`, `crash_stats.py`, `commit_range.py`. `crash_query` applies no per-result access check, so a non-privileged user can confirm the existence of, and obtain the testcase id and linked bug id of, a restricted security testcase that the rest of the UI hides from them.

## Fix

Gate the duplicate disclosure behind `access.can_user_access_testcase()` (the same check used by `check_access_and_get_testcase`, which enforces `need_privileged_access` for `security_flag` testcases plus uploader/issue-owner relations). If the current user cannot access the matched testcase, respond as if no duplicate exists, consistent with that user's view everywhere else.

The computed `security` boolean (derived from the caller's own submitted stacktrace) is unchanged.
