### PR TITLE
Fix issue with double-opening temp corpus files

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -368,7 +368,7 @@ def _is_testcase_minimized(testcase):
 
 def download_testcase(testcase_download_url, dst):
   """Downloads a testcase from a signed url"""
-  return storage.download_signed_url_to_file(testcase_download_url, dst)
+  return storage.download_signed_url_to_filepath(testcase_download_url, dst)
 
 
 def unpack_testcase(testcase, testcase_download_url):
@@ -637,8 +637,8 @@ def _update_fuzzer(
 
   # Copy the archive to local disk and unpack it.
   archive_path = os.path.join(fuzzer_directory, fuzzer.filename)
-  if not storage.download_signed_url_to_file(update_input.fuzzer_download_url,
-                                             archive_path):
+  if not storage.download_signed_url_to_filepath(
+      update_input.fuzzer_download_url, archive_path):
     logs.error('Failed to copy fuzzer archive.')
     return False
 

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -327,7 +327,7 @@ def update_tests_if_needed(tests_url=None):
     try:
       shell.remove_directory(data_directory, recreate=True)
       if tests_url.startswith('http'):
-        storage.download_signed_url_to_file(tests_url, temp_archive)
+        storage.download_signed_url_to_filepath(tests_url, temp_archive)
       else:
         storage.copy_file_from(tests_url, temp_archive)
 

--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -480,17 +480,21 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
     shell.create_directory(directory, create_intermediates=True)
     if corpus.backup_url:
       tmpdir = environment.get_value('FUZZ_INPUTS')
-      with tempfile.NamedTemporaryFile(
-          dir=tmpdir, suffix='.zip') as temp_zipfile:
-        try:
-          storage.download_signed_url_to_file(corpus.backup_url,
-                                              temp_zipfile.name)
-          with archive.open(temp_zipfile.name) as reader:
-            reader.extract_all(directory)
-            for member in reader.list_members():
-              self._filenames_to_delete_urls_mapping[member.name] = None
-        except RuntimeError:
-          logs.warning('Couldn\'t download corpus backup')
+      # To avoid opening the file multiple times on Windows, manually close the
+      # file after write and delete it after extraction.
+      temp_zipfile = tempfile.NamedTemporaryFile(
+          dir=tmpdir, suffix='.zip', delete=False)
+      try:
+        storage.download_signed_url_to_file(corpus.backup_url, temp_zipfile)
+        temp_zipfile.close()
+        with archive.open(temp_zipfile.name) as reader:
+          reader.extract_all(directory)
+          for member in reader.list_members():
+            self._filenames_to_delete_urls_mapping[member.name] = None
+      except RuntimeError:
+        logs.warning('Couldn\'t download corpus backup')
+      finally:
+        os.unlink(temp_zipfile.name)
 
     results = storage.download_signed_urls(corpus.corpus_urls, directory)
     fails = 0

--- a/src/clusterfuzz/_internal/google_cloud_utils/storage.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/storage.py
@@ -18,6 +18,7 @@ import collections
 from concurrent import futures
 import copy
 import datetime
+import io
 import json
 import os
 import shutil
@@ -1302,12 +1303,16 @@ def str_to_bytes(data):
   return bytes(data, 'utf-8')
 
 
-def download_signed_url_to_file(url, filepath):
-  contents = download_signed_url(url)
+def download_signed_url_to_filepath(url, filepath: str):
   os.makedirs(os.path.dirname(filepath), exist_ok=True)
   with open(filepath, 'wb') as fp:
-    fp.write(contents)
-  return filepath
+    download_signed_url_to_file(url, fp)
+    return filepath
+
+
+def download_signed_url_to_file(url, file: io.IOBase):
+  contents = download_signed_url(url)
+  file.write(contents)
 
 
 def get_signed_upload_url(remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES):
@@ -1327,7 +1332,7 @@ def get_signed_download_url(remote_path, minutes=SIGNED_URL_EXPIRATION_MINUTES):
 def _error_tolerant_download_signed_url_to_file(url_and_path) -> bool:
   url, path = url_and_path
   try:
-    download_signed_url_to_file(url, path)
+    download_signed_url_to_filepath(url, path)
     return True
   except Exception:
     return False


### PR DESCRIPTION
It is fine for Linux and Mac bots to create multiple file objects to the same on-disk file but Windows does not allow this and throws a PermissionError for any attempts to open a file that is already opened.

This slightly refactors `src/clusterfuzz/_internal/google_cloud_utils/storage.py` (and its callers) to allow passing a filepath or file object when downloading from signed URLs and changes `src/clusterfuzz/_internal/fuzzing/corpus_manager.py` to use the file-based method.

Bug: crbug.com/529346593