### PR TITLE
symbolizer: Add success tests and clean up tests

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_symbolizer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_symbolizer_test.py
@@ -268,7 +268,8 @@ class LLVMSymbolizerTest(unittest.TestCase):
     mock_llvm_process.stdin = mock_llvm_stdin
     mock_llvm_process.stdout = mock.Mock()
 
-    # Symbolize the first frame successfully, then return EOF the same way a
+    # Symbolize the first frame successfully by returning a function name,
+    # file name, and a new line. Then return EOF the same way a
     # crashing symbolizer would.
     mock_llvm_process.stdout.readline.side_effect = list(
         SYMBOLIZED_LLVM_FRAMES[:3]) + [b'']

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_symbolizer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_symbolizer_test.py
@@ -19,8 +19,90 @@ from unittest import mock
 
 from clusterfuzz._internal.crash_analysis.stack_parsing import stack_symbolizer
 
-TEST_STACK_TRACE = ("    #0 0x1234 (/lib/foo.so+0x5678)\n"
-                    "    #1 0x5678 (/lib/foo.so+0x9abc)\n")
+TEST_STACK_TRACE = ("    #0 0x0001 (/lib/foo.so+0x1000)\n"
+                    "    #1 0x0002 (/lib/foo.so+0x2000)\n"
+                    "    #2 0x0003 (/lib/foo.so+0x3000)\n")
+
+TEST_STACK_TRACE_INLINE = ("    #0 0x0001 (/lib/foo.so+0x1000)\n"
+                           "    #1 0x0002 (/lib/foo.so+0x2000)\n")
+
+# Expected inputs and outputs for LLVM symbolizer (3 frames).
+UNSYMBOLIZED_LLVM_FRAMES = [
+    b'"/lib/foo.so" 0x1000\n',
+    b'"/lib/foo.so" 0x2000\n',
+    b'"/lib/foo.so" 0x3000\n',
+]
+
+SYMBOLIZED_LLVM_FRAMES = [
+    # Frame 0
+    b'llvm_func0\n',
+    b'llvm_file0:10\n',
+    b'\n',
+    # Frame 1
+    b'llvm_func1\n',
+    b'llvm_file1:20\n',
+    b'\n',
+    # Frame 2
+    b'llvm_func2\n',
+    b'llvm_file2:30\n',
+    b'\n'
+]
+
+# Expected inputs and outputs for addr2line symbolizer (3 frames).
+UNSYMBOLIZED_ADDR2LINE_FRAMES = [
+    b'0x1000\n',
+    b'0x2000\n',
+    b'0x3000\n',
+]
+
+SYMBOLIZED_ADDR2LINE_FRAMES = [
+    # Frame 0
+    b'addr2line_func0\n',
+    b'addr2line_file0:1\n',
+    # Frame 1
+    b'addr2line_func1\n',
+    b'addr2line_file1:1\n',
+    # Frame 2
+    b'addr2line_func2\n',
+    b'addr2line_file2:1\n',
+]
+
+# In practice, both symbolizers format their output the same way, but we use
+# distinct mocked function names (e.g. 'llvm_func0' vs 'addr2line_func0')
+# in our tests to verify which symbolizer was actually used.
+EXPECTED_LLVM_OUTPUT = ("    #0 0x0001 in llvm_func0 llvm_file0:10\n"
+                        "    #1 0x0002 in llvm_func1 llvm_file1:20\n"
+                        "    #2 0x0003 in llvm_func2 llvm_file2:30\n")
+
+EXPECTED_ADDR2LINE_OUTPUT = (
+    "    #0 0x0001 in addr2line_func0 addr2line_file0:1\n"
+    "    #1 0x0002 in addr2line_func1 addr2line_file1:1\n"
+    "    #2 0x0003 in addr2line_func2 addr2line_file2:1\n")
+
+# Expected inputs and outputs for LLVM inline frames test.
+UNSYMBOLIZED_LLVM_INLINE_FRAMES = [
+    b'"/lib/foo.so" 0x1000\n',
+    b'"/lib/foo.so" 0x2000\n',
+]
+
+SYMBOLIZED_LLVM_INLINE_FRAMES = [
+    # Frame 0 (Inline)
+    b'llvm_inline_func\n',
+    b'llvm_inline_file:5\n',
+    # Frame 0 (Caller)
+    b'llvm_caller_func\n',
+    b'llvm_caller_file:10\n',
+    b'\n',
+    # Frame 1
+    b'llvm_func1\n',
+    b'llvm_file1:20\n',
+    b'\n'
+]
+
+EXPECTED_LLVM_INLINE_OUTPUT = (
+    "    #0 0x0001 in llvm_inline_func llvm_inline_file:5\n"
+    "    #1 0x0001 in llvm_caller_func llvm_caller_file:10\n"
+    "    #2 0x0002 in llvm_func1 llvm_file1:20\n")
 
 
 class ChromeDsymHintsTests(unittest.TestCase):
