### PR TITLE
Use fuzz_targets from clusterfuzz_manifest.json if available

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -32,6 +32,9 @@ FUZZ_TARGET_SEARCH_BYTES = [b'LLVMFuzzerTestOneInput', b'LLVMFuzzerRunDriver']
 VALID_TARGET_NAME_REGEX = re.compile(r'^[a-zA-Z0-9@_.-]+$')
 BLOCKLISTED_TARGET_NAME_REGEX = re.compile(r'^(jazzer_driver.*|jazzerjs)$')
 EXTRA_BUILD_DIR = '__extra_build'
+# Manifest file present in Chrome build archives. Specifies the archive
+# schema version along with optional build metadata (e.g., fuzz targets).
+CHROME_MANIFEST_FILENAME = 'clusterfuzz_manifest.json'
 
 
 def is_fuzz_target(file_path, file_opener: Optional[Callable] = None):
@@ -99,38 +102,63 @@ def is_fuzz_target(file_path, file_opener: Optional[Callable] = None):
     return False
 
 
-def _get_manifest_fuzz_targets(path):
-  """Get list of fuzz targets from clusterfuzz_manifest.json if present."""
-  manifest_path = os.path.join(path, 'clusterfuzz_manifest.json')
-  if not os.path.exists(manifest_path):
+def extract_fuzz_targets_from_manifest(
+    manifest_dict: dict,
+    manifest_filename: str = CHROME_MANIFEST_FILENAME) -> list[str] | None:
+  """Extract list of target paths from a loaded manifest dict if present."""
+  if not isinstance(manifest_dict, dict):
+    logs.error(f'{manifest_filename} is not a dict')
     return None
 
-  try:
-    with open(manifest_path, 'r', encoding='utf-8') as f:
-      manifest = json.load(f)
-  except Exception as e:
-    logs.error(f'Failed to read {manifest_path}: {e}')
-    return None
-
-  if not isinstance(manifest, dict):
-    logs.error(f'{manifest_path} is not a dict')
-    return None
-
-  manifest_targets = manifest.get('fuzz_targets')
+  manifest_targets = manifest_dict.get('fuzz_targets')
   if manifest_targets is None:
     return None
 
   if not isinstance(manifest_targets, list):
-    logs.error(f'fuzz_targets in {manifest_path} is not a list')
+    logs.error(f'fuzz_targets in {manifest_filename} is not a list')
     return None
 
   fuzz_target_paths = []
   for target_path in manifest_targets:
     if not isinstance(target_path, str):
-      logs.error(f'Entry in fuzz_targets ({manifest_path}) is not a string: '
-                 f'{target_path}')
+      logs.error(
+          f'Entry in fuzz_targets ({manifest_filename}) is not a string: '
+          f'{target_path}')
       continue
-    file_path = os.path.join(path, target_path)
+    fuzz_target_paths.append(target_path)
+
+  return fuzz_target_paths
+
+
+def read_chrome_manifest(build_dir: str) -> dict | None:
+  """Reads and parses clusterfuzz_manifest.json from build_dir if present."""
+  manifest_path = os.path.join(build_dir, CHROME_MANIFEST_FILENAME)
+  if not os.path.exists(manifest_path):
+    return None
+
+  try:
+    with open(manifest_path, 'r', encoding='utf-8') as f:
+      return json.load(f)
+  except Exception as e:
+    logs.error(f'Failed to read {manifest_path}: {e}')
+    return None
+
+
+def _get_manifest_fuzz_targets(build_dir: str) -> list[str] | None:
+  """Get list of fuzz targets from clusterfuzz_manifest.json if present."""
+  manifest = read_chrome_manifest(build_dir)
+  if manifest is None:
+    return None
+
+  manifest_path = os.path.join(build_dir, CHROME_MANIFEST_FILENAME)
+  manifest_targets = extract_fuzz_targets_from_manifest(
+      manifest, manifest_filename=manifest_path)
+  if manifest_targets is None:
+    return None
+
+  fuzz_target_paths = []
+  for target_path in manifest_targets:
+    file_path = os.path.join(build_dir, target_path)
     if os.path.exists(file_path):
       fuzz_target_paths.append(file_path)
     else:
@@ -140,7 +168,12 @@ def _get_manifest_fuzz_targets(path):
 
 
 def get_fuzz_targets_local(path):
