### PR TITLE
[NDB PERMISSION_DENIED error] Fix trusty stacktrace on ANDROID_EMULATOR

### DIFF
--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -596,6 +596,19 @@ class SymbolizationLoop:
         pass
 
   def _can_process_trusty_stack_trace(self, trusty_app, trusty_bid) -> bool:
+    """Checks whether the trusty stacktrace can be processed.
+
+    Uworker bots can't access DB nor GCS, which are required to process the
+    trusty stacktrace. This checks if the current bot context 
+    is able to process the stacktrace.
+
+    Args:
+      trusty_app: The name of the crashed Trusted App.
+      trusty_bid: The build ID of the crashed Trusted App.
+
+    Returns:
+      True if the trusty stacktrace can be processed, False otherwise.
+    """
     symbols_dir = environment.get_value('SYMBOLS_DIR')
     return bool(
         trusty_app and trusty_bid and

--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -597,10 +597,12 @@ class SymbolizationLoop:
 
   def process_trusty_stacktrace(self, unsymbolized_crash_stacktrace):
     """Adds debug line information to a Trusted App stacktrace."""
-    symbols_dir = environment.get_value('SYMBOLS_DIR')
     trusty_app = self._extract_trusty_app_name(unsymbolized_crash_stacktrace)
     trusty_bid = self._extract_trusty_bid(unsymbolized_crash_stacktrace)
+    if not trusty_app or not trusty_bid:
+      return unsymbolized_crash_stacktrace
 
+    symbols_dir = environment.get_value('SYMBOLS_DIR')
     symbols_downloader.download_trusty_symbols_if_needed(
         symbols_dir, trusty_app, trusty_bid)
     kernel_binary = f'{symbols_dir}/lk.elf'
@@ -743,11 +745,12 @@ def symbolize_stacktrace(unsymbolized_crash_stacktrace,
   loop = SymbolizationLoop(
       binary_path_filter=filter_binary_path,
       dsym_hint_producer=chrome_dsym_hints)
+  symbolized_crash_stacktrace = unsymbolized_crash_stacktrace
   if environment.is_android_emulator():
     symbolized_crash_stacktrace = loop.process_trusty_stacktrace(
-        unsymbolized_crash_stacktrace)
+        symbolized_crash_stacktrace)
 
   symbolized_crash_stacktrace = loop.process_stacktrace(
-      unsymbolized_crash_stacktrace)
+      symbolized_crash_stacktrace)
 
   return symbolized_crash_stacktrace

--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -595,14 +595,23 @@ class SymbolizationLoop:
       except ProcessLookupError:
         pass
 
+  def _can_process_trusty_stack_trace(self, trusty_app, trusty_bid) -> bool:
+    symbols_dir = environment.get_value('SYMBOLS_DIR')
+    return bool(
+        trusty_app and trusty_bid and
+        (symbols_dir or not environment.is_uworker()))
+
   def process_trusty_stacktrace(self, unsymbolized_crash_stacktrace):
     """Adds debug line information to a Trusted App stacktrace."""
     trusty_app = self._extract_trusty_app_name(unsymbolized_crash_stacktrace)
     trusty_bid = self._extract_trusty_bid(unsymbolized_crash_stacktrace)
-    if not trusty_app or not trusty_bid:
+    symbols_dir = environment.get_value('SYMBOLS_DIR')
+    if not self._can_process_trusty_stack_trace(trusty_app, trusty_bid):
+      logs.warning('Wont process trusty stacktrace, missing one of: '
+                   f'trusty_app={trusty_app}, trusty_bid={trusty_bid}, '
+                   f'SYMBOLS_DIR={symbols_dir}')
       return unsymbolized_crash_stacktrace
 
-    symbols_dir = environment.get_value('SYMBOLS_DIR')
     symbols_downloader.download_trusty_symbols_if_needed(
         symbols_dir, trusty_app, trusty_bid)
     kernel_binary = f'{symbols_dir}/lk.elf'

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_symbolizer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_symbolizer_test.py
@@ -215,3 +215,110 @@ class LLVMSymbolizerCrashTest(unittest.TestCase):
         mock_popen=mock_popen,
         mock_get_symbolizer_path=mock_get_symbolizer_path,
         mock_log_error=mock_log_error)
