### PR TITLE
Gracefully handle metadata look up for update_task check for bots off GCE

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/bot/startup/run_bot_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/startup/run_bot_test.py
@@ -172,6 +172,27 @@ class TaskLoopTest(unittest.TestCase):
     self.assertEqual(0, self.mock.process_command.call_count)
 
 
+class UpdateTaskEnabledTest(unittest.TestCase):
+  """Test update_task_enabled check"""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_uworker',
+        'clusterfuzz._internal.google_cloud_utils.compute_metadata.is_gce',
+        'requests.get',
+    ])
+    self.mock.is_uworker.return_value = False
+    self.mock.is_gce.return_value = True
+
+  def test_off_gce(self):
+    """Test that bots off GCE fallback gracefully without triggering requests."""
+    self.mock.is_gce.return_value = False
+
+    self.assertTrue(run_bot.update_task_enabled())
+    # We shouldn't have made a request to the metadata server.
+    self.assertEqual(0, self.mock.get.call_count)
+
+
 class LeaseAllTasksTest(unittest.TestCase):
   """Tests for lease_all_tasks."""
 

--- a/src/clusterfuzz/_internal/tests/core/bot/startup/run_bot_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/startup/run_bot_test.py
@@ -86,16 +86,31 @@ class MonitorTest(unittest.TestCase):
 class TaskLoopTest(unittest.TestCase):
   """Test task_loop."""
 
+  def _setup_metric_mocks(self):
+    """Mock out system queries used to populate tracking metric labels."""
+    helpers.patch(self, [
+        'clusterfuzz._internal.bot.tasks.update_task.get_local_source_revision',
+        'clusterfuzz._internal.system.environment.platform',
+        'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
+        'platform.release',
+    ])
+    self.mock.get_local_source_revision.return_value = 'test-revision'
+    self.mock.platform.return_value = 'test-os'
+    self.mock.release.return_value = 'test-version'
+    self.mock.get_clusterfuzz_release.return_value = 'test-release'
+
   def setUp(self):
     helpers.patch_environ(self)
+    self._setup_metric_mocks()
     helpers.patch(self, [
         'clusterfuzz._internal.base.tasks.get_task',
         'clusterfuzz._internal.bot.tasks.commands.process_command',
         'clusterfuzz._internal.bot.tasks.update_task.run',
-        'clusterfuzz._internal.bot.tasks.update_task.track_revision',
         'python.bot.startup.run_bot.update_task_enabled',
     ])
     self.mock.update_task_enabled.return_value = True
+
+    monitor.metrics_store().reset_for_testing()
 
     self.task = mock.MagicMock()
     self.task.payload.return_value = 'payload'
@@ -112,6 +127,14 @@ class TaskLoopTest(unittest.TestCase):
     self.assertIn('Exception: text', exception)
     self.assertFalse(clean_exit)
     self.assertEqual('payload', payload)
+    self.assertEqual(
+        1,
+        monitoring_metrics.BOT_COUNT.get({
+            'revision': 'test-revision',
+            'os_type': 'test-os',
+            'os_version': 'test-version',
+            'release': 'test-release',
+        }))
 
   def test_max_executions(self):
     """Test that the loop breaks after MAX_TASK_EXECUTIONS iterations."""
@@ -124,6 +147,14 @@ class TaskLoopTest(unittest.TestCase):
     self.assertEqual(3, self.mock.process_command.call_count)
     self.assertTrue(clean_exit)
     self.assertEqual('payload', payload)
+    self.assertEqual(
+        1,
+        monitoring_metrics.BOT_COUNT.get({
+            'revision': 'test-revision',
+            'os_type': 'test-os',
+            'os_version': 'test-version',
+            'release': 'test-release',
+        }))
 
   @mock.patch('clusterfuzz._internal.metrics.logs.log_fatal_and_exit')
   def test_max_executions_invalid(self, mock_log_fatal_and_exit):

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -271,6 +271,10 @@ def update_task_enabled() -> bool:
 
   running_on_batch = bool(environment.is_uworker())
 
+  if not compute_metadata.is_gce():
+    logs.info('Bot was detected to be off GCE, falling back to legacy '
+              'update_task flow.')
+    return not running_on_batch
   try:
     # Construct the full URL for your specific metadata key
     response = requests.get(

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -177,19 +177,22 @@ def task_loop():
     # This caches the current environment on first run. Don't move this.
     environment.reset_environment()
     try:
+      # We need to keep the update task flow for bots managed outside of
+      # terraform.
       if update_task_enabled():
         logs.info("Running update task.")
         # Run regular updates.
         # TODO(metzman): Move this after utask_main execution
         # so that utasks can't be updated on subsequent attempts.
         update_task.run()
-        update_task.track_revision()
       else:
         logs.info(
             "Update task not enabled. Running environment cleanup and platform "
             "init scripts.")
         update_task.prepare_environment_for_new_task()
         update_task.run_platform_init_scripts()
+
+      update_task.track_revision()
 
       if environment.is_uworker():
         # Batch/Swarming tasks only run one at a time.
@@ -259,7 +262,7 @@ def update_task_enabled() -> bool:
 
       This flag will be used to rollout the update_task deprecation
       by disabling it progressively for each instance group through
-      the instance template metadata 
+      the instance template metadata
   """
   metadata_url = ("http://metadata.google.internal/computeMetadata/v1/" +
                   "instance/attributes/")


### PR DESCRIPTION
We are making a bunch of invalid requests to the metadata server when the bot is off GCE. See crbug.com/534369736 for investigation and the corresponding [error group](https://pantheon.corp.google.com/errors/detail/CIb-6vLIioHJaw;time=P30D;locations=global?project=google.com:clusterfuzz&e=-13802955&mods=logs_tg_prod)

This PR checks that the bot can access the metadata server before making a GET request. If it can't it logs the case rather than an error.

Testing
[Metrics in dev](https://pantheon.corp.google.com/monitoring/metrics-explorer;duration=P2D?pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesQuery%22:%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22custom.googleapis.com%2Fbot_count%5C%22%20resource.type%3D%5C%22gce_instance%5C%22%22,%22aggregation%22:%7B%22perSeriesAligner%22:%22ALIGN_MEAN%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%22metric.label.%5C%22os_type%5C%22%22%5D,%22alignmentPeriod%22:%2260s%22%7D%7D%7D,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22,%22minAlignmentPeriod%22:%2260s%22%7D%5D,%22chartOptions%22:%7B%22mode%22:%22COLOR%22,%22displayHorizontal%22:false%7D,%22thresholds%22:%5B%5D,%22yAxis%22:%7B%22scale%22:%22LINEAR%22%7D%7D%7D&project=clusterfuzz-development)
