### PR TITLE
Adds support for --no-streaming flag in Android ASan jobs

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/app.py
+++ b/src/clusterfuzz/_internal/platforms/android/app.py
@@ -93,13 +93,23 @@ def get_package_name(apk_path=None):
   return match.group(1)
 
 
-def install(package_apk_path: str, additional_flags: list[str] = None):
-  """Install a package from an apk path."""
-  if additional_flags is None:
-    additional_flags = []
+def install(package_apk_path: str, **kwargs):
+  """Install a package from an apk path.
 
+  Args:
+    package_apk_path: Path to the apk file to install.
+    **kwargs: Additional arguments to pass to the install command.
+  """
   cmd = ['install', '-r']
-  cmd.extend(additional_flags)
+  for key, value in kwargs.items():
+    if not value:
+      continue
+
+    flag = '-' + key if len(key) == 1 else '--' + key.replace('_', '-')
+    cmd.append(flag)
+    if not isinstance(value, bool):
+      cmd.append(str(value))
+
   cmd.append(package_apk_path)
   return adb.run_command(cmd)
 

--- a/src/clusterfuzz/_internal/platforms/android/app.py
+++ b/src/clusterfuzz/_internal/platforms/android/app.py
@@ -93,9 +93,15 @@ def get_package_name(apk_path=None):
   return match.group(1)
 
 
-def install(package_apk_path):
+def install(package_apk_path: str, additional_flags: list[str] = None):
   """Install a package from an apk path."""
-  return adb.run_command(['install', '-r', package_apk_path])
+  if additional_flags is None:
+    additional_flags = []
+
+  cmd = ['install', '-r']
+  cmd.extend(additional_flags)
+  cmd.append(package_apk_path)
+  return adb.run_command(cmd)
 
 
 def is_installed(package_name):

--- a/src/clusterfuzz/_internal/platforms/android/device.py
+++ b/src/clusterfuzz/_internal/platforms/android/device.py
@@ -352,6 +352,32 @@ def initialize_environment():
   environment.set_value('LOG_TASK_TIMES', True)
 
 
+def _get_no_streaming_flag():
+  """Returns a list containing the '--no-streaming' flag if the job or device
+  requires ASan. Returns an empty list otherwise.
+
+  This is required because streaming installation prevents wrap.sh from
+  functioning correctly on modern Android versions.
+  """
+  additional_flags = []
+
+  is_asan_job = False
+  job_name = environment.get_value('JOB_NAME')
+  if job_name:
+    memory_tool = environment.get_memory_tool_name(job_name)
+    if memory_tool == 'ASAN':
+      is_asan_job = True
+
+  is_asan_device = (
+      environment.get_value('ASAN_DEVICE_SETUP') or
+      settings.get_sanitizer_tool_name() == 'asan')
+
+  if is_asan_job or is_asan_device:
+    additional_flags.append('--no-streaming')
+
+  return additional_flags
+
+
 def install_application_if_needed(apk_path, force_update):
   """Install application package if it does not exist on device
   or if force_update is set."""
@@ -377,7 +403,7 @@ def install_application_if_needed(apk_path, force_update):
   # package list or force_update flag has been set.
   if force_update or not app.is_installed(package_name):
     app.uninstall(package_name)
-    app.install(apk_path)
+    app.install(apk_path, additional_flags=_get_no_streaming_flag())
 
     if not app.is_installed(package_name):
       logs.error('Package %s was not installed successfully.' % package_name)

--- a/src/clusterfuzz/_internal/platforms/android/device.py
+++ b/src/clusterfuzz/_internal/platforms/android/device.py
@@ -352,12 +352,14 @@ def initialize_environment():
   environment.set_value('LOG_TASK_TIMES', True)
 
 
-def _get_no_streaming_flag() -> str:
-  """Returns '--no-streaming' if the job or device requires ASan. Otherwise,
-  returns an empty string.
+def _needs_no_streaming_for_asan() -> bool:
+  """
+  Asan setup requires non-streaming installation because streaming
+  installation prevents wrap.sh from being invoked on modern Android
+  versions which is necessary for ASan to function correctly.
 
