### PR TITLE
Use clusterfuzz_manifest.json to set ChromeBuildArchive

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -54,6 +54,10 @@ FUZZ_TARGET_ALLOWLISTED_PREFIXES = [
     'src_root',
 ]
 
+# Manifest file present in Chrome build archives. Specifies the archive
+# schema version along with optional build metadata (e.g., fuzz targets).
+MANIFEST_FILENAME = 'clusterfuzz_manifest.json'
+
 
 class BuildArchive(archive.ArchiveReader):
   """Abstract class for representing a build archive. This is mostly an
@@ -309,7 +313,7 @@ class ChromeBuildArchive(DefaultBuildArchive):
     self._manifest_fuzz_targets = None
     # The manifest may not exist for earlier versions of archives. In this
     # case, default to schema version 0.
-    manifest_path = 'clusterfuzz_manifest.json'
+    manifest_path = MANIFEST_FILENAME
     if not self.file_exists(manifest_path):
       self._archive_schema_version = default_archive_schema_version
       return
@@ -469,12 +473,13 @@ def open_with_reader(reader: archive.ArchiveReader) -> BuildArchive:
   # archive implementation to use.
   # Hopefully, we can search in the archive whether some files are present and
   # give us some hints.
-  # For instance, chrome build archives are embedding `gn.args`. Let's use
-  # this for now.
+  # For instance, chrome build archives are embedding `gn.args` and
+  # `clusterfuzz_manifest.json`. Let's use this for now.
   # Being wrong is no big deal here, because BuildArchive is designed so that
   # we always fall back on default behaviour.
   args_gn_path = os.path.join(reader.root_dir(), 'args.gn')
-  if reader.file_exists(args_gn_path):
+  manifest_path = os.path.join(reader.root_dir(), MANIFEST_FILENAME)
+  if reader.file_exists(args_gn_path) or reader.file_exists(manifest_path):
     return ChromeBuildArchive(reader)
   return DefaultBuildArchive(reader)
 

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -473,7 +473,7 @@ def open_with_reader(reader: archive.ArchiveReader) -> BuildArchive:
   # archive implementation to use.
   # Hopefully, we can search in the archive whether some files are present and
   # give us some hints.
-  # For instance, chrome build archives are embedding `gn.args` and
+  # For instance, chrome build archives contain `args.gn` and/or
   # `clusterfuzz_manifest.json`. Let's use this for now.
   # Being wrong is no big deal here, because BuildArchive is designed so that
   # we always fall back on default behaviour.

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -56,7 +56,7 @@ FUZZ_TARGET_ALLOWLISTED_PREFIXES = [
 
 # Manifest file present in Chrome build archives. Specifies the archive
 # schema version along with optional build metadata (e.g., fuzz targets).
-MANIFEST_FILENAME = 'clusterfuzz_manifest.json'
+CHROME_MANIFEST_FILENAME = 'clusterfuzz_manifest.json'
 
 
 class BuildArchive(archive.ArchiveReader):
@@ -313,7 +313,7 @@ class ChromeBuildArchive(DefaultBuildArchive):
     self._manifest_fuzz_targets = None
     # The manifest may not exist for earlier versions of archives. In this
     # case, default to schema version 0.
-    manifest_path = MANIFEST_FILENAME
+    manifest_path = CHROME_MANIFEST_FILENAME
     if not self.file_exists(manifest_path):
       self._archive_schema_version = default_archive_schema_version
       return
@@ -478,7 +478,7 @@ def open_with_reader(reader: archive.ArchiveReader) -> BuildArchive:
   # Being wrong is no big deal here, because BuildArchive is designed so that
   # we always fall back on default behaviour.
   args_gn_path = os.path.join(reader.root_dir(), 'args.gn')
-  manifest_path = os.path.join(reader.root_dir(), MANIFEST_FILENAME)
+  manifest_path = os.path.join(reader.root_dir(), CHROME_MANIFEST_FILENAME)
   if reader.file_exists(args_gn_path) or reader.file_exists(manifest_path):
     return ChromeBuildArchive(reader)
   return DefaultBuildArchive(reader)

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
@@ -495,3 +495,43 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
         test_archive.get_path_for_target('my_fuzzer'), 'out/build/my_fuzzer')
     # Ensure list_members was never called for fuzz target discovery.
     self.mock_archive_reader.list_members.assert_not_called()
+
+
+class OpenWithReaderTest(unittest.TestCase):
+  """Tests for open_with_reader."""
+
+  def setUp(self):
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.system.archive.ArchiveReader',
+    ])
+    self.mock_archive_reader = self.mock.ArchiveReader.return_value
+    self.mock_archive_reader.root_dir.return_value = ''
+
+  def test_manifest_present(self):
+    """Tests that an archive with clusterfuzz_manifest.json returns ChromeBuildArchive."""
+
+    def _mock_file_exists(path):
+      return path == 'clusterfuzz_manifest.json'
+
+    self.mock_archive_reader.file_exists.side_effect = _mock_file_exists
+    self.mock_archive_reader.open.return_value = io.BytesIO(
+        b'{"archive_schema_version": 1}')
+    build = build_archive.open_with_reader(self.mock_archive_reader)
+    self.assertIsInstance(build, build_archive.ChromeBuildArchive)
+
+  def test_args_gn_present(self):
+    """Tests that an archive with args.gn returns ChromeBuildArchive."""
+
+    def _mock_file_exists(path):
+      return path == 'args.gn'
+
+    self.mock_archive_reader.file_exists.side_effect = _mock_file_exists
+    self.mock_archive_reader.open.return_value = io.BytesIO(b'')
+    build = build_archive.open_with_reader(self.mock_archive_reader)
+    self.assertIsInstance(build, build_archive.ChromeBuildArchive)
+
+  def test_neither_present(self):
+    """Tests that an archive with neither file returns DefaultBuildArchive."""
+    self.mock_archive_reader.file_exists.return_value = False
+    build = build_archive.open_with_reader(self.mock_archive_reader)
+    self.assertIsInstance(build, build_archive.DefaultBuildArchive)


### PR DESCRIPTION
Chrome build archives using archive schema v1 don't have `args.gn` at the root of the zip, so they are run as `DefaultBuildArchive` instead of `ChromeBuildArchive`. This leads to them not utilizing `clusterfuzz_manifest.json` later in the run, and in turn, waste time running `run_*_fuzzer` binaries. 

Adding `clusterfuzz_manifest.json` to the heuristic used to categorize `ChromeBuildArchive` in `open_with_reader()` since only Chrome archives create and include this file. Adding unit tests to help test this section.

Bug: https://crbug.com/507833074