### PR TITLE
Remove blackbox fuzzing debug logs

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1455,12 +1455,6 @@ class FuzzingSession:
         if not isinstance(log_output, str):
           log_output = str(log_output)
 
-        # TODO:(paulovlb) remove this after validating in dev
-        logs.info(
-            f"[Blackbox fuzzer logs] Main thread dequeued run result: "
-            f"has_crash={bool(run_result.crash)}, log_len={len(log_output)}, "
-            f"has_testcase_data={bool(run_result.testcase_data)}")
-
         # Delegate formatting, warnings, timestamping, and packaging completely
         blackbox_output = _to_fuzzer_run_output(
             log_output,
@@ -2383,13 +2377,6 @@ def _upload_fuzzer_run_output(run_output, fuzzer_name):
   """
   timestamp = uworker_io.proto_timestamp_to_timestamp(run_output.timestamp)
 
-  # TODO:(paulovlb) remove this after validating in dev
-  fuzz_logs_bucket = environment.get_value('FUZZ_LOGS_BUCKET')
-  logs.info(f"[Blackbox fuzzer logs] Trusted Postprocess uploading run to "
-            f"bucket '{fuzz_logs_bucket}': "
-            f"log_bytes={len(run_output.output)}, "
-            f"testcase_bytes={len(run_output.testcase)}, "
-            f"timestamp={timestamp}")
   testcase_manager.upload_log(
       run_output.output.decode(),
       run_output.return_code,

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -572,13 +572,6 @@ def _do_run_testcase_and_return_result_in_queue(crash_queue,
       uworker_log_time = log_time
       if crash_obj:
         testcase_data = read_testcase_data(file_path)
-
-      # TODO:(paulovlb) remove this after validating in dev
-      logs.info(f"[Blackbox fuzzer logs] Untrusted worker GCS bypass. "
-                f"Packaged run result: "
-                f"has_crash={bool(crash_obj)}, "
-                f"log_len={len(log_data) if log_data else 0}, "
-                f"testcase_bytes={len(testcase_data) if testcase_data else 0}")
     else:
       if crash_obj and upload_output:
         upload_testcase(file_path, None, log_time)


### PR DESCRIPTION
This PR only removes the logs that were intended as debugging filters for deferring blackbox fuzzing session logs for postprocess

Related: https://github.com/google/clusterfuzz/pull/5311