-  This is required because streaming installation prevents wrap.sh from
-  functioning correctly on modern Android versions.
+  Returns:
+    bool: True if the job or device requires ASan, False otherwise.
   """
   is_asan_job = False
   job_name = environment.get_value('JOB_NAME')
@@ -370,10 +372,7 @@ def _get_no_streaming_flag() -> str:
       environment.get_value('ASAN_DEVICE_SETUP') or
       settings.get_sanitizer_tool_name() == 'asan')
 
-  if is_asan_job or is_asan_device:
-    return '--no-streaming'
-
-  return ''
+  return is_asan_job or is_asan_device
 
 
 def install_application_if_needed(apk_path, force_update):
@@ -401,7 +400,7 @@ def install_application_if_needed(apk_path, force_update):
   # package list or force_update flag has been set.
   if force_update or not app.is_installed(package_name):
     app.uninstall(package_name)
-    app.install(apk_path, additional_flags=[_get_no_streaming_flag()])
+    app.install(apk_path, no_streaming=_needs_no_streaming_for_asan())
 
     if not app.is_installed(package_name):
       logs.error('Package %s was not installed successfully.' % package_name)

--- a/src/clusterfuzz/_internal/platforms/android/device.py
+++ b/src/clusterfuzz/_internal/platforms/android/device.py
@@ -352,15 +352,13 @@ def initialize_environment():
   environment.set_value('LOG_TASK_TIMES', True)
 
 
-def _get_no_streaming_flag():
-  """Returns a list containing the '--no-streaming' flag if the job or device
-  requires ASan. Returns an empty list otherwise.
+def _get_no_streaming_flag() -> str:
+  """Returns '--no-streaming' if the job or device requires ASan. Otherwise,
+  returns an empty string.
 
   This is required because streaming installation prevents wrap.sh from
   functioning correctly on modern Android versions.
   """
-  additional_flags = []
-
   is_asan_job = False
   job_name = environment.get_value('JOB_NAME')
   if job_name:
@@ -373,9 +371,9 @@ def _get_no_streaming_flag():
       settings.get_sanitizer_tool_name() == 'asan')
 
   if is_asan_job or is_asan_device:
-    additional_flags.append('--no-streaming')
+    return '--no-streaming'
 
-  return additional_flags
+  return ''
 
 
 def install_application_if_needed(apk_path, force_update):
@@ -403,7 +401,7 @@ def install_application_if_needed(apk_path, force_update):
   # package list or force_update flag has been set.
   if force_update or not app.is_installed(package_name):
     app.uninstall(package_name)
-    app.install(apk_path, additional_flags=_get_no_streaming_flag())
+    app.install(apk_path, additional_flags=[_get_no_streaming_flag()])
 
     if not app.is_installed(package_name):
       logs.error('Package %s was not installed successfully.' % package_name)

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/app_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/app_test.py
@@ -85,6 +85,12 @@ class InstallTest(TestCase):
 
   def test_install_with_additional_flags(self):
     """Test installation with additional flags."""
-    app.install('/path/to/app.apk', additional_flags=['-g', '-t'])
+    app.install('/path/to/app.apk', g=True, t=True)
     self.mock_run_command.assert_called_once_with(
         ['install', '-r', '-g', '-t', '/path/to/app.apk'])
+
+  def test_install_with_valued_flags(self):
+    """Test installation with flags that take string/numeric values."""
+    app.install('/path/to/app.apk', abi='x86', no_streaming=True)
+    self.mock_run_command.assert_called_once_with(
+        ['install', '-r', '--abi', 'x86', '--no-streaming', '/path/to/app.apk'])

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/app_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/app_test.py
@@ -14,10 +14,13 @@
 """Tests for app functions."""
 
 import os
+import unittest
+from unittest import mock
 
 from clusterfuzz._internal.platforms.android import app
 from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.tests.test_libs import android_helpers
+from clusterfuzz._internal.tests.test_libs import helpers
 
 
 class IsInstalledTest(android_helpers.AndroidTest):
@@ -61,3 +64,27 @@ class GetPackageNameTest(android_helpers.AndroidTest):
     """Test apk path passed as argument."""
     self.assertEqual(
         app.get_package_name(self.test_apk_path), self.test_apk_pkg_name)
