### PR TITLE
Gracefully shut down Centipede fuzzers

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/constants.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/constants.py
@@ -42,6 +42,7 @@ EXIT_ON_CRASH_FLAGNAME = 'exit_on_crash'
 MAX_LEN_FLAGNAME = 'max_len'
 NUM_RUNS_FLAGNAME = 'num_runs'
 BATCH_SIZE_FLAGNAME = 'batch_size'
+STOP_AFTER_FLAGNAME = 'stop_after'
 
 SYMBOLIZER_PATH_FLAGNAME = 'symbolizer_path'
 SYMBOLIZER_PATH_DEFAULT = '/dev/null'

--- a/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/centipede/engine.py
@@ -320,9 +320,21 @@ class Engine(engine.Engine):
 
     old_corpus_len = shell.get_directory_file_count(options.corpus_dir)
     logs.info(f'Corpus length before fuzzing: {old_corpus_len}')
-    logs.info(f'Launching a fuzzer run with arguments: {options.arguments}')
+
+    # Centipede is the only fuzzing engine to support fuzzing durations so set
+    # that here using the max_time.
+    # Note: Sending a SIGTERM is enough for Centipede to cleanly shut down but
+    # Windows bots can only do the equivalent of SIGKILL and will benefit from
+    # the fuzzing duration flag.
+    args = list(
+        options.arguments) + [f'--{constants.STOP_AFTER_FLAGNAME}={max_time}s']
+
+    logs.info(f'Launching a fuzzer run with arguments: {args}')
     fuzz_result = runner.run_and_wait(
-        additional_args=options.arguments, timeout=timeout)
+        additional_args=args,
+        timeout=timeout,
+        terminate_before_kill=True,
+        terminate_wait_time=_CLEAN_EXIT_SECS)
     log_lines = fuzz_result.output.splitlines()
     fuzz_result.output = Engine.trim_logs(fuzz_result.output)
 
@@ -634,14 +646,20 @@ class Engine(engine.Engine):
     """
     runner = _get_runner(target_path)
     workdir = engine_common.create_temp_fuzzing_dir('workdir')
+    timeout = max_time + _CLEAN_EXIT_SECS
     args = [
         f'--binary={target_path}',
         f'--workdir={workdir}',
         f'--minimize_crash={input_path}',
         f'--num_runs={constants.NUM_RUNS_PER_MINIMIZATION}',
+        f'--{constants.STOP_AFTER_FLAGNAME}={max_time}s',
         '--seed=1',
     ]
-    result = runner.run_and_wait(additional_args=args, timeout=max_time)
+    result = runner.run_and_wait(
+        additional_args=args,
+        timeout=timeout,
+        terminate_before_kill=True,
+        terminate_wait_time=_CLEAN_EXIT_SECS)
     if result.timed_out:
       logs.warning(
           'Testcase minimization timed out.', fuzzer_output=result.output)

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/centipede/centipede_engine_test.py
@@ -228,7 +228,8 @@ class IntegrationTest(unittest.TestCase):
                      timeout_per_input=None,
                      rss_limit=centipede_constants.RSS_LIMIT_MB_DEFAULT,
                      centipede_bin=None,
-                     sanitized_target_dir=None):
+                     sanitized_target_dir=None,
+                     max_time=MAX_TIME):
     """Run Centipede for other unittest."""
     if centipede_bin is None:
       centipede_bin = self.test_paths.centipede
@@ -257,7 +258,7 @@ class IntegrationTest(unittest.TestCase):
 
     options.arguments = arguments.list()
     results = engine_impl.fuzz(target_path, options, self.test_paths.crashes,
-                               MAX_TIME)
+                               max_time)
 
     expected_command = [self.test_paths.centipede]
     expected_args = fuzzer_options.FuzzerArguments(
@@ -278,6 +279,8 @@ class IntegrationTest(unittest.TestCase):
     expected_args[centipede_constants.RSS_LIMIT_MB_FLAGNAME] = rss_limit
 
     expected_command.extend(expected_args.list())
+    expected_command.append(
+        f'--{centipede_constants.STOP_AFTER_FLAGNAME}={max_time}s')
 
     self.compare_arguments(expected_command, results.command)
     return results
@@ -306,7 +309,8 @@ class IntegrationTest(unittest.TestCase):
                             rss_limit=centipede_constants.RSS_LIMIT_MB_DEFAULT,
                             centipede_bin=None,
                             target_name='clusterfuzz_format_target',
-                            sanitized_target_dir=None):
+                            sanitized_target_dir=None,
+                            max_time=MAX_TIME):
     """Fuzzes the target and check if regex matches Centipede's crash log."""
     if centipede_bin is None:
       centipede_bin = self.test_paths.centipede
@@ -315,7 +319,8 @@ class IntegrationTest(unittest.TestCase):
         timeout_per_input=timeout_per_input,
         rss_limit=rss_limit,
         centipede_bin=centipede_bin,
-        sanitized_target_dir=sanitized_target_dir)
+        sanitized_target_dir=sanitized_target_dir,
+        max_time=max_time)
 
     # Check there is one and only one expected crash.
     self.assertEqual(1, len(results.crashes))
@@ -381,7 +386,8 @@ class IntegrationTest(unittest.TestCase):
     self._test_crash_log_regex(
         constants.CENTIPEDE_TIMEOUT_REGEX,
         'slo',
-        timeout_per_input=_TIMEOUT_PER_INPUT_TEST)
+        timeout_per_input=_TIMEOUT_PER_INPUT_TEST,
+        max_time=15)
 
   def test_minimize_corpus(self):
     """Tests minimizing a corpus."""


### PR DESCRIPTION
Currently, Centipede fuzzing sessions are sent a `SIGKILL` after the allotted time has passed, unlike libFuzzer sessions which send a `SIGTERM` and then a `SIGKILL` after 10s if the fuzzing process has not exited. Sending a `SIGKILL` to Centipede fuzzers does not let them update the corpus with the latest batch's data and could have other unintended side effects.

Centipede supports fuzzing durations, so this change passes the duration to the `centipede` binary and also instructs the bot to send `SIGTERM` (which causes Centipede to immediately begin wrapping up the session) before trying to kill the process later if it hasn't already stopped. The only exception to this is Windows where it has to just [jump](https://github.com/google/clusterfuzz/blob/04d37b351397bcd7a62c2e34a0b91c0ec4e5961e/src/clusterfuzz/_internal/system/new_process.py#L87) to process termination.

Bug: 533039107