+
+
+class ProcessTrustyStacktraceTest(unittest.TestCase):
+  """Tests for process_trusty_stacktrace early return behavior."""
+
+  def setUp(self):
+    self.loop = stack_symbolizer.SymbolizationLoop()
+
+  @mock.patch('clusterfuzz._internal.system.environment.get_value')
+  @mock.patch(
+      'clusterfuzz._internal.platforms.android.symbols_downloader.download_trusty_symbols_if_needed'
+  )
+  def test_early_return_when_missing_app_and_bid(self, mock_download,
+                                                 mock_get_value):
+    """Tests that process_trusty_stacktrace returns early without downloading symbols when both trusty_app and trusty_bid are missing."""
+    stacktrace = 'Some standard crash without trusty metadata\n#0 0x1234'
+    result = self.loop.process_trusty_stacktrace(stacktrace)
+    self.assertEqual(stacktrace, result)
+    mock_download.assert_not_called()
+    mock_get_value.assert_not_called()
+
+  @mock.patch('clusterfuzz._internal.system.environment.get_value')
+  @mock.patch(
+      'clusterfuzz._internal.platforms.android.symbols_downloader.download_trusty_symbols_if_needed'
+  )
+  def test_early_return_when_missing_app(self, mock_download, mock_get_value):
+    """Tests that process_trusty_stacktrace returns early when trusty_app is missing but trusty_bid is present."""
+    stacktrace = ', Build: 1234567, Built:\n#0 0x1234'
+    result = self.loop.process_trusty_stacktrace(stacktrace)
+    self.assertEqual(stacktrace, result)
+    mock_download.assert_not_called()
+    mock_get_value.assert_not_called()
+
+  @mock.patch('clusterfuzz._internal.system.environment.get_value')
+  @mock.patch(
+      'clusterfuzz._internal.platforms.android.symbols_downloader.download_trusty_symbols_if_needed'
+  )
+  def test_early_return_when_missing_bid(self, mock_download, mock_get_value):
+    """Tests that process_trusty_stacktrace returns early when trusty_bid is missing but trusty_app is present."""
+    stacktrace = '(app: keymaster)\n#0 0x1234'
+    result = self.loop.process_trusty_stacktrace(stacktrace)
+    self.assertEqual(stacktrace, result)
+    mock_download.assert_not_called()
+    mock_get_value.assert_not_called()
+
+
+class SymbolizeStacktraceChainTest(unittest.TestCase):
+  """Tests for chaining in symbolize_stacktrace."""
+
+  @mock.patch(
+      'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop.process_stacktrace'
+  )
+  @mock.patch(
+      'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop.process_trusty_stacktrace'
+  )
+  @mock.patch('clusterfuzz._internal.system.environment.is_android_emulator')
+  @mock.patch(
+      'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path')
+  @mock.patch('clusterfuzz._internal.system.environment.platform')
+  @mock.patch('clusterfuzz._internal.system.environment.is_trusted_host')
+  def test_symbolize_stacktrace_chaining_on_android_emulator(
+      self, mock_is_trusted_host, mock_platform, mock_get_llvm,
+      mock_is_android_emulator, mock_process_trusty, mock_process_stacktrace):
+    """Tests that on an Android emulator, symbolize_stacktrace correctly chains process_trusty_stacktrace and process_stacktrace without discarding intermediate results."""
+    mock_is_trusted_host.return_value = False
+    mock_platform.return_value = 'LINUX'
+    mock_get_llvm.return_value = '/path/to/llvm-symbolizer'
+    mock_is_android_emulator.return_value = True
+
+    mock_process_trusty.return_value = 'trusty_symbolized_output'
+    mock_process_stacktrace.return_value = 'final_symbolized_output'
+
+    input_trace = 'unsymbolized_input'
+    result = stack_symbolizer.symbolize_stacktrace(input_trace)
+
+    mock_process_trusty.assert_called_once_with(input_trace)
+    mock_process_stacktrace.assert_called_once_with('trusty_symbolized_output')
+    self.assertEqual('final_symbolized_output', result)
+
+  @mock.patch(
+      'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop.process_stacktrace'
+  )
+  @mock.patch(
+      'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop.process_trusty_stacktrace'
+  )
+  @mock.patch('clusterfuzz._internal.system.environment.is_android_emulator')
+  @mock.patch(
+      'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path')
+  @mock.patch('clusterfuzz._internal.system.environment.platform')
+  @mock.patch('clusterfuzz._internal.system.environment.is_trusted_host')
+  def test_symbolize_stacktrace_no_trusty_on_non_emulator(
+      self, mock_is_trusted_host, mock_platform, mock_get_llvm,
+      mock_is_android_emulator, mock_process_trusty, mock_process_stacktrace):
+    """Tests that when not on an Android emulator, process_trusty_stacktrace is not called and process_stacktrace receives the unsymbolized stacktrace."""
+    mock_is_trusted_host.return_value = False
+    mock_platform.return_value = 'LINUX'
+    mock_get_llvm.return_value = '/path/to/llvm-symbolizer'
+    mock_is_android_emulator.return_value = False
+
+    mock_process_stacktrace.return_value = 'final_symbolized_output'
+
+    input_trace = 'unsymbolized_input'
+    result = stack_symbolizer.symbolize_stacktrace(input_trace)
+
+    mock_process_trusty.assert_not_called()
+    mock_process_stacktrace.assert_called_once_with(input_trace)
+    self.assertEqual('final_symbolized_output', result)

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_symbolizer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_symbolizer_test.py
@@ -18,6 +18,7 @@ import unittest
 from unittest import mock
 
 from clusterfuzz._internal.crash_analysis.stack_parsing import stack_symbolizer