@@ -55,34 +137,141 @@ class ChromeDsymHintsTests(unittest.TestCase):
             '/Content Shell Helper.app/Contents/MacOS/Content Shell Helper'))
 
 
-class LLVMSymbolizerCrashTest(unittest.TestCase):
-  """Tests handling of llvm-symbolizer crashes."""
+class LLVMSymbolizerTest(unittest.TestCase):
+  """Tests for llvm-symbolizer."""
 
-  def _mock_addr2line(self):
-    """Mocks a working addr2line binary symbolizing TEST_STACK_TRACE."""
-    mock_addr2line_stdin = mock.Mock()
-    mock_addr2line_process = mock.Mock()
-    mock_addr2line_process.stdin = mock_addr2line_stdin
-    mock_addr2line_process.stdout = mock.Mock()
-    mock_addr2line_process.stdout.readline.side_effect = [
-        b'mock_func0\n', b'mock_file0:1\n', b'mock_func1\n', b'mock_file1:1\n'
-    ]
-    mock_addr2line_process.poll.return_value = 0
-    return mock_addr2line_process
+  def setUp(self):
+    super().setUp()
+    get_llvm_symbolizer_path_patcher = mock.patch(
+        'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path',
+        return_value='llvm-symbolizer')
+    get_llvm_symbolizer_path_patcher.start()
+    self.addCleanup(get_llvm_symbolizer_path_patcher.stop)
 
-  def _mock_llvm_symbolizer(self, return_code=-11, stderr_content=''):
-    """Mocks a llvm-symbolizer that crashes after the first write."""
+    original_exists = os.path.exists
+    exists_patcher = mock.patch(
+        'os.path.exists',
+        side_effect=
+        lambda path: path == 'llvm-symbolizer' or original_exists(path))
+    exists_patcher.start()
+    self.addCleanup(exists_patcher.stop)
+
+  def _get_called_binaries(self, mock_popen):
+    """Returns the list of binary paths called by mock_popen, in order."""
+    # Each call in call_args_list is (args, kwargs).
+    # args[0] is the 'cmd' list, and cmd[0] is the binary path.
+    return [args[0][0] for args, _ in mock_popen.call_args_list]
+
+  def _mock_successful_llvm_process(self):
+    """Mocks a successful llvm-symbolizer process.
+
+    This mock expects to be called with UNSYMBOLIZED_LLVM_FRAMES and returns
+    SYMBOLIZED_LLVM_FRAMES.
+    """
     mock_llvm_stdin = mock.Mock()
-    mock_llvm_stdin.write.side_effect = [
-        None, BrokenPipeError(32, 'Broken pipe')
-    ]
-    mock_llvm_stdin.flush.side_effect = BrokenPipeError(32, 'Broken pipe')
-    mock_llvm_stdin.close.side_effect = BrokenPipeError(32, 'Broken pipe')
+    num_writes = 0
+
+    def write_side_effect(data):
+      nonlocal num_writes
+      self.assertEqual(UNSYMBOLIZED_LLVM_FRAMES[num_writes], data)
+      num_writes += 1
+
+    mock_llvm_stdin.write.side_effect = write_side_effect
 
     mock_llvm_process = mock.Mock()
     mock_llvm_process.stdin = mock_llvm_stdin
     mock_llvm_process.stdout = mock.Mock()
