### PR TITLE
Support fuzz_targets property in clusterfuzz_manifest.json

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -62,6 +62,7 @@ class BuildArchive(archive.ArchiveReader):
 
   def __init__(self, reader: archive.ArchiveReader):
     self._reader = reader
+    self._fuzz_targets = None
 
   def list_members(self) -> List[archive.ArchiveMemberInfo]:
     return self._reader.list_members()
@@ -78,12 +79,33 @@ class BuildArchive(archive.ArchiveReader):
   def close(self) -> None:
     self._reader.close()
 
-  @abc.abstractmethod
   def list_fuzz_targets(self) -> List[str]:
     """Lists fuzzing targets in the archive.
 
+    Guarantees that self._fuzz_targets is populated with a dict mapping
+    normalized target names to their paths in the archive.
+
     Returns:
         The list of fuzz targets.
+    """
+    if self._fuzz_targets is not None:
+      return list(self._fuzz_targets.keys())
+
+    # Import here as this path is not available in App Engine context.
+    from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+
+    self._fuzz_targets = {
+        fuzzer_utils.normalize_target_name(path): path
+        for path in self.find_fuzz_targets()
+    }
+    return list(self._fuzz_targets.keys())
+
+  @abc.abstractmethod
+  def find_fuzz_targets(self) -> List[str]:
+    """Finds fuzzing targets in the archive.
+
+    Returns:
+        The list of paths to fuzz targets in the archive.
     """
     raise NotImplementedError
 
@@ -139,10 +161,6 @@ class DefaultBuildArchive(BuildArchive):
   """Default class for handling builds. This should work with everything.
   """
 
-  def __init__(self, reader: archive.ArchiveReader):
-    super().__init__(reader)
-    self._fuzz_targets = None
-
   def get_path_for_target(self, fuzz_target: str) -> str:
     """Returns the path in the archive of the fuzz_target if found.
     This is needed because target name normalization means we're losing
@@ -151,10 +169,7 @@ class DefaultBuildArchive(BuildArchive):
     if self._fuzz_targets is None:
       self.list_fuzz_targets()
 
-    if not self._fuzz_targets or fuzz_target not in self._fuzz_targets:
-      return None
-
-    return self._fuzz_targets[fuzz_target]
+    return self._fuzz_targets.get(fuzz_target)
 
   def get_target_dependencies(
       self, fuzz_target: str) -> List[archive.ArchiveMemberInfo]:
@@ -184,20 +199,20 @@ class DefaultBuildArchive(BuildArchive):
 
     return to_extract
 
-  def list_fuzz_targets(self) -> List[str]:
-    if self._fuzz_targets is not None:
-      return list(self._fuzz_targets.keys())
+  def find_fuzz_targets(self) -> List[str]:
+    """Finds fuzzing targets in the archive.
 
-    self._fuzz_targets = {}
+    Returns:
+        The list of paths to fuzz targets in the archive.
+    """
     # Import here as this path is not available in App Engine context.
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
-    for archive_file in self.list_members():
-      if fuzzer_utils.is_fuzz_target(archive_file.name, self.open):
-        fuzz_target = fuzzer_utils.normalize_target_name(archive_file.name)
-        self._fuzz_targets[fuzz_target] = archive_file.name
-
-    return list(self._fuzz_targets.keys())
+    return [
+        member.name
+        for member in self.list_members()
+        if fuzzer_utils.is_fuzz_target(member.name, self.open)
+    ]
 
   def unpacked_size(self, fuzz_target: Optional[str] = None) -> int:
     if not fuzz_target:
@@ -294,35 +309,39 @@ class ChromeBuildArchive(DefaultBuildArchive):
         to expect if `clusterfuzz_manifest.json` is missing or badly formatted.
     """
     super().__init__(reader)
+    self._manifest_fuzz_targets = None
     # The manifest may not exist for earlier versions of archives. In this
     # case, default to schema version 0.
     manifest_path = 'clusterfuzz_manifest.json'
-    if self.file_exists(manifest_path):
-      with self.open(manifest_path) as f:
-        manifest = json.load(f)
-      self._archive_schema_version = manifest.get('archive_schema_version')
-      if self._archive_schema_version is None:
-        logs.warning(
-            'clusterfuzz_manifest.json was incorrectly formatted or missing an '
-            'archive_schema_version field')
-        self._archive_schema_version = default_archive_schema_version
-
-      fuzz_targets_data = manifest.get('fuzz_targets')
-      if isinstance(fuzz_targets_data, list):
-        self._fuzz_targets = {}
-        from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
-        for target_path in fuzz_targets_data:
-          if isinstance(target_path, str):
-            fuzz_target = fuzzer_utils.normalize_target_name(target_path)
-            self._fuzz_targets[fuzz_target] = target_path
-          else:
-            logs.error(
-                f'Entry in fuzz_targets (clusterfuzz_manifest.json) is not a '
-                f'string: {target_path}')
-      elif fuzz_targets_data is not None:
-        logs.error('fuzz_targets in clusterfuzz_manifest.json is not a list')
-    else:
+    if not self.file_exists(manifest_path):
       self._archive_schema_version = default_archive_schema_version
+      return
+
+    with self.open(manifest_path) as f:
+      manifest = json.load(f)
+    self._archive_schema_version = manifest.get('archive_schema_version')
+    if self._archive_schema_version is None:
+      logs.warning(
+          'clusterfuzz_manifest.json was incorrectly formatted or missing an '
+          'archive_schema_version field')
+      self._archive_schema_version = default_archive_schema_version
+
+    fuzz_target_paths = manifest.get('fuzz_targets')
+    if fuzz_target_paths is None:
+      return
+
+    if not isinstance(fuzz_target_paths, list):
+      logs.error('fuzz_targets in clusterfuzz_manifest.json is not a list')
+      return
+
+    self._manifest_fuzz_targets = []
+    for target_path in fuzz_target_paths:
+      if isinstance(target_path, str):
+        self._manifest_fuzz_targets.append(target_path)
+      else:
+        logs.error(
+            f'Entry in fuzz_targets (clusterfuzz_manifest.json) is not a '
+            f'string: {target_path}')
 
   def root_dir(self) -> str:
     if not hasattr(self, '_root_dir'):