-  """Get list of fuzz targets paths (local)."""
+  """Get list of fuzz target paths (local).
+
+  If clusterfuzz_manifest.json is present and defines fuzz_targets, those
+  targets are returned. Otherwise, falls back to scanning the directory for
+  executables ending in `_fuzzer`.
+  """
   manifest_fuzz_targets = _get_manifest_fuzz_targets(path)
   if manifest_fuzz_targets is not None:
     return manifest_fuzz_targets

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -128,6 +128,7 @@ def extract_fuzz_targets_from_manifest(manifest_dict: dict) -> list[str] | None:
 
   manifest_targets = manifest_dict.get('fuzz_targets')
   if manifest_targets is None:
+    logs.info(f'No fuzz_targets found in manifest: {manifest_dict}')
     return None
 
   if not isinstance(manifest_targets, list):
@@ -141,6 +142,7 @@ def extract_fuzz_targets_from_manifest(manifest_dict: dict) -> list[str] | None:
       continue
     fuzz_target_paths.append(target_path)
 
+  logs.info(f'{len(fuzz_target_paths)} found in manifest.')
   return fuzz_target_paths
 
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -104,10 +104,20 @@ def is_fuzz_target(file_path, file_opener: Optional[Callable] = None):
 
 def extract_fuzz_targets_from_manifest(
     manifest_dict: dict,
-    manifest_filename: str = CHROME_MANIFEST_FILENAME) -> list[str] | None:
-  """Extract list of target paths from a loaded manifest dict if present."""
+    manifest_path: str = CHROME_MANIFEST_FILENAME) -> list[str] | None:
+  """Extract list of target paths from a loaded manifest dict.
+
+  Looks for `fuzz_targets` property in the dict and checks that the whole dict
+  is in the expected format. For example, `manifest` might look like:
+  {
+    fuzz_targets: [
+      "fuzz_target_a",
+      "fuzz_target_b"
+    ]
+  }
+  """
   if not isinstance(manifest_dict, dict):
-    logs.error(f'{manifest_filename} is not a dict')
+    logs.error(f'{manifest_path} is not a dict')
     return None
 
   manifest_targets = manifest_dict.get('fuzz_targets')
