### PR TITLE
Upload Fuzzer Logs to GCS only if not in a uworker

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1839,7 +1839,7 @@ class FuzzingSession:
         thread = process_handler.get_process()(
             target=testcase_manager.run_testcase_and_return_result_in_queue,
             args=(temp_queue, thread_index, testcase_file_path, gestures,
-                  env_copy, True))
+                  env_copy, not environment.is_uworker()))
 
         try:
           thread.start()


### PR DESCRIPTION
Bug: b/473624472 

## Overview
After reverting [this PR](https://github.com/google/clusterfuzz/pull/5339/changes) `PERMISSION_DENIED` errors started to reappear in CF. Its clear that we can't follow the same approach of doing a short-circuit in the DB calls.
<img width="1861" height="104" alt="image" src="https://github.com/user-attachments/assets/eb438ecb-004d-4f10-a142-dbcd78645253" />


This instance of `PERMISSION_DENIED` errors occurs on `uworkers` that perform the `fuzz` task, in this workflow theres a logic to upload the Fuzzer logs to GCS at the `utask_main` stage. As we know `uworkers` cant access DB nor GCS, so when a `uworker` reaches this code it fails. Now instead of always uploading the Fuzzer logs to GCS, we only upload them if not in a `uworker`, this allows regular bots that perform the fuzz task(pre->main->pos) locally to continue to work. 


## Tests performed
Changes have been in `dev` since Jul-13. Since then error logs related to this instance of `PERMISSION_DENIED` issues have been resolved.
<img width="945" height="67" alt="image" src="https://github.com/user-attachments/assets/0542cfc3-4981-45f1-89ed-6957d5e10a28" />
Note how this error dramatically decreases. Other instances of this error like this one:
<img width="1468" height="105" alt="image" src="https://github.com/user-attachments/assets/ef01199e-3c1a-46eb-8bed-2521098157de" />
Are unrelated to this changes and seem intermittent errors due to external reasons.

## Note:
This PR is the first of 3(maybe 4) PRs to tackle the PERMISSION_DENIED issues