+from clusterfuzz._internal.tests.test_libs import helpers
 
 TEST_STACK_TRACE = ("    #0 0x1234 (/lib/foo.so+0x5678)\n"
                     "    #1 0x5678 (/lib/foo.so+0x9abc)\n")
@@ -218,107 +219,93 @@ class LLVMSymbolizerCrashTest(unittest.TestCase):
 
 
 class ProcessTrustyStacktraceTest(unittest.TestCase):
-  """Tests for process_trusty_stacktrace early return behavior."""
+  """Tests that process_trusty_stacktrace returns early without downloading symbols 
+  when required Trusty metadata is missing."""
 
   def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.platforms.android.symbols_downloader.download_trusty_symbols_if_needed',
+        'clusterfuzz._internal.system.environment.get_value',
+        'clusterfuzz._internal.system.environment.is_uworker',
+    ])
+    self.mock.is_uworker.return_value = False
     self.loop = stack_symbolizer.SymbolizationLoop()
 
-  @mock.patch('clusterfuzz._internal.system.environment.get_value')
-  @mock.patch(
-      'clusterfuzz._internal.platforms.android.symbols_downloader.download_trusty_symbols_if_needed'
-  )
-  def test_early_return_when_missing_app_and_bid(self, mock_download,
-                                                 mock_get_value):
-    """Tests that process_trusty_stacktrace returns early without downloading symbols when both trusty_app and trusty_bid are missing."""
+  def test_early_return_when_missing_app_and_bid(self):
+    """Tests that we avoid processing the Trusty stacktrace and downloading 
+    symbols when both trusty_app and trusty_bid are missing."""
     stacktrace = 'Some standard crash without trusty metadata\n#0 0x1234'
-    result = self.loop.process_trusty_stacktrace(stacktrace)
-    self.assertEqual(stacktrace, result)
-    mock_download.assert_not_called()
-    mock_get_value.assert_not_called()
+    self.assertEqual(stacktrace,
+                     self.loop.process_trusty_stacktrace(stacktrace))
+    self.mock.download_trusty_symbols_if_needed.assert_not_called()
 
-  @mock.patch('clusterfuzz._internal.system.environment.get_value')
-  @mock.patch(
-      'clusterfuzz._internal.platforms.android.symbols_downloader.download_trusty_symbols_if_needed'
-  )
-  def test_early_return_when_missing_app(self, mock_download, mock_get_value):
-    """Tests that process_trusty_stacktrace returns early when trusty_app is missing but trusty_bid is present."""
+  def test_early_return_when_missing_app(self):
+    """Tests that we avoid processing the Trusty stacktrace and downloading symbols
+    when trusty_app is missing (even if trusty_bid is present)."""
     stacktrace = ', Build: 1234567, Built:\n#0 0x1234'
-    result = self.loop.process_trusty_stacktrace(stacktrace)
-    self.assertEqual(stacktrace, result)
-    mock_download.assert_not_called()
-    mock_get_value.assert_not_called()
+    self.assertEqual(stacktrace,
+                     self.loop.process_trusty_stacktrace(stacktrace))
+    self.mock.download_trusty_symbols_if_needed.assert_not_called()
 
