### PR TITLE
[Android V4 api Migration] Creates Feature Flag

### DIFF
--- a/src/clusterfuzz/_internal/base/feature_flags.py
+++ b/src/clusterfuzz/_internal/base/feature_flags.py
@@ -44,6 +44,7 @@ class FeatureFlags(Enum):
 
   ENABLE_FUZZ_FOR_BOTS = 'enable_fuzz_for_bots'
   STORAGE_THREADED_OPS_FUZZ_TARGETS = 'storage_threaded_ops_fuzz_targets'
+  CALL_ANDROID_API = 'call_android_api'
 
   @property
   def flag(self):

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -25,6 +25,7 @@ from typing import Optional
 import apiclient
 from oauth2client.service_account import ServiceAccountCredentials
 
+from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.config import db_config
 from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import logs
@@ -62,6 +63,14 @@ def _use_v4():
         'Defaulting to False.',
         error=str(e))
     return False
+
+
+def _call_android_api_enabled():
+  """Return True if we should call the Android Build API. Enabled by default."""
+  flag = feature_flags.FeatureFlags.CALL_ANDROID_API.flag
+  if flag is None:
+    return True
+  return flag.enabled
 
 
 def execute_request_with_retries(request):
@@ -332,6 +341,11 @@ def get_stable_build_info():
 
 def get_latest_artifact_info(branch, target, signed=False, stable_build=False):
   """Return latest artifact for a branch and target."""
+  if not _call_android_api_enabled():
+    logs.warning(
+        'Android build API is disabled by feature flag call_android_api.')
+    return None
+
   client = get_client()
   if not client:
     return None
@@ -405,6 +419,11 @@ def get_latest_artifact_info(branch, target, signed=False, stable_build=False):
 
 def get(bid, target, regex, output_directory, output_filename=None):
   """Return artifact for a given build id, target and file regex."""
+  if not _call_android_api_enabled():
+    logs.warning(
+        'Android build API is disabled by feature flag call_android_api.')
+    return None
+
   client = get_client()
   if not client:
     return None

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -31,8 +31,6 @@ from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
 
-from . import adb
-
 # 20 MB default chunk size.
 DEFAULT_CHUNK_SIZE = 20 * 1024 * 1024
 
@@ -281,7 +279,6 @@ def get_artifacts_for_build(client,
   if not artifacts:
     logs.error(f'No artifact found for target {target}, build id {bid}.\n'
                f'request {request_str}, results {results}')
-    adb.bad_state_reached()
 
   return artifacts
 

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -288,7 +288,7 @@ def _get_artifacts_for_build(client,
 
   if not artifacts:
     logs.error(f'No artifact found for target {target}, build id {bid}.\n'
-               f'request {request_str}, results {results}')
+               f'results {results}')
 
   return artifacts
 

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -72,7 +72,13 @@ def _use_v4():
 
 
 def _call_android_api_enabled():
-  """Return True if we should call the Android Build API. Enabled by default."""
+  """Return True if we should call the Android Build API, enabled by default,
+  Disabled always if invoked in a uworker
+  """
+  if environment.is_uworker():
+    logs.info('AndroidBuildAPI access disabled for uworker.')
+    return False
+
   flag = feature_flags.FeatureFlags.CALL_ANDROID_API.flag
   if flag is None:
     return True

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -188,7 +188,7 @@ def flash_to_latest_build_if_needed():
   if not build_info and not has_local_images:
     logs.error(
         'No valid build info available (API may be disabled) and no local '
-        'images found in %s. Bot cannot recover.' % image_directory)
+        f'images found in {image_directory}. Bot cannot recover.')
     adb.bad_state_reached()
 
   instance_id = None

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -85,7 +85,7 @@ def download_latest_build(build_info, image_regexes, image_directory):
       logs.error('Failed to download artifact %s for '
                  'branch %s and target %s.' % (image_file_paths,
                                                build_info['branch'], target))
-      return
+      adb.bad_state_reached()
 
     for file_path in image_file_paths:
       if file_path.endswith('.zip') or file_path.endswith('.tar.gz'):
@@ -99,8 +99,8 @@ def boot_stable_build_cuttlefish(branch, target, image_directory):
       branch, target, stable_build=True)
   if not build_info:
     logs.error('Unable to fetch stable build info for cuttlefish.')
