### PR TITLE
Remove .exe on targets before appending .runtime_deps

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -432,7 +432,12 @@ class ChromeBuildArchive(DefaultBuildArchive):
   def get_target_dependencies(
       self, fuzz_target: str) -> List[archive.ArchiveMemberInfo]:
     target_path = self.get_path_for_target(fuzz_target)
-    deps_file = f'{target_path}.runtime_deps'
+    if not target_path:
+      logs.warning(f'Target path not found for {fuzz_target}')
+      return super().get_target_dependencies(fuzz_target)
+
+    target_name = target_path.removesuffix('.exe')
+    deps_file = f'{target_name}.runtime_deps'
     if not self.file_exists(deps_file):
       logs.warning(f'runtime_deps file not found for {target_path}')
       return super().get_target_dependencies(fuzz_target)

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -436,6 +436,11 @@ class ChromeBuildArchive(DefaultBuildArchive):
       logs.warning(f'Target path not found for {fuzz_target}')
       return super().get_target_dependencies(fuzz_target)
 
+    # On Windows, `target_path` ends in `.exe`, but the Chrome convention is for
+    # `.runtime_deps` files to not include the `.exe` suffix. For example:
+    # ./fuzzer.exe
+    # ./fuzzer.runtime_deps
+    # So the `.exe` suffix must be stripped before appending `.runtime_deps`.
     target_name = target_path.removesuffix('.exe')
     deps_file = f'{target_name}.runtime_deps'
     if not self.file_exists(deps_file):

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
@@ -353,6 +353,33 @@ class ChromeBuildArchiveSelectiveUnpack(unittest.TestCase):
         'out/build/my_fuzzer.dSYM/Contents/Resources/DWARF/some_dependency',
         to_extract)
 
+  def test_exe_target_dependencies(self):
+    """Tests that a target with .exe extension uses .runtime_deps without .exe."""
+    self._set_archive_schema_version(1)
+    deps_entries = self._generate_possible_fuzzer_dependencies('my_fuzzer')
+    deps_files = self._resolve_relative_dependency_paths(deps_entries)
+    archive_files = deps_files + ['out/build/my_fuzzer.exe']
+    self._add_files_to_archive(archive_files)
+    self._generate_runtime_deps(deps_entries)
+    self._declare_fuzzers(['my_fuzzer.exe'])
+    to_extract = self.build.get_target_dependencies('my_fuzzer')
+    to_extract = [f.name for f in to_extract]
+    self.assertCountEqual(to_extract, archive_files)
+
+  def test_exe_target_dependencies_legacy(self):
+    """Tests that a target with .exe extension uses .runtime_deps without .exe
+    under legacy schema."""
+    deps_files = self._generate_possible_fuzzer_dependencies_legacy(
+        '', 'my_fuzzer')
+    needed_files = self._generate_possible_fuzzer_dependencies_legacy(
+        'build/', 'my_fuzzer')
+    self._add_files_to_archive(needed_files)
+    self._generate_runtime_deps(deps_files)
+    self._declare_fuzzers(['my_fuzzer.exe'])
+    to_extract = self.build.get_target_dependencies('my_fuzzer')
+    to_extract = [f.name for f in to_extract]
+    self.assertCountEqual(to_extract, needed_files)
+
 
 class ChromeBuildArchiveManifestTest(unittest.TestCase):
   """Test for reading clusterfuzz_manifest.json for Chrome archives."""


### PR DESCRIPTION
`ChromeBuildArchive`s look at `.runtime_deps` files for respective fuzzers to unpack the paths necessary to run. For Windows, fuzzers have `.exe` file extensions (`fuzzer.exe`), however, the associated `.runtime_deps` file is `fuzzer.runtime_deps`, not `fuzzer.exe.runtime_deps`. Thus, simply appending `.runtime_deps` means the associated `.runtime_deps` file won't be found and we can't reliably extract all the needed runtime dependencies.

Removing `.exe` suffix if it exists before appending `.runtime_deps` to find the correct deps file. Adding unit tests that verify we correctly access `.runtime_deps` file and extract the expected dependencies.

Bug: https://crbug.com/536913420