+
+
+class InstallTest(unittest.TestCase):
+  """Tests install."""
+
+  def setUp(self):
+    super().setUp()
+    helpers.patch_environ(self)
+    self.run_command_patcher = mock.patch(
+        'clusterfuzz._internal.platforms.android.adb.run_command')
+    self.mock_run_command = self.run_command_patcher.start()
+    self.addCleanup(self.run_command_patcher.stop)
+
+  def test_install_normal(self):
+    """Test normal installation without any additional flags."""
+    app.install('/path/to/app.apk')
+    self.mock_run_command.assert_called_once_with(
+        ['install', '-r', '/path/to/app.apk'])
+
+  def test_install_with_additional_flags(self):
+    """Test installation with additional flags."""
+    app.install('/path/to/app.apk', additional_flags=['-g', '-t'])
+    self.mock_run_command.assert_called_once_with(
+        ['install', '-r', '-g', '-t', '/path/to/app.apk'])

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/app_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/app_test.py
@@ -14,8 +14,8 @@
 """Tests for app functions."""
 
 import os
-import unittest
 from unittest import mock
+from unittest import TestCase
 
 from clusterfuzz._internal.platforms.android import app
 from clusterfuzz._internal.system import environment
@@ -66,7 +66,7 @@ class GetPackageNameTest(android_helpers.AndroidTest):
         app.get_package_name(self.test_apk_path), self.test_apk_pkg_name)
 
 
-class InstallTest(unittest.TestCase):
+class InstallTest(TestCase):
   """Tests install."""
 
   def setUp(self):

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/device_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/device_test.py
@@ -84,8 +84,8 @@ class AddTestAccountsIfNeededTest(unittest.TestCase):
     self.mock.get_value.assert_not_called()
 
 
-class GetNoStreamingFlagTest(unittest.TestCase):
-  """Tests _get_no_streaming_flag."""
+class NeedsNoStreamingForAsanTest(unittest.TestCase):
+  """Tests _needs_no_streaming_for_asan."""
 
   # pylint: disable=protected-access
 
@@ -98,25 +98,25 @@ class GetNoStreamingFlagTest(unittest.TestCase):
     self.mock.get_sanitizer_tool_name.return_value = None
 
   def test_normal_job(self):
-    """Test flags returned for a normal job."""
-    self.assertEqual(device._get_no_streaming_flag(), '')
+    """Test outcome for a normal job."""
+    self.assertFalse(device._needs_no_streaming_for_asan())
 
   def test_asan_job(self):
-    """Test flags returned for an ASan job."""
+    """Test outcome for an ASan job."""
     environment.set_value('JOB_NAME', 'android_asan_job')
-    self.assertEqual(device._get_no_streaming_flag(), '--no-streaming')
+    self.assertTrue(device._needs_no_streaming_for_asan())
 
   def test_hwasan_job(self):
-    """Test flags returned for a non ASAN job like HWASan."""
+    """Test outcome for a non ASAN job like HWASan."""
     environment.set_value('JOB_NAME', 'android_hwasan_job')
-    self.assertEqual(device._get_no_streaming_flag(), '')
+    self.assertFalse(device._needs_no_streaming_for_asan())
 
   def test_asan_device_env(self):
-    """Test flags returned for an ASan device via ASAN_DEVICE_SETUP env."""
+    """Test outcome for an ASan device via ASAN_DEVICE_SETUP env."""
     environment.set_value('ASAN_DEVICE_SETUP', True)
-    self.assertEqual(device._get_no_streaming_flag(), '--no-streaming')
+    self.assertTrue(device._needs_no_streaming_for_asan())
 
   def test_asan_device_flavor(self):
-    """Test flags returned for an ASan device via settings build flavor."""
+    """Test outcome for an ASan device via settings build flavor."""
     self.mock.get_sanitizer_tool_name.return_value = 'asan'
-    self.assertEqual(device._get_no_streaming_flag(), '--no-streaming')
+    self.assertTrue(device._needs_no_streaming_for_asan())

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/device_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/device_test.py
@@ -16,6 +16,7 @@
 import unittest
 
 from clusterfuzz._internal.platforms.android import device
+from clusterfuzz._internal.system import environment
 from clusterfuzz._internal.tests.test_libs import android_helpers
 from clusterfuzz._internal.tests.test_libs import helpers
 
@@ -81,3 +82,41 @@ class AddTestAccountsIfNeededTest(unittest.TestCase):
     self.mock.is_uworker.return_value = True
     device.add_test_accounts_if_needed()
     self.mock.get_value.assert_not_called()
