### PR TITLE
[DO NOT SUBMIT] Clean up orphaned FuzzerJob mapping entities

### DIFF
--- a/src/local/butler/scripts/clean_invalid_fuzzer_jobs.py
+++ b/src/local/butler/scripts/clean_invalid_fuzzer_jobs.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cleans up orphaned FuzzerJob entities that have no corresponding Fuzzer."""
+
+from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.datastore import ndb_utils
+
+
+def execute(args):
+  """Query all FuzzerJobs and delete any mapped to a non-existent fuzzer."""
+  print('Starting invalid FuzzerJob cleanup pass.')
+
+  valid_fuzzers = {fuzzer.name for fuzzer in data_types.Fuzzer.query()}
+
+  fuzzer_jobs = data_types.FuzzerJob.query()
+
+  fuzzer_jobs_to_delete = []
+  for mapping in fuzzer_jobs:
+    # A invalid FuzzerJob has an empty fuzzer name or a fuzzer name
+    # that no longer maps to an active Fuzzer entity.
+    if not mapping.fuzzer or mapping.fuzzer not in valid_fuzzers:
+      fuzzer_jobs_to_delete.append(mapping.key)
+      print(f'Found invalid mapping to delete: ID={mapping.key.id()}, '
+            f'fuzzer="{mapping.fuzzer}", job="{mapping.job}"')
+
+  print(f'Total invalid mappings found: {len(fuzzer_jobs_to_delete)}')
+
+  if not fuzzer_jobs_to_delete:
+    print('No mappings to delete.')
+
+  if args.non_dry_run:
+    print('Executing datastore deletion...')
+    ndb_utils.delete_multi(fuzzer_jobs_to_delete)
+    print('Deletion complete.')
+  else:
+    print('Run with --non-dry-run to actually delete the mappings.')


### PR DESCRIPTION
Previously, `update_mappings_for_job` iterates over valid Fuzzer parent entities and adds a `FuzzerJob`. 

This means that any invalid `FuzzerJob` mappings lacking a parent Fuzzer are permanently orphaned in Datastore.

This PR adds a clean up script that looks for `FuzzerJobs` and deletes any entities that are no longer linked to a valid Fuzzer.

One thing to note: the reason Clusterfuzz thinks that FuzzerJobs with `fuzzer=""` is valid is because we have a Fuzzer without a name in the datastore, which we didn't delete because it's unsafe to do so.


There aren't any other entities we need to clean up besides the FuzzerJob. 

We query the `FuzzerJob`s [here](https://github.com/google/clusterfuzz/blob/05360c5aa9db354f6a9d83a105583eae7a230551/src/clusterfuzz/_internal/cron/schedule_fuzz.py#L276) and that creates the invalid task to schedule. Batch is done [here](https://github.com/google/clusterfuzz/blob/05360c5aa9db354f6a9d83a105583eae7a230551/src/clusterfuzz/_internal/cron/batch_fuzzer_jobs.py#L32)

Since the invalid `FuzzerJob` without a matching `Fuzzer` isn't validated before we create the task, we schedule the invalid task and flood our queue if we can't process those.

## Roll out

I don't plan to submit this PR. I'm just going to run this against our prod DB after verifying in dev and in dry run mode

### Dev

I ran this in dev and verified it deleted some invalid mappings for a blackbox fuzzer `ochang_js_fuzzer_untrusted`

#### Dry run mode results
```
python butler.py run -c   ../clusterfuzz-config/configs/internal  clean_invalid_fuzzer_jobs

/usr/local/google/home/dylanj/clusterfuzz/src/third_party/google/cloud/ndb/__init__.py:24: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution
Running in dry-run mode, no datastore writes are committed. For permanent modifications, re-run with --non-dry-run.
Starting invalid FuzzerJob cleanup pass.
Found invalid mapping to delete: ID=5114699494490112, fuzzer="", job="centipede_chrome_asan_dchecks_highend"
Found invalid mapping to delete: ID=5319049844129792, fuzzer="", job="centipede_chrome_asan_highend"
Found invalid mapping to delete: ID=5534634553147392, fuzzer="", job="libfuzzer_chrome_asan_highend"
Found invalid mapping to delete: ID=6357342853562368, fuzzer="", job="libfuzzer_chrome_asan_debug_highend"
Total invalid mappings found: 4
Run with --non-dry-run to actually delete the mappings.
```