-    mock_llvm_process.stdout.readline.return_value = b''
+    mock_llvm_process.stdout.readline.side_effect = list(SYMBOLIZED_LLVM_FRAMES)
+    mock_llvm_process.stderr = mock.Mock()
+    mock_llvm_process.stderr.readline.return_value = b''
+    # return None to indicate the process is still running.
+    mock_llvm_process.poll.return_value = None
+
+    return mock_llvm_process
+
+  def _mock_llvm_inline_process(self):
+    """Mocks an llvm-symbolizer process returning inline frames.
+
+    This mock expects to be called with UNSYMBOLIZED_LLVM_INLINE_FRAMES and
+    returns SYMBOLIZED_LLVM_INLINE_FRAMES.
+    """
+    mock_llvm_stdin = mock.Mock()
+    num_writes = 0
+
+    def write_side_effect(data):
+      nonlocal num_writes
+      self.assertEqual(UNSYMBOLIZED_LLVM_INLINE_FRAMES[num_writes], data)
+      num_writes += 1
+
+    mock_llvm_stdin.write.side_effect = write_side_effect
+
+    mock_llvm_process = mock.Mock()
+    mock_llvm_process.stdin = mock_llvm_stdin
+    mock_llvm_process.stdout = mock.Mock()
+    mock_llvm_process.stdout.readline.side_effect = list(
+        SYMBOLIZED_LLVM_INLINE_FRAMES)
+    mock_llvm_process.stderr = mock.Mock()
+    mock_llvm_process.stderr.readline.return_value = b''
+    # return None to indicate the process is still running.
+    mock_llvm_process.poll.return_value = None
+
+    return mock_llvm_process
+
+  def _mock_addr2line_process(self, starting_frame=0):
+    """Mocks a working addr2line process.
+
+    This mock expects to be called with UNSYMBOLIZED_ADDR2LINE_FRAMES and
+    returns SYMBOLIZED_ADDR2LINE_FRAMES.
+    """
+    mock_addr2line_stdin = mock.Mock()
+    num_writes = starting_frame
+
+    def write_side_effect(data):
+      nonlocal num_writes
+      self.assertEqual(UNSYMBOLIZED_ADDR2LINE_FRAMES[num_writes], data)
+      num_writes += 1
+
+    mock_addr2line_stdin.write.side_effect = write_side_effect
+
+    mock_addr2line_process = mock.Mock()
+    mock_addr2line_process.stdin = mock_addr2line_stdin
+    mock_addr2line_process.stdout = mock.Mock()
+    start_readline_index = starting_frame * 2
+    mock_addr2line_process.stdout.readline.side_effect = list(
+        SYMBOLIZED_ADDR2LINE_FRAMES[start_readline_index:])
+    mock_addr2line_process.poll.return_value = 0
+    return mock_addr2line_process
+
+  def _mock_crashing_llvm_symbolizer(self, return_code=-11, stderr_content=''):
+    """Mocks a llvm-symbolizer that acts as if it crashed when `UNSYMBOLIZED_LLVM_FRAMES[1]` is written to it."""
+    mock_llvm_stdin = mock.Mock()
+    mock_llvm_stdin.close.side_effect = BrokenPipeError(32, 'Broken pipe')
+
+    crashed = False
+
+    def write_side_effect(data):
+      nonlocal crashed
+      if data == UNSYMBOLIZED_LLVM_FRAMES[1]:
+        crashed = True
+
+    mock_llvm_stdin.write.side_effect = write_side_effect
+
+    def flush_side_effect():
+      if crashed:
+        raise BrokenPipeError(32, 'Broken pipe')
+
+    mock_llvm_stdin.flush.side_effect = flush_side_effect
+
+    mock_llvm_process = mock.Mock()
+    # poll() returns exit code after we crash
+    mock_llvm_process.poll.side_effect = lambda: return_code if crashed else None
+    mock_llvm_process.stdin = mock_llvm_stdin
+    mock_llvm_process.stdout = mock.Mock()
+
+    # Symbolize the first frame successfully, then return EOF the same way a
+    # crashing symbolizer would.
+    mock_llvm_process.stdout.readline.side_effect = list(
+        SYMBOLIZED_LLVM_FRAMES[:3]) + [b'']
     mock_llvm_process.stderr = mock.Mock()
 
     if stderr_content:
@@ -94,124 +283,120 @@ class LLVMSymbolizerCrashTest(unittest.TestCase):
     else:
       mock_llvm_process.stderr.readline.return_value = b''
 
-    mock_llvm_process.poll.return_value = return_code
     return mock_llvm_process
 
   def _check_logging(self, return_code, stderr_content, expected_log_msgs,
-                     mock_exists, mock_popen, mock_get_symbolizer_path,
-                     mock_log_error):
+                     mock_popen, mock_log_error):
     """Helper to check logging behavior under different crash scenarios."""
-    mock_get_symbolizer_path.return_value = '/path/to/llvm-symbolizer'
-    mock_exists.side_effect = lambda path: path == '/path/to/llvm-symbolizer' or os.path.exists(path)
 
     # Set up mock for llvm-symbolizer process that exits after the first write.
