### PR TITLE
Security: Validate issue ID against testcase in update-issue handler

### DIFF
--- a/src/appengine/handlers/testcase_detail/update_issue.py
+++ b/src/appengine/handlers/testcase_detail/update_issue.py
@@ -32,6 +32,17 @@ class Handler(base_handler.Handler):
     """Associate (or update) an existing issue with the testcase."""
     issue_id = helpers.cast(issue_id, int,
                             'Issue ID (%s) is not a number!' % issue_id)
+
+    # Verify that the supplied issue ID matches the testcase's currently linked
+    # issue. Without this check, a user authorized for one testcase could use
+    # that authorization to trigger issue-tracker writes on an arbitrary issue.
+    existing_issue_id = testcase.bug_information
+    if existing_issue_id and str(existing_issue_id) != str(issue_id):
+      raise helpers.EarlyExitError(
+          'The supplied issue ID (%d) does not match the issue currently '
+          'linked to this testcase (%s). You cannot update an unrelated '
+          'issue through this endpoint.' % (issue_id, existing_issue_id), 403)
+
     issue_tracker = helpers.get_issue_tracker_for_testcase(testcase)
 
     issue = helpers.get_or_exit(lambda: issue_tracker.get_issue(issue_id),


### PR DESCRIPTION
## Summary

Fix cross-object authorization issue in `/testcase-detail/update-issue` where a user with access to one testcase can trigger issue-tracker writes on an unrelated issue by supplying a different `issueId` in the request.

## Problem

The handler at `update_issue.py` performs access control checks on the **testcase** (via `@handler.check_testcase_access`), but the `issueId` parameter is accepted directly from the request without any validation against the testcase's currently linked issue.

This means:
1. Access is checked for the testcase ✅
2. `issueId` is taken from request input (attacker-controlled) ⚠️
3. The issue tracker fetches and updates that supplied issue ID ❌
4. The testcase is rebound to the supplied issue ID ❌

A user authorized for testcase A (linked to issue 1111) can supply `issueId=2002` to update issue 2002: adding comments, modifying labels/title, and rebinding the testcase.

## Fix

Add a check that verifies the request-supplied `issueId` matches the testcase's existing `bug_information` before performing any issue-tracker operations. If the testcase has no linked issue yet (first-time linking), the check is skipped to preserve existing functionality.

```diff
     issue_id = helpers.cast(issue_id, int,
                             'Issue ID (%s) is not a number!' % issue_id)
+
+    # Verify that the supplied issue ID matches the testcase's currently linked
+    # issue. Without this check, a user authorized for one testcase could use
+    # that authorization to trigger issue-tracker writes on an arbitrary issue.
+    existing_issue_id = testcase.bug_information
+    if existing_issue_id and str(existing_issue_id) != str(issue_id):
+      raise helpers.EarlyExitError(
+          'The supplied issue ID (%d) does not match the issue currently '
+          'linked to this testcase (%s). You cannot update an unrelated '
+          'issue through this endpoint.' % (issue_id, existing_issue_id), 403)
```

## Impact

Without this fix, a user with testcase-scoped access can cause the trusted issue-tracker integration to:
- Add attacker-influenced comments to unrelated issues
- Update issue titles when summary update is enabled
- Apply policy-driven labels to unrelated issues
- Rebind the testcase to a different issue

Fixes #5262
