### PR TITLE
Add job-level authorization check to revisions info handler

### DIFF
--- a/src/appengine/handlers/revisions_info.py
+++ b/src/appengine/handlers/revisions_info.py
@@ -17,6 +17,7 @@ from flask import request
 
 from clusterfuzz._internal.build_management import revisions
 from handlers import base_handler
+from libs import access
 from libs import handler
 from libs import helpers
 
@@ -29,6 +30,8 @@ class Handler(base_handler.Handler):
   def get(self):
     """GET handler."""
     job_type = request.get('job')
+    if job_type and not access.has_access(job_type=job_type):
+      raise helpers.AccessDeniedError()
     revision = request.get('revision')
     revision_range = request.get('range')
 


### PR DESCRIPTION
## Summary

`revisions_info.py` (`GET /revisions`) is decorated with `@handler.oauth` (which provides identity only, not authorization) and reads the `job` request parameter without any access check before calling `revisions.get_component_range_list(..., job_type)`. A user who is not authorized for the job/project can therefore read its source-repository layout — component names, repository URLs, and revisions/commit hashes derived from the job's `REVISION_VARS_URL`/DEPS.

This is the same class as the missing access checks on `issue_redirector` and `coverage_report` tracked in #5258 / #5304 (job/testcase-keyed read handlers without an access check); `revisions_info` is a third handler of that class that those changes do not cover.

## Change

Mirror the gate used for the sibling handlers (`coverage_report`, `fuzzer_stats`): if a `job` is supplied, require access to it.

```python
job_type = request.get('job')
if job_type and not access.has_access(job_type=job_type):
  raise helpers.AccessDeniedError()
```

An empty `job` falls through to the existing general-access path (the project-default `REVISION_VARS_URL`), so authorized usage is unaffected.