-    mock_llvm_process = self._mock_llvm_symbolizer(
+    mock_llvm_process = self._mock_crashing_llvm_symbolizer(
         return_code=return_code, stderr_content=stderr_content)
 
     # Setup fallback addr2line symbolizer.
-    mock_addr2line_process = self._mock_addr2line()
+    mock_addr2line_process = self._mock_addr2line_process(starting_frame=1)
 
-    def popen_side_effect(cmd, *_args, **_kwargs):
-      if 'llvm-symbolizer' in cmd[0]:
-        return mock_llvm_process
-      if 'addr2line' in cmd[0]:
-        return mock_addr2line_process
-      raise AssertionError(f'Unexpected Popen call: {cmd}')
-
-    mock_popen.side_effect = popen_side_effect
+    mock_popen.side_effect = [mock_llvm_process, mock_addr2line_process]
 
     stack_symbolizer.symbolize_stacktrace(TEST_STACK_TRACE)
 
     expected_calls = [mock.call(msg) for msg in expected_log_msgs]
     mock_log_error.assert_has_calls(expected_calls)
 
-  @mock.patch(
-      'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path')
+    # Verify Popen calls
+    self.assertEqual(['llvm-symbolizer', 'addr2line'],
+                     self._get_called_binaries(mock_popen))
+
   @mock.patch('subprocess.Popen')
   @mock.patch('sys.platform', 'linux')
-  @mock.patch('os.path.exists')
-  def test_symbolizer_crash(self, mock_exists, mock_popen,
-                            mock_get_symbolizer_path):
+  def test_successful_llvm_symbolization(self, mock_popen):
+    """Test successful symbolization using llvm-symbolizer."""
+    mock_successful_llvm_process = self._mock_successful_llvm_process()
+    mock_popen.return_value = mock_successful_llvm_process
+
+    actual_output = stack_symbolizer.symbolize_stacktrace(TEST_STACK_TRACE)
+    self.assertEqual(EXPECTED_LLVM_OUTPUT, actual_output)
+
+    # Verify Popen calls
+    self.assertEqual(['llvm-symbolizer'], self._get_called_binaries(mock_popen))
+
+  @mock.patch('subprocess.Popen')
+  @mock.patch('sys.platform', 'linux')
+  def test_llvm_inline_frames(self, mock_popen):
+    """Test that llvm-symbolizer inline frames are correctly parsed and numbered."""
+    mock_llvm_process = self._mock_llvm_inline_process()
+    mock_popen.return_value = mock_llvm_process
+
+    actual_output = stack_symbolizer.symbolize_stacktrace(
+        TEST_STACK_TRACE_INLINE)
+    self.assertEqual(EXPECTED_LLVM_INLINE_OUTPUT, actual_output)
+
+    # Verify Popen calls
+    self.assertEqual(['llvm-symbolizer'], self._get_called_binaries(mock_popen))
+
+  @mock.patch('subprocess.Popen')
+  @mock.patch('sys.platform', 'linux')
+  def test_symbolizer_crash(self, mock_popen):
     """Test that a crash in llvm-symbolizer is handled and falls back to system symbolizer."""
-    mock_get_symbolizer_path.return_value = '/path/to/llvm-symbolizer'
-    mock_exists.side_effect = lambda path: path == '/path/to/llvm-symbolizer' or os.path.exists(path)
 
     # Set up mock for llvm-symbolizer process (crashes with SIGSEGV)
-    mock_llvm_process = self._mock_llvm_symbolizer(return_code=-11)
+    mock_llvm_process = self._mock_crashing_llvm_symbolizer(return_code=-11)
 
     # Set up mock for addr2line process (fallback)
-    mock_addr2line_process = self._mock_addr2line()
+    mock_addr2line_process = self._mock_addr2line_process(starting_frame=1)
 
-    def popen_side_effect(cmd, *_args, **_kwargs):
-      if 'llvm-symbolizer' in cmd[0]:
-        return mock_llvm_process
-      if 'addr2line' in cmd[0]:
-        return mock_addr2line_process
-      raise AssertionError(f'Unexpected Popen call: {cmd}')
+    mock_popen.side_effect = [mock_llvm_process, mock_addr2line_process]
 
-    mock_popen.side_effect = popen_side_effect
-
-    expected_output = ("    #0 0x1234 in mock_func0 mock_file0:1\n"
-                       "    #1 0x5678 in mock_func1 mock_file1:1\n")
     actual_output = stack_symbolizer.symbolize_stacktrace(TEST_STACK_TRACE)
+
+    # Frame 0 is symbolized by LLVM, Frame 1 & 2 fallback to addr2line
+    expected_output = ("    #0 0x0001 in llvm_func0 llvm_file0:10\n"
+                       "    #1 0x0002 in addr2line_func1 addr2line_file1:1\n"
+                       "    #2 0x0003 in addr2line_func2 addr2line_file2:1\n")
     self.assertEqual(expected_output, actual_output)
 
+    # Verify Popen calls
+    self.assertEqual(['llvm-symbolizer', 'addr2line'],
+                     self._get_called_binaries(mock_popen))
+
   @mock.patch('clusterfuzz._internal.metrics.logs.error')
-  @mock.patch(
-      'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path')
   @mock.patch('subprocess.Popen')
   @mock.patch('sys.platform', 'linux')
-  @mock.patch('os.path.exists')
-  def test_return_code_neg11_no_stderr(
-      self, mock_exists, mock_popen, mock_get_symbolizer_path, mock_log_error):
+  def test_return_code_neg11_no_stderr(self, mock_popen, mock_log_error):
     self._check_logging(
         return_code=-11,
         stderr_content='',
         expected_log_msgs=[
-            'Symbolization using llvm-symbolizer failed (exit code -11) for: ""/lib/foo.so" 0x5678".',
-            'Symbolization using llvm-symbolizer failed (exit code -11) for: ""/lib/foo.so" 0x9abc".'
+            'Symbolization using llvm-symbolizer failed (exit code -11) for: ""/lib/foo.so" 0x2000".',
+            'Symbolization using llvm-symbolizer failed (exit code -11) for: ""/lib/foo.so" 0x3000".'
         ],
-        mock_exists=mock_exists,
         mock_popen=mock_popen,
-        mock_get_symbolizer_path=mock_get_symbolizer_path,
         mock_log_error=mock_log_error)
 
   @mock.patch('clusterfuzz._internal.metrics.logs.error')
-  @mock.patch(
-      'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path')
   @mock.patch('subprocess.Popen')
   @mock.patch('sys.platform', 'linux')
-  @mock.patch('os.path.exists')
-  def test_return_code_neg11_with_stderr(
-      self, mock_exists, mock_popen, mock_get_symbolizer_path, mock_log_error):
+  def test_return_code_neg11_with_stderr(self, mock_popen, mock_log_error):
     self._check_logging(
         return_code=-11,
         stderr_content='some error info',
         expected_log_msgs=[
-            'Symbolization using llvm-symbolizer failed (exit code -11) for: ""/lib/foo.so" 0x5678". Stderr: some error info',
-            'Symbolization using llvm-symbolizer failed (exit code -11) for: ""/lib/foo.so" 0x9abc". Stderr: some error info'
+            'Symbolization using llvm-symbolizer failed (exit code -11) for: ""/lib/foo.so" 0x2000". Stderr: some error info',
+            'Symbolization using llvm-symbolizer failed (exit code -11) for: ""/lib/foo.so" 0x3000". Stderr: some error info'
         ],
-        mock_exists=mock_exists,
         mock_popen=mock_popen,
-        mock_get_symbolizer_path=mock_get_symbolizer_path,
         mock_log_error=mock_log_error)
 
   @mock.patch('clusterfuzz._internal.metrics.logs.error')
-  @mock.patch(
-      'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path')
   @mock.patch('subprocess.Popen')
   @mock.patch('sys.platform', 'linux')
-  @mock.patch('os.path.exists')
-  def test_return_code_none_no_stderr(self, mock_exists, mock_popen,
-                                      mock_get_symbolizer_path, mock_log_error):
+  def test_return_code_none_no_stderr(self, mock_popen, mock_log_error):
     self._check_logging(
         return_code=None,
         stderr_content='',
         expected_log_msgs=[
-            'Symbolization using llvm-symbolizer failed for: ""/lib/foo.so" 0x5678".',
-            'Symbolization using llvm-symbolizer failed for: ""/lib/foo.so" 0x9abc".'
+            'Symbolization using llvm-symbolizer failed for: ""/lib/foo.so" 0x2000".',
+            'Symbolization using llvm-symbolizer failed for: ""/lib/foo.so" 0x3000".'
         ],
-        mock_exists=mock_exists,
         mock_popen=mock_popen,
-        mock_get_symbolizer_path=mock_get_symbolizer_path,
         mock_log_error=mock_log_error)


### PR DESCRIPTION
Adds a new test for llvm-symbolizer successfully symbolizing a normal stack trace and one for frames that return multiple frames.

Also refactors the crashing mock to more closely match a real crashing llvm-symbolizer i.e. succeeding for the first frame but crashing when symbolizing the second line.