### PR TITLE
check platform on feature flag for enabling fuzz for bots

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -439,7 +439,9 @@ def get_task():
 
   logs.info(f'Could not get task from {regular_queue()}. Fuzzing.')
 
-  if not feature_flags.FeatureFlags.ENABLE_FUZZ_FOR_BOTS.enabled:
+  if (not feature_flags.FeatureFlags.ENABLE_FUZZ_FOR_BOTS.enabled or
+      environment.platform().lower() not in
+      feature_flags.FeatureFlags.ENABLE_FUZZ_FOR_BOTS.string_value):
     logs.warning('Fuzzing is disabled for long-lived bots.')
     return None
 

--- a/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py
@@ -589,3 +589,72 @@ class TworkerGetTaskTest(unittest.TestCase):
     self.assertEqual(tasks.tworker_get_task(override_queue=''), 'task2')
     self.mock.get_postprocess_task.assert_called_once()
     self.mock.get_preprocess_task.assert_not_called()
+
+
+class GetFuzzTaskFallbackTest(unittest.TestCase):
+  """Tests for get_task when falling back to fuzzing."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.base.tasks.get_regular_task',
+        'clusterfuzz._internal.base.tasks.get_postprocess_task',
+        'clusterfuzz._internal.base.tasks.get_preprocess_task',
+        'clusterfuzz._internal.base.tasks.get_fuzz_task',
+        'clusterfuzz._internal.system.environment.platform',
+        'clusterfuzz._internal.system.environment.is_android',
+        'clusterfuzz._internal.base.tasks.allow_all_tasks',
+    ])
+    self.mock.get_regular_task.return_value = None
+    self.mock.get_postprocess_task.return_value = None
+    self.mock.get_preprocess_task.return_value = None
+    self.mock.is_android.return_value = False
+    self.mock.allow_all_tasks.return_value = True
+
+    self.mock.get_fuzz_task.return_value = 'fuzz_task'
+    self.mock.platform.return_value = 'LINUX'
+
+  @mock.patch(
+      'clusterfuzz._internal.base.feature_flags.FeatureFlags.enabled',
+      new_callable=mock.PropertyMock)
+  @mock.patch(
+      'clusterfuzz._internal.base.feature_flags.FeatureFlags.string_value',
+      new_callable=mock.PropertyMock)
+  def test_fuzzing_disabled_by_flag(self, mock_string_value, mock_enabled):
+    """Test that fuzzing is not picked if flag is disabled."""
+    mock_enabled.return_value = False
+    mock_string_value.return_value = 'linux'
+
+    task = tasks.get_task()
+    self.assertIsNone(task)
+    self.mock.get_fuzz_task.assert_not_called()
+
+  @mock.patch(
+      'clusterfuzz._internal.base.feature_flags.FeatureFlags.enabled',
+      new_callable=mock.PropertyMock)
+  @mock.patch(
+      'clusterfuzz._internal.base.feature_flags.FeatureFlags.string_value',
+      new_callable=mock.PropertyMock)
+  def test_fuzzing_disabled_by_platform_mismatch(self, mock_string_value,
+                                                 mock_enabled):
+    """Test that fuzzing is not picked if platform does not match."""
+    mock_enabled.return_value = True
+    mock_string_value.return_value = 'windows'
+
+    task = tasks.get_task()
+    self.assertIsNone(task)
+    self.mock.get_fuzz_task.assert_not_called()
+
+  @mock.patch(
+      'clusterfuzz._internal.base.feature_flags.FeatureFlags.enabled',
+      new_callable=mock.PropertyMock)
+  @mock.patch(
+      'clusterfuzz._internal.base.feature_flags.FeatureFlags.string_value',
+      new_callable=mock.PropertyMock)
+  def test_fuzzing_enabled(self, mock_string_value, mock_enabled):
+    """Test that fuzzing is picked if flag is enabled and platform matches."""
+    mock_enabled.return_value = True
+    mock_string_value.return_value = 'linux,windows'
+
+    task = tasks.get_task()
+    self.assertEqual(task, 'fuzz_task')
+    self.mock.get_fuzz_task.assert_called_once()


### PR DESCRIPTION
This PR refines the bot fuzzing fallback behavior controlled by the `ENABLE_FUZZ_FOR_BOTS` feature flag. Specifically, it introduces a platform-based check to verify if the bot's current platform is allowed to execute fuzzing tasks, as specified by the feature flag's string value. 

This prevents bots running on unauthorized platforms from picking up fuzzing tasks when they fall back from regular task queues.

## Changes

### 1. Fallback Logic Refinement
* **File:** [tasks/__init__.py](file:///usr/local/google/home/javanlacerda/repos/clusterfuzz/src/clusterfuzz/_internal/base/tasks/__init__.py#L442-L446)
* **Details:** 
  * Updated the fallback conditional check inside `get_task()`.
  * In addition to checking if `ENABLE_FUZZ_FOR_BOTS` is enabled, the bot now checks if `environment.platform().lower()` is present in `ENABLE_FUZZ_FOR_BOTS.string_value`.
  * Changed the log severity and message to a warning: `logs.warning('Fuzzing is disabled for long-lived bots.')` when the flag or platform check fails.

### 2. Unit Tests
* **File:** [tasks_test.py](file:///usr/local/google/home/javanlacerda/repos/clusterfuzz/src/clusterfuzz/_internal/tests/core/base/tasks/tasks_test.py#L593-L660)
* **Details:** 
  * Added `GetFuzzTaskFallbackTest` to verify all cases of falling back to fuzzing:
    * `test_fuzzing_disabled_by_flag`: Asserts that fuzzing is skipped if the flag is disabled.
    * `test_fuzzing_disabled_by_platform_mismatch`: Asserts that fuzzing is skipped if the flag is enabled but the bot's platform doesn't match any allowed platforms in the flag's value (e.g., bot is `LINUX` but allowed is `windows`).
    * `test_fuzzing_enabled`: Asserts that fuzzing is correctly selected if the flag is enabled and the bot's platform is in the allowed list (e.g., bot is `LINUX` and allowed is `linux,windows`).

