### PR TITLE
symbolizer: Fix args for the default symbolizer

### DIFF
--- a/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
+++ b/src/clusterfuzz/_internal/crash_analysis/stack_parsing/stack_symbolizer.py
@@ -260,7 +260,8 @@ class LLVMSymbolizer(Symbolizer):
         '--functions=linkage',
         '--inlining=%s' % stack_inlining,
     ]
-    if self.system == 'darwin':
+    if self.system == 'darwin' and self.symbolizer_path != environment.get_default_tool_path(
+        'llvm-symbolizer'):
       # TODO(crbug.com/532093354): Remove --cache-size once llvm-symbolizer is fixed.
       cmd.append('--cache-size=%d' % (5 * 1024 * 1024 * 1024))  # 5 GiB
       for hint in self.dsym_hints:


### PR DESCRIPTION
The default symbolizer is too old and doesn't accept the `--cache-size` argument which throws an error for certain jobs that use the default symbolizer e.g. mac_asan_webkit. This PR only adds the `--cache-size` argument if we're not using the default symbolizer.