### PR TITLE
Check for string before decoding db_config value

### DIFF
--- a/src/clusterfuzz/_internal/config/db_config.py
+++ b/src/clusterfuzz/_internal/config/db_config.py
@@ -38,7 +38,7 @@ def get_value(key):
   value = config.__getattribute__(key)
 
   # Decode if the value is base64 encoded.
-  if value.startswith(BASE64_MARKER):
+  if isinstance(value, str) and value.startswith(BASE64_MARKER):
     return base64.b64decode(value[len(BASE64_MARKER):])
 
   return value


### PR DESCRIPTION
`db_config.get_value` assumes that the value is a string, since we blindly call `startswith` on the value. This breaks for boolean flags, such as `use_android_build_api_v4`.

Resulting in the error 
```
AttributeError: 'bool' object has no attribute 'startswith'
```

This PR checks that the config value is actually a string before attempting to decode it as such.


## Testing
I verified this works with the default value, `False` and `True` by running a script to call `set_value` and `get_value` locally with the dev config.

This wasn't caught before because the code calling `fetch_artifact` requires android bots for testing, and I didn't realize that the flag mechanism we were using `db_config` was only used for strings/text previously, and not booleans

Unfortunately, I couldn't set a non boolean, but falsey value like empty string `''`, to get around this bug without a prod release. The underlying data type for [use_android_build_api_v4](https://github.com/google/clusterfuzz/blob/be0597ad4c21deb720ae7b01e37d859c5f635a3d/src/clusterfuzz/_internal/datastore/data_types.py#L888) is validated as a boolean.