@@ -115,15 +125,14 @@ def extract_fuzz_targets_from_manifest(
     return None
 
   if not isinstance(manifest_targets, list):
-    logs.error(f'fuzz_targets in {manifest_filename} is not a list')
+    logs.error(f'fuzz_targets in {manifest_path} is not a list')
     return None
 
   fuzz_target_paths = []
   for target_path in manifest_targets:
     if not isinstance(target_path, str):
-      logs.error(
-          f'Entry in fuzz_targets ({manifest_filename}) is not a string: '
-          f'{target_path}')
+      logs.error(f'Entry in fuzz_targets ({manifest_path}) is not a string: '
+                 f'{target_path}')
       continue
     fuzz_target_paths.append(target_path)
 
@@ -131,7 +140,13 @@ def extract_fuzz_targets_from_manifest(
 
 
 def read_chrome_manifest(build_dir: str) -> dict | None:
-  """Reads and parses clusterfuzz_manifest.json from build_dir if present."""
+  """Reads and parses clusterfuzz_manifest.json from build_dir.
+
+  Returns the contents of 'clusterfuzz_manifest.json' if found and read,
+  otherwise returns None.
+
+  build_dir: The directory 'clusterfuzz_manifest.json' is to be read from.
+  """
   manifest_path = os.path.join(build_dir, CHROME_MANIFEST_FILENAME)
   if not os.path.exists(manifest_path):
     return None
@@ -145,14 +160,17 @@ def read_chrome_manifest(build_dir: str) -> dict | None:
 
 
 def _get_manifest_fuzz_targets(build_dir: str) -> list[str] | None:
-  """Get list of fuzz targets from clusterfuzz_manifest.json if present."""
+  """Get list of fuzz targets from clusterfuzz_manifest.json.
+
+  Returns list of fuzz targets to pick for fuzzing. Returns None, if it
+  encounters an error parsing clusterfuzz_manifest.json for `fuzz_targets`.
+  """
   manifest = read_chrome_manifest(build_dir)
   if manifest is None:
     return None
 
   manifest_path = os.path.join(build_dir, CHROME_MANIFEST_FILENAME)
-  manifest_targets = extract_fuzz_targets_from_manifest(
-      manifest, manifest_filename=manifest_path)
+  manifest_targets = extract_fuzz_targets_from_manifest(manifest, manifest_path)
   if manifest_targets is None:
     return None
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -14,6 +14,7 @@
 """Fuzzer utils."""
 
 import functools
+import json
 import os
 import re
 import stat
@@ -98,8 +99,52 @@ def is_fuzz_target(file_path, file_opener: Optional[Callable] = None):
     return False
 
 
+def _get_manifest_fuzz_targets(path):
+  """Get list of fuzz targets from clusterfuzz_manifest.json if present."""
+  manifest_path = os.path.join(path, 'clusterfuzz_manifest.json')
+  if not os.path.exists(manifest_path):
+    return None
+
+  try:
+    with open(manifest_path, 'r', encoding='utf-8') as f:
+      manifest = json.load(f)
+  except Exception as e:
+    logs.error(f'Failed to read {manifest_path}: {e}')
+    return None
+
+  if not isinstance(manifest, dict):
+    logs.error(f'{manifest_path} is not a dict')
+    return None
+
+  manifest_targets = manifest.get('fuzz_targets')
+  if manifest_targets is None:
+    return None
+
+  if not isinstance(manifest_targets, list):
+    logs.error(f'fuzz_targets in {manifest_path} is not a list')
+    return None
+
+  fuzz_target_paths = []
+  for target_path in manifest_targets:
+    if not isinstance(target_path, str):
+      logs.error(f'Entry in fuzz_targets ({manifest_path}) is not a string: '
+                 f'{target_path}')
+      continue
+    file_path = os.path.join(path, target_path)
+    if os.path.exists(file_path):
+      fuzz_target_paths.append(file_path)
+    else:
+      logs.warning(f'Fuzz target {target_path} in {manifest_path} not found.')
+
+  return fuzz_target_paths
+
+
 def get_fuzz_targets_local(path):
   """Get list of fuzz targets paths (local)."""
+  manifest_fuzz_targets = _get_manifest_fuzz_targets(path)
+  if manifest_fuzz_targets is not None:
+    return manifest_fuzz_targets
+
   fuzz_target_paths = []
 
   for root, _, files in shell.walk(path):

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -102,9 +102,7 @@ def is_fuzz_target(file_path, file_opener: Optional[Callable] = None):
     return False
 
 
-def extract_fuzz_targets_from_manifest(
-    manifest_dict: dict,
-    manifest_path: str = CHROME_MANIFEST_FILENAME) -> list[str] | None:
+def extract_fuzz_targets_from_manifest(manifest_dict: dict) -> list[str] | None:
   """Extracts the list of target paths from a loaded manifest dict.
 
   Looks for the `fuzz_targets` property in the dictionary and validates that
@@ -119,14 +117,13 @@ def extract_fuzz_targets_from_manifest(
 
   Args:
       manifest_dict: the loaded manifest dictionary
-      manifest_path: the path or filename of the manifest (used for logging)
 
   Returns:
       the list of fuzz target paths, or None if invalid or missing
       `fuzz_targets`
   """
   if not isinstance(manifest_dict, dict):
-    logs.error(f'{manifest_path} is not a dict')
+    logs.error(f'Manifest is not a dict: {manifest_dict}')
     return None
 
   manifest_targets = manifest_dict.get('fuzz_targets')
@@ -134,14 +131,13 @@ def extract_fuzz_targets_from_manifest(
     return None
 
   if not isinstance(manifest_targets, list):
-    logs.error(f'fuzz_targets in {manifest_path} is not a list')
+    logs.error(f'fuzz_targets in manifest is not a list: {manifest_dict}')
     return None
 
   fuzz_target_paths = []
   for target_path in manifest_targets:
     if not isinstance(target_path, str):
-      logs.error(f'Entry in fuzz_targets ({manifest_path}) is not a string: '
-                 f'{target_path}')
+      logs.error(f'Entry in fuzz_targets is not a string: {target_path}')
       continue
     fuzz_target_paths.append(target_path)
 
@@ -185,7 +181,7 @@ def _get_manifest_fuzz_targets(build_dir: str) -> list[str] | None:
     return None
 
   manifest_path = os.path.join(build_dir, CHROME_MANIFEST_FILENAME)
-  manifest_targets = extract_fuzz_targets_from_manifest(manifest, manifest_path)
+  manifest_targets = extract_fuzz_targets_from_manifest(manifest)
   if manifest_targets is None:
     return None
 

--- a/src/clusterfuzz/_internal/bot/fuzzers/utils.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/utils.py
@@ -105,16 +105,25 @@ def is_fuzz_target(file_path, file_opener: Optional[Callable] = None):
 def extract_fuzz_targets_from_manifest(
     manifest_dict: dict,
     manifest_path: str = CHROME_MANIFEST_FILENAME) -> list[str] | None:
-  """Extract list of target paths from a loaded manifest dict.
+  """Extracts the list of target paths from a loaded manifest dict.
 
-  Looks for `fuzz_targets` property in the dict and checks that the whole dict
-  is in the expected format. For example, `manifest` might look like:
+  Looks for the `fuzz_targets` property in the dictionary and validates that
+  the dictionary is in the expected format. For example, `manifest_dict` might
+  look like:
   {
-    fuzz_targets: [
-      "fuzz_target_a",
-      "fuzz_target_b"
-    ]
+      "fuzz_targets": [
+          "fuzz_target_a",
+          "fuzz_target_b"
+      ]
   }
+
+  Args:
+      manifest_dict: the loaded manifest dictionary
+      manifest_path: the path or filename of the manifest (used for logging)
+
+  Returns:
+      the list of fuzz target paths, or None if invalid or missing
+      `fuzz_targets`
   """
   if not isinstance(manifest_dict, dict):
     logs.error(f'{manifest_path} is not a dict')
@@ -142,10 +151,12 @@ def extract_fuzz_targets_from_manifest(
 def read_chrome_manifest(build_dir: str) -> dict | None:
   """Reads and parses clusterfuzz_manifest.json from build_dir.
 
-  Returns the contents of 'clusterfuzz_manifest.json' if found and read,
-  otherwise returns None.
+  Args:
+      build_dir: the directory to read clusterfuzz_manifest.json from
 
-  build_dir: The directory 'clusterfuzz_manifest.json' is to be read from.
+  Returns:
+      the parsed dictionary from clusterfuzz_manifest.json, or None if missing
+      or unreadable
   """
   manifest_path = os.path.join(build_dir, CHROME_MANIFEST_FILENAME)
   if not os.path.exists(manifest_path):
@@ -160,10 +171,14 @@ def read_chrome_manifest(build_dir: str) -> dict | None:
 
 
 def _get_manifest_fuzz_targets(build_dir: str) -> list[str] | None:
-  """Get list of fuzz targets from clusterfuzz_manifest.json.
+  """Gets the list of fuzz targets from clusterfuzz_manifest.json.
 
-  Returns list of fuzz targets to pick for fuzzing. Returns None, if it
-  encounters an error parsing clusterfuzz_manifest.json for `fuzz_targets`.
+  Args:
+      build_dir: the directory containing clusterfuzz_manifest.json
+
+  Returns:
+      the list of existing fuzz target paths in build_dir, or None if missing
+      or invalid
   """
   manifest = read_chrome_manifest(build_dir)
   if manifest is None:
@@ -186,11 +201,17 @@ def _get_manifest_fuzz_targets(build_dir: str) -> list[str] | None:
 
 
 def get_fuzz_targets_local(path):
-  """Get list of fuzz target paths (local).
+  """Gets the list of local fuzz target paths.
 
-  If clusterfuzz_manifest.json is present and defines fuzz_targets, those
+  If clusterfuzz_manifest.json is present and defines `fuzz_targets`, those
   targets are returned. Otherwise, falls back to scanning the directory for
   executables ending in `_fuzzer`.
+
+  Args:
+      path: the directory path to search for fuzz targets
+
+  Returns:
+      the list of local fuzz target paths
   """
   manifest_fuzz_targets = _get_manifest_fuzz_targets(path)
   if manifest_fuzz_targets is not None:

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -314,7 +314,7 @@ class ChromeBuildArchive(DefaultBuildArchive):
     self._manifest_fuzz_targets = None
     # The manifest may not exist for earlier versions of archives. In this
     # case, default to schema version 0.
-    manifest_path = CHROME_MANIFEST_FILENAME
+    manifest_path = os.path.join(reader.root_dir(), CHROME_MANIFEST_FILENAME)
     if not self.file_exists(manifest_path):
       self._archive_schema_version = default_archive_schema_version
       return

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -24,6 +24,7 @@ from typing import Union
 
 from typing_extensions import override
 
+from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import archive
 
@@ -96,9 +97,6 @@ class BuildArchive(archive.ArchiveReader):
         The list of fuzz targets.
     """
     if self._fuzz_targets is None:
-      # Import here as this path is not available in App Engine context.
-      from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
-
       self._fuzz_targets = {
           fuzzer_utils.normalize_target_name(path): path
           for path in self.find_fuzz_targets()
@@ -207,9 +205,6 @@ class DefaultBuildArchive(BuildArchive):
 
   @override
   def find_fuzz_targets(self) -> List[str]:
-    # Import here as this path is not available in App Engine context.
-    from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
-
     return [
         member.name
         for member in self.list_members()
@@ -328,10 +323,8 @@ class ChromeBuildArchive(DefaultBuildArchive):
           'archive_schema_version field')
       self._archive_schema_version = default_archive_schema_version
 
-    from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
     self._manifest_fuzz_targets = (
-        fuzzer_utils.extract_fuzz_targets_from_manifest(manifest,
-                                                        manifest_path))
+        fuzzer_utils.extract_fuzz_targets_from_manifest(manifest))
 
   def root_dir(self) -> str:
     if not hasattr(self, '_root_dir'):

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -328,21 +328,10 @@ class ChromeBuildArchive(DefaultBuildArchive):
           'archive_schema_version field')
       self._archive_schema_version = default_archive_schema_version
 
-    fuzz_target_paths = manifest.get('fuzz_targets')
-    if fuzz_target_paths is None:
-      return
-
-    if not isinstance(fuzz_target_paths, list):
-      logs.error('fuzz_targets in clusterfuzz_manifest.json is not a list')
-      return
-
-    self._manifest_fuzz_targets = []
-    for target_path in fuzz_target_paths:
-      if isinstance(target_path, str):
-        self._manifest_fuzz_targets.append(target_path)
-      else:
-        logs.error('Entry in fuzz_targets (clusterfuzz_manifest.json) is not a '
-                   f'string: {target_path}')
+    from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+    self._manifest_fuzz_targets = (
+        fuzzer_utils.extract_fuzz_targets_from_manifest(
+            manifest, manifest_filename=manifest_path))
 
   def root_dir(self) -> str:
     if not hasattr(self, '_root_dir'):

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -330,8 +330,8 @@ class ChromeBuildArchive(DefaultBuildArchive):
 
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
     self._manifest_fuzz_targets = (
-        fuzzer_utils.extract_fuzz_targets_from_manifest(
-            manifest, manifest_filename=manifest_path))
+        fuzzer_utils.extract_fuzz_targets_from_manifest(manifest,
+                                                        manifest_path))
 
   def root_dir(self) -> str:
     if not hasattr(self, '_root_dir'):
@@ -344,7 +344,7 @@ class ChromeBuildArchive(DefaultBuildArchive):
 
   @override
   def find_fuzz_targets(self) -> List[str]:
-    if self._manifest_fuzz_targets:
+    if self._manifest_fuzz_targets is not None:
       return self._manifest_fuzz_targets
     return super().find_fuzz_targets()
 

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -16,7 +16,6 @@
 from collections import namedtuple
 import contextlib
 import datetime
-import json
 import os
 import re
 import shutil
@@ -331,15 +330,14 @@ class BaseBuild:
 
 def _read_schema_version_from_manifest(build_dir: str) -> int:
   """Reads archive_schema_version from clusterfuzz_manifest.json."""
-  manifest_path = os.path.join(build_dir, 'clusterfuzz_manifest.json')
-  if not os.path.exists(manifest_path):
+  from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+  manifest = fuzzer_utils.read_chrome_manifest(build_dir)
+  if not manifest:
     return 0
   try:
-    with open(manifest_path) as f:
-      manifest = json.load(f)
     return int(manifest.get('archive_schema_version') or 0)
   except Exception as e:
-    logs.warning(f'Failed to read schema version from {manifest_path}: {e}')
+    logs.warning(f'Failed to read schema version from {build_dir}: {e}')
     return 0
 
 

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -337,7 +337,8 @@ def _read_schema_version_from_manifest(build_dir: str) -> int:
   try:
     return int(manifest.get('archive_schema_version') or 0)
   except Exception as e:
-    logs.warning(f'Failed to read schema version from {build_dir}: {e}')
+    logs.warning(f'Failed to read schema version from chrome manifest in '
+                 f'{build_dir}: {e}')
     return 0
 
 

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/utils_test.py
@@ -174,49 +174,103 @@ class GetFuzzTargetsLocalTest(unittest.TestCase):
 
   def test_manifest_targets_used(self):
     """Test that clusterfuzz_manifest.json is used to find targets."""
-    target_a = self._create_file('target_a', contents=b'LLVMFuzzerTestOneInput')
-    self._create_file('run_target_a_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+    manifest_target = self._create_file(
+        'manifest_target', contents=b'LLVMFuzzerTestOneInput')
+    self._create_file('not_a_fuzzer', contents=b'LLVMFuzzerTestOneInput')
     manifest_contents = json.dumps({
         'archive_schema_version': 1,
-        'fuzz_targets': ['target_a']
+        'fuzz_targets': ['manifest_target']
     }).encode('utf-8')
     self._create_file('clusterfuzz_manifest.json', contents=manifest_contents)
 
     targets = utils.get_fuzz_targets_local(self.temp_dir)
-    self.assertEqual([target_a], targets)
+    self.assertEqual([manifest_target], targets)
 
   def test_manifest_missing_fallback(self):
     """Test fallback to scanning when manifest is missing."""
-    target_a = self._create_file(
-        'target_a_fuzzer', contents=b'LLVMFuzzerTestOneInput')
-    target_b = self._create_file(
-        'target_b_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+    file_target_a = self._create_file(
+        'file_target_a_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+    file_target_b = self._create_file(
+        'file_target_b_fuzzer', contents=b'LLVMFuzzerTestOneInput')
 
     targets = utils.get_fuzz_targets_local(self.temp_dir)
-    self.assertCountEqual([target_a, target_b], targets)
+    self.assertCountEqual([file_target_a, file_target_b], targets)
 
   def test_manifest_invalid_entries_skipped(self):
     """Test that non-string entries in manifest fuzz_targets are skipped."""
-    target_a = self._create_file('target_a', contents=b'LLVMFuzzerTestOneInput')
+    manifest_target = self._create_file(
+        'manifest_target', contents=b'LLVMFuzzerTestOneInput')
     manifest_contents = json.dumps({
         'archive_schema_version': 1,
-        'fuzz_targets': [123, None, 'target_a', {
+        'fuzz_targets': [123, None, 'manifest_target', {
             'invalid': 'dict'
         }]
     }).encode('utf-8')
     self._create_file('clusterfuzz_manifest.json', contents=manifest_contents)
 
     targets = utils.get_fuzz_targets_local(self.temp_dir)
-    self.assertEqual([target_a], targets)
+    self.assertEqual([manifest_target], targets)
 
   def test_manifest_without_fuzz_targets_fallback(self):
     """Test fallback to scanning when fuzz_targets property is missing."""
-    target_a = self._create_file(
-        'target_a_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+    file_target = self._create_file(
+        'file_target_fuzzer', contents=b'LLVMFuzzerTestOneInput')
     manifest_contents = json.dumps({
         'archive_schema_version': 1
     }).encode('utf-8')
     self._create_file('clusterfuzz_manifest.json', contents=manifest_contents)
 
     targets = utils.get_fuzz_targets_local(self.temp_dir)
-    self.assertEqual([target_a], targets)
+    self.assertEqual([file_target], targets)
+
+  def test_manifest_empty_fuzz_targets(self):
+    """Test that an empty fuzz_targets list in manifest returns an empty list without fallback."""
+    self._create_file('file_target_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+    manifest_contents = json.dumps({
+        'archive_schema_version': 1,
+        'fuzz_targets': []
+    }).encode('utf-8')
+    self._create_file('clusterfuzz_manifest.json', contents=manifest_contents)
+
+    targets = utils.get_fuzz_targets_local(self.temp_dir)
+    self.assertEqual([], targets)
+
+
+class ExtractFuzzTargetsFromManifestTest(unittest.TestCase):
+  """Tests for extract_fuzz_targets_from_manifest."""
+
+  def setUp(self):
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.metrics.logs.error',
+        'clusterfuzz._internal.metrics.logs.warning',
+    ])
+
+  def test_extract_valid(self):
+    manifest = {'fuzz_targets': ['manifest_target1', 'manifest_target2']}
+    result = utils.extract_fuzz_targets_from_manifest(manifest)
+    self.assertEqual(['manifest_target1', 'manifest_target2'], result)
+
+  def test_extract_empty_fuzz_targets(self):
+    manifest = {'fuzz_targets': []}
+    result = utils.extract_fuzz_targets_from_manifest(manifest)
+    self.assertEqual([], result)
+
+  def test_extract_missing_fuzz_targets(self):
+    manifest = {'archive_schema_version': 1}
+    result = utils.extract_fuzz_targets_from_manifest(manifest)
+    self.assertIsNone(result)
+
+  def test_extract_invalid_not_dict(self):
+    manifest = 'invalid'
+    result = utils.extract_fuzz_targets_from_manifest(manifest)
+    self.assertIsNone(result)
+
+  def test_extract_invalid_fuzz_targets_type(self):
+    manifest = {'fuzz_targets': 'not_a_list'}
+    result = utils.extract_fuzz_targets_from_manifest(manifest)
+    self.assertIsNone(result)
+
+  def test_extract_mixed_entries(self):
+    manifest = {'fuzz_targets': ['foo_fuzzer', 123, None, 'bar_fuzzer']}
+    result = utils.extract_fuzz_targets_from_manifest(manifest)
+    self.assertEqual(['foo_fuzzer', 'bar_fuzzer'], result)

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/utils_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for fuzzers.utils."""
 
+import json
 import os
 import shutil
 import tempfile
@@ -148,3 +149,74 @@ class GetSupportingFileTest(unittest.TestCase):
     """Test par extension."""
     self.assertEqual('/a/b.labels',
                      utils.get_supporting_file('/a/b.par', '.labels'))
+
+
+class GetFuzzTargetsLocalTest(unittest.TestCase):
+  """Tests for get_fuzz_targets_local."""
+
+  def setUp(self):
+    test_helpers.patch_environ(self)
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.metrics.logs.error',
+        'clusterfuzz._internal.metrics.logs.warning',
+    ])
+    self.temp_dir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+  def _create_file(self, name, contents=b''):
+    path = os.path.join(self.temp_dir, name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'wb') as f:
+      f.write(contents)
+    return path
+
+  def test_manifest_targets_used(self):
+    """Test that clusterfuzz_manifest.json is used to find targets."""
+    target_a = self._create_file('target_a', contents=b'LLVMFuzzerTestOneInput')
+    self._create_file('run_target_a_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+    manifest_contents = json.dumps({
+        'archive_schema_version': 1,
+        'fuzz_targets': ['target_a']
+    }).encode('utf-8')
+    self._create_file('clusterfuzz_manifest.json', contents=manifest_contents)
+
+    targets = utils.get_fuzz_targets_local(self.temp_dir)
+    self.assertEqual([target_a], targets)
+
+  def test_manifest_missing_fallback(self):
+    """Test fallback to scanning when manifest is missing."""
+    target_a = self._create_file(
+        'target_a_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+    target_b = self._create_file(
+        'target_b_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+
+    targets = utils.get_fuzz_targets_local(self.temp_dir)
+    self.assertCountEqual([target_a, target_b], targets)
+
+  def test_manifest_invalid_entries_skipped(self):
+    """Test that non-string entries in manifest fuzz_targets are skipped."""
+    target_a = self._create_file('target_a', contents=b'LLVMFuzzerTestOneInput')
+    manifest_contents = json.dumps({
+        'archive_schema_version': 1,
+        'fuzz_targets': [123, None, 'target_a', {
+            'invalid': 'dict'
+        }]
+    }).encode('utf-8')
+    self._create_file('clusterfuzz_manifest.json', contents=manifest_contents)
+
+    targets = utils.get_fuzz_targets_local(self.temp_dir)
+    self.assertEqual([target_a], targets)
+
+  def test_manifest_without_fuzz_targets_fallback(self):
+    """Test fallback to scanning when fuzz_targets property is missing."""
+    target_a = self._create_file(
+        'target_a_fuzzer', contents=b'LLVMFuzzerTestOneInput')
+    manifest_contents = json.dumps({
+        'archive_schema_version': 1
+    }).encode('utf-8')
+    self._create_file('clusterfuzz_manifest.json', contents=manifest_contents)
+
+    targets = utils.get_fuzz_targets_local(self.temp_dir)
+    self.assertEqual([target_a], targets)

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
@@ -498,33 +498,31 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
     self.mock_archive_reader.list_members.assert_called_once()
 
   def test_manifest_fuzz_targets_empty(self):
-    """Tests that empty fuzz_targets list in the manifest is ignored
-    and we fallback to discovery."""
+    """Tests that empty fuzz_targets list in the manifest returns empty list
+    without falling back to discovery."""
     self.mock.file_exists.return_value = True
     self._generate_manifest({'archive_schema_version': 1, 'fuzz_targets': []})
-    self.mock_archive_reader.list_members.return_value = []
 
     test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
 
     self.assertEqual(test_archive.archive_schema_version(), 1)
-    test_archive.list_fuzz_targets()
-    self.mock_archive_reader.list_members.assert_called_once()
+    self.assertEqual(test_archive.list_fuzz_targets(), [])
+    self.mock_archive_reader.list_members.assert_not_called()
 
   def test_manifest_fuzz_targets_all_invalid(self):
-    """Tests that fuzz_targets list with only invalid entries in the manifest is
-    ignored and we fallback to discovery."""
+    """Tests that fuzz_targets list with only invalid entries in the manifest
+    returns empty list without falling back to discovery."""
     self.mock.file_exists.return_value = True
     self._generate_manifest({
         'archive_schema_version': 1,
         'fuzz_targets': [1, 2]
     })
-    self.mock_archive_reader.list_members.return_value = []
 
     test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
 
     self.assertEqual(test_archive.archive_schema_version(), 1)
-    test_archive.list_fuzz_targets()
-    self.mock_archive_reader.list_members.assert_called_once()
+    self.assertEqual(test_archive.list_fuzz_targets(), [])
+    self.mock_archive_reader.list_members.assert_not_called()
 
   def test_manifest_fuzz_targets_mixed(self):
     """Tests that fuzz_targets list with mixed valid and invalid entries in the

