### PR TITLE
Defer fuzzer logs to postprocess

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1441,6 +1441,35 @@ class FuzzingSession:
     self.gcs_corpus = None
     self.fuzz_task_output = uworker_msg_pb2.FuzzTaskOutput()  # pylint: disable=no-member
 
+  def _process_blackbox_queue(self, queue, crashes):
+    """Consumes run results from the queue and packages logs for uworkers."""
+    while not queue.empty():
+      run_result = queue.get()
+      if run_result.crash:
+        crashes.append(run_result.crash)
+
+      # Ingest and package GCS upload logs
+      # (only populated on uworker execution runs)
+      if run_result.log_output:
+        log_output = run_result.log_output
+        if not isinstance(log_output, str):
+          log_output = str(log_output)
+
+        # TODO:(paulovlb) remove this after validating in dev
+        logs.info(
+            f"[Blackbox fuzzer logs] Main thread dequeued run result: "
+            f"has_crash={bool(run_result.crash)}, log_len={len(log_output)}, "
+            f"has_testcase_data={bool(run_result.testcase_data)}")
+
+        # Delegate formatting, warnings, timestamping, and packaging completely
+        blackbox_output = _to_fuzzer_run_output(
+            log_output,
+            run_result.return_code,
+            run_result.log_time,
+            testcase_data=run_result.testcase_data)
+
+        self.fuzz_task_output.fuzzer_run_outputs.append(blackbox_output)
+
   @property
   def fully_qualified_fuzzer_name(self):
     """Get the fully qualified fuzzer name."""
@@ -1692,8 +1721,8 @@ class FuzzingSession:
       else:
         result_crash = None
 
-      fuzzer_run_output = _to_fuzzer_run_output(output, result_crash,
-                                                return_code, log_time)
+      fuzzer_run_output = _to_fuzzer_run_output(
+          output, return_code, log_time, testcase_path=result_crash)
       self.fuzz_task_output.fuzzer_run_outputs.append(fuzzer_run_output)
 
       add_additional_testcase_run_data(testcase_run,
@@ -1872,8 +1901,8 @@ class FuzzingSession:
         process_handler.terminate_stale_application_instances()
         needs_stale_process_cleanup = False
 
-      while not temp_queue.empty():
-        crashes.append(temp_queue.get())
+      # Process, extract, and package all parallel run execution results
+      self._process_blackbox_queue(temp_queue, crashes)
 
       process_handler.close_queue(temp_queue)
       logs.info(f'Upto {test_number}')
@@ -2304,12 +2333,18 @@ def save_fuzz_targets(output):
                                    output.uworker_input.job_type)
 
 
-def _to_fuzzer_run_output(output: str, crash_path: str, return_code: int,
-                          log_time: datetime.datetime):
+def _to_fuzzer_run_output(output,
+                          return_code,
+                          log_time,
+                          testcase_path=None,
+                          testcase_data=None):
   """Returns a FuzzerRunOutput proto."""
   truncated_output = truncate_fuzzer_output(output, ENGINE_OUTPUT_LIMIT)
   if len(output) != len(truncated_output):
     logs.warning('Fuzzer output truncated.')
