### PR TITLE
Hide Chromium trusted job warning on non-Chromium instances

### DIFF
--- a/src/appengine/private/components/upload-testcase/upload-form-simplified.html
+++ b/src/appengine/private/components/upload-testcase/upload-form-simplified.html
@@ -145,13 +145,15 @@
           </div>
         </template>
       </div>
-      <div class="warning">
-      <span><strong>WARNING</strong>: ClusterFuzz only partially supports untrusted workloads.<br></span>
-        ClusterFuzz supports untrusted workloads when the platform is Linux<br>
-        If your upload does not use Linux as the platform, Clusterfuzz will treat the input testcase as trusted,
-        and therefore run with privileged jobs. Only upload this testcase if you trust it enough to run on your own machine.<br>
-        To confirm this testcase is trusted, you must fill out the extra field confirming so.
-      </div>
+      <template is="dom-if" if="[[fieldValues.isChromium]]">
+        <div class="warning">
+        <span><strong>WARNING</strong>: ClusterFuzz only partially supports untrusted workloads.<br></span>
+          ClusterFuzz supports untrusted workloads when the platform is Linux<br>
+          If your upload does not use Linux as the platform, Clusterfuzz will treat the input testcase as trusted,
+          and therefore run with privileged jobs. Only upload this testcase if you trust it enough to run on your own machine.<br>
+          To confirm this testcase is trusted, you must fill out the extra field confirming so.
+        </div>
+      </template>
       <div class="inline wide">
         <paper-dropdown-menu
             class="dropdown-filter"

--- a/src/appengine/private/components/upload-testcase/upload-form.html
+++ b/src/appengine/private/components/upload-testcase/upload-form.html
@@ -192,13 +192,15 @@
           </paper-dropdown-menu>
         </template>
       </div>
-      <div class="warning">
-      <span><strong>WARNING</strong>: ClusterFuzz only partially supports untrusted workloads.<br></span>
-        ClusterFuzz supports untrusted workloads when the platform is Linux<br>
-        If your upload does not use Linux as the platform, Clusterfuzz will treat the input testcase as trusted,
-        and therefore run with privileged jobs. Only upload this testcase if you trust it enough to run on your own machine.<br>
-        To confirm this testcase is trusted, you must fill out the extra field confirming so.
-      </div>
+      <template is="dom-if" if="[[fieldValues.isChromium]]">
+        <div class="warning">
+        <span><strong>WARNING</strong>: ClusterFuzz only partially supports untrusted workloads.<br></span>
+          ClusterFuzz supports untrusted workloads when the platform is Linux<br>
+          If your upload does not use Linux as the platform, Clusterfuzz will treat the input testcase as trusted,
+          and therefore run with privileged jobs. Only upload this testcase if you trust it enough to run on your own machine.<br>
+          To confirm this testcase is trusted, you must fill out the extra field confirming so.
+        </div>
+      </template>
       <div class="inline narrow">
         <template is="dom-if" if="[[shouldShowIssueField()]]">
           <paper-input value="{{uploadParams.issue}}" label="Issue ID (optional)" title="Issue ID in the associated project's tracker to update for this test case."></paper-input>


### PR DESCRIPTION
This PR resolves a bug where the "untrusted workloads" warning banner was showing up unconditionally on non-Chromium instances of ClusterFuzz (such as OSS-Fuzz), despite the fact that the actual "trusted agreement" input field is correctly hidden.

### Changes
* **`src/appengine/private/components/upload-testcase/upload-form.html`**:  Wrapped the warning block in a `<template is="dom-if" if="[[fieldValues.isChromium]]">` block so that it is only rendered on Chromium instances. 
* **`src/appengine/private/components/upload-testcase/upload-form-simplified.html`**: Similarly wrapped the warning block in a `<template is="dom-if" if="[[fieldValues.isChromium]]">` block for consistency.

Related: b/390151007