### PR TITLE
Add --date parameter to load_bigquery_stats job

### DIFF
--- a/src/clusterfuzz/_internal/cron/load_bigquery_stats.py
+++ b/src/clusterfuzz/_internal/cron/load_bigquery_stats.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Cron job used for loading bigquery data."""
 
+import argparse
 from concurrent.futures import ThreadPoolExecutor
 import datetime
 import random
@@ -116,14 +117,13 @@ def _poll_completion(bigquery, project_id, job_id):
   return response
 
 
-def _load_data(fuzzer):
-  """Load yesterday's stats into BigQuery."""
+def _load_data(fuzzer, target_date):
+  """Load stats into BigQuery."""
   bigquery = big_query.get_api_client()
   project_id = utils.get_application_id()
 
-  yesterday = (_utc_now().date() - datetime.timedelta(days=1))
-  date_string = yesterday.strftime('%Y%m%d')
-  timestamp = utils.utc_date_to_timestamp(yesterday)
+  date_string = target_date.strftime('%Y%m%d')
+  timestamp = utils.utc_date_to_timestamp(target_date)
 
   dataset_id = fuzzer_stats.dataset_name(fuzzer)
   if not _create_dataset_if_needed(bigquery, dataset_id):
@@ -193,8 +193,25 @@ def _load_data(fuzzer):
         logs.error(f'Failed to load: {str(e)}')
 
 
-def main():
+def main(argv=None):
   """Load bigquery stats from GCS."""
+  parser = argparse.ArgumentParser(prog='load_bigquery_stats')
+  parser.add_argument(
+      '--date',
+      help=('Date for loading stats (YYYY-MM-DD). Defaults to yesterday '
+            'UTC.'),
+      type=str)
+  args = parser.parse_args(argv if argv is not None else [])
+
+  if args.date:
+    try:
+      target_date = datetime.datetime.strptime(args.date, '%Y-%m-%d').date()
+    except ValueError:
+      parser.error(f'Invalid date format: {args.date}. Expected YYYY-MM-DD.')
+  else:
+    # Default to yesterday.
+    target_date = _utc_now().date() - datetime.timedelta(days=1)
+
   if not big_query.get_bucket():
     logs.error('Loading stats to BigQuery failed: missing bucket name.')
     return False
@@ -205,7 +222,7 @@ def main():
   # as we create the load jobs.
   for fuzzer in list(data_types.Fuzzer.query()):
     logs.info('Loading stats to BigQuery for %s.' % fuzzer.name)
-    thread_pool.submit(_load_data, fuzzer.name)
+    thread_pool.submit(_load_data, fuzzer.name, target_date)
 
   thread_pool.shutdown(wait=True)
   logs.info('Load big query task finished successfully.')

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -207,9 +207,12 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                       'configuration': {
                           'load': {
                               'destinationTable': {
-                                  'projectId': 'test-clusterfuzz',
-                                  'tableId': f'TestcaseRun${expected_date_str}',
-                                  'datasetId': 'fuzzer_stats'
+                                  'projectId':
+                                      'test-clusterfuzz',
+                                  'tableId':
+                                      f'TestcaseRun${expected_date_str}',
+                                  'datasetId':
+                                      'fuzzer_stats'
                               },
                               'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
                               'writeDisposition':
@@ -217,7 +220,8 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                                   if i == 0 else 'WRITE_APPEND',
                               'sourceUris': [
                                   'gs://test-bigquery-bucket/fuzzer/TestcaseRun/'
-                                  f'date/{expected_date_str}/' + prefix + '*.json'
+                                  f'date/{expected_date_str}/' + prefix +
+                                  '*.json'
                               ],
                               'sourceFormat':
                                   'NEWLINE_DELIMITED_JSON',

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -48,10 +48,8 @@ class LoadBigQueryStatsTest(unittest.TestCase):
         },
     }
 