+
+  if not log_time:
+    log_time = datetime.datetime.utcnow()
 
   proto_timestamp = uworker_io.timestamp_to_proto_timestamp(log_time)
   fuzzer_run_output = uworker_msg_pb2.FuzzerRunOutput(
@@ -2317,12 +2352,16 @@ def _to_fuzzer_run_output(output: str, crash_path: str, return_code: int,
       return_code=return_code,
       timestamp=proto_timestamp)
 
-  if crash_path is None:
-    return fuzzer_run_output
-  if os.path.getsize(crash_path) > 10 * 1024**2:
-    return fuzzer_run_output
-  with open(crash_path, 'rb') as fp:
-    fuzzer_run_output.testcase = fp.read()
+  if testcase_data:
+    fuzzer_run_output.testcase = testcase_data
+  elif testcase_path:
+    if os.path.exists(
+        testcase_path) and os.path.getsize(testcase_path) <= 10 * 1024**2:
+      try:
+        with open(testcase_path, 'rb') as fp:
+          fuzzer_run_output.testcase = fp.read()
+      except Exception:
+        logs.error(f'Failed to read fuzzer testcase file: {testcase_path}')
 
   return fuzzer_run_output
 
@@ -2335,16 +2374,29 @@ def _add_build_metadata_to_output(
   fuzz_task_output.gn_args = data_handler.get_filtered_gn_args() or ''
 
 
-def _upload_fuzzer_run_output(fuzzer_run_output, fuzzer_name):
-  timestamp = uworker_io.proto_timestamp_to_timestamp(
-      fuzzer_run_output.timestamp)
+def _upload_fuzzer_run_output(run_output, fuzzer_name):
+  """Uploads fuzzer execution run logs and testcases to GCS.
+
+  This generalized function handles target execution output from both
+  engine fuzzers and blackbox fuzzers,
+  guaranteeing identical GCS formatting and path conventions.
+  """
+  timestamp = uworker_io.proto_timestamp_to_timestamp(run_output.timestamp)
+
+  # TODO:(paulovlb) remove this after validating in dev
+  fuzz_logs_bucket = environment.get_value('FUZZ_LOGS_BUCKET')
+  logs.info(f"[Blackbox fuzzer logs] Trusted Postprocess uploading run to "
+            f"bucket '{fuzz_logs_bucket}': "
+            f"log_bytes={len(run_output.output)}, "
+            f"testcase_bytes={len(run_output.testcase)}, "
+            f"timestamp={timestamp}")
   testcase_manager.upload_log(
-      fuzzer_run_output.output.decode(),
-      fuzzer_run_output.return_code,
+      run_output.output.decode(),
+      run_output.return_code,
       timestamp,
       fuzzer_name=fuzzer_name)
   testcase_manager.upload_testcase(
-      None, fuzzer_run_output.testcase, timestamp, fuzzer_name=fuzzer_name)
+      None, run_output.testcase, timestamp, fuzzer_name=fuzzer_name)
 
 
 def _utask_postprocess(output):

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -424,6 +424,25 @@ def _get_testcase_time(testcase_path):
   return None
 
 
+class FuzzerRunResult(
+    collections.namedtuple(
+        'FuzzerRunResult',
+        'crash log_output return_code log_time testcase_data')):
+  """Payload representing a single fuzzer run execution."""
+
+
+def read_testcase_data(testcase_path):
+  """Reads the binary contents of the testcase from disk."""
+  if not testcase_path or not os.path.exists(testcase_path):
+    return None
+  try:
+    with open(testcase_path, 'rb') as f:
+      return f.read()
+  except Exception:
+    logs.error(f'Failed to read testcase file {testcase_path}.')
+    return None
+
+
 def upload_testcase(testcase_path, testcase_data, log_time, fuzzer_name=None):
   """Uploads testcase so that a log file can be matched with it folder."""
   fuzz_logs_bucket = environment.get_value('FUZZ_LOGS_BUCKET')
@@ -432,10 +451,7 @@ def upload_testcase(testcase_path, testcase_data, log_time, fuzzer_name=None):
 
   assert not (testcase_path and testcase_data)
   if testcase_path:
-    if not os.path.exists(testcase_path):
-      return
-    with open(testcase_path, 'rb') as file_handle:
-      testcase_data = file_handle.read()
+    testcase_data = read_testcase_data(testcase_path)
 
   if not testcase_data:
     return
@@ -509,11 +525,13 @@ def _do_run_testcase_and_return_result_in_queue(crash_queue,
     crash_output = _get_crash_output(output)
     crash_result = CrashResult(return_code, crash_time, crash_output)
 
+    log_time = None
     # To provide consistency between stats and logs, we use timestamp taken
     # from stats when uploading logs and testcase.
     if upload_output:
       log_time = _get_testcase_time(file_path)
 
+    crash_obj = None
     if crash_result.is_crash():
       # Initialize resource list with the testcase path.
       resource_list = [file_path]
@@ -526,25 +544,54 @@ def _do_run_testcase_and_return_result_in_queue(crash_queue,
                                      utils.string_hash(file_path))
       utils.write_data_to_file(crash_output, stack_file_path)
 
-      # Put crash/no-crash results in the crash queue.
-      crash_queue.put(
-          Crash(
-              file_path=file_path,
-              crash_time=crash_time,
-              return_code=return_code,
-              resource_list=resource_list,
-              gestures=gestures,
-              stack_file_path=stack_file_path))
+      crash_obj = Crash(
+          file_path=file_path,
+          crash_time=crash_time,
+          return_code=return_code,
+          resource_list=resource_list,
+          gestures=gestures,
+          stack_file_path=stack_file_path)
 
-      # Don't upload uninteresting testcases (no crash) or if there is no log to
-      # correlate it with (not upload_output).
-      if upload_output:
-        upload_testcase(file_path, None, log_time)
-
+    # Include full output for uploaded logs (crash output, merge output, etc).
+    log_data = None
     if upload_output:
-      # Include full output for uploaded logs (crash output, merge output, etc).
       crash_result_full = CrashResult(return_code, crash_time, output)
-      upload_log(crash_result_full.get_stacktrace(), return_code, log_time)
+      log_data = crash_result_full.get_stacktrace()
+
+    # Determine uworker payload parameters.
+    # Standard long-lived bots perform direct uploads and do not
+    # transmit GCS payloads back through the queue.
+    testcase_data = None
+    uworker_log_data = None
+    uworker_return_code = None
+    uworker_log_time = None
+
+    if environment.is_uworker():
+      uworker_log_data = log_data
+      uworker_return_code = return_code
+      uworker_log_time = log_time
+      if crash_obj:
+        testcase_data = read_testcase_data(file_path)
+
+      # TODO:(paulovlb) remove this after validating in dev
+      logs.info(f"[Blackbox fuzzer logs] Untrusted worker GCS bypass. "
+                f"Packaged run result: "
+                f"has_crash={bool(crash_obj)}, "
+                f"log_len={len(log_data) if log_data else 0}, "
+                f"testcase_bytes={len(testcase_data) if testcase_data else 0}")
+    else:
+      if crash_obj and upload_output:
+        upload_testcase(file_path, None, log_time)
+      if upload_output:
+        upload_log(log_data, return_code, log_time)
+
+    crash_queue.put(
+        FuzzerRunResult(
+            crash=crash_obj,
+            log_output=uworker_log_data,
+            return_code=uworker_return_code,
+            log_time=uworker_log_time,
+            testcase_data=testcase_data))
   except Exception:
     logs.error('Exception occurred while running '
                'run_testcase_and_return_result_in_queue.')

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
@@ -1371,6 +1371,67 @@ class DoBlackboxFuzzingTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(3, actual.fuzz_task_output.testcases_generated)
     self.assertEqual(3, actual.fuzz_task_output.testcases_executed)
 
+  @mock.patch(
+      'clusterfuzz._internal.bot.tasks.utasks.fuzz_task.FuzzingSession.generate_blackbox_testcases'
+  )
+  @mock.patch('clusterfuzz._internal.bot.testcase_manager.read_testcase_data')
+  @mock.patch('clusterfuzz._internal.system.environment.is_uworker')
+  def test_utask_main_blackbox_fuzzer_uworker(self, mock_is_uworker,
+                                              mock_read_testcase_data,
+                                              mock_generate_blackbox_testcases):
+    """Test utask_main processing for a blackbox fuzzer on a uworker."""
+    mock_is_uworker.return_value = True
+    self._setup_utask_env()
+    fuzzer = self._create_test_fuzzer()
+
+    # Configure get_crash_data to return a proper CrashInfo with string attributes
+    from clusterfuzz.stacktraces import CrashInfo
+    mock_crash_info = CrashInfo()
+    mock_crash_info.crash_stacktrace = 'Fuzzer output stacktrace'
+    mock_crash_info.crash_type = 'Type'
+    mock_crash_info.crash_state = 'State'
+    self.mock.get_crash_data.return_value = mock_crash_info
+    mock_read_testcase_data.side_effect = lambda path: b'testcase-content-' + path.encode()
+
+    fuzz_task_input = uworker_msg_pb2.FuzzTaskInput()
+    setup_input = uworker_msg_pb2.SetupInput(
+        fuzzer_name=fuzzer.name, fuzzer=uworker_io.entity_to_protobuf(fuzzer))
+
+    uworker_input = uworker_msg_pb2.Input(
+        fuzzer_name=fuzzer.name,
+        job_type='asan_test',
+        fuzz_task_input=fuzz_task_input,
+        setup_input=setup_input)
+
+    # Mock out actual test-case generation for 3 tests.
+    expected_testcase_file_paths = ['/tests/0', '/tests/1', '/tests/2']
+    mock_generate_blackbox_testcases.return_value = (
+        fuzz_task.GenerateBlackboxTestcasesResult(
+            True, expected_testcase_file_paths,
+            {'fuzzer_binary_name': fuzzer.name}))
+
+    actual = fuzz_task.utask_main(uworker_input)
+
+    self.assertEqual(3, actual.fuzz_task_output.testcases_generated)
+    self.assertEqual(3, actual.fuzz_task_output.testcases_executed)
+
+    # Verify that direct GCS uploads were NOT called on the sandboxed worker.
+    self.assertEqual(0, self.mock.upload_log.call_count)
+    self.assertEqual(0, self.mock.upload_testcase.call_count)
+
+    # Verify that fuzzer logs/testcases are returned inside fuzzer_run_outputs.
+    self.assertEqual(3, len(actual.fuzz_task_output.fuzzer_run_outputs))
+    for i, fuzzer_run_output in enumerate(
+        actual.fuzz_task_output.fuzzer_run_outputs):
+      self.assertIn(b'Fuzzer output stacktrace', fuzzer_run_output.output)
+      # For crashes (first and third are crashed based on is_crash side_effect),
+      # verify the testcase content is passed back.
+      if i in (0, 2):
+        expected_content = b'testcase-content-/tests/' + str(i).encode()
+        self.assertEqual(expected_content, fuzzer_run_output.testcase)
+      else:
+        self.assertEqual(b'', fuzzer_run_output.testcase)
+
 
 @test_utils.with_cloud_emulators('datastore')
 class DoEngineFuzzingTest(fake_filesystem_unittest.TestCase):


### PR DESCRIPTION
This PR depends on #5310, which must be merged first.
Bug: b/487905050


## Changes
Implement deferred blackbox logging and GCS bypass. 

This PR:
1. Refactors `upload_testcase` in `testcase_manager.py` by extracting fuzzer testcase file reading logic into a new helper function `read_testcase_data`.
2. Intercepts fuzzer execution logs and crash testcases on untrusted bots (inside `testcase_manager.py`) and packages them into the `FuzzerRunResult` queue payload instead of writing directly to GCS.
3. Updates `fuzz_task.py` to read these packaged logs from the queue on the trusted bot and upload them to GCS in postprocess.
4. Simplifies the postprocess upload loops and adds tests.

### Tests Results
All unit tests in `fuzz_task_test.py` and `testcase_manager_test.py` run and pass locally.

## Evidence in dev

### Full task flow 

These logs show the successful execution of the trusted -> untrusted -> trusted flow of a blackbox fuzzing session in the dev environment with these changes. 

The log queries used:
 * https://cloudlogging.app.goo.gl/YL1tMBYzeWSJA1ty5
 * https://cloudlogging.app.goo.gl/MXszfcKgTQNg8KEb8

> Note: The `task_id` is highlighted in green.

1. Preprocess, which has no significant changes in this PR:

<img width="2007" height="219" alt="image" src="https://github.com/user-attachments/assets/1e875b00-f69e-44ee-bded-9e047dda4408" />

2. During execution, each parallel fuzzer run enqueues its result inside the worker thread while the main process dequeues it:

<img width="2069" height="602" alt="image" src="https://github.com/user-attachments/assets/a26a7985-29ad-4062-9282-1d9dcc6cf602" />

3. Finally, in postprocess, the trusted bot uploads the fuzzer execution data received from the worker stage:

<img width="1971" height="304" alt="image" src="https://github.com/user-attachments/assets/1b23620b-fdf1-45ef-9dab-c10b702dea52" />
 

### The uploaded logs in GCS
To verify that logs were uploaded successfully to GCS under the correct paths, we checked the corresponding job (`linux_asan_d8_dbg`) and fuzzer (`binaryen_wasm_fuzzer`), as shown in the image below:

<img width="368" height="309" alt="image" src="https://github.com/user-attachments/assets/93c43c31-2af9-4910-ab2d-343a205ab7f2" />

* Uploaded Log File Path: [GCS Link](https://pantheon.corp.google.com/storage/browser/clusterfuzz-fuzz-logs-dev/binaryen_wasm_fuzzer/linux_asan_d8_dbg/2026-06-03?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22,%22s%22:%5B(%22i%22:%22displayName%22,%22s%22:%221%22)%5D))&e=-13802955&mods=logs_tg_prod&project=clusterfuzz-development&prefix=&forceOnObjectsSortingFiltering=false)
