### PR TITLE
bump casper image tag

### DIFF
--- a/cli/casp/src/casp/utils/docker_utils.py
+++ b/cli/casp/src/casp/utils/docker_utils.py
@@ -26,14 +26,14 @@ import docker
 PROJECT_TO_IMAGE = {
     'dev': ("us-central1-docker.pkg.dev/clusterfuzz-images/"
             "clusterfuzz-immutable-images/chromium/base/immutable/dev:"
-            "20251008165901-utc-893e97e-640142509185-compute-d609115-prod"),
+            "20260602195617-utc-2b32898-640142509185-compute-44245e9-prod"),
     'internal': (
         "us-central1-docker.pkg.dev/clusterfuzz-images/"
         "clusterfuzz-immutable-images/chromium/base/immutable/internal:"
-        "20251110132749-utc-363160d-640142509185-compute-c7f2f8c-prod"),
+        "20260602195617-utc-2b32898-640142509185-compute-44245e9-prod"),
     'external': ("us-central1-docker.pkg.dev/clusterfuzz-images/"
                  "clusterfuzz-immutable-images/base/immutable/external:"
-                 "20251111191918-utc-b5863ff-640142509185-compute-c5c296c-prod")
+                 "20260602195617-utc-2b32898-640142509185-compute-44245e9-prod")
 }
 _DEFAULT_WORKING_DIR = '/data/clusterfuzz'
 


### PR DESCRIPTION
It follows up #5256 and fix b/520371484

Standardized the images used for dev, internal, and external environments to version 20260602195617-utc-2b32898-640142509185-compute-44245e9-prod.

The older tag doesn't exist for the new docker registry for immutable artifacts. 

It worked after the changes:
<img width="790" height="253" alt="image" src="https://github.com/user-attachments/assets/8d4fce74-effa-4736-8e5c-10a105602caa" />