@@ -332,6 +351,11 @@ class ChromeBuildArchive(DefaultBuildArchive):
   def archive_schema_version(self) -> int:
     """Returns the schema version number for this archive."""
     return self._archive_schema_version
+
+  def find_fuzz_targets(self) -> List[str]:
+    if self._manifest_fuzz_targets:
+      return self._manifest_fuzz_targets
+    return super().find_fuzz_targets()
 
   def get_dependency_path(self, path: str, deps_file_path: str) -> str:
     """Deps are given as paths relative to the deps file where they are listed,

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -88,16 +88,15 @@ class BuildArchive(archive.ArchiveReader):
     Returns:
         The list of fuzz targets.
     """
-    if self._fuzz_targets is not None:
-      return list(self._fuzz_targets.keys())
+    if self._fuzz_targets is None:
+      # Import here as this path is not available in App Engine context.
+      from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
-    # Import here as this path is not available in App Engine context.
-    from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+      self._fuzz_targets = {
+          fuzzer_utils.normalize_target_name(path): path
+          for path in self.find_fuzz_targets()
+      }
 
-    self._fuzz_targets = {
-        fuzzer_utils.normalize_target_name(path): path
-        for path in self.find_fuzz_targets()
-    }
     return list(self._fuzz_targets.keys())
 
   @abc.abstractmethod
@@ -339,9 +338,8 @@ class ChromeBuildArchive(DefaultBuildArchive):
       if isinstance(target_path, str):
         self._manifest_fuzz_targets.append(target_path)
       else:
-        logs.error(
-            f'Entry in fuzz_targets (clusterfuzz_manifest.json) is not a '
-            f'string: {target_path}')
+        logs.error('Entry in fuzz_targets (clusterfuzz_manifest.json) is not a '
+                   f'string: {target_path}')
 
   def root_dir(self) -> str:
     if not hasattr(self, '_root_dir'):

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -141,17 +141,17 @@ class DefaultBuildArchive(BuildArchive):
 
   def __init__(self, reader: archive.ArchiveReader):
     super().__init__(reader)
-    self._fuzz_targets = {}
+    self._fuzz_targets = None
 
   def get_path_for_target(self, fuzz_target: str) -> str:
     """Returns the path in the archive of the fuzz_target if found.
     This is needed because target name normalization means we're losing
     information about the actual file reprensenting the fuzz_target.
     """
-    if not self._fuzz_targets:
+    if self._fuzz_targets is None:
       self.list_fuzz_targets()
 
-    if not fuzz_target in self._fuzz_targets:
+    if not self._fuzz_targets or fuzz_target not in self._fuzz_targets:
       return None
 
     return self._fuzz_targets[fuzz_target]
@@ -185,8 +185,10 @@ class DefaultBuildArchive(BuildArchive):
     return to_extract
 
   def list_fuzz_targets(self) -> List[str]:
-    if self._fuzz_targets:
+    if self._fuzz_targets is not None:
       return list(self._fuzz_targets.keys())
+
+    self._fuzz_targets = {}
     # Import here as this path is not available in App Engine context.
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -304,6 +306,21 @@ class ChromeBuildArchive(DefaultBuildArchive):
             'clusterfuzz_manifest.json was incorrectly formatted or missing an '
             'archive_schema_version field')
         self._archive_schema_version = default_archive_schema_version
+
+      fuzz_targets_data = manifest.get('fuzz_targets')
+      if isinstance(fuzz_targets_data, list):
+        self._fuzz_targets = {}
+        from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+        for target_path in fuzz_targets_data:
+          if isinstance(target_path, str):
+            fuzz_target = fuzzer_utils.normalize_target_name(target_path)
+            self._fuzz_targets[fuzz_target] = target_path
+          else:
+            logs.error(
+                f'Entry in fuzz_targets (clusterfuzz_manifest.json) is not a '
+                f'string: {target_path}')
+      elif fuzz_targets_data is not None:
+        logs.error('fuzz_targets in clusterfuzz_manifest.json is not a list')
     else:
       self._archive_schema_version = default_archive_schema_version
 

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -22,6 +22,8 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+from typing_extensions import override
+
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import archive
 
@@ -198,12 +200,8 @@ class DefaultBuildArchive(BuildArchive):
 
     return to_extract
 
+  @override
   def find_fuzz_targets(self) -> List[str]:
-    """Finds fuzzing targets in the archive.
-
-    Returns:
-        The list of paths to fuzz targets in the archive.
-    """
     # Import here as this path is not available in App Engine context.
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -350,6 +348,7 @@ class ChromeBuildArchive(DefaultBuildArchive):
     """Returns the schema version number for this archive."""
     return self._archive_schema_version
 
+  @override
   def find_fuzz_targets(self) -> List[str]:
     if self._manifest_fuzz_targets:
       return self._manifest_fuzz_targets

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -522,27 +522,26 @@ class Build(BaseBuild):
       with self._open_build_archive(base_build_dir, build_dir, build_url,
                                     http_build_url) as build:
         unpack_start_time = time.time()
-        if environment.is_engine_fuzzer_job() and not self.fuzz_target:
-          # If no fuzz target is selected (e.g. during initial fuzz target
-          # discovery), we only need the list of fuzz targets. We get them
-          # from the build archive (which instantly reads
-          # clusterfuzz_manifest.json if present) and skip unpacking the
-          # archive to disk entirely to prevent out of disk space errors.
+        is_discovery = (
+            environment.is_engine_fuzzer_job() and not self.fuzz_target and
+            not self.build_prefix)
+        if is_discovery or not self._unpack_everything:
+          # We need the list of fuzz targets, either because we are performing
+          # initial fuzz target discovery, or because we are only unpacking
+          # selected fuzz targets.
           list_fuzz_target_start_time = time.time()
           self._fuzz_targets = list(build.list_fuzz_targets())
           _emit_job_build_retrieval_metric(list_fuzz_target_start_time,
                                            'list_fuzz_targets',
                                            self._build_type)
