### PR TITLE
Guard Fuzzing Tasks Behind ENABLE_FUZZ_FOR_BOTS Feature Flag

### DIFF
--- a/src/clusterfuzz/_internal/base/feature_flags.py
+++ b/src/clusterfuzz/_internal/base/feature_flags.py
@@ -42,6 +42,8 @@ class FeatureFlags(Enum):
   # TODO(b/516836939): Migrate feature flag to static config value.
   SWARMING_MAX_PENDING_TASKS = 'swarming_max_pending_tasks'
 
+  ENABLE_FUZZ_FOR_BOTS = 'enable_fuzz_for_bots'
+
   @property
   def flag(self):
     """Get the feature flag."""

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -440,7 +440,7 @@ def get_task():
   logs.info(f'Could not get task from {regular_queue()}. Fuzzing.')
 
   if not feature_flags.FeatureFlags.ENABLE_FUZZ_FOR_BOTS.enabled:
-    logs.info('Fuzzing is disabled.')
+    logs.warning('Fuzzing is disabled for long-lived bots.')
     return None
 
   task = get_fuzz_task()

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -26,6 +26,7 @@ from typing import Optional
 from google.cloud import monitoring_v3
 
 from clusterfuzz._internal.base import external_tasks
+from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.base import memoize
 from clusterfuzz._internal.base import persistent_cache
 from clusterfuzz._internal.base import utils
@@ -437,6 +438,10 @@ def get_task():
                   f'default {default_android_queue()} queue.')
 
   logs.info(f'Could not get task from {regular_queue()}. Fuzzing.')
+
+  if not feature_flags.FeatureFlags.ENABLE_FUZZ_FOR_BOTS.enabled:
+    logs.info(f'Fuzzing is disabled.')
+    return None
 
   task = get_fuzz_task()
   if not task:

--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -440,7 +440,7 @@ def get_task():
   logs.info(f'Could not get task from {regular_queue()}. Fuzzing.')
 
   if not feature_flags.FeatureFlags.ENABLE_FUZZ_FOR_BOTS.enabled:
-    logs.info(f'Fuzzing is disabled.')
+    logs.info('Fuzzing is disabled.')
     return None
 
   task = get_fuzz_task()


### PR DESCRIPTION
This change introduces a new feature flag `ENABLE_FUZZ_FOR_BOTS` to control whether bots can pull new fuzzing tasks when other regular queues are exhausted. When disabled, bots will log a message indicating that fuzzing is disabled and return `None` instead of calling `get_fuzz_task()`.

## Changes

### 1. Feature Flag Definition
* **File:** [feature_flags.py](file:///usr/local/google/home/javanlacerda/repos/clusterfuzz/src/clusterfuzz/_internal/base/feature_flags.py)
* **Change:** Added `ENABLE_FUZZ_FOR_BOTS = 'enable_fuzz_for_bots'` to the `FeatureFlags` enum class.

### 2. Task Selection Update
* **File:** [__init__.py](file:///usr/local/google/home/javanlacerda/repos/clusterfuzz/src/clusterfuzz/_internal/base/tasks/__init__.py)
* **Change:** 
  * Imported `feature_flags`.
  * Wrapped the fuzz task retrieval code inside `get_task()` with a check on the new feature flag:
    ```python
    if not feature_flags.FeatureFlags.ENABLE_FUZZ_FOR_BOTS.enabled:
      logs.info(f'Fuzzing is disabled.')
      return None
    ```

## Verification & Testing
* **Manual Verification:** Verified logic code paths.
