### PR TITLE
Fix UI form parsing that created invalid FuzzerJob entries

### DIFF
--- a/src/appengine/handlers/jobs.py
+++ b/src/appengine/handlers/jobs.py
@@ -147,7 +147,8 @@ class UpdateJob(base_handler.GcsUploadHandler):
           'Job name can only contain letters, numbers, dashes and underscores.',
           400)
 
-    fuzzers = request.form.get('fuzzers', []).split(',')
+    fuzzers_string = request.form.get('fuzzers')
+    fuzzers = fuzzers_string.split(',') if fuzzers_string else []
     templates = request.form.get('templates', '').splitlines()
     for template in templates:
       if not data_types.JobTemplate.query(

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/jobs_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/jobs_test.py
@@ -222,3 +222,21 @@ class JobsUpdateTest(unittest.TestCase):
     self.assertEqual(200, resp.status_int)
     self.mock.update_mappings_for_job.assert_called_with(
         mock.ANY, ['test_fuzzer'])
+
+  def test_post_empty_fuzzers(self):
+    """Test post method with no fuzzers provided."""
+    self.mock.has_access.return_value = True
+    job = self._create_job('test_job', 'PROJECT_NAME = proj\n')
+
+    resp = self.app.post(
+        '/', {
+            'csrf_token': form.generate_csrf_token(),
+            'name': job.name,
+            'desciption': job.description,
+            'platform': job.platform,
+            'fuzzers': ''
+        },
+        expect_errors=True)
+
+    self.assertEqual(200, resp.status_int)
+    self.mock.update_mappings_for_job.assert_called_with(mock.ANY, [])


### PR DESCRIPTION
The `/jobs` form submission retrieved `'fuzzers'` as a string and blindly called .split(','), meaning an empty field evaluated as `['']` instead of `[]`.  

I tested in dev and the browser is actually sending a POST with the `fuzzer` key, i.e. `...&fuzzers=&description=...` which results in an empty string `fuzzers= ""` in Flask . Since there is a value `""`, this overrides the default `[]`

This fuzzers value of `['']` leads to the creation of invalid `FuzzerJob` entries in Datastore with `fuzzer=""`

This updates the form ingestion to correctly ignore missing values as an empty list.

## Testing

I verified this with the unit test by reverting the PR back to the old behavior:
```
Traceback (most recent call last):
  File "/workspaces/clusterfuzz/src/clusterfuzz/_internal/tests/appengine/handlers/jobs_test.py", line 240, in test_post_empty_fuzzers
    self.mock.update_mappings_for_job.assert_called_with(mock.ANY, [])
  File "/usr/local/python/current/lib/python3.11/unittest/mock.py", line 212, in assert_called_with
    return mock.assert_called_with(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python/current/lib/python3.11/unittest/mock.py", line 939, in assert_called_with
    raise AssertionError(_error_message()) from cause
AssertionError: expected call not found.
Expected: update_mappings_for_job(<ANY>, [])
  Actual: update_mappings_for_job(Job(key=Key('Job', 1), base_os_version=None, custom_binary_filename=None, custom_binary_key=None, custom_binary_revision=None, description='', environment_string='', external_reproduction_topic=None, external_updates_subscription=None, keywords=['job', 'test_job', 'test', 'project', 'test-project'], name='test_job', platform='LINUX', project='test-project', templates=[]), [''])
```

The last parameter in the assert is the fuzzers `['']`. We're passing an empty string into the list of fuzzers to map to the job

dev:
- [x]  Verify in dev via the Jobs UI
1. Create a FuzzerJob in dev by enabling the  `libfuzzer` `Fuzzer`  on the `libfuzzer_chrome_asan_highend` job in dev.
2. Disable the `Fuzzer` by unchecking `libfuzzer`, then querying the Datastore to verify no dangling `FuzzerJob` was created with `fuzzer=''` `SELECT * FROM `FuzzerJob`  where job = 'libfuzzer_chrome_asan_highend'` 