+
+
+class GetNoStreamingFlagTest(unittest.TestCase):
+  """Tests _get_no_streaming_flag."""
+
+  # pylint: disable=protected-access
+
+  def setUp(self):
+    super().setUp()
+    helpers.patch_environ(self)
+    helpers.patch(self, [
+        'clusterfuzz._internal.platforms.android.settings.get_sanitizer_tool_name',
+    ])
+    self.mock.get_sanitizer_tool_name.return_value = None
+
+  def test_normal_job(self):
+    """Test flags returned for a normal job."""
+    self.assertEqual(device._get_no_streaming_flag(), [])
+
+  def test_asan_job(self):
+    """Test flags returned for an ASan job."""
+    environment.set_value('JOB_NAME', 'android_asan_job')
+    self.assertEqual(device._get_no_streaming_flag(), ['--no-streaming'])
+
+  def test_hwasan_job(self):
+    """Test flags returned for a non ASAN job like HWASan."""
+    environment.set_value('JOB_NAME', 'android_hwasan_job')
+    self.assertEqual(device._get_no_streaming_flag(), [])
+
+  def test_asan_device_env(self):
+    """Test flags returned for an ASan device via ASAN_DEVICE_SETUP env."""
+    environment.set_value('ASAN_DEVICE_SETUP', True)
+    self.assertEqual(device._get_no_streaming_flag(), ['--no-streaming'])
+
+  def test_asan_device_flavor(self):
+    """Test flags returned for an ASan device via settings build flavor."""
+    self.mock.get_sanitizer_tool_name.return_value = 'asan'
+    self.assertEqual(device._get_no_streaming_flag(), ['--no-streaming'])

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/device_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/device_test.py
@@ -99,24 +99,24 @@ class GetNoStreamingFlagTest(unittest.TestCase):
 
   def test_normal_job(self):
     """Test flags returned for a normal job."""
-    self.assertEqual(device._get_no_streaming_flag(), [])
+    self.assertEqual(device._get_no_streaming_flag(), '')
 
   def test_asan_job(self):
     """Test flags returned for an ASan job."""
     environment.set_value('JOB_NAME', 'android_asan_job')
-    self.assertEqual(device._get_no_streaming_flag(), ['--no-streaming'])
+    self.assertEqual(device._get_no_streaming_flag(), '--no-streaming')
 
   def test_hwasan_job(self):
     """Test flags returned for a non ASAN job like HWASan."""
     environment.set_value('JOB_NAME', 'android_hwasan_job')
-    self.assertEqual(device._get_no_streaming_flag(), [])
+    self.assertEqual(device._get_no_streaming_flag(), '')
 
   def test_asan_device_env(self):
     """Test flags returned for an ASan device via ASAN_DEVICE_SETUP env."""
     environment.set_value('ASAN_DEVICE_SETUP', True)
-    self.assertEqual(device._get_no_streaming_flag(), ['--no-streaming'])
+    self.assertEqual(device._get_no_streaming_flag(), '--no-streaming')
 
   def test_asan_device_flavor(self):
     """Test flags returned for an ASan device via settings build flavor."""
     self.mock.get_sanitizer_tool_name.return_value = 'asan'
-    self.assertEqual(device._get_no_streaming_flag(), ['--no-streaming'])
+    self.assertEqual(device._get_no_streaming_flag(), '--no-streaming')


### PR DESCRIPTION
## Overview: 
This PR ensures that Android APKs are installed using the `--no-streaming` flag during ASan fuzzing jobs. Modern Android versions default to streaming installation, which prevents the bundled wrap.sh script (responsible for setting up the ASan library environment) from triggering correctly. This change dynamically detects ASan environments and applies the `--no-streaming` workaround. We still left intact the legacy `asan_device_setup.sh` logic in case any other `haiku` fuzzer job depends on it

For more details for the `wrap.sh` script see the [NDK doc](https://developer.android.com/ndk/guides/wrap-script) and the [ASan docs](https://developer.android.com/ndk/guides/asan)

## Changes:

- `app.py`: Updated the install method signature to accept and forward additional flags trough `**kwargs`.
- `device.py`: Added a private helper to identify ASan jobs or device environments options, and to then pass the `--no-streaming` flag during installation.
- Added new unit tests for this 