### PR TITLE
Require verified email for whitelisted-domain trust

### DIFF
--- a/src/appengine/libs/access.py
+++ b/src/appengine/libs/access.py
@@ -102,6 +102,15 @@ def _is_domain_allowed(email):
   return False
 
 
+def _is_trusted_domain_user(user):
+  """Check if a user should be trusted based on their email domain.
+
+  Domain-allowlist trust requires a verified email: a self-assertable
+  federated email (e.g. an unverified GitHub/Enterprise Managed User address)
+  must not be trusted as a whitelisted domain."""
+  return bool(user) and user.email_verified and _is_domain_allowed(user.email)
+
+
 class UserAccess:
   Allowed, Denied, Redirected = list(range(3))  # pylint: disable=invalid-name
 
@@ -139,7 +148,7 @@ def get_access(need_privileged_access=False, job_type=None, fuzzer_name=None):
       external_users.is_fuzzer_allowed_for_user(email, fuzzer_name)):
     return UserAccess.Allowed
 
-  if not need_privileged_access and _is_domain_allowed(email):
+  if not need_privileged_access and _is_trusted_domain_user(user):
     return UserAccess.Allowed
 
   return UserAccess.Denied
@@ -180,7 +189,8 @@ def can_user_access_testcase(testcase):
       issues_to_check.append(original_issue)
 
   relaxed_restrictions = (
-      config.relax_testcase_restrictions or _is_domain_allowed(user_email))
+      config.relax_testcase_restrictions or
+      _is_trusted_domain_user(auth.get_current_user()))
   for issue in issues_to_check:
     if relaxed_restrictions:
       if (any(utils.emails_equal(user_email, cc) for cc in issue.ccs) or

--- a/src/appengine/libs/auth.py
+++ b/src/appengine/libs/auth.py
@@ -32,7 +32,8 @@ from clusterfuzz._internal.system import environment
 from libs import helpers
 from libs import request_cache
 
-User = collections.namedtuple('User', ['email', 'email_verified'], defaults=(True,))
+User = collections.namedtuple(
+    'User', ['email', 'email_verified'], defaults=(True,))
 BEARER_PREFIX = 'Bearer '
 
 

--- a/src/appengine/libs/auth.py
+++ b/src/appengine/libs/auth.py
@@ -32,7 +32,7 @@ from clusterfuzz._internal.system import environment
 from libs import helpers
 from libs import request_cache
 
-User = collections.namedtuple('User', ['email'])
+User = collections.namedtuple('User', ['email', 'email_verified'], defaults=(True,))
 BEARER_PREFIX = 'Bearer '
 
 
@@ -185,7 +185,8 @@ def get_current_user():
 
   cached_email = getattr(cache_backing, '_cached_email', None)
   if cached_email:
-    return User(cached_email)
+    return User(cached_email,
+                getattr(cache_backing, '_cached_email_verified', True))
 
   session_cookie = get_session_cookie()
   if not session_cookie:
@@ -209,9 +210,13 @@ def get_current_user():
   # Per https://docs.github.com/en/authentication/
   #       keeping-your-account-and-data-secure/authorizing-oauth-apps
   # GitHub requires emails to be verified before an OAuth app can be
-  # authorized, so we make an exception.
-  if (not decoded_claims.get('email_verified') and
-      sign_in_provider != 'github.com'):
+  # authorized, so we still allow GitHub sign-ins through here. However, the
+  # email itself may be unverified (e.g. GitHub Enterprise Managed Users can
+  # assert an arbitrary, GitHub-unverified email), so we carry the real
+  # email_verified state on the User and never trust an unverified email as a
+  # whitelisted domain (see libs/access.py).
+  email_verified = bool(decoded_claims.get('email_verified'))
+  if not email_verified and sign_in_provider != 'github.com':
     return None
 
   email = decoded_claims.get('email')
@@ -221,7 +226,8 @@ def get_current_user():
   # We cache the email for this request if we've validated the user to make
   # subsequent get_current_user() calls fast.
   setattr(cache_backing, '_cached_email', email)
-  return User(email)
+  setattr(cache_backing, '_cached_email_verified', email_verified)
+  return User(email, email_verified)
 
 
 def create_session_cookie(token, expires_in):

--- a/src/clusterfuzz/_internal/tests/appengine/libs/access_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/access_test.py
@@ -179,6 +179,36 @@ class IsDomainAllowedTest(unittest.TestCase):
     self.assertFalse(access._is_domain_allowed('test@test24234.com'))
 
 
+class IsTrustedDomainUserTest(unittest.TestCase):
+  """Test _is_trusted_domain_user."""
+
+  def setUp(self):
+    test_helpers.patch(self, ['libs.access._is_domain_allowed'])
+
+  def test_verified_allowed_domain(self):
+    """A verified email on an allowed domain is trusted."""
+    self.mock._is_domain_allowed.return_value = True
+    user = auth.User('test@test.com', email_verified=True)
+    self.assertTrue(access._is_trusted_domain_user(user))
+
+  def test_unverified_allowed_domain(self):
+    """An unverified email on an allowed domain is NOT trusted, even though the
+    domain matches (the GitHub/EMU TOCTOU bypass)."""
+    self.mock._is_domain_allowed.return_value = True
+    user = auth.User('test@test.com', email_verified=False)
+    self.assertFalse(access._is_trusted_domain_user(user))
+
+  def test_verified_disallowed_domain(self):
+    """A verified email on a non-allowed domain is not trusted."""
+    self.mock._is_domain_allowed.return_value = False
+    user = auth.User('test@test.com', email_verified=True)
+    self.assertFalse(access._is_trusted_domain_user(user))
+
+  def test_none_user(self):
+    """A missing user is not trusted."""
+    self.assertFalse(access._is_trusted_domain_user(None))
+
+
 class GetAccessTest(unittest.TestCase):
   """Test get_access."""
 
@@ -226,6 +256,20 @@ class GetAccessTest(unittest.TestCase):
         access.UserAccess.Allowed)
     self.assertEqual(
         access.get_access(need_privileged_access=True),
+        access.UserAccess.Denied)
+
+  def test_get_access_unverified_domain(self):
+    """For an allowed domain but an unverified email, ensure it denies: an
+    unverified federated email must not be trusted as a whitelisted domain."""
+    self.mock.get_current_user.return_value = auth.User(
+        'test@test.com', email_verified=False)
+    self.mock.is_current_user_admin.return_value = False
+    self.mock._is_privileged_user.return_value = False
+    self.mock._is_domain_allowed.return_value = True
+    self.mock.is_fuzzer_allowed_for_user.return_value = False
+    self.mock.is_job_allowed_for_user.return_value = False
+    self.assertEqual(
+        access.get_access(need_privileged_access=False),
         access.UserAccess.Denied)
 
   def test_get_access_external_fuzzer(self):
@@ -413,6 +457,20 @@ class CanUserAccessTestcaseTest(unittest.TestCase):
         data_types.Config(relax_testcase_restrictions=False))
     self.bug.add_cc(self.email)
     self._test_bug_access()
+
+  def test_not_relaxed_for_unverified_domain(self):
+    """Ensure an unverified email on the domain list does NOT get relaxed
+    (CC-based) bug access: only a verified domain email relaxes restrictions."""
+    self.mock.get_current_user.return_value = auth.User(
+        self.email, email_verified=False)
+    self.mock._is_domain_allowed.return_value = True
+    self.testcase.security_flag = True
+    self.mock.get.return_value = (
+        data_types.Config(relax_testcase_restrictions=False))
+    self.get_issue.return_value = self.bug
+    self.bug.add_cc(self.email)
+    self.testcase.bug_information = '1234'
+    self.assertFalse(access.can_user_access_testcase(self.testcase))
 
   def test_allowed_because_of_uploader(self):
     """Ensure it is allowed because the user is the uploader."""


### PR DESCRIPTION
Carry the real email_verified state on the User and require it before trusting an email's domain, closing the GitHub/EMU email-verification bypass. GitHub login and own-testcase access are unaffected.

b/516412711