### PR TITLE
[Corpus] Fix stale mapping and respect delete in rsync_from_disk

### DIFF
--- a/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
+++ b/src/clusterfuzz/_internal/fuzzing/corpus_manager.py
@@ -450,9 +450,14 @@ class ProtoFuzzTargetCorpus(FuzzTargetCorpus):
         self._filenames_to_delete_urls_mapping)) or
             len(filenames_to_delete) < 1_000)
 
-    logs.info('Deleting files.')
-    storage.delete_signed_urls(filenames_to_delete)
-    logs.info('Done files.')
+    if delete:
+      logs.info('Deleting files.')
+      storage.delete_signed_urls(filenames_to_delete)
+      logs.info('Done files.')
+      for filename, delete_url in filenames_to_delete_dict.items():
+        if delete_url and filename in self._filenames_to_delete_urls_mapping:
+          del self._filenames_to_delete_urls_mapping[filename]
+
     logs.info(f'Corpus. {results.count(True)} uploaded. '
               f'{len(filenames_to_delete)} deleted. '
               f'{len(self._filenames_to_delete_urls_mapping)} originally.')

--- a/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/fuzzing/corpus_manager_test.py
@@ -481,6 +481,27 @@ class ProtoFuzzTargetCorpusRsyncTest(fake_filesystem_unittest.TestCase):
     self.mock.delete_signed_urls.assert_called_with(
         [self.DELETED_FILE_DELETION_URL])
 
+  def test_rsync_multiple_calls(self):
+    """Tests that multiple rsync_from_disk calls don't try to delete same files."""
+    corpus = corpus_manager.get_fuzz_target_corpus(
+        'libFuzzer', 'fake_fuzzer', include_delete_urls=True)
+    corpus.rsync_to_disk(self.INITIAL_CORPUS_PATH)
+    self.fs.create_file(
+        self.PRESERVED_FILE_PATH_IN_NEW, contents=self.PRESERVED_CONTENTS)
+
+    # First call
+    corpus.rsync_from_disk(self.MINIMIZED_CORPUS_PATH)
+    self.mock.delete_signed_urls.assert_called_with(
+        [self.DELETED_FILE_DELETION_URL])
+
+    # Reset mock
+    self.mock.delete_signed_urls.reset_mock()
+
+    # Second call
+    corpus.rsync_from_disk(self.MINIMIZED_CORPUS_PATH)
+    # Should NOT be called with the deleted file URL again.
+    self.mock.delete_signed_urls.assert_called_with([])
+
 
 class GetProtoCorpusTest(unittest.TestCase):
   """Tests for get_proto_corpus."""


### PR DESCRIPTION
b/530149063

### Problem
`ProtoFuzzTargetCorpus.rsync_from_disk` keeps a stale internal mapping of files to delete. Since the `corpus_pruning` task calls this method twice (once after initial pruning and again after cross-pollination), the second pass attempts to delete the exact same files again, causing a flood of 404 warnings. It was also completely ignoring the `delete` argument.

[Link for logs](https://cloudlogging.app.goo.gl/77M36EVPLVwFMCaE7)

<img width="1232" height="388" alt="image" src="https://github.com/user-attachments/assets/a1626280-ccab-479a-8f36-32c0c92b40c7" />

### Proposed Solution
Update the internal mapping after deletion to remove the files that were just deleted. Also, wrap the deletion logic to respect the `delete` flag.

### Validation
Added a new unit test `test_rsync_multiple_calls` in `corpus_manager_test.py` to confirm that multiple calls don't try to delete the same files.

Also validated in dev environment: those are logs from a `corpus_pruning` task successfully executing without the mentioned warnings.

[Link](cloudlogging.app.goo.gl/xZxPAfDvuom4uFKk6)

<img width="2516" height="590" alt="image" src="https://github.com/user-attachments/assets/1a759b63-fbb7-473f-929b-0eb6e6b4d666" />

### Why weren't these warnings visible before?

The bug was always there but silent. Before switching to threads, we used processes. On Linux, the background thread responsible for flushing logs to Cloud Logging dies in forked child processes. Thus, warnings from child processes (like these 404s) were swallowed. Threads keep execution in the same process, making the warnings visible.