+
+        if is_discovery:
+          # If no fuzz target is selected, we only needed the list of fuzz
+          # targets and can skip unpacking the archive entirely.
           logs.info('No fuzz target selected; skipping unpack for discovery.')
           return True
+
         if not self._unpack_everything:
-          # We will never unpack the full build so we need to get the targets
-          # from the build archive.
-          list_fuzz_target_start_time = time.time()
-          self._fuzz_targets = list(build.list_fuzz_targets())
-          _emit_job_build_retrieval_metric(list_fuzz_target_start_time,
-                                           'list_fuzz_targets',
-                                           self._build_type)
           # We only want to unpack a single fuzz target if unpack_everything is
           # False.
           fuzz_target_to_unpack = self.fuzz_target
@@ -1349,7 +1348,8 @@ def setup_regular_build(revision,
 
   # Additional binaries to pull (for fuzzing engines such as Centipede).
   extra_bucket_path = get_bucket_path('EXTRA_BUILD_BUCKET_PATH')
-  if extra_bucket_path:
+  is_discovery = environment.is_engine_fuzzer_job() and not fuzz_target
+  if extra_bucket_path and not is_discovery:
     # Import here as this path is not available in App Engine context.
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
     extra_build_urls = get_build_urls_list(extra_bucket_path)
@@ -1364,8 +1364,7 @@ def setup_regular_build(revision,
         build.build_dir,  # Store inside the main build.
         revision,
         extra_build_url,
-        build_prefix=fuzzer_utils.EXTRA_BUILD_DIR,
-        fuzz_target=fuzz_target)
+        build_prefix=fuzzer_utils.EXTRA_BUILD_DIR)
     if not build.setup():
       return None
 

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -605,7 +605,11 @@ class Build(BaseBuild):
 
   @property
   def is_discovery(self):
-    """Return True if this is a discovery run."""
+    """Return True if this is a discovery run.
+
+    A discovery run is an engine fuzzer job (e.g., LibFuzzer) with no fuzz
+    target selected. build_prefix is checked to exclude extra builds, which
+    don't set fuzz_target but need to be unpacked."""
     return (environment.is_engine_fuzzer_job() and not self.fuzz_target and
             not self.build_prefix)
 

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -522,10 +522,7 @@ class Build(BaseBuild):
       with self._open_build_archive(base_build_dir, build_dir, build_url,
                                     http_build_url) as build:
         unpack_start_time = time.time()
-        is_discovery = (
-            environment.is_engine_fuzzer_job() and not self.fuzz_target and
-            not self.build_prefix)
-        if is_discovery or not self._unpack_everything:
+        if self.is_discovery or not self._unpack_everything:
           # We need the list of fuzz targets, either because we are performing
           # initial fuzz target discovery, or because we are only unpacking
           # selected fuzz targets.
@@ -535,7 +532,7 @@ class Build(BaseBuild):
                                            'list_fuzz_targets',
                                            self._build_type)
 
-        if is_discovery:
+        if self.is_discovery:
           # If no fuzz target is selected, we only needed the list of fuzz
           # targets and can skip unpacking the archive entirely.
           logs.info('No fuzz target selected; skipping unpack for discovery.')
@@ -605,6 +602,12 @@ class Build(BaseBuild):
   def build_dir(self):
     """The build directory. Usually a subdirectory of base_build_dir."""
     raise NotImplementedError
+
+  @property
+  def is_discovery(self):
+    """Return True if this is a discovery run."""
+    return (environment.is_engine_fuzzer_job() and not self.fuzz_target and
+            not self.build_prefix)
 
   @property
   def fuzz_targets(self):
@@ -1348,8 +1351,7 @@ def setup_regular_build(revision,
 
   # Additional binaries to pull (for fuzzing engines such as Centipede).
   extra_bucket_path = get_bucket_path('EXTRA_BUILD_BUCKET_PATH')
-  is_discovery = environment.is_engine_fuzzer_job() and not fuzz_target
-  if extra_bucket_path and not is_discovery:
+  if extra_bucket_path and not build.is_discovery:
     # Import here as this path is not available in App Engine context.
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
     extra_build_urls = get_build_urls_list(extra_bucket_path)

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -522,6 +522,19 @@ class Build(BaseBuild):
       with self._open_build_archive(base_build_dir, build_dir, build_url,
                                     http_build_url) as build:
         unpack_start_time = time.time()
+        if environment.is_engine_fuzzer_job() and not self.fuzz_target:
+          # If no fuzz target is selected (e.g. during initial fuzz target
+          # discovery), we only need the list of fuzz targets. We get them
+          # from the build archive (which instantly reads
+          # clusterfuzz_manifest.json if present) and skip unpacking the
+          # archive to disk entirely to prevent out of disk space errors.
+          list_fuzz_target_start_time = time.time()
+          self._fuzz_targets = list(build.list_fuzz_targets())
+          _emit_job_build_retrieval_metric(list_fuzz_target_start_time,
+                                           'list_fuzz_targets',
+                                           self._build_type)
+          logs.info('No fuzz target selected; skipping unpack for discovery.')
+          return True
         if not self._unpack_everything:
           # We will never unpack the full build so we need to get the targets
           # from the build archive.
@@ -1351,7 +1364,8 @@ def setup_regular_build(revision,
         build.build_dir,  # Store inside the main build.
         revision,
         extra_build_url,
-        build_prefix=fuzzer_utils.EXTRA_BUILD_DIR)
+        build_prefix=fuzzer_utils.EXTRA_BUILD_DIR,
+        fuzz_target=fuzz_target)
     if not build.setup():
       return None
 

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -546,7 +546,7 @@ class Build(BaseBuild):
           fuzz_target_to_unpack = None
 
         # If the fuzz_target is None, this will return the full size.
-        extracted_size = build.unpacked_size(fuzz_target=self.fuzz_target)
+        extracted_size = build.unpacked_size(fuzz_target=fuzz_target_to_unpack)
 
         if not _make_space(extracted_size, current_build_dir=base_build_dir):
           shell.clear_data_directories()

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
@@ -1530,7 +1530,7 @@ class UntrustedRunEngineFuzzerTest(
         '[{"strategy_name": "value_profile", '
         '"probability": 1.0, "engine": "libFuzzer"}]')
 
