### PR TITLE
[NDB PERMISSION_DENIED] Introduce FuzzerRunOutputData and utils

### DIFF
--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -36,6 +36,7 @@ from clusterfuzz._internal.base import retry
 from clusterfuzz._internal.config import local_config
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import environment
+from clusterfuzz._internal.system import shell
 
 try:
   import psutil
@@ -686,6 +687,17 @@ def read_data_from_file(file_path, eval_data=True, default=None):
     return ast.literal_eval(file_content.decode('utf-8'))
   except (SyntaxError, TypeError):
     return None
+
+
+def read_data_from_file_and_remove(file_path, eval_data=False, default=None):
+  """Reads file content and removes the file after read"""
+  if not file_path or not os.path.exists(file_path):
+    return default
+
+  try:
+    return read_data_from_file(file_path, eval_data=eval_data, default=default)
+  finally:
+    shell.remove_file(file_path)
 
 
 def remove_prefix(string, prefix):

--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -690,7 +690,17 @@ def read_data_from_file(file_path, eval_data=True, default=None):
 
 
 def read_data_from_file_and_remove(file_path, eval_data=False, default=None):
-  """Reads file content and removes the file after read"""
+  """Reads file content and removes the file after reading.
+
+  Args:
+    file_path: Path to the file to read.
+    eval_data: Whether to evaluate file content as a Python literal.
+    default: Value to return if file is empty, missing, or unreadable.
+
+  Returns:
+    The file content (or evaluated object if eval_data is True), or `default`
+    if reading fails or file does not exist.
+  """
   if not file_path or not os.path.exists(file_path):
     return default
 

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -360,31 +360,53 @@ class Crash(
 @dataclasses.dataclass
 class FuzzerRunOutputData:
   """Output metadata for a single fuzzer run stored in memory or a temp file."""
-  output_or_file_path: str | bytes
+  _output: str | bytes | None = None
+  _file_path: str | None = None
   crash_path: str | None = None
   return_code: int = 0
   log_time: datetime.datetime | None = None
 
-  def _is_file_path(self) -> bool:
-    """Returns True if output_or_file_path is an existing file path."""
-    return isinstance(self.output_or_file_path, str) and os.path.exists(
-        self.output_or_file_path)
+  @classmethod
+  def from_file_path(cls,
+                     file_path: str,
+                     crash_path: str | None = None,
+                     return_code: int = 0,
+                     log_time: datetime.datetime | None = None):
+    return cls(
+        _file_path=file_path,
+        crash_path=crash_path,
+        return_code=return_code,
+        log_time=log_time)
+
+  @classmethod
+  def from_memory(cls,
+                  output: str | bytes,
+                  crash_path: str | None = None,
+                  return_code: int = 0,
+                  log_time: datetime.datetime | None = None):
+    return cls(
+        _output=output,
+        crash_path=crash_path,
+        return_code=return_code,
+        log_time=log_time)
 
   def get_output(self) -> str | None:
     """Reads or decodes the fuzzer output text."""
-    if not self.output_or_file_path:
-      return None
-
-    if self._is_file_path():
+    if self._file_path:
+      if not os.path.exists(self._file_path):
+        return None
       output = utils.read_data_from_file_and_remove(
-          self.output_or_file_path, eval_data=False)
+          self._file_path, eval_data=False)
       return None if output is None else output.decode(
           'utf-8', errors='replace')
 
-    if isinstance(self.output_or_file_path, bytes):
-      return self.output_or_file_path.decode('utf-8', errors='replace')
+    if not self._output:
+      return None
 
-    return self.output_or_file_path
+    if isinstance(self._output, bytes):
+      return self._output.decode('utf-8', errors='replace')
+
+    return self._output
 
 
 @dataclasses.dataclass

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -15,6 +15,7 @@
 
 import base64
 import collections
+import dataclasses
 import datetime
 import os
 import re
