### PR TITLE
Do not file public GitHub issues for security testcases

### DIFF
--- a/src/clusterfuzz/_internal/issue_management/oss_fuzz_github.py
+++ b/src/clusterfuzz/_internal/issue_management/oss_fuzz_github.py
@@ -141,6 +141,13 @@ def file_issue(testcase):
   if not _filing_enabled(testcase):
     return
 
+  # Never disclose an embargoed security testcase's id/report URL in a public
+  # GitHub issue. Public filing is for non-security bugs only.
+  if testcase.security_flag:
+    logs.info('Skipping public GitHub issue filing for security testcase '
+              f'{testcase.key.id()}.')
+    return
+
   if testcase.github_repo_id and testcase.github_issue_num:
     logs.info('Issue already filed under'
               f'issue number {testcase.github_issue_num} in '

--- a/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/libs/oss_fuzz_github_test.py
@@ -123,6 +123,20 @@ class OSSFuzzGithubTests(unittest.TestCase):
     mock_github.Github().get_repo().create_issue.assert_not_called()
 
   @mock.patch('clusterfuzz._internal.issue_management.oss_fuzz_github.github')
+  def test_not_file_issue_security_flag(self, mock_github):
+    """A security testcase must not be filed as a public GitHub issue, even
+    when filing is enabled for the job."""
+    security_testcase = data_types.Testcase(
+        job_type='job1', bug_information='300', security_flag=True)
+    security_testcase.put()
+
+    oss_fuzz_github.file_issue(security_testcase)
+
+    mock_github.Github().get_repo().create_issue.assert_not_called()
+    self.assertIsNone(security_testcase.github_repo_id)
+    self.assertIsNone(security_testcase.github_issue_num)
+
+  @mock.patch('clusterfuzz._internal.issue_management.oss_fuzz_github.github')
   def test_file_issue_to_repo_disabled_issues(self, mock_github):
     """File an issue to a repo that has disabled issues."""
     mock_github.Github().get_repo.return_value = mock.MagicMock(


### PR DESCRIPTION
oss-fuzz-robot filed a public issue containing the testcase id and report URL with no security_flag gate, disclosing embargoed testcase identifiers. Skip filing entirely for security testcases.