-    build_manager.setup_build()
+    build_manager.setup_build(fuzz_target='test_fuzzer')
     corpus_directory = os.path.join(self.temp_dir, 'corpus')
     testcase_directory = os.path.join(self.temp_dir, 'artifacts')
     os.makedirs(file_host.rebase_to_worker_root(corpus_directory))

--- a/src/clusterfuzz/_internal/tests/core/bot/testcase_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/testcase_manager_test.py
@@ -904,7 +904,7 @@ class UntrustedEngineReproduceTest(
 
     self._setup_env(job_type='libfuzzer_asan_job')
 
-    build_manager.setup_build()
+    build_manager.setup_build(fuzz_target='test_fuzzer')
     result = testcase_manager.engine_reproduce(
         libfuzzer_engine.Engine(), 'test_fuzzer', testcase_file_path, [], 30)
 

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
@@ -409,3 +409,58 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
     self._generate_manifest(1)
     test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
     self.assertEqual(test_archive.archive_schema_version(), 1)
+
+  def _generate_manifest_with_fuzz_targets(self, archive_schema_version,
+                                           fuzz_targets):
+    """Mocks open calls so that they return a buffer containing valid JSON for
+    the given archive schema version and fuzz_targets."""
+
+    def _mock_open(_):
+      buffer = io.BytesIO(b'')
+      buffer.write(
+          json.dumps({
+              'archive_schema_version': archive_schema_version,
+              'fuzz_targets': fuzz_targets,
+          }).encode())
+      buffer.seek(0)
+      return buffer
+
+    self.mock.open.return_value.open.side_effect = _mock_open
+
+  def test_manifest_fuzz_targets_list(self):
+    """Tests that fuzz_targets specified as a list in the manifest correctly
+    populates self._fuzz_targets and bypasses discovery."""
+    self.mock.file_exists.return_value = True
+    self._generate_manifest_with_fuzz_targets(
+        1, ['out/build/my_fuzzer', 'out/build/other_fuzzer'])
+    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self.assertEqual(test_archive.archive_schema_version(), 1)
+    self.assertCountEqual(test_archive.list_fuzz_targets(),
+                          ['my_fuzzer', 'other_fuzzer'])
+    self.assertEqual(
+        test_archive.get_path_for_target('my_fuzzer'), 'out/build/my_fuzzer')
+    # Ensure list_members was never called for fuzz target discovery.
+    self.mock.open.return_value.list_members.assert_not_called()
+
+  def test_manifest_fuzz_targets_invalid(self):
+    """Tests that invalid fuzz_targets (e.g. dict) in the manifest are ignored
+    and we fallback to discovery."""
+    self.mock.file_exists.return_value = True
+    self._generate_manifest_with_fuzz_targets(
+        1, {'my_fuzzer': 'out/build/my_fuzzer'})
+    self.mock.open.return_value.list_members.return_value = []
+    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self.assertEqual(test_archive.archive_schema_version(), 1)
+    test_archive.list_fuzz_targets()
+    self.mock.open.return_value.list_members.assert_called_once()
+
+  def test_manifest_fuzz_targets_missing(self):
+    """Tests that missing fuzz_targets in the manifest are ignored
+    and we fallback to discovery."""
+    self.mock.file_exists.return_value = True
+    self._generate_manifest(1)
+    self.mock.open.return_value.list_members.return_value = []
+    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self.assertEqual(test_archive.archive_schema_version(), 1)
+    test_archive.list_fuzz_targets()
+    self.mock.open.return_value.list_members.assert_called_once()

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
@@ -366,7 +366,7 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
     self.mock.file_exists.return_value = False
     self.mock_archive_reader = self.mock.open.return_value
 
-  def _generate_manifest(self, contents):
+  def _generate_manifest(self, contents: any):
     """Mocks open calls so that they return a buffer containing the given
     contents serialized as JSON."""
     json_contents = json.dumps(contents).encode()
@@ -407,7 +407,9 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
         'archive_schema_version': 1,
         'fuzz_targets': ['out/build/my_fuzzer', 'out/build/other_fuzzer']
     })
+
     test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+
     self.assertEqual(test_archive.archive_schema_version(), 1)
     self.assertCountEqual(test_archive.list_fuzz_targets(),
                           ['my_fuzzer', 'other_fuzzer'])
@@ -427,7 +429,9 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
         }
     })
     self.mock_archive_reader.list_members.return_value = []
+
     test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+
     self.assertEqual(test_archive.archive_schema_version(), 1)
     test_archive.list_fuzz_targets()
     self.mock_archive_reader.list_members.assert_called_once()
@@ -438,7 +442,9 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
     self.mock.file_exists.return_value = True
     self._generate_manifest({'archive_schema_version': 1})
     self.mock_archive_reader.list_members.return_value = []
+
     test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+
     self.assertEqual(test_archive.archive_schema_version(), 1)
     test_archive.list_fuzz_targets()
     self.mock_archive_reader.list_members.assert_called_once()
@@ -449,7 +455,9 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
     self.mock.file_exists.return_value = True
     self._generate_manifest({'archive_schema_version': 1, 'fuzz_targets': []})
     self.mock_archive_reader.list_members.return_value = []
+
     test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+
     self.assertEqual(test_archive.archive_schema_version(), 1)
     test_archive.list_fuzz_targets()
     self.mock_archive_reader.list_members.assert_called_once()
@@ -463,7 +471,9 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
         'fuzz_targets': [1, 2]
     })
     self.mock_archive_reader.list_members.return_value = []
+
     test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+
     self.assertEqual(test_archive.archive_schema_version(), 1)
     test_archive.list_fuzz_targets()
     self.mock_archive_reader.list_members.assert_called_once()
@@ -476,7 +486,9 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
         'archive_schema_version': 1,
         'fuzz_targets': ['out/build/my_fuzzer', 123]
     })
+
     test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+
     self.assertEqual(test_archive.archive_schema_version(), 1)
     self.assertCountEqual(test_archive.list_fuzz_targets(), ['my_fuzzer'])
     self.assertEqual(

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
@@ -62,8 +62,9 @@ class DefaultBuildArchiveSelectiveUnpack(unittest.TestCase):
         'clusterfuzz._internal.system.archive.ArchiveReader',
         'clusterfuzz._internal.system.archive.open',
     ])
