### PR TITLE
Fix engine fuzzers blobstore downloads 

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/setup.py
+++ b/src/clusterfuzz/_internal/bot/tasks/setup.py
@@ -593,9 +593,6 @@ def preprocess_update_fuzzer_and_data_bundles(
   if not fuzzer:
     logs.error('No fuzzer exists with name %s.' % fuzzer_name)
     raise errors.InvalidFuzzerError
-  if not fuzzer.blobstore_key:
-    logs.error(f'Fuzzer {fuzzer_name} does not have a blobstore_key.')
-    raise errors.InvalidFuzzerError
 
   update_input = uworker_msg_pb2.SetupInput(  # pylint: disable=no-member
       fuzzer_name=fuzzer_name,
@@ -604,6 +601,11 @@ def preprocess_update_fuzzer_and_data_bundles(
   update_input.fuzzer_log_upload_url = storage.get_signed_upload_url(
       fuzzer_logs.get_logs_gcs_path(fuzzer_name=fuzzer_name))
   if not fuzzer.builtin:
+    if not fuzzer.blobstore_key:
+      logs.error(f'Blackbox fuzzer {fuzzer_name} does not have a '
+                 'blobstore_key.')
+      raise errors.InvalidFuzzerError
+
     update_input.fuzzer_download_url = blobs.get_signed_download_url(
         fuzzer.blobstore_key)
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/setup_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/setup_test.py
@@ -18,6 +18,7 @@ import unittest
 
 from pyfakefs import fake_filesystem_unittest
 
+from clusterfuzz._internal.base import errors
 from clusterfuzz._internal.bot.tasks import setup
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.datastore import data_types
@@ -239,6 +240,25 @@ class TestPreprocessUpdateFuzzerAndDataBundles(unittest.TestCase):
         self.fuzzer_name)
     setup.update_fuzzer_and_data_bundles(setup_input)
     self.assertEqual(self.mock.update_data_bundle.call_count, 2)
+
+  def test_invalid_fuzzer_no_blobstore_key(self):
+    """Tests that a blackbox fuzzer without a blobstore_key raises an error."""
+    fuzzer_name = 'invalid_fuzzer'
+    data_types.Fuzzer(name=fuzzer_name, builtin=False, blobstore_key=None).put()
+
+    with self.assertRaises(errors.InvalidFuzzerError):
+      setup.preprocess_update_fuzzer_and_data_bundles(fuzzer_name)
+
+  def test_builtin_fuzzer_no_blobstore_key(self):
+    """
+    Tests that a builtin fuzzer without a blobstore_key does not raise an error.
+    """
+    fuzzer_name = 'builtin_fuzzer'
+    data_types.Fuzzer(name=fuzzer_name, builtin=True, blobstore_key=None).put()
+
+    setup_input = setup.preprocess_update_fuzzer_and_data_bundles(fuzzer_name)
+
+    self.assertEqual(setup_input.fuzzer_name, fuzzer_name)
 
 
 class SetupLocalFuzzerTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/setup_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/setup_test.py
@@ -224,8 +224,8 @@ class TestPreprocessUpdateFuzzerAndDataBundles(unittest.TestCase):
     data_types.Fuzzer(
         name=self.fuzzer_name,
         data_bundle_name=data_bundle_name,
-        blobstore_key='blobstore_key',
-    ).put()
+        builtin=False,
+        blobstore_key='blobstore_key').put()
     self.data_bundle = data_types.DataBundle(name=data_bundle_name)
     self.data_bundle.put()
     data_types.DataBundle(name=data_bundle_name).put()


### PR DESCRIPTION
https://github.com/google/clusterfuzz/pull/5380 fixed the issue where our queue was getting flooded with bad tasks but broke libfuzzer because engine fuzzers do not need a `blobstore_key`. Instead it skips the function that was causing an error for the misconfigured fuzzers

I queried the Datastore and confirmed that when builtin=True, the blobstore_key is null for the engine fuzzers: `syzkaller, googlefuzztest, centipede, libfuzzer`. Additionally, the invalid fuzzer  with `"Name/ID": "name=ochang_js_fuzzer_test"` is also there, which was what caused the initial errors

This fixed the invalid FuzzerJob handling, but caused an issue with other libfuzzer fuzzers because libfuzzer has no blobstore key, but skips this look up that would fail because it has not blobstore key since `builtin = False`
https://github.com/google/clusterfuzz/blob/05360c5aa9db354f6a9d83a105583eae7a230551/src/clusterfuzz/_internal/bot/tasks/setup.py#L606-L608
