### PR TITLE
Security: Escape HTML in testcase event history to prevent stored XSS

### DIFF
--- a/src/appengine/private/components/testcase-detail/testcase-event-history.html
+++ b/src/appengine/private/components/testcase-detail/testcase-event-history.html
@@ -193,6 +193,16 @@
       toggle() {
         this.shouldPreview = !this.shouldPreview;
       },
+      _escapeHtml(value) {
+        const replacements = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+        };
+        return String(value).replace(/[&<>"']/g, char => replacements[char]);
+      },
       _formatEvent(event) {
         if (!event) {
           return '';
@@ -203,11 +213,12 @@
         const keys = Object.keys(eventCopy).sort();
         let result = '{';
         result += keys.map(key => {
-          const value = JSON.stringify(eventCopy[key]);
+          const escapedKey = this._escapeHtml(key);
+          const escapedValue = this._escapeHtml(JSON.stringify(eventCopy[key]));
           if (boldKeys.includes(key)) {
-            return `<b>"${key}"</b>: <b>${value}</b>`;
+            return `<b>"${escapedKey}"</b>: <b>${escapedValue}</b>`;
           }
-          return `"${key}": ${value}`;
+          return `"${escapedKey}": ${escapedValue}`;
         }).join(', ');
         result += '}';
         return result;


### PR DESCRIPTION
## Summary

Fix stored XSS vulnerability in the testcase event history component where attacker-controlled event data (e.g., fuzzer name from testcase uploads) is rendered as HTML without escaping.

## Problem

The `_formatEvent()` method in `testcase-event-history.html` constructs an HTML string from event data and assigns it via Polymer's `inner-h-t-m-l` binding. While `JSON.stringify()` is called on values, the resulting string still contains raw `<` and `>` characters that are parsed as HTML when assigned through `inner-h-t-m-l`.

**Attack vector**: A user with testcase upload permissions injects a payload like `<img src=x onerror='...'>` in the `fuzzer` form field. This value flows through:

1. Upload handler → `testcase.fuzzer_name` (stored in datastore)
2. `BaseTestcaseEvent.__post_init__()` → `event.fuzzer` (copied from testcase)
3. `_format_event_for_history()` → event dict (returned to frontend)
4. `_formatEvent()` → HTML string (rendered via `inner-h-t-m-l`)

When any user views the testcase detail page, the stored payload executes in their browser session, enabling cross-user data theft.

## Fix

Add an `_escapeHtml()` helper that replaces `&`, `<`, `>`, `"`, and `'` with their HTML entity equivalents. Both event keys and JSON-stringified values are escaped before interpolation into the HTML string.

```diff
+      _escapeHtml(value) {
+        const replacements = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+        };
+        return String(value).replace(/[&<>"']/g, char => replacements[char]);
+      },
       _formatEvent(event) {
         ...
-          const value = JSON.stringify(eventCopy[key]);
+          const escapedKey = this._escapeHtml(key);
+          const escapedValue = this._escapeHtml(JSON.stringify(eventCopy[key]));
           if (boldKeys.includes(key)) {
-            return `<b>"${key}"</b>: <b>${value}</b>`;
+            return `<b>"${escapedKey}"</b>: <b>${escapedValue}</b>`;
           }
-          return `"${key}": ${value}`;
+          return `"${escapedKey}": ${escapedValue}`;
```

## Impact

A limited ClusterFuzz user who can upload testcases can execute arbitrary JavaScript in the browser session of any user (including admins) who views the uploaded testcase's detail page. The demonstrated impact includes reading data from other testcases that the attacker cannot directly access.

Fixes #5257
