### PR TITLE
Anchor CORS Origin allowlist matching (re.fullmatch)

### DIFF
--- a/configs/test/gae/auth.yaml
+++ b/configs/test/gae/auth.yaml
@@ -27,9 +27,12 @@ whitelisted_oauth_emails:
 #  - test-client-email1@developer.gserviceaccount.com
 
 # CORS urls that have access to some pages in ClusterFuzz (e.g. Crashes by range).
+# These are full-match regexes against the request Origin, so escape literal
+# dots and avoid trailing wildcards to prevent origins such as
+# 'https://test-client-site.appspot.com.evil.com' from being whitelisted.
 whitelisted_cors_urls:
-#  - https?://(.*-dot-)?test-client-site-staging.appspot.com
-#  - https?://(.*-dot-)?test-client-site.appspot.com
+#  - https?://(.*-dot-)?test-client-site-staging\.appspot\.com
+#  - https?://(.*-dot-)?test-client-site\.appspot\.com
 
 # All users are privileged. This should not be used in the majority of cases,
 # and only be turned on when access to the web interface is tightly controlled

--- a/src/appengine/libs/handler.py
+++ b/src/appengine/libs/handler.py
@@ -346,7 +346,13 @@ def allowed_cors(func):
 
     if origin and whitelisted_cors_urls:
       for domain_regex in whitelisted_cors_urls:
-        if re.match(domain_regex, origin):
+        # Use fullmatch (not match) so the regex must match the ENTIRE Origin.
+        # re.match only anchors at the start, so an unanchored pattern such as
+        # 'https?://...test-client-site.appspot.com' would also match a
+        # malicious origin like 'https://test-client-site.appspot.com.evil.com',
+        # which then gets reflected into Access-Control-Allow-Origin together
+        # with Access-Control-Allow-Credentials: true.
+        if re.fullmatch(domain_regex, origin):
           response.headers['Access-Control-Allow-Origin'] = origin
           response.headers['Vary'] = 'Origin'
           response.headers['Access-Control-Allow-Credentials'] = 'true'


### PR DESCRIPTION
## Problem

`allowed_cors` (`libs/handler.py`) matches the request `Origin` against each configured `whitelisted_cors_urls` regex with `re.match`, which only anchors at the start of the string. On a match it reflects the origin into `Access-Control-Allow-Origin` together with `Access-Control-Allow-Credentials: true`.

With the shipped example pattern `https?://(.*-dot-)?test-client-site.appspot.com`, `re.match` also matches malicious origins such as:

- `https://test-client-site.appspot.com.evil.com` (trailing suffix)
- `https://anything.evil.com-dot-test-client-site.appspot.com` (the `.*` prefix)
- `https://test-client-siteXappspot.com` (unescaped `.`)

A page on such an origin can then make credentialed cross-origin requests to the CORS-enabled endpoint and read the victim's authorized crash/testcase data.

## Fix

- Use `re.fullmatch` so the pattern must match the entire `Origin` (anchors both ends), closing the trailing-suffix and prefix bypasses.
- Update the example regexes in `configs/test/gae/auth.yaml` to escape literal dots and document the requirement, so copied configs are safe by default.