-    self.mock.open.return_value.list_members.return_value = []
-    self.build = build_archive.DefaultBuildArchive(self.mock.open.return_value)
+    self.mock_archive_reader = self.mock.open.return_value
+    self.mock_archive_reader.list_members.return_value = []
+    self.build = build_archive.DefaultBuildArchive(self.mock_archive_reader)
     self.assertIsInstance(self.build, build_archive.DefaultBuildArchive)
 
   def _add_files_to_archive(self, files):
@@ -72,7 +73,7 @@ class DefaultBuildArchiveSelectiveUnpack(unittest.TestCase):
       res.append(
           archive.ArchiveMemberInfo(
               name=file, is_dir=False, size_bytes=0, mode=0))
-    self.mock.open.return_value.list_members.return_value = res
+    self.mock_archive_reader.list_members.return_value = res
 
   def _generate_possible_fuzzer_dependencies(self, dir_prefix, fuzz_target):
     """Generates all possible dependencies for the given target."""
@@ -135,9 +136,10 @@ class ChromeBuildArchiveSelectiveUnpack(unittest.TestCase):
         'clusterfuzz._internal.system.archive.open',
         'clusterfuzz._internal.bot.fuzzers.utils.is_fuzz_target',
     ])
-    self.mock.open.return_value.list_members.return_value = []
+    self.mock_archive_reader = self.mock.open.return_value
+    self.mock_archive_reader.list_members.return_value = []
     self.mock.is_fuzz_target.side_effect = self._mock_is_fuzz_target
-    self.build = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self.build = build_archive.ChromeBuildArchive(self.mock_archive_reader)
     self._declared_fuzzers = []
     self.maxDiff = None
 
@@ -151,7 +153,7 @@ class ChromeBuildArchiveSelectiveUnpack(unittest.TestCase):
       res.append(
           archive.ArchiveMemberInfo(
               name=file, is_dir=False, size_bytes=0, mode=0))
-    self.mock.open.return_value.list_members.return_value = res
+    self.mock_archive_reader.list_members.return_value = res
 
   def _generate_possible_fuzzer_dependencies_legacy(self, dir_prefix,
                                                     fuzz_target):
@@ -229,13 +231,13 @@ class ChromeBuildArchiveSelectiveUnpack(unittest.TestCase):
       buffer.seek(0)
       return buffer
 
-    self.mock.open.return_value.open.side_effect = _mock_open
+    self.mock_archive_reader.open.side_effect = _mock_open
 
   def _declare_fuzzers(self, fuzzers):
     self._declared_fuzzers = fuzzers
 
   def _set_archive_schema_version(self, version):
-    self.build = build_archive.ChromeBuildArchive(self.mock.open.return_value,
+    self.build = build_archive.ChromeBuildArchive(self.mock_archive_reader,
                                                   version)
 
   @parameterized.parameterized.expand(['/b/build/', 'build/', ''])
@@ -362,33 +364,20 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
         'clusterfuzz._internal.system.archive.open',
     ])
     self.mock.file_exists.return_value = False
+    self.mock_archive_reader = self.mock.open.return_value
 
-  def _generate_manifest(self, archive_schema_version):
-    """Mocks open calls so that they return a buffer containing valid JSON for
-    the given archive schema version."""
-
-    def _mock_open(_):
-      buffer = io.BytesIO(b'')
-      buffer.write(
-          json.dumps({
-              'archive_schema_version': archive_schema_version
-          }).encode())
-      buffer.seek(0)
-      return buffer
-
-    self.mock.open.return_value.open.side_effect = _mock_open
-
-  def _generate_invalid_manifest(self):
-    """Mocks open calls so that they return a buffer containing invalid contents
-    for clusterfuzz_manifest.json."""
+  def _generate_manifest(self, contents):
+    """Mocks open calls so that they return a buffer containing the given
+    contents serialized as JSON."""
+    json_contents = json.dumps(contents).encode()
 
     def _mock_open(_):
       buffer = io.BytesIO(b'')
-      buffer.write(json.dumps({'my_field': 1}).encode())
+      buffer.write(json_contents)
       buffer.seek(0)
       return buffer
 
-    self.mock.open.return_value.open.side_effect = _mock_open
+    self.mock_archive_reader.open.side_effect = _mock_open
 
   def test_manifest_is_correctly_read(self):
     """Tests that the manifest is correctly read and used to set the archive
@@ -396,71 +385,101 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
     manifest are handled correctly."""
 
     # No manifest exists; should default to archive schema version 0 (legacy).
-    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
     self.assertEqual(test_archive.archive_schema_version(), 0)
 
     # Invalid manifest; should default to version 0.
     self.mock.file_exists.return_value = True
-    self._generate_invalid_manifest()
-    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self._generate_manifest({'my_field': 1})
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
     self.assertEqual(test_archive.archive_schema_version(), 0)
 
     # Valid manifest.
-    self._generate_manifest(1)
-    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self._generate_manifest({'archive_schema_version': 1})
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
     self.assertEqual(test_archive.archive_schema_version(), 1)
-
-  def _generate_manifest_with_fuzz_targets(self, archive_schema_version,
-                                           fuzz_targets):
-    """Mocks open calls so that they return a buffer containing valid JSON for
-    the given archive schema version and fuzz_targets."""
-
-    def _mock_open(_):
-      buffer = io.BytesIO(b'')
-      buffer.write(
-          json.dumps({
-              'archive_schema_version': archive_schema_version,
-              'fuzz_targets': fuzz_targets,
-          }).encode())
-      buffer.seek(0)
-      return buffer
-
-    self.mock.open.return_value.open.side_effect = _mock_open
 
   def test_manifest_fuzz_targets_list(self):
     """Tests that fuzz_targets specified as a list in the manifest correctly
     populates self._fuzz_targets and bypasses discovery."""
     self.mock.file_exists.return_value = True
