### PR TITLE
symbolizer: Temporarily increase llvm-symbolizer cache size on macOS

### DIFF
--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -261,6 +261,8 @@ class LLVMSymbolizer(Symbolizer):
         '--inlining=%s' % stack_inlining,
     ]
     if self.system == 'darwin':
+      # TODO(crbug.com/532093354): Remove --cache-size once llvm-symbolizer is fixed.
+      cmd.append('--cache-size=5000000000')
       for hint in self.dsym_hints:
         cmd.append('--dsym-hint=%s' % hint)
 

--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -262,7 +262,7 @@ class LLVMSymbolizer(Symbolizer):
     ]
     if self.system == 'darwin':
       # TODO(crbug.com/532093354): Remove --cache-size once llvm-symbolizer is fixed.
-      cmd.append('--cache-size=5000000000')
+      cmd.append('--cache-size=%d' % (5 * 1024 * 1024 * 1024))  # 5 GiB
       for hint in self.dsym_hints:
         cmd.append('--dsym-hint=%s' % hint)
 


### PR DESCRIPTION
llvm-symbolizer has been crashing for a few weeks: https://crbug.com/532093354.

We suspect it's because the size of Chromium or dSYM has increased past the cache size and is triggering a bug in LLVM.

This PR increases the cache size for llvm-symbolizer on macOS to get around the bug and avoid crashing.