-  def test_execute(self):
-    """Tests executing of cron job."""
-    load_bigquery_stats.main()
-
+  def _assert_load_calls(self, expected_date_str):
+    """Helper method to assert BigQuery dataset, table, and load job API calls."""
     self.mock_bigquery.datasets().insert.assert_has_calls([
         mock.call(
             projectId='test-clusterfuzz',
@@ -108,7 +106,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                           'load': {
                               'destinationTable': {
                                   'projectId': 'test-clusterfuzz',
-                                  'tableId': 'JobRun$20160907',
+                                  'tableId': f'JobRun${expected_date_str}',
                                   'datasetId': 'fuzzer_stats'
                               },
                               'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
@@ -117,7 +115,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                                   if i == 0 else 'WRITE_APPEND',
                               'sourceUris': [
                                   'gs://test-bigquery-bucket/fuzzer/JobRun/date/'
-                                  '20160907/' + prefix + '*.json'
+                                  f'{expected_date_str}/' + prefix + '*.json'
                               ],
                               'sourceFormat':
                                   'NEWLINE_DELIMITED_JSON',
@@ -210,7 +208,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                           'load': {
                               'destinationTable': {
                                   'projectId': 'test-clusterfuzz',
-                                  'tableId': 'TestcaseRun$20160907',
+                                  'tableId': f'TestcaseRun${expected_date_str}',
                                   'datasetId': 'fuzzer_stats'
                               },
                               'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
@@ -219,7 +217,7 @@ class LoadBigQueryStatsTest(unittest.TestCase):
                                   if i == 0 else 'WRITE_APPEND',
                               'sourceUris': [
                                   'gs://test-bigquery-bucket/fuzzer/TestcaseRun/'
-                                  'date/20160907/' + prefix + '*.json'
+                                  f'date/{expected_date_str}/' + prefix + '*.json'
                               ],
                               'sourceFormat':
                                   'NEWLINE_DELIMITED_JSON',
@@ -234,190 +232,13 @@ class LoadBigQueryStatsTest(unittest.TestCase):
           # Otherwise we need to mock two calls to mock.call().execute().__str__()
           # which does not seem to work well.
           any_order=True)
+
+  def test_execute(self):
+    """Tests executing of cron job."""
+    load_bigquery_stats.main()
+    self._assert_load_calls('20160907')
 
   def test_execute_with_date(self):
     """Tests executing of cron job with an explicit date."""
     load_bigquery_stats.main(['--date', '2016-10-15'])
-
-    self.mock_bigquery.datasets().insert.assert_has_calls([
-        mock.call(
-            projectId='test-clusterfuzz',
-            body={
-                'datasetReference': {
-                    'projectId': 'test-clusterfuzz',
-                    'datasetId': 'fuzzer_stats'
-                }
-            }),
-        mock.call().execute()
-    ])
-
-    self.mock_bigquery.tables().insert.assert_has_calls([
-        mock.call(
-            body={
-                'timePartitioning': {
-                    'type': 'DAY'
-                },
-                'tableReference': {
-                    'projectId': 'test-clusterfuzz',
-                    'tableId': 'JobRun',
-                    'datasetId': 'fuzzer_stats',
-                },
-                'schema': fuzzer_stats.JobRun.SCHEMA,
-            },
-            datasetId='fuzzer_stats',
-            projectId='test-clusterfuzz'),
-        mock.call().execute(),
-        mock.call(
-            body={
-                'timePartitioning': {
-                    'type': 'DAY'
-                },
-                'tableReference': {
-                    'projectId': 'test-clusterfuzz',
-                    'tableId': 'TestcaseRun',
-                    'datasetId': 'fuzzer_stats',
-                },
-                'schema': {
-                    'schema': 'schema'
-                },
-            },
-            datasetId='fuzzer_stats',
-            projectId='test-clusterfuzz'),
-        mock.call().execute(),
-    ])
-
-    for i, prefix in enumerate(load_bigquery_stats._HEX_DIGITS):  # pylint: disable=protected-access
-      self.mock_bigquery.jobs().insert.assert_has_calls(
-          [
-              mock.call(
-                  body={
-                      'configuration': {
-                          'load': {
-                              'destinationTable': {
-                                  'projectId': 'test-clusterfuzz',
-                                  'tableId': 'JobRun$20161015',
-                                  'datasetId': 'fuzzer_stats'
-                              },
-                              'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
-                              'writeDisposition':
-                                  'WRITE_TRUNCATE'
-                                  if i == 0 else 'WRITE_APPEND',
-                              'sourceUris': [
-                                  'gs://test-bigquery-bucket/fuzzer/JobRun/date/'
-                                  '20161015/' + prefix + '*.json'
-                              ],
-                              'sourceFormat':
-                                  'NEWLINE_DELIMITED_JSON',
-                              'schema': {
-                                  'fields': [{
-                                      'type': 'INTEGER',
-                                      'name': 'testcases_executed',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'INTEGER',
-                                      'name': 'build_revision',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'INTEGER',
-                                      'name': 'new_crashes',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'STRING',
-                                      'name': 'job',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'FLOAT',
-                                      'name': 'timestamp',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'fields': [{
-                                          'type': 'STRING',
-                                          'name': 'crash_type',
-                                          'mode': 'NULLABLE'
-                                      }, {
-                                          'type': 'BOOLEAN',
-                                          'name': 'is_new',
-                                          'mode': 'NULLABLE'
-                                      }, {
-                                          'type': 'STRING',
-                                          'name': 'crash_state',
-                                          'mode': 'NULLABLE'
-                                      }, {
-                                          'type': 'BOOLEAN',
-                                          'name': 'security_flag',
-                                          'mode': 'NULLABLE'
-                                      }, {
-                                          'type': 'INTEGER',
-                                          'name': 'count',
-                                          'mode': 'NULLABLE'
-                                      }],
-                                      'type':
-                                          'RECORD',
-                                      'name':
-                                          'crashes',
-                                      'mode':
-                                          'REPEATED'
-                                  }, {
-                                      'type': 'INTEGER',
-                                      'name': 'known_crashes',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'STRING',
-                                      'name': 'fuzzer',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'STRING',
-                                      'name': 'kind',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'INTEGER',
-                                      'name': 'testcases_generated',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'INTERVAL',
-                                      'name': 'testcase_generation_duration',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'INTERVAL',
-                                      'name': 'testcase_execution_duration',
-                                      'mode': 'NULLABLE'
-                                  }, {
-                                      'type': 'INTERVAL',
-                                      'name': 'fuzzing_duration',
-                                      'mode': 'NULLABLE'
-                                  }]
-                              },
-                          }
-                      }
-                  },
-                  projectId='test-clusterfuzz'),
-              mock.call(
-                  body={
-                      'configuration': {
-                          'load': {
-                              'destinationTable': {
-                                  'projectId': 'test-clusterfuzz',
-                                  'tableId': 'TestcaseRun$20161015',
-                                  'datasetId': 'fuzzer_stats'
-                              },
-                              'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
-                              'writeDisposition':
-                                  'WRITE_TRUNCATE'
-                                  if i == 0 else 'WRITE_APPEND',
-                              'sourceUris': [
-                                  'gs://test-bigquery-bucket/fuzzer/TestcaseRun/'
-                                  'date/20161015/' + prefix + '*.json'
-                              ],
-                              'sourceFormat':
-                                  'NEWLINE_DELIMITED_JSON',
-                              'schema': {
-                                  'schema': 'schema'
-                              },
-                          }
-                      }
-                  },
-                  projectId='test-clusterfuzz'),
-          ],
-          # Otherwise we need to mock two calls to mock.call().execute().__str__()
-          # which does not seem to work well.
-          any_order=True)
+    self._assert_load_calls('20161015')

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -234,3 +234,190 @@ class LoadBigQueryStatsTest(unittest.TestCase):
           # Otherwise we need to mock two calls to mock.call().execute().__str__()
           # which does not seem to work well.
           any_order=True)
+
+  def test_execute_with_date(self):
+    """Tests executing of cron job with an explicit date."""
+    load_bigquery_stats.main(['--date', '2016-10-15'])
+
+    self.mock_bigquery.datasets().insert.assert_has_calls([
+        mock.call(
+            projectId='test-clusterfuzz',
+            body={
+                'datasetReference': {
+                    'projectId': 'test-clusterfuzz',
+                    'datasetId': 'fuzzer_stats'
+                }
+            }),
+        mock.call().execute()
+    ])
+
+    self.mock_bigquery.tables().insert.assert_has_calls([
+        mock.call(
+            body={
+                'timePartitioning': {
+                    'type': 'DAY'
+                },
+                'tableReference': {
+                    'projectId': 'test-clusterfuzz',
+                    'tableId': 'JobRun',
+                    'datasetId': 'fuzzer_stats',
+                },
+                'schema': fuzzer_stats.JobRun.SCHEMA,
+            },
+            datasetId='fuzzer_stats',
+            projectId='test-clusterfuzz'),
+        mock.call().execute(),
+        mock.call(
+            body={
+                'timePartitioning': {
+                    'type': 'DAY'
+                },
+                'tableReference': {
+                    'projectId': 'test-clusterfuzz',
+                    'tableId': 'TestcaseRun',
+                    'datasetId': 'fuzzer_stats',
+                },
+                'schema': {
+                    'schema': 'schema'
+                },
+            },
+            datasetId='fuzzer_stats',
+            projectId='test-clusterfuzz'),
+        mock.call().execute(),
+    ])
+
+    for i, prefix in enumerate(load_bigquery_stats._HEX_DIGITS):  # pylint: disable=protected-access
+      self.mock_bigquery.jobs().insert.assert_has_calls(
+          [
+              mock.call(
+                  body={
+                      'configuration': {
+                          'load': {
+                              'destinationTable': {
+                                  'projectId': 'test-clusterfuzz',
+                                  'tableId': 'JobRun$20161015',
+                                  'datasetId': 'fuzzer_stats'
+                              },
+                              'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
+                              'writeDisposition':
+                                  'WRITE_TRUNCATE'
+                                  if i == 0 else 'WRITE_APPEND',
+                              'sourceUris': [
+                                  'gs://test-bigquery-bucket/fuzzer/JobRun/date/'
+                                  '20161015/' + prefix + '*.json'
+                              ],
+                              'sourceFormat':
+                                  'NEWLINE_DELIMITED_JSON',
+                              'schema': {
+                                  'fields': [{
+                                      'type': 'INTEGER',
+                                      'name': 'testcases_executed',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'INTEGER',
+                                      'name': 'build_revision',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'INTEGER',
+                                      'name': 'new_crashes',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'STRING',
+                                      'name': 'job',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'FLOAT',
+                                      'name': 'timestamp',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'fields': [{
+                                          'type': 'STRING',
+                                          'name': 'crash_type',
+                                          'mode': 'NULLABLE'
+                                      }, {
+                                          'type': 'BOOLEAN',
+                                          'name': 'is_new',
+                                          'mode': 'NULLABLE'
+                                      }, {
+                                          'type': 'STRING',
+                                          'name': 'crash_state',
+                                          'mode': 'NULLABLE'
+                                      }, {
+                                          'type': 'BOOLEAN',
+                                          'name': 'security_flag',
+                                          'mode': 'NULLABLE'
+                                      }, {
+                                          'type': 'INTEGER',
+                                          'name': 'count',
+                                          'mode': 'NULLABLE'
+                                      }],
+                                      'type':
+                                          'RECORD',
+                                      'name':
+                                          'crashes',
+                                      'mode':
+                                          'REPEATED'
+                                  }, {
+                                      'type': 'INTEGER',
+                                      'name': 'known_crashes',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'STRING',
+                                      'name': 'fuzzer',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'STRING',
+                                      'name': 'kind',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'INTEGER',
+                                      'name': 'testcases_generated',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'INTERVAL',
+                                      'name': 'testcase_generation_duration',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'INTERVAL',
+                                      'name': 'testcase_execution_duration',
+                                      'mode': 'NULLABLE'
+                                  }, {
+                                      'type': 'INTERVAL',
+                                      'name': 'fuzzing_duration',
+                                      'mode': 'NULLABLE'
+                                  }]
+                              },
+                          }
+                      }
+                  },
+                  projectId='test-clusterfuzz'),
+              mock.call(
+                  body={
+                      'configuration': {
+                          'load': {
+                              'destinationTable': {
+                                  'projectId': 'test-clusterfuzz',
+                                  'tableId': 'TestcaseRun$20161015',
+                                  'datasetId': 'fuzzer_stats'
+                              },
+                              'schemaUpdateOptions': ['ALLOW_FIELD_ADDITION',],
+                              'writeDisposition':
+                                  'WRITE_TRUNCATE'
+                                  if i == 0 else 'WRITE_APPEND',
+                              'sourceUris': [
+                                  'gs://test-bigquery-bucket/fuzzer/TestcaseRun/'
+                                  'date/20161015/' + prefix + '*.json'
+                              ],
+                              'sourceFormat':
+                                  'NEWLINE_DELIMITED_JSON',
+                              'schema': {
+                                  'schema': 'schema'
+                              },
+                          }
+                      }
+                  },
+                  projectId='test-clusterfuzz'),
+          ],
+          # Otherwise we need to mock two calls to mock.call().execute().__str__()
+          # which does not seem to work well.
+          any_order=True)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -241,9 +241,8 @@ class LoadBigQueryStatsTest(unittest.TestCase):
   def test_execute(self):
     """Tests executing of cron job without a date argument (defaults to yesterday)."""
     load_bigquery_stats.main()
-    expected_yesterday = (
-        self.mocked_today.date() -
-        datetime.timedelta(days=1)).strftime('%Y%m%d')
+    expected_yesterday = (self.mocked_today.date() -
+                          datetime.timedelta(days=1)).strftime('%Y%m%d')
     self._assert_load_calls(expected_yesterday)
 
   def test_execute_with_date(self):

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/load_bigquery_stats_test.py
@@ -38,7 +38,8 @@ class LoadBigQueryStatsTest(unittest.TestCase):
         'clusterfuzz._internal.cron.load_bigquery_stats._utc_now',
     ])
 
-    self.mock._utc_now.return_value = datetime.datetime(2016, 9, 8)  # pylint: disable=protected-access
+    self.mocked_today = datetime.datetime(2016, 9, 8)
+    self.mock._utc_now.return_value = self.mocked_today  # pylint: disable=protected-access
     self.mock_bigquery = mock.MagicMock()
     self.mock.get_api_client.return_value = self.mock_bigquery
     self.mock.get.return_value = {'schema': 'schema'}
@@ -238,9 +239,12 @@ class LoadBigQueryStatsTest(unittest.TestCase):
           any_order=True)
 
   def test_execute(self):