@@ -354,6 +355,43 @@ class Crash(
   """Represents a crash in a queue. This class is transformed into
     fuzz_task.Crash. Therefore, please be careful when adding/removing
     fields."""
+
+
+@dataclasses.dataclass
+class FuzzerRunOutputData:
+  """Output metadata for a single fuzzer run stored in memory or a temp file."""
+  output_or_file_path: str | bytes
+  crash_path: str | None = None
+  return_code: int = 0
+  log_time: datetime.datetime | None = None
+
+  def _is_file_path(self) -> bool:
+    """Returns True if output_or_file_path is an existing file path."""
+    return isinstance(self.output_or_file_path, str) and os.path.exists(
+        self.output_or_file_path)
+
+  def get_output(self) -> str | None:
+    """Reads or decodes the fuzzer output text."""
+    if not self.output_or_file_path:
+      return None
+
+    if self._is_file_path():
+      output = utils.read_data_from_file_and_remove(
+          self.output_or_file_path, eval_data=False)
+      return None if output is None else output.decode(
+          'utf-8', errors='replace')
+
+    if isinstance(self.output_or_file_path, bytes):
+      return self.output_or_file_path.decode('utf-8', errors='replace')
+
+    return self.output_or_file_path
+
+
+@dataclasses.dataclass
+class TestcaseRunResult:
+  """Result of a testcase execution queued for processing."""
+  crash: Crash | None = None
+  fuzzer_run_output_data: FuzzerRunOutputData | None = None
 
 
 def get_resource_paths(output):

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -400,18 +400,16 @@ class FuzzerRunOutputData:
   def get_output(self) -> str | None:
     """Reads or decodes the fuzzer output text."""
     if self._file_path:
-      if not os.path.exists(self._file_path):
-        return None
       output = utils.read_data_from_file_and_remove(
           self._file_path, eval_data=False)
-      return None if output is None else output.decode(
-          'utf-8', errors='replace')
+      self._output = output if output is not None else None
+      self._file_path = None
 
-    if not self._output:
+    if self._output is None:
       return None
 
     if isinstance(self._output, bytes):
-      return self._output.decode('utf-8', errors='replace')
+      self._output = self._output.decode('utf-8', errors='replace')
 
     return self._output
 

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -359,7 +359,14 @@ class Crash(
 
 @dataclasses.dataclass
 class FuzzerRunOutputData:
-  """Output metadata for a single fuzzer run stored in memory or a temp file."""
+  """Output metadata for a single fuzzer run.
+
+  - This class should be constructed either via `from_file_path()` or
+  `from_output()` - directly using the constructor is not recommended.
+
+  - `_output` and `_file_path` are mutually exclusive (oneof); exactly one of
+    them should be set.
+  """
   _output: str | bytes | None = None
   _file_path: str | None = None
   crash_path: str | None = None

--- a/src/clusterfuzz/_internal/tests/core/bot/testcase_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/testcase_manager_test.py
@@ -1013,3 +1013,47 @@ class PreprocessTestcaseManagerTest(unittest.TestCase):
     testcase_manager.preprocess_testcase_manager(blackbox_testcase,
                                                  uworker_input)
     self.assertFalse(uworker_input.HasField('fuzz_target'))
+
+
+class FuzzerRunOutputDataTest(fake_filesystem_unittest.TestCase):
+  """Tests for FuzzerRunOutputData output retrieval and file cleanup behavior."""
+
+  def setUp(self):
+    test_helpers.patch_environ(self)
+    test_utils.set_up_pyfakefs(self)
+
+  def test_get_output_from_memory_str(self):
+    """Tests that get_output returns in-memory string output repeatably."""
+    output_data = testcase_manager.FuzzerRunOutputData.from_memory(
+        output='test output')
+    self.assertEqual(output_data.get_output(), 'test output')
+    self.assertEqual(output_data.get_output(), 'test output')
+
+  def test_get_output_from_memory_bytes(self):
+    """Tests that get_output decodes and caches in-memory bytes output as string."""
+    output_data = testcase_manager.FuzzerRunOutputData.from_memory(
+        output=b'test bytes output')
+    self.assertEqual(output_data.get_output(), 'test bytes output')
+    self.assertEqual(output_data.get_output(), 'test bytes output')
+
+  def test_get_output_from_file_path(self):
+    """Tests that get_output reads file content, deletes the file, and caches output for subsequent calls."""
+    file_path = '/tmp/fuzzer_output.txt'
+    self.fs.create_file(file_path, contents='file content')
+
+    output_data = testcase_manager.FuzzerRunOutputData.from_file_path(file_path)
+    self.assertEqual(output_data.get_output(), 'file content')
+    self.assertFalse(os.path.exists(file_path))
+    self.assertEqual(output_data.get_output(), 'file content')
+
+  def test_get_output_from_missing_file_path(self):
+    """Tests that get_output returns None when the backed file path does not exist."""
+    file_path = '/tmp/nonexistent.txt'
+    output_data = testcase_manager.FuzzerRunOutputData.from_file_path(file_path)
+    self.assertIsNone(output_data.get_output())
+    self.assertIsNone(output_data.get_output())
+
+  def test_get_output_empty(self):
+    """Tests that get_output returns None when neither output nor file path is set."""
+    output_data = testcase_manager.FuzzerRunOutputData()
+    self.assertIsNone(output_data.get_output())


### PR DESCRIPTION
Bug: b/532610906

## Context
- This PR comes as a need after the revert of this https://github.com/google/clusterfuzz/pull/5339 PR which introduced short circuit mechanisms to avoid DB queries, this however proved to provoke issues, so short circuit is no longer an option to fix any PERMISION_DENIED erros.
- There were 2 instances of PERMISSION_DENIED issues, the first one is already solved trough this https://github.com/google/clusterfuzz/pull/5375

## Overview
This First PR(Of 4) to tackle an instance of PERMISSION_DENIED issues when executing a BlackBox test case in a `uworker` bot.

This PR creates 2 new classes that will help us handle the processing of a test case execution in the next prs

## Changes
- Introduces two new classes to encapsulate all the info obtained from a BlackBox test case execution
  - The fuzzer output can be received either trough bits, a string, or a log file
- Adds a new utils logic to read and delete a file after reading

## PR stack
Current -> PR #5376: Introduce FuzzerRunOutputData and utils (Base: master)
PR #5377: Refactor _to_fuzzer_run_output to use FuzzerRunOutputData (Base: PR 1)
PR #5388: refactor: Add utils.create_temp_file helper (Base: PR 2)
PR #5378: Defer Blackbox Fuzzer Log Uploads (Base: PR 3)

Please only approve I'll merge the PRs to handle any merge conflicts :D