### PR TITLE
Security: Add missing authorization checks to web handlers

### DIFF
--- a/src/appengine/handlers/coverage_report.py
+++ b/src/appengine/handlers/coverage_report.py
@@ -20,6 +20,7 @@ from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.metrics import fuzzer_stats
 from handlers import base_handler
+from libs import access
 from libs import handler
 from libs import helpers
 
@@ -74,6 +75,10 @@ class Handler(base_handler.Handler):
   @handler.oauth
   def get(self, report_type=None, argument=None, date=None, extra=None):
     """Handle a get request."""
+    job = argument
+    if job and not access.has_access(job_type=job):
+      raise helpers.AccessDeniedError()
+
     report_url = get_report_url(report_type, argument, date)
     if report_url:
       return self.redirect(report_url)

--- a/src/appengine/handlers/issue_redirector.py
+++ b/src/appengine/handlers/issue_redirector.py
@@ -16,6 +16,7 @@
 
 from clusterfuzz._internal.issue_management import issue_tracker_utils
 from handlers import base_handler
+from libs import access
 from libs import helpers
 
 
@@ -24,7 +25,7 @@ class Handler(base_handler.Handler):
 
   def get(self, testcase_id=None):
     """Redirect user to the correct URL."""
-    testcase = helpers.get_testcase(testcase_id)
+    testcase = access.check_access_and_get_testcase(testcase_id)
     issue_url = helpers.get_or_exit(
         lambda: issue_tracker_utils.get_issue_url(testcase),
         'Issue tracker for testcase (id=%s) is not found.' % testcase_id,

--- a/src/appengine/handlers/testcase_detail/update_issue.py
+++ b/src/appengine/handlers/testcase_detail/update_issue.py
@@ -15,11 +15,14 @@
 
 from flask import request
 
+from clusterfuzz._internal.base import utils
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.issue_management import issue_filer
 from clusterfuzz._internal.issue_management import issue_tracker_policy
 from handlers import base_handler
 from handlers.testcase_detail import show
+from libs import access
+from libs import auth
 from libs import handler
 from libs import helpers
 
@@ -38,6 +41,17 @@ class Handler(base_handler.Handler):
                                 'Issue (id=%d) is not found!' % issue_id,
                                 'Failed to get the issue (id=%s).' % issue_id,
                                 Exception)
+
+    # Check if the user is allowed to access/modify this issue
+    user_email = helpers.get_user_email()
+    if not auth.is_current_user_admin() and not access._is_privileged_user(user_email):
+      is_associated = (
+          utils.emails_equal(user_email, issue.reporter) or
+          utils.emails_equal(user_email, issue.assignee) or
+          any(utils.emails_equal(user_email, cc) for cc in issue.ccs)
+      )
+      if not is_associated:
+        raise helpers.AccessDeniedError('You do not have access to this issue.')
 
     if not issue.is_open:
       raise helpers.EarlyExitError(


### PR DESCRIPTION
## Summary

Add missing authorization checks to three web handlers in ClusterFuzz to prevent unauthorized access to testcase data, coverage reports, and cross-object issue manipulation.

## Problems Fixed

### 1. issue_redirector.py - Missing Access Control
The handler uses `helpers.get_testcase()` which only checks if a testcase exists, NOT if the current user has permission to view it. This leaks private issue tracker URLs to unauthorized users.

**Fix:** Replaced with `access.check_access_and_get_testcase()` which enforces proper permission checks.

### 2. coverage_report.py - Missing Job-Level Authorization
Any authenticated user can request coverage reports for any fuzzer job across any project, regardless of their access level.

**Fix:** Added `access.has_access(job_type=job)` check before serving coverage data.

### 3. update_issue.py - Cross-Object Authorization Bypass (IDOR)
The handler checks if the user has access to the testcase, but NOT to the target issue. Since it runs as a high-privilege service account, it can post comments and modify metadata on private issues in other projects.

**Fix:** Added user-association check verifying the requesting user is an admin, privileged user, or explicitly associated (reporter/assignee/CC) with the target issue.

## Impact

Without these fixes:
- Unauthenticated users can enumerate testcase IDs and discover private issue URLs
- Any user can access coverage data for restricted projects
- Users with testcase access can modify unrelated private issues

## Related

This PR extends the scope of #5258 by also fixing the cross-object authorization bypass in `update_issue.py`, which is not covered by PR #5259.