-    """Tests executing of cron job."""
+    """Tests executing of cron job without a date argument (defaults to yesterday)."""
     load_bigquery_stats.main()
-    self._assert_load_calls('20160907')
+    expected_yesterday = (
+        self.mocked_today.date() -
+        datetime.timedelta(days=1)).strftime('%Y%m%d')
+    self._assert_load_calls(expected_yesterday)
 
   def test_execute_with_date(self):
     """Tests executing of cron job with an explicit date."""


### PR DESCRIPTION
This PR updates `load_bigquery_stats.py` to accept an optional `--date` flag (in `YYYY-MM-DD` format), allowing cluster operators and developers to execute the BigQuery stats loading job against an arbitrary target date (useful for backfilling or re-processing past stats).

### Key Highlights
- **Optional `--date` Flag**: Supports loading stats for a specified date (e.g. `--date 2026-06-20`).
- **Backward Compatible**: Defaults to yesterday's date (`_utc_now().date() - datetime.timedelta(days=1)`), maintaining standard daily cron execution behavior.
- **Design Parity**: Follows the existing command-line argument pattern established in `aggregate_fuzzer_stats.py`.
- **Unit Test Coverage**: Added `test_execute_with_date` to verify that target partition tables (`$YYYYMMDD`) and GCS source URIs (`/date/YYYYMMDD/`) are correctly generated when a custom date is provided.
- **Unit Test Refactoring**: Extracted BigQuery dataset, table, and load job assertions into a shared _assert_load_calls(expected_date_str) helper method to avoid code duplication across default and date-specific test cases.

### Testing Instructions
- **Unit Tests**:
  ```bash
  python butler.py py_unittest -t appengine -p load_bigquery_stats_test.py

- **Unit Tests results**:
<img width="1284" height="156" alt="image" src="https://github.com/user-attachments/assets/9b14734d-39e4-4408-b13f-b115d798a4e0" />