--- a/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
+++ b/src/clusterfuzz/_internal/tests/core/build_management/build_archive_test.py
@@ -386,6 +386,8 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
 
   def setUp(self):
     test_helpers.patch(self, [
+        'clusterfuzz._internal.metrics.logs.error',
+        'clusterfuzz._internal.metrics.logs.warning',
         'clusterfuzz._internal.system.archive.ArchiveReader.file_exists',
         'clusterfuzz._internal.system.archive.ArchiveReader',
         'clusterfuzz._internal.system.archive.open',
@@ -444,6 +446,25 @@ class ChromeBuildArchiveManifestTest(unittest.TestCase):
         test_archive.get_path_for_target('my_fuzzer'), 'out/build/my_fuzzer')
     # Ensure list_members was never called for fuzz target discovery.
     self.mock_archive_reader.list_members.assert_not_called()
+
+  def test_manifest_fuzz_targets_with_root_dir(self):
+    """Tests that manifest is read when archive has a root directory prefix."""
+    self.mock_archive_reader.root_dir.return_value = 'build'
+
+    def _mock_file_exists(_, path):
+      return path == 'build/clusterfuzz_manifest.json'
+
+    self.mock.file_exists.side_effect = _mock_file_exists
+    self._generate_manifest({
+        'archive_schema_version': 1,
+        'fuzz_targets': ['out/build/my_fuzzer', 'out/build/other_fuzzer']
+    })
+
+    test_archive = build_archive.ChromeBuildArchive(self.mock_archive_reader)
+
+    self.assertEqual(test_archive.archive_schema_version(), 1)
+    self.assertCountEqual(test_archive.list_fuzz_targets(),
+                          ['my_fuzzer', 'other_fuzzer'])
 
   def test_manifest_fuzz_targets_invalid(self):
     """Tests that invalid fuzz_targets (e.g. dict) in the manifest are ignored


### PR DESCRIPTION
Chrome archives initially pick fuzz targets from a `fuzz_targets` property from `clusterfuzz_manifest.json`, but it doesn't use the same `fuzz_targets`  on future runs if the build on disk is reused. This leads to wasting time doing a directory scan for `_fuzzer` binaries to choose a fuzz target and can pick a binary that is not intended to be run (`run_*_fuzzer`). This change is largely meant for long running bots which are not used for Chrome but essentially closes the loop on using `fuzz_targets` when possible.

Modifying fuzzer utils to re-access `clusterfuzz_manifest.json` for `fuzz_targets` if available otherwise fall back to existing behavior. Adding unit tests for fuzzer utils. Refactoring `build_archive.py` and `build_manager.py` to use the new common utility functions.

Drive-by: Improve Chrome manifest path search by joining to `root_dir` for wrapped directories where ClusterFuzz's build directory is not the Chrome archives root directory with respective unit tests.

Bug: https://crbug.com/507833074