### PR TITLE
[Swarming] Decouples linux from android_emulator fuzzing

### DIFF
--- a/configs/test/swarming/swarming.yaml
+++ b/configs/test/swarming/swarming.yaml
@@ -30,6 +30,26 @@ mapping:
     expiration_secs: 86400
     execution_timeout_secs: 86400
     docker_image: 'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
+  ANDROID_EMULATOR:
+    priority: 1
+    command: 
+      - 'luci-auth'
+      - 'context'
+      - '--'
+      - './linux_entry_point.sh'
+    cas_input_root:
+      cas_instance: 'projects/server-name/instances/instance_name'
+      digest:
+        hash: 'linux_entry_point_archive_hash'
+        size_bytes: 1234
+    service_account_email: test-clusterfuzz-service-account-email
+    preemptible: false
+    expiration_secs: 86400
+    execution_timeout_secs: 86400
+    docker_image: 'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
+    env:
+      - key: OS_OVERRIDE
+        value: ANDROID_EMULATOR
   MAC:
     priority: 1
     command:

--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -221,7 +221,7 @@ def _get_jobs_for_platforms(platforms: list[str]) -> list[data_types.Job]:
 
 def _get_swarming_jobs():
   """Returns all jobs that have swarming environment variables."""
-  jobs = _get_jobs_for_platforms(['ANDROID', 'LINUX'])
+  jobs = _get_jobs_for_platforms(['ANDROID', 'LINUX', 'ANDROID_EMULATOR'])
   return [
       job for job in jobs
       if swarming.has_swarming_env_vars(job.get_environment())

--- a/src/clusterfuzz/_internal/platforms/android/battery.py
+++ b/src/clusterfuzz/_internal/platforms/android/battery.py
@@ -60,7 +60,8 @@ def wait_until_good_state():
   """Check battery and make sure it is charged beyond minimum level and
   temperature thresholds."""
   # Battery levels are not applicable on GCE.
-  if environment.is_android_cuttlefish() or settings.is_automotive():
+  if (environment.is_android_cuttlefish() or
+      environment.is_android_emulator() or settings.is_automotive()):
     return
 
   # Make sure device is online.

--- a/src/clusterfuzz/_internal/swarming/__init__.py
+++ b/src/clusterfuzz/_internal/swarming/__init__.py
@@ -91,7 +91,10 @@ def _get_task_dimensions(job: data_types.Job, platform_specific_dimensions: list
     return []
 
   unique_dimensions = {}
-  unique_dimensions['os'] = str(job.platform).capitalize()
+  if job.platform == 'ANDROID_EMULATOR':
+    unique_dimensions['os'] = 'Linux'
+  else:
+    unique_dimensions['os'] = str(job.platform).capitalize()
   unique_dimensions['pool'] = swarming_config.get('swarming_pool')
 
   for dimension in platform_specific_dimensions:

--- a/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
+++ b/src/clusterfuzz/_internal/tests/core/swarming/swarming_test.py
@@ -291,6 +291,70 @@ class SwarmingTest(unittest.TestCase):
         ])
     self.assertEqual(spec, expected_spec)
 