-    return
-  download_latest_build(build_info, FLASH_CUTTLEFISH_REGEXES, image_directory)
+  else:
+    download_latest_build(build_info, FLASH_CUTTLEFISH_REGEXES, image_directory)
   adb.recreate_cuttlefish_device()
   adb.connect_to_cuttlefish_device()
 
@@ -182,12 +182,21 @@ def flash_to_latest_build_if_needed():
   if not build_info:
     logs.error('Unable to fetch information on latest build artifact for '
                'branch %s and target %s.' % (branch, target))
-    return
+
+  has_local_images = os.path.exists(image_directory) and bool(
+      os.listdir(image_directory))
+  if not build_info and not has_local_images:
+    logs.error(
+        'No valid build info available (API may be disabled) and no local '
+        'images found in %s. Bot cannot recover.' % image_directory)
+    adb.bad_state_reached()
 
   instance_id = None
   is_candidate = None
   if environment.is_android_cuttlefish():
-    download_latest_build(build_info, FLASH_CUTTLEFISH_REGEXES, image_directory)
+    if build_info:
+      download_latest_build(build_info, FLASH_CUTTLEFISH_REGEXES,
+                            image_directory)
     adb.recreate_cuttlefish_device()
     adb.connect_to_cuttlefish_device()
     if compute_metadata.is_gce():
@@ -196,7 +205,8 @@ def flash_to_latest_build_if_needed():
       # Determine if the current instance is a candidate.
       is_candidate = utils.get_clusterfuzz_release() == 'candidate'
   else:
-    download_latest_build(build_info, FLASH_IMAGE_REGEXES, image_directory)
+    if build_info:
+      download_latest_build(build_info, FLASH_IMAGE_REGEXES, image_directory)
     # We do one device flash at a time on one host, otherwise we run into
     # failures and device being stuck in a bad state.
     flash_lock_key_name = 'flash:%s' % socket.gethostname()