-  @mock.patch('clusterfuzz._internal.system.environment.get_value')
-  @mock.patch(
-      'clusterfuzz._internal.platforms.android.symbols_downloader.download_trusty_symbols_if_needed'
-  )
-  def test_early_return_when_missing_bid(self, mock_download, mock_get_value):
-    """Tests that process_trusty_stacktrace returns early when trusty_bid is missing but trusty_app is present."""
+  def test_early_return_when_missing_bid(self):
+    """Tests that we avoid processing the Trusty stacktrace and downloading symbols 
+    when trusty_bid is missing (even if trusty_app is present)."""
     stacktrace = '(app: keymaster)\n#0 0x1234'
-    result = self.loop.process_trusty_stacktrace(stacktrace)
-    self.assertEqual(stacktrace, result)
-    mock_download.assert_not_called()
-    mock_get_value.assert_not_called()
+    self.assertEqual(stacktrace,
+                     self.loop.process_trusty_stacktrace(stacktrace))
+    self.mock.download_trusty_symbols_if_needed.assert_not_called()
+
+  def test_early_return_on_uworker_without_symbols_dir(self):
+    """Tests that we avoid processing the Trusty stacktrace and downloading symbols when on a uworker without a SYMBOLS_DIR (even if both trusty_app and trusty_bid are present)."""
+    self.mock.is_uworker.return_value = True
+    self.mock.get_value.return_value = None
+
+    stacktrace = '(app: keymaster), Build: 1234567, Built:\n#0 0x1234'
+    self.assertEqual(stacktrace,
+                     self.loop.process_trusty_stacktrace(stacktrace))
+    self.mock.download_trusty_symbols_if_needed.assert_not_called()
 
 
 class SymbolizeStacktraceChainTest(unittest.TestCase):
-  """Tests for chaining in symbolize_stacktrace."""
+  """Tests that symbolize_stacktrace correctly chains Trusty and standard stacktrace symbolization workflows based on the environment."""
 
-  @mock.patch(
-      'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop.process_stacktrace'
-  )
-  @mock.patch(
-      'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop.process_trusty_stacktrace'
-  )
-  @mock.patch('clusterfuzz._internal.system.environment.is_android_emulator')
-  @mock.patch(
-      'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path')
-  @mock.patch('clusterfuzz._internal.system.environment.platform')
-  @mock.patch('clusterfuzz._internal.system.environment.is_trusted_host')
-  def test_symbolize_stacktrace_chaining_on_android_emulator(
-      self, mock_is_trusted_host, mock_platform, mock_get_llvm,
-      mock_is_android_emulator, mock_process_trusty, mock_process_stacktrace):
-    """Tests that on an Android emulator, symbolize_stacktrace correctly chains process_trusty_stacktrace and process_stacktrace without discarding intermediate results."""
-    mock_is_trusted_host.return_value = False
-    mock_platform.return_value = 'LINUX'
-    mock_get_llvm.return_value = '/path/to/llvm-symbolizer'
-    mock_is_android_emulator.return_value = True
+  def setUp(self):
+    helpers.patch(self, [
+        'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop',
+        'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path',
+        'clusterfuzz._internal.system.environment.is_android_emulator',
+        'clusterfuzz._internal.system.environment.is_trusted_host',
+        'clusterfuzz._internal.system.environment.platform',
+    ])
+    self.mock.is_trusted_host.return_value = False
+    self.mock.platform.return_value = 'LINUX'
+    self.mock.get_llvm_symbolizer_path.return_value = '/path/to/llvm-symbolizer'
+    self.mock_loop = self.mock.SymbolizationLoop.return_value
+    self.mock_loop.process_stacktrace.return_value = 'final_symbolized_output'
 
-    mock_process_trusty.return_value = 'trusty_symbolized_output'
-    mock_process_stacktrace.return_value = 'final_symbolized_output'
+  def test_symbolize_stacktrace_chaining_on_android_emulator(self):
+    """Tests that on an Android emulator, both process_trusty_stacktrace and process_stacktrace 
+    execute sequentially and preserve intermediate results."""
+    self.mock.is_android_emulator.return_value = True
+    self.mock_loop.process_trusty_stacktrace.return_value = (
+        'trusty_symbolized_output')
 