+  def test_get_spec_from_config_for_android_emulator(self):
+    """Tests that create_new_task_request overrides dimensions with (os=Linux)
+    and environment with (OS_OVERRIDE=ANDROID_EMULATOR)
+    for ANDROID_EMULATOR platform tasks."""
+    job = data_types.Job(
+        name='libfuzzer_chrome_asan', platform='ANDROID_EMULATOR')
+    job.put()
+    spec = swarming.create_new_task_request('corpus_pruning', job.name,
+                                            'https://download_url')
+    expected_spec = swarming_pb2.NewTaskRequest(
+        name='task_name',
+        priority=1,
+        realm='realm-name',
+        service_account='test-clusterfuzz-service-account-email',
+        task_slices=[
+            swarming_pb2.TaskSlice(
+                expiration_secs=86400,
+                properties=swarming_pb2.TaskProperties(
+                    command=[
+                        'luci-auth', 'context', '--', './linux_entry_point.sh'
+                    ],
+                    dimensions=[
+                        swarming_pb2.StringPair(key='os', value='Linux'),
+                        swarming_pb2.StringPair(key='pool', value='pool-name')
+                    ],
+                    cipd_input=swarming_pb2.CipdInput(),  # pylint: disable=no-member
+                    cas_input_root=swarming_pb2.CASReference(
+                        cas_instance=
+                        'projects/server-name/instances/instance_name',
+                        digest=swarming_pb2.Digest(
+                            hash='linux_entry_point_archive_hash',
+                            size_bytes=1234)),
+                    execution_timeout_secs=86400,
+                    env=[
+                        swarming_pb2.StringPair(
+                            key='DOCKER_IMAGE',
+                            value=
+                            'gcr.io/clusterfuzz-images/base:a2f4dd6-202202070654'
+                        ),
+                        swarming_pb2.StringPair(
+                            key='OS_OVERRIDE', value='ANDROID_EMULATOR'),
+                        swarming_pb2.StringPair(key='UWORKER', value='True'),
+                        swarming_pb2.StringPair(
+                            key='SWARMING_BOT', value='True'),
+                        swarming_pb2.StringPair(key='LOG_TO_GCP', value='True'),
+                        swarming_pb2.StringPair(key='IS_K8S_ENV', value='True'),
+                        swarming_pb2.StringPair(
+                            key='DISABLE_MOUNTS', value='True'),
+                        swarming_pb2.StringPair(
+                            key='LOGGING_CLOUD_PROJECT_ID', value='project_id'),
+                        swarming_pb2.StringPair(
+                            key='DOCKER_ENV_VARS',
+                            value=(
+                                '{"DOCKER_IMAGE": "gcr.io/clusterfuzz-images/'
+                                'base:a2f4dd6-202202070654", "OS_OVERRIDE": '
+                                '"ANDROID_EMULATOR", "UWORKER": "True", '
+                                '"SWARMING_BOT": "True", "LOG_TO_GCP": "True", '
+                                '"IS_K8S_ENV": "True", "DISABLE_MOUNTS": "True", '
+                                '"LOGGING_CLOUD_PROJECT_ID": "project_id"}')),
+                    ],
+                    secret_bytes='https://download_url'.encode('utf-8')))
+        ])
+    self.assertEqual(spec, expected_spec)
+
   def test_is_swarming_task(self):
     """Tests that is_swarming_task works as expected."""
     job = data_types.Job(


### PR DESCRIPTION
## Overview
This small PR focuses on re enabling linux fuzzing in swarming by decoupling the linux jobs from automatically being treated as android jobs.

Previously we always booted up an al emulator on every single job that reached swarming(as per the config's specs) and we always used the `OS_OVERRIDE:ANDROID` env var, so that clusterfuzz followed the setup/logic decisions of a android device. This had 2 issues:
- Our android jobs have had to set `PLATFORM=LINUX` so that CF could send a swarming request targeting a Linux bot(which contained our emulated devices)
- Thanks to that, our actual Linux Jobs were always overriden to android

## Changes
- When the `job.platform` is android_emulator we override is target swarming bot OS to linux in the swarming request, which is the one that contains the emulator setup logic.
  - When we construct the task request we will still gather the new config specs(see other pr) from the ANDROID_EMULATOR platform
- Added the ANDROID_EMULATOR to the list of jobs that we want to schedule in swarming queues.
- Added the is_android_emulator() method to the battery check.


#### Note
This Pr is dependant of this other config pr
- https://clusterfuzz-config-472119376969.us-central1.sourcemanager.dev/clusterfuzz-testing/clusterfuzz-config/pulls/352/files
Which adds the config specs for android emulator jobs 

## Tests performed 
Since this type of change is more focused on swarming.yaml config changes i tested this by creating a new job using the `ANDROID_EMULATOR` platform and i verified if it was correctly scheduled in a linux swarming bot, and that said bot launched the emulator and also that the fuzzing task executed successfully
See [the logs](https://cloudlogging.app.goo.gl/goynt3MZBS49VTpEA)