### PR TITLE
process: Adds logs to the timeout timers that terminate processes

### DIFF
--- a/src/clusterfuzz/_internal/system/new_process.py
+++ b/src/clusterfuzz/_internal/system/new_process.py
@@ -84,20 +84,38 @@ def wait_process(process,
   result = ProcessResult()
   is_windows = environment.platform() == 'WINDOWS'
 
+  def create_timeout_timer(interval, function, args):
+    """Helper to create a timer that logs timeout info."""
+    def target():
+      binary_name = os.path.basename(process.command[0])
+      action_fn = args[0]
+      logs.info(
+          f"TIMEOUT: Terminating {binary_name} after {interval} seconds "
+          f"(using {action_fn.__name__})."
+      )
+      function(*args)
+    return threading.Timer(interval, target)
+
   # On Windows, terminate() just calls Win32 API function TerminateProcess()
   # which is equivalent to process kill. So, skip terminate_before_kill.
   if terminate_before_kill and not is_windows:
     first_timeout_function = process.terminate
 
     # Use a second timer to send the process kill.
-    second_timer = threading.Timer(timeout + terminate_wait_time, _end_process,
-                                   [process.kill, result])
+    second_timer = create_timeout_timer(
+        timeout + terminate_wait_time,
+        _end_process,
+        [process.kill, result],
+    )
   else:
     first_timeout_function = process.kill
     second_timer = None
 
-  first_timer = threading.Timer(timeout, _end_process,
-                                [first_timeout_function, result])
+  first_timer = create_timeout_timer(
+      timeout,
+      _end_process,
+      [first_timeout_function, result],
+  )
 
   output = None
   start_time = time.time()

--- a/src/clusterfuzz/_internal/system/new_process.py
+++ b/src/clusterfuzz/_internal/system/new_process.py
@@ -85,7 +85,18 @@ def wait_process(process,
   is_windows = environment.platform() == 'WINDOWS'
 
   def create_timeout_timer(interval, function, args):
-    """Helper to create a timer that logs timeout info."""
+    """Helper to create a timer that logs timeout info.
+
+    This function takes the same arguments as threading.Timer.
+
+    Args:
+      interval: The delay in seconds before the timer action is executed.
+      function: The function to be called when the timer expires.
+      args: The arguments to be passed to the function.
+
+    Returns:
+      A threading.Timer object.
+    """
 
     def target():
       binary_name = os.path.basename(process.command[0])

--- a/src/clusterfuzz/_internal/system/new_process.py
+++ b/src/clusterfuzz/_internal/system/new_process.py
@@ -86,14 +86,14 @@ def wait_process(process,
 
   def create_timeout_timer(interval, function, args):
     """Helper to create a timer that logs timeout info."""
+
     def target():
       binary_name = os.path.basename(process.command[0])
       action_fn = args[0]
-      logs.info(
-          f"TIMEOUT: Terminating {binary_name} after {interval} seconds "
-          f"(using {action_fn.__name__})."
-      )
+      logs.info(f"TIMEOUT: Terminating {binary_name} after {interval} seconds "
+                f"(using {action_fn.__name__}).")
       function(*args)
+
     return threading.Timer(interval, target)
 
   # On Windows, terminate() just calls Win32 API function TerminateProcess()


### PR DESCRIPTION
In https://crbug.com/529865766, we are seeing that corpus files are being deleted after the fuzzing round finishes and during corpus merging. We suspect the FuzzTest wrapper is being sent a SIGTERM signal which doesn't properly propagate to the underlying binary, which continue to fuzz.

This PR changes new_process.py to log when we send SIGTERM and SIGKILL after a timeout.