### PR TITLE
Require testcase access in issue_redirector before redirecting

### DIFF
--- a/src/appengine/handlers/issue_redirector.py
+++ b/src/appengine/handlers/issue_redirector.py
@@ -16,6 +16,7 @@
 
 from clusterfuzz._internal.issue_management import issue_tracker_utils
 from handlers import base_handler
+from libs import access
 from libs import helpers
 
 
@@ -25,6 +26,9 @@ class Handler(base_handler.Handler):
   def get(self, testcase_id=None):
     """Redirect user to the correct URL."""
     testcase = helpers.get_testcase(testcase_id)
+    if not access.can_user_access_testcase(testcase):
+      raise helpers.AccessDeniedError()
+
     issue_url = helpers.get_or_exit(
         lambda: issue_tracker_utils.get_issue_url(testcase),
         'Issue tracker for testcase (id=%s) is not found.' % testcase_id,

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/issue_redirector_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/issue_redirector_test.py
@@ -29,9 +29,11 @@ class HandlerTest(unittest.TestCase):
     test_helpers.patch(self, [
         'clusterfuzz._internal.issue_management.issue_tracker_utils.get_issue_url',
         'libs.helpers.get_testcase',
+        'libs.access.can_user_access_testcase',
         'clusterfuzz._internal.system.environment.is_running_on_app_engine',
     ])
     self.mock.is_running_on_app_engine.return_value = True
+    self.mock.can_user_access_testcase.return_value = True
 
     import server
     self.app = webtest.TestApp(server.app)
@@ -58,3 +60,17 @@ class HandlerTest(unittest.TestCase):
 
     response = self.app.get('/issue/12345', expect_errors=True)
     self.assertEqual(404, response.status_int)
+
+  def test_no_access(self):
+    """A caller without access to the testcase must not be redirected to its
+    issue URL, previously this handler had no access check at all."""
+    self.mock.can_user_access_testcase.return_value = False
+    testcase = data_types.Testcase()
+    testcase.bug_information = '456789'
+    self.mock.get_testcase.return_value = testcase
+    self.mock.get_issue_url.return_value = 'http://google.com/456789'
+
+    response = self.app.get('/issue/12345', expect_errors=True)
+
+    self.assertEqual(403, response.status_int)
+    self.mock.get_issue_url.assert_not_called()


### PR DESCRIPTION
`issue_redirector` takes a testcase id and 302-redirects the caller to that testcase's bug URL, with no access check at all:

```python
class Handler(base_handler.Handler):
  def get(self, testcase_id):
    testcase = ...
    self.redirect(get_issue_url(testcase))
```

There was no authorization on the testcase, so any caller could hit `/issue/<testcase_id>` and be redirected to the linked bug for any testcase, including security-restricted ones, disclosing the bug id and the existence of the testcase.

```python
from libs import access
...
if not access.can_user_access_testcase(testcase):
  raise helpers.AccessDeniedError()
```

The redirect is now gated on the same testcase-access check the rest of the app uses. Adds a regression test asserting a caller without access is denied instead of redirected.