### PR TITLE
Add utils.create_temp_file helper

### DIFF
--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -1144,7 +1144,19 @@ def batched(iterator, batch_size):
 
 
 def create_temp_file(directory: str, prefix: str, suffix: str) -> str:
-  """Creates a temporary file and returns its path."""
+  """Creates a temporary file and returns its path.
+
+  Args:
+    directory: The directory in which to create the temporary file.
+    prefix: Prefix to use for the temporary file name.
+    suffix: Suffix to use for the temporary file name.
+
+  Returns:
+    The absolute path to the created temporary file.
+
+  Raises:
+    OSError: If the file cannot be created in the specified directory.
+  """
   fd, file_path = tempfile.mkstemp(dir=directory, prefix=prefix, suffix=suffix)
   os.close(fd)
   return file_path

--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -23,6 +23,7 @@ import os
 import random
 import re
 import sys
+import tempfile
 import time
 import urllib.parse
 import urllib.request
@@ -1140,3 +1141,10 @@ def batched(iterator, batch_size):
 
   if batch:
     yield batch
+
+
+def create_temp_file(directory: str, prefix: str, suffix: str) -> str:
+  """Creates a temporary file and returns its path."""
+  fd, file_path = tempfile.mkstemp(dir=directory, prefix=prefix, suffix=suffix)
+  os.close(fd)
+  return file_path

--- a/src/clusterfuzz/_internal/tests/core/base/utils_test.py
+++ b/src/clusterfuzz/_internal/tests/core/base/utils_test.py
@@ -721,3 +721,16 @@ class ParseManifestDataTest(unittest.TestCase):
     """Test parsing manifest data with an added prefix."""
     file_data = 'prefix123-20250402153042-utc-40773ac0-username_test123-cad6977-prod'
     self.assertIsNone(utils.parse_manifest_data(file_data))
+
+
+class CreateTempFileTest(unittest.TestCase):
+  """Tests for create_temp_file."""
+
+  def test_create_temp_file(self):
+    """Test create_temp_file creates a file and returns its path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+      file_path = utils.create_temp_file(tmpdir, 'prefix_', '_suffix')
+      self.assertTrue(os.path.exists(file_path))
+      self.assertTrue(file_path.startswith(tmpdir))
+      self.assertIn('prefix_', file_path)
+      self.assertTrue(file_path.endswith('_suffix'))


### PR DESCRIPTION
## Overview
This is the Third PR(Of 4) to tackle an instance of PERMISSION_DENIED issues when executing a BlackBox test case in a `uworker` bot.

This PR adds a small util that creates a temp file to be used by the next PR in the PR review stack.

## Changes
- Adds a new method to `utils.py` that creates a temp_file and returns its path
- Adds a unit test for it

## PR stack
PR #5376: Introduce FuzzerRunOutputData and utils (Base: master)
PR #5377: Refactor _to_fuzzer_run_output to use FuzzerRunOutputData (Base: PR 1)
Current -> PR #5388: refactor: Add utils.create_temp_file helper (Base: PR 2)
PR #5378: Defer Blackbox Fuzzer Log Uploads (Base: PR 3)