-    input_trace = 'unsymbolized_input'
-    result = stack_symbolizer.symbolize_stacktrace(input_trace)
+    result = stack_symbolizer.symbolize_stacktrace('unsymbolized_input')
 
-    mock_process_trusty.assert_called_once_with(input_trace)
-    mock_process_stacktrace.assert_called_once_with('trusty_symbolized_output')
+    self.mock_loop.process_trusty_stacktrace.assert_called_once_with(
+        'unsymbolized_input')
+    self.mock_loop.process_stacktrace.assert_called_once_with(
+        'trusty_symbolized_output')
     self.assertEqual('final_symbolized_output', result)
 
-  @mock.patch(
-      'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop.process_stacktrace'
-  )
-  @mock.patch(
-      'clusterfuzz._internal.crash_analysis.stack_parsing.stack_symbolizer.SymbolizationLoop.process_trusty_stacktrace'
-  )
-  @mock.patch('clusterfuzz._internal.system.environment.is_android_emulator')
-  @mock.patch(
-      'clusterfuzz._internal.system.environment.get_llvm_symbolizer_path')
-  @mock.patch('clusterfuzz._internal.system.environment.platform')
-  @mock.patch('clusterfuzz._internal.system.environment.is_trusted_host')
-  def test_symbolize_stacktrace_no_trusty_on_non_emulator(
-      self, mock_is_trusted_host, mock_platform, mock_get_llvm,
-      mock_is_android_emulator, mock_process_trusty, mock_process_stacktrace):
-    """Tests that when not on an Android emulator, process_trusty_stacktrace is not called and process_stacktrace receives the unsymbolized stacktrace."""
-    mock_is_trusted_host.return_value = False
-    mock_platform.return_value = 'LINUX'
-    mock_get_llvm.return_value = '/path/to/llvm-symbolizer'
-    mock_is_android_emulator.return_value = False
+  def test_symbolize_stacktrace_no_trusty_on_non_emulator(self):
+    """Tests that on non-emulator environments, process_trusty_stacktrace is bypassed and process_stacktrace 
+    receives the raw unsymbolized stacktrace directly."""
+    self.mock.is_android_emulator.return_value = False
 
-    mock_process_stacktrace.return_value = 'final_symbolized_output'
+    result = stack_symbolizer.symbolize_stacktrace('unsymbolized_input')
 
-    input_trace = 'unsymbolized_input'
-    result = stack_symbolizer.symbolize_stacktrace(input_trace)
-
-    mock_process_trusty.assert_not_called()
-    mock_process_stacktrace.assert_called_once_with(input_trace)
+    self.mock_loop.process_trusty_stacktrace.assert_not_called()
+    self.mock_loop.process_stacktrace.assert_called_once_with(
+        'unsymbolized_input')
     self.assertEqual('final_symbolized_output', result)


### PR DESCRIPTION

This PR comes as a need after the revert of this https://github.com/google/clusterfuzz/pull/5339 PR which introduced short circuit mechanisms to avoid DB queries, this however proved to provoke issues, so short circuit is no longer an option to fix any PERMISION_DENIED erros.

When we run jobs with an `ANDROID_EMULATOR` jobs, they all fail after executing a testcase. This happens because `ANDROID_EMULATOR` platform goes trough some legacy code(before the pre/main/pos separation of tasks) which expects the current bot to have access to DB or GCS.

This error only appear for `uworkers` and doesn't happen for `pre-emptible` bots. Because pre-emptibles do contain a trusted service account, where as uworkers dont.

## Changes
- When entering the process in which we analyze the stacktrace we now check if we can process this stacktrace or not, validating the kind of bot we are at.
- Creates Unit tests for this new edge cases

## Test performed
Changes initially present in dev since July 13th, and it didn't seem to non brake anything under ANDROID_EMULATOR jobs. Now for `ANDROID_EMULATOR` jobs.

Before:
<img width="3042" height="436" alt="image" src="https://github.com/user-attachments/assets/4a9660cf-002e-4d61-a777-12ab2efca37a" />


After:
<img width="2066" height="863" alt="image" src="https://github.com/user-attachments/assets/998de0f8-3d2c-4e84-a02a-17fc7673e713" />