@@ -239,7 +249,7 @@ def flash_to_latest_build_if_needed():
     if environment.is_android_cuttlefish():
       logs.info('Trying to boot cuttlefish instance using stable build.')
       monitoring_metrics.CF_TIP_BOOT_FAILED_COUNT.increment({
-          'build_id': build_info['bid'],
+          'build_id': build_info['bid'] if build_info else 'unknown',
           'instance_id': instance_id,
           'is_candidate': is_candidate,
           'is_succeeded': False
@@ -252,7 +262,7 @@ def flash_to_latest_build_if_needed():
       logs.error('Unable to find device. Reimaging failed.')
       adb.bad_state_reached()
   monitoring_metrics.CF_TIP_BOOT_FAILED_COUNT.increment({
-      'build_id': build_info['bid'],
+      'build_id': build_info['bid'] if build_info else 'unknown',
       'instance_id': instance_id,
       'is_candidate': is_candidate,
       'is_succeeded': True

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -182,21 +182,12 @@ def flash_to_latest_build_if_needed():
   if not build_info:
     logs.error('Unable to fetch information on latest build artifact for '
                'branch %s and target %s.' % (branch, target))
-
-  has_local_images = os.path.exists(image_directory) and bool(
-      os.listdir(image_directory))
-  if not build_info and not has_local_images:
-    logs.error(
-        'No valid build info available (API may be disabled) and no local '
-        f'images found in {image_directory}. Bot cannot recover.')
-    adb.bad_state_reached()
+    return
 
   instance_id = None
   is_candidate = None
   if environment.is_android_cuttlefish():
-    if build_info:
-      download_latest_build(build_info, FLASH_CUTTLEFISH_REGEXES,
-                            image_directory)
+    download_latest_build(build_info, FLASH_CUTTLEFISH_REGEXES, image_directory)
     adb.recreate_cuttlefish_device()
     adb.connect_to_cuttlefish_device()
     if compute_metadata.is_gce():
@@ -205,8 +196,7 @@ def flash_to_latest_build_if_needed():
       # Determine if the current instance is a candidate.
       is_candidate = utils.get_clusterfuzz_release() == 'candidate'
   else:
-    if build_info:
-      download_latest_build(build_info, FLASH_IMAGE_REGEXES, image_directory)
+    download_latest_build(build_info, FLASH_IMAGE_REGEXES, image_directory)
     # We do one device flash at a time on one host, otherwise we run into
     # failures and device being stuck in a bad state.
     flash_lock_key_name = 'flash:%s' % socket.gethostname()
@@ -249,7 +239,7 @@ def flash_to_latest_build_if_needed():
     if environment.is_android_cuttlefish():
       logs.info('Trying to boot cuttlefish instance using stable build.')
       monitoring_metrics.CF_TIP_BOOT_FAILED_COUNT.increment({
-          'build_id': build_info['bid'] if build_info else 'unknown',
+          'build_id': build_info['bid'],
           'instance_id': instance_id,
           'is_candidate': is_candidate,
           'is_succeeded': False
@@ -262,7 +252,7 @@ def flash_to_latest_build_if_needed():
       logs.error('Unable to find device. Reimaging failed.')
       adb.bad_state_reached()
   monitoring_metrics.CF_TIP_BOOT_FAILED_COUNT.increment({
-      'build_id': build_info['bid'] if build_info else 'unknown',
+      'build_id': build_info['bid'],
       'instance_id': instance_id,
       'is_candidate': is_candidate,
       'is_succeeded': True

--- a/src/clusterfuzz/_internal/platforms/android/flash.py
+++ b/src/clusterfuzz/_internal/platforms/android/flash.py
@@ -97,6 +97,9 @@ def boot_stable_build_cuttlefish(branch, target, image_directory):
   """Boot cuttlefish instance using stable build id fetched from gcs."""
   build_info = fetch_artifact.get_latest_artifact_info(
       branch, target, stable_build=True)
+  if not build_info:
+    logs.error('Unable to fetch stable build info for cuttlefish.')
+    return
   download_latest_build(build_info, FLASH_CUTTLEFISH_REGEXES, image_directory)
   adb.recreate_cuttlefish_device()
   adb.connect_to_cuttlefish_device()

--- a/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
+++ b/src/clusterfuzz/_internal/platforms/android/symbols_downloader.py
@@ -196,13 +196,22 @@ def download_trusty_symbols_if_needed(symbols_directory, app_name, bid):
 
   branch = 'polygon-trusty-whitechapel-master'
   if not bid:
-    bid = fetch_artifact.get_latest_artifact_info(branch, ab_target)['bid']
+    build_info = fetch_artifact.get_latest_artifact_info(branch, ab_target)
+    if not build_info:
+      logs.error(f'Unable to fetch build info for branch {branch} '
+                 f'and target {ab_target}.')
+      return
+    bid = build_info['bid']
 
   artifact_filename = f'{ab_target}-{bid}.syms.zip'
   symbols_archive_path = os.path.join(symbols_directory, artifact_filename)
 
   download_artifact_if_needed(bid, symbols_directory, symbols_archive_path,
                               [ab_target], artifact_filename, None)
+
+  if not os.path.exists(symbols_archive_path):
+    logs.error(f'Unable to locate symbols archive {symbols_archive_path}.')
+    return
 
   with zipfile.ZipFile(symbols_archive_path, 'r') as symbols_zipfile:
     for filepath in symbols_zipfile.namelist():

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/fetch_artifact_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/fetch_artifact_test.py
@@ -18,6 +18,7 @@
 import unittest
 from unittest import mock
 
+from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.platforms.android import fetch_artifact
 from clusterfuzz._internal.tests.test_libs import helpers
 
@@ -132,3 +133,42 @@ class FetchArtifactTest(unittest.TestCase):
     self.assertEqual(result, [])
     self.mock_client.list_artifacts.assert_not_called()
     self.mock_client.buildartifact().list.assert_not_called()
+
+
+class CallAndroidApiEnabledTest(unittest.TestCase):
+  """Tests for _call_android_api_enabled."""
+
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_uworker',
+    ])
+    self.mock.is_uworker.return_value = False
+
+  def test_is_uworker_returns_false(self):
+    self.mock.is_uworker.return_value = True
+    self.assertFalse(fetch_artifact._call_android_api_enabled())
+
+  def test_flag_none_returns_true(self):
+    with mock.patch.object(
+        feature_flags.FeatureFlags, 'flag',
+        new_callable=mock.PropertyMock) as mock_flag:
+      mock_flag.return_value = None
+      self.assertTrue(fetch_artifact._call_android_api_enabled())
+
+  def test_flag_enabled_returns_true(self):
+    mock_flag_obj = mock.MagicMock()
+    mock_flag_obj.enabled = True
+    with mock.patch.object(
+        feature_flags.FeatureFlags, 'flag',
+        new_callable=mock.PropertyMock) as mock_flag:
+      mock_flag.return_value = mock_flag_obj
+      self.assertTrue(fetch_artifact._call_android_api_enabled())
+
+  def test_flag_disabled_returns_false(self):
+    mock_flag_obj = mock.MagicMock()
+    mock_flag_obj.enabled = False
+    with mock.patch.object(
+        feature_flags.FeatureFlags, 'flag',
+        new_callable=mock.PropertyMock) as mock_flag:
+      mock_flag.return_value = mock_flag_obj
+      self.assertFalse(fetch_artifact._call_android_api_enabled())

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/fetch_artifact_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/fetch_artifact_test.py
@@ -29,10 +29,12 @@ class FetchArtifactTest(unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.platforms.android.fetch_artifact._get_client',
         'clusterfuzz._internal.platforms.android.fetch_artifact._use_v4',
+        'clusterfuzz._internal.platforms.android.fetch_artifact._call_android_api_enabled',
         'clusterfuzz._internal.platforms.android.fetch_artifact._execute_request_with_retries',
     ])
     self.mock_client = mock.MagicMock()
     self.mock._get_client.return_value = self.mock_client
+    self.mock._call_android_api_enabled.return_value = True
 
   def test_get_latest_artifact_v4_success(self):
     """Tests get_latest_artifact_info (V4). Expects extraction of {bid, branch, target} when list_builds returns data."""
@@ -112,6 +114,13 @@ class FetchArtifactTest(unittest.TestCase):
   def test_get_latest_artifact_client_auth_failure(self):
     """Tests get_latest_artifact_info exits early and returns None when client auth fails."""
     self.mock._get_client.return_value = None
+
+    result = fetch_artifact.get_latest_artifact_info('branch1', 'target1')
+    self.assertIsNone(result)
+
+  def test_get_latest_artifact_disabled_by_feature_flag(self):
+    """Tests get_latest_artifact_info exits early and returns None when disabled by feature flag."""
+    self.mock._call_android_api_enabled.return_value = False
 
     result = fetch_artifact.get_latest_artifact_info('branch1', 'target1')
     self.assertIsNone(result)


### PR DESCRIPTION
## Overview

As per requested, we created a new feature flag to disable definitely the API build use cases(used trough `fetch_artifact.py`), this feature flag is enabled by default, because that's the current API & ClusterFuzz workflow.

But can be disabled by adding the feature flag to the DB and marking it as enabled=false.

## Changes
- Creates new feature_flag, and enables it by default in `fetch_artifact.py`
  - Logs warnings when the feature flag is disabled in `fetch_artifact.py`
- Safely exists the related methods in `symbols_downloader` and `flash.py` which consume the `fetch_artifact.py`
- Moved up the `adb.bad_state_reach()` method from the `fetch_artifact.py` module to its callers, this way we can now handle better the None values and raised errors from the API being turned off by the feature flag.

## Tests
After the initial tests in the PR parents, i tested this changes once more in dev(including all 3 prs), looking specifically for `utils.fetch_url` or errors inherent to the return value from this method. Basically since my changes landed in dev the following error groups where seen:
<img width="1735" height="1240" alt="image" src="https://github.com/user-attachments/assets/0591fb5c-d728-406a-b888-4f2534b2daab" />

Discarded the errors following this logic:
- 403 Errors are expected to appear as per the changes that were previously there to avoid them are no longer in dev
- Some error groups only appeared on previous clusterfuzz versions 
- Other errors are expected(like the queue size limit or bad revision errors)
- There are errors from corpus pruning & fuzzer not found, this have been seen for a while now, not related to my changes
- Lastly there are some errors in a cron_job, specifically in [this file ](https://github.com/google/clusterfuzz/blob/master/src/clusterfuzz/_internal/cron/load_bigquery_stats.py)but this one doesn't make usage of `fetch_url` and nor does the method that triggered the error

#### PR review
1. [**#5370** Add Android Build API V4 REST client and tests ](https://github.com/google/clusterfuzz/pull/5370)
2. [#5371 Migrate fetch_artifact to use new V4 API](https://github.com/google/clusterfuzz/pull/5371) 
3.  👉 [#5373 Creates Feature Flag for Android V4 API](https://github.com/google/clusterfuzz/pull/5373) *(This PR)*

Please only approve, I'll merge this PR's to avoid any possible merge conflict that can appear in the process :D