-    self._generate_manifest_with_fuzz_targets(
-        1, ['out/build/my_fuzzer', 'out/build/other_fuzzer'])
-    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self._generate_manifest({
+        'archive_schema_version': 1,
+        'fuzz_targets': ['out/build/my_fuzzer', 'out/build/other_fuzzer']
+    })
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
     self.assertEqual(test_archive.archive_schema_version(), 1)
     self.assertCountEqual(test_archive.list_fuzz_targets(),
                           ['my_fuzzer', 'other_fuzzer'])
     self.assertEqual(
         test_archive.get_path_for_target('my_fuzzer'), 'out/build/my_fuzzer')
     # Ensure list_members was never called for fuzz target discovery.
-    self.mock.open.return_value.list_members.assert_not_called()
+    self.mock_archive_reader.list_members.assert_not_called()
 
   def test_manifest_fuzz_targets_invalid(self):
     """Tests that invalid fuzz_targets (e.g. dict) in the manifest are ignored
     and we fallback to discovery."""
     self.mock.file_exists.return_value = True
-    self._generate_manifest_with_fuzz_targets(
-        1, {'my_fuzzer': 'out/build/my_fuzzer'})
-    self.mock.open.return_value.list_members.return_value = []
-    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self._generate_manifest({
+        'archive_schema_version': 1,
+        'fuzz_targets': {
+            'my_fuzzer': 'out/build/my_fuzzer'
+        }
+    })
+    self.mock_archive_reader.list_members.return_value = []
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
     self.assertEqual(test_archive.archive_schema_version(), 1)
     test_archive.list_fuzz_targets()
-    self.mock.open.return_value.list_members.assert_called_once()
+    self.mock_archive_reader.list_members.assert_called_once()
 
   def test_manifest_fuzz_targets_missing(self):
     """Tests that missing fuzz_targets in the manifest are ignored
     and we fallback to discovery."""
     self.mock.file_exists.return_value = True
-    self._generate_manifest(1)
-    self.mock.open.return_value.list_members.return_value = []
-    test_archive = build_archive.ChromeBuildArchive(self.mock.open.return_value)
+    self._generate_manifest({'archive_schema_version': 1})
+    self.mock_archive_reader.list_members.return_value = []
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
     self.assertEqual(test_archive.archive_schema_version(), 1)
     test_archive.list_fuzz_targets()
-    self.mock.open.return_value.list_members.assert_called_once()
+    self.mock_archive_reader.list_members.assert_called_once()
+
+  def test_manifest_fuzz_targets_empty(self):
+    """Tests that empty fuzz_targets list in the manifest is ignored
+    and we fallback to discovery."""
+    self.mock.file_exists.return_value = True
+    self._generate_manifest({'archive_schema_version': 1, 'fuzz_targets': []})
+    self.mock_archive_reader.list_members.return_value = []
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+    self.assertEqual(test_archive.archive_schema_version(), 1)
+    test_archive.list_fuzz_targets()
+    self.mock_archive_reader.list_members.assert_called_once()
+
+  def test_manifest_fuzz_targets_all_invalid(self):
+    """Tests that fuzz_targets list with only invalid entries in the manifest is
+    ignored and we fallback to discovery."""
+    self.mock.file_exists.return_value = True
+    self._generate_manifest({
+        'archive_schema_version': 1,
+        'fuzz_targets': [1, 2]
+    })
+    self.mock_archive_reader.list_members.return_value = []
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+    self.assertEqual(test_archive.archive_schema_version(), 1)
+    test_archive.list_fuzz_targets()
+    self.mock_archive_reader.list_members.assert_called_once()
+
+  def test_manifest_fuzz_targets_mixed(self):
+    """Tests that fuzz_targets list with mixed valid and invalid entries in the
+    manifest uses the valid entries and does not fallback to discovery."""
+    self.mock.file_exists.return_value = True
+    self._generate_manifest({
+        'archive_schema_version': 1,
+        'fuzz_targets': ['out/build/my_fuzzer', 123]
+    })
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+    self.assertEqual(test_archive.archive_schema_version(), 1)
+    self.assertCountEqual(test_archive.list_fuzz_targets(), ['my_fuzzer'])
+    self.assertEqual(
+        test_archive.get_path_for_target('my_fuzzer'), 'out/build/my_fuzzer')
+    # Ensure list_members was never called for fuzz target discovery.
+    self.mock_archive_reader.list_members.assert_not_called()

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -539,10 +539,11 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     """
     os.environ['TASK_NAME'] = 'fuzz'
     self.mock.time.return_value = 1000.0
+
     build = build_manager.setup_regular_build(2, fuzz_target=None)
+
     self.assertIsInstance(build, build_manager.RegularBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
-
     self._assert_env_vars()
     self.assertEqual(os.environ['APP_REVISION'], '2')
 
@@ -561,7 +562,9 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     self.mock.time.return_value = 1000.0
     fuzz_target = build_manager.pick_random_fuzz_target(
         target_weights=self.target_weights)
+
     build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
+
     self.assertIsInstance(build, build_manager.RegularBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
 
@@ -810,7 +813,7 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(os.environ['APP_REVISION'], '2')
 
     self.assertEqual(
-        1, self.mock.open.return_value.__enter__.return_value.unpack.call_count)
+        self.mock.open.return_value.__enter__.return_value.unpack.call_count, 1)
 
     # Test setting up build again.
     os.environ['FUZZ_TARGET'] = ''
@@ -823,7 +826,7 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
     # Not a partial build, so unpack shouldn't be called again.
     self.assertEqual(
-        1, self.mock.open.return_value.__enter__.return_value.unpack.call_count)
+        self.mock.open.return_value.__enter__.return_value.unpack.call_count, 1)
 
     self.assertCountEqual(['target1', 'target2', 'target3'], build.fuzz_targets)
 
@@ -836,22 +839,23 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     os.environ['ALLOW_UNPACK_OVER_HTTP'] = 'True'
     self.mock.unzip_over_http_compatible.return_value = True
     self.mock.time.return_value = 1000.0
+
     build = build_manager.setup_regular_build(2, fuzz_target=None)
+
     self.assertIsInstance(build, build_manager.RegularBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
-
     self._assert_env_vars()
     self.assertEqual(os.environ['APP_REVISION'], '2')
 
     # We expect unpack to be called because it is not skipped for blackbox.
     self.assertEqual(
-        1,
-        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
-    )
-    self.assertEqual(1, self.mock.unzip_over_http_compatible.call_count)
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.
+        call_count, 1)
+    self.assertEqual(self.mock.unzip_over_http_compatible.call_count, 1)
 
     # Test setting up build again.
     self.mock.time.return_value = 1005.0
+
     build = build_manager.setup_regular_build(2, fuzz_target=None)
 
     self.assertIsInstance(build, build_manager.RegularBuild)
@@ -860,9 +864,8 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     # Since UNPACK_ALL_FUZZ_TARGETS_AND_FILES is not True, it was marked as partial,
     # so it should be unpacked again.
     self.assertEqual(
-        2,
-        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
-    )
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.
+        call_count, 2)
 
   def test_setup_blackbox_over_http_unpack_all(self):
     """Tests setup blackbox build with compatible remote unzipping and unpack all."""
@@ -874,20 +877,20 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     os.environ['ALLOW_UNPACK_OVER_HTTP'] = 'True'
     self.mock.unzip_over_http_compatible.return_value = True
     self.mock.time.return_value = 1000.0
+
     build = build_manager.setup_regular_build(2, fuzz_target=None)
+
     self.assertIsInstance(build, build_manager.RegularBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
-
     self._assert_env_vars()
     self.assertEqual(os.environ['APP_REVISION'], '2')
-
     self.assertEqual(
-        1,
-        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
-    )
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.
+        call_count, 1)
 
     # Test setting up build again.
     self.mock.time.return_value = 1005.0
+
     build = build_manager.setup_regular_build(2, fuzz_target=None)
 
     self.assertIsInstance(build, build_manager.RegularBuild)
@@ -895,9 +898,8 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
     # Not a partial build, so unpack shouldn't be called again.
     self.assertEqual(
-        1,
-        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
-    )
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.
+        call_count, 1)
 
   def test_delete(self):
     """Test deleting this build."""
@@ -1926,3 +1928,39 @@ class GetPrimaryBucketPathTest(unittest.TestCase):
     """Test no bucket paths defined."""
     with self.assertRaises(build_manager.BuildManagerError):
       build_manager.get_primary_bucket_path()
+
+
+class BuildPropertyTest(unittest.TestCase):
+  """Tests for Build class properties."""
+
+  def setUp(self):
+    test_helpers.patch_environ(self)
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_engine_fuzzer_job',
+    ])
+
+  def test_is_discovery_fuzzing_discovery(self):
+    """Test is_discovery is True for engine fuzzer job with no target and no prefix."""
+    self.mock.is_engine_fuzzer_job.return_value = True
+    build = build_manager.Build('/base', 1, build_prefix='', fuzz_target=None)
+    self.assertTrue(build.is_discovery)
+
+  def test_is_discovery_fuzzing_with_target(self):
+    """Test is_discovery is False for engine fuzzer job with target."""
+    self.mock.is_engine_fuzzer_job.return_value = True
+    build = build_manager.Build(
+        '/base', 1, build_prefix='', fuzz_target='target')
+    self.assertFalse(build.is_discovery)
+
+  def test_is_discovery_fuzzing_with_prefix(self):
+    """Test is_discovery is False for engine fuzzer job with build prefix."""
+    self.mock.is_engine_fuzzer_job.return_value = True
+    build = build_manager.Build(
+        '/base', 1, build_prefix='extra', fuzz_target=None)
+    self.assertFalse(build.is_discovery)
+
+  def test_is_discovery_non_fuzzing(self):
+    """Test is_discovery is False for non-engine fuzzer job."""
+    self.mock.is_engine_fuzzer_job.return_value = False
+    build = build_manager.Build('/base', 1, build_prefix='', fuzz_target=None)
+    self.assertFalse(build.is_discovery)

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -827,6 +827,78 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
     self.assertCountEqual(['target1', 'target2', 'target3'], build.fuzz_targets)
 
+  def test_setup_blackbox_over_http(self):
+    """Tests setup blackbox (non-engine) build with compatible remote unzipping."""
+    os.environ['JOB_NAME'] = 'blackbox_job'
+    os.environ['TASK_NAME'] = 'fuzz'
+    os.environ['RELEASE_BUILD_URL_PATTERN'] = (
+        'https://example.com/path/file-release-([0-9]+).zip')
+    os.environ['ALLOW_UNPACK_OVER_HTTP'] = 'True'
+    self.mock.unzip_over_http_compatible.return_value = True
+    self.mock.time.return_value = 1000.0
+    build = build_manager.setup_regular_build(2, fuzz_target=None)
+    self.assertIsInstance(build, build_manager.RegularBuild)
+    self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
+
+    self._assert_env_vars()
+    self.assertEqual(os.environ['APP_REVISION'], '2')
+
+    # We expect unpack to be called because it is not skipped for blackbox.
+    self.assertEqual(
+        1,
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
+    )
+    self.assertEqual(1, self.mock.unzip_over_http_compatible.call_count)
+
+    # Test setting up build again.
+    self.mock.time.return_value = 1005.0
+    build = build_manager.setup_regular_build(2, fuzz_target=None)
+
+    self.assertIsInstance(build, build_manager.RegularBuild)
+    self.assertEqual(_get_timestamp(build.base_build_dir), 1005.0)
+
+    # Since UNPACK_ALL_FUZZ_TARGETS_AND_FILES is not True, it was marked as partial,
+    # so it should be unpacked again.
+    self.assertEqual(
+        2,
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
+    )
+
+  def test_setup_blackbox_over_http_unpack_all(self):
+    """Tests setup blackbox build with compatible remote unzipping and unpack all."""
+    os.environ['UNPACK_ALL_FUZZ_TARGETS_AND_FILES'] = 'True'
+    os.environ['JOB_NAME'] = 'blackbox_job'
+    os.environ['TASK_NAME'] = 'fuzz'
+    os.environ['RELEASE_BUILD_URL_PATTERN'] = (
+        'https://example.com/path/file-release-([0-9]+).zip')
+    os.environ['ALLOW_UNPACK_OVER_HTTP'] = 'True'
+    self.mock.unzip_over_http_compatible.return_value = True
+    self.mock.time.return_value = 1000.0
+    build = build_manager.setup_regular_build(2, fuzz_target=None)
+    self.assertIsInstance(build, build_manager.RegularBuild)
+    self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
+
+    self._assert_env_vars()
+    self.assertEqual(os.environ['APP_REVISION'], '2')
+
+    self.assertEqual(
+        1,
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
+    )
+
+    # Test setting up build again.
+    self.mock.time.return_value = 1005.0
+    build = build_manager.setup_regular_build(2, fuzz_target=None)
+
+    self.assertIsInstance(build, build_manager.RegularBuild)
+    self.assertEqual(_get_timestamp(build.base_build_dir), 1005.0)
+
+    # Not a partial build, so unpack shouldn't be called again.
+    self.assertEqual(
+        1,
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.call_count
+    )
+
   def test_delete(self):
     """Test deleting this build."""
     os.environ['FUZZ_TARGET'] = 'fuzz_target'

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -801,6 +801,7 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     os.environ['TASK_NAME'] = 'fuzz'
     os.environ['RELEASE_BUILD_URL_PATTERN'] = (
         'https://example.com/path/file-release-([0-9]+).zip')
+    os.environ['ALLOW_UNPACK_OVER_HTTP'] = 'True'
     self.mock.unzip_over_http_compatible.return_value = True
     self.mock.time.return_value = 1000.0
     fuzz_target = build_manager.pick_random_fuzz_target(
@@ -813,7 +814,10 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(os.environ['APP_REVISION'], '2')
 
     self.assertEqual(
-        self.mock.open.return_value.__enter__.return_value.unpack.call_count, 1)
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.
+        call_count, 1)
+    self.mock.open_uri.return_value.__enter__.return_value.unpacked_size.assert_called_with(
+        fuzz_target=None)
 
     # Test setting up build again.
     os.environ['FUZZ_TARGET'] = ''
@@ -826,7 +830,8 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
     # Not a partial build, so unpack shouldn't be called again.
     self.assertEqual(
-        self.mock.open.return_value.__enter__.return_value.unpack.call_count, 1)
+        self.mock.open_uri.return_value.__enter__.return_value.unpack.
+        call_count, 1)
 
     self.assertCountEqual(['target1', 'target2', 'target3'], build.fuzz_targets)
 

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_manager_test.py
@@ -532,6 +532,26 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         os.environ['BUILD_DIR'],
         '/builds/path_be4c9ca0267afcd38b7c1a3eebb5998d0908f025/revisions')
 
+  def test_setup_fuzz_discovery(self):
+    """Tests setting up a build during initial fuzz target discovery.
+
+    (fuzz_target=None).
+    """
+    os.environ['TASK_NAME'] = 'fuzz'
+    self.mock.time.return_value = 1000.0
+    build = build_manager.setup_regular_build(2, fuzz_target=None)
+    self.assertIsInstance(build, build_manager.RegularBuild)
+    self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
+
+    self._assert_env_vars()
+    self.assertEqual(os.environ['APP_REVISION'], '2')
+
+    # Verify unpack() was never called because we skipped unpacking
+    # for discovery.
+    unpack_mock = self.mock.open.return_value.__enter__.return_value.unpack
+    self.assertEqual(unpack_mock.call_count, 0)
+    self.assertCountEqual(['target1', 'target2', 'target3'], build.fuzz_targets)
+
   @parameterized.parameterized.expand(['True', 'False'])
   def test_setup_fuzz(self, unpack_all):
     """Tests setting up a build during fuzzing."""
@@ -741,7 +761,9 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     os.environ['ALLOW_UNPACK_OVER_HTTP'] = "True"
     self.mock.unzip_over_http_compatible.return_value = True
     self.mock.time.return_value = 1000.0
-    build = build_manager.setup_regular_build(2)
+    fuzz_target = build_manager.pick_random_fuzz_target(
+        target_weights=self.target_weights)
+    build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
     self.assertIsInstance(build, build_manager.RegularBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
 
@@ -756,7 +778,7 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
 
     # Test setting up build again.
     self.mock.time.return_value = 1005.0
-    build = build_manager.setup_regular_build(2)
+    build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
 
     self.assertIsInstance(build, build_manager.RegularBuild)
 
@@ -778,7 +800,9 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
         'https://example.com/path/file-release-([0-9]+).zip')
     self.mock.unzip_over_http_compatible.return_value = True
     self.mock.time.return_value = 1000.0
-    build = build_manager.setup_regular_build(2)
+    fuzz_target = build_manager.pick_random_fuzz_target(
+        target_weights=self.target_weights)
+    build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
     self.assertIsInstance(build, build_manager.RegularBuild)
     self.assertEqual(_get_timestamp(build.base_build_dir), 1000.0)
 
@@ -791,7 +815,7 @@ class RegularLibFuzzerBuildTest(fake_filesystem_unittest.TestCase):
     # Test setting up build again.
     os.environ['FUZZ_TARGET'] = ''
     self.mock.time.return_value = 1005.0
-    build = build_manager.setup_regular_build(2)
+    build = build_manager.setup_regular_build(2, fuzz_target=fuzz_target)
 
     self.assertIsInstance(build, build_manager.RegularBuild)
 


### PR DESCRIPTION
Adds support for `fuzz_targets` property in `clusterfuzz_manifest.json`. This allows coverage-guided fuzzing jobs with `ChromeBuildArchive`s to skip the unpacking and fuzz target discovery phases.

**Problem:**
Currently, ClusterFuzz wastes time unpacking complete archives to then traverse the directory to discover fuzz targets. Furthermore, on certain large build types, this unpacking process frequently triggers out-of-disk-space errors due to the massive size of the zip files.

**Solution:**
By introducing `fuzz_targets` — a list of fuzz target paths relative to `clusterfuzz_manifest.json` — we can bypass the discovery step entirely. ClusterFuzz will now map this list so that each fuzz target has a normalized name (key) and its corresponding path (value).

More Info: crbug.com/508214240