### PR TITLE
[Metrics] Add tracking for preempted fuzzing hours

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -20,6 +20,7 @@ import json
 import os
 import random
 import re
+import threading
 import time
 from typing import Any
 from typing import Dict
@@ -61,6 +62,7 @@ from clusterfuzz._internal.metrics import events
 from clusterfuzz._internal.metrics import fuzzer_logs
 from clusterfuzz._internal.metrics import fuzzer_stats
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.metrics import monitor
 from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.platforms import android
 from clusterfuzz._internal.protos import uworker_msg_pb2
@@ -406,6 +408,37 @@ def _should_create_testcase(group: uworker_msg_pb2.FuzzTaskCrashGroup,
 
 class _TrackFuzzTime:
   """Track the actual fuzzing time (e.g. excluding preparing binary)."""
+  _active_trackers = set()
+  _lock = threading.Lock()
+  _callback_registered = False
+
+  @classmethod
+  def get_active_trackers(cls):
+    with cls._lock:
+      return list(cls._active_trackers)
+
+  @classmethod
+  def _preemption_callback(cls):
+    """Callback to record wasted fuzzing time on preemption."""
+    logs.info('Running preemption callback to record wasted time.')
+    for tracker in cls.get_active_trackers():
+      duration = tracker.time.time() - tracker.start_time
+      logs.info(f'Recording {int(duration)} seconds of preempted time for '
+                f'{tracker.fuzzer_name} on {tracker.job_type}.')
+      monitoring_metrics.FUZZER_PREEMPTED_TOTAL_FUZZ_TIME.increment_by(
+          int(duration), {
+              'fuzzer': tracker.fuzzer_name,
+              'platform': environment.platform(),
+              'is_batch': environment.is_uworker(),
+              'runtime': environment.get_runtime().value,
+          })
+      monitoring_metrics.JOB_PREEMPTED_TOTAL_FUZZ_TIME.increment_by(
+          int(duration), {
+              'job': tracker.job_type,
+              'platform': environment.platform(),
+              'is_batch': environment.is_uworker(),
+              'runtime': environment.get_runtime().value,
+          })
 
   def __init__(self, fuzzer_name, job_type, time_module=time):
     self.fuzzer_name = fuzzer_name
@@ -415,11 +448,20 @@ class _TrackFuzzTime:
     self.timeout = None
 
   def __enter__(self):
+    if not _TrackFuzzTime._callback_registered:
+      monitor.register_on_sigterm(_TrackFuzzTime._preemption_callback)
+      _TrackFuzzTime._callback_registered = True
+
     self.start_time = self.time.time()
     self.timeout = False
+    with self._lock:
+      self._active_trackers.add(self)
     return self
 
   def __exit__(self, exc_type, value, traceback):
+    with self._lock:
+      self._active_trackers.discard(self)
+
     duration = self.time.time() - self.start_time
     monitoring_metrics.FUZZER_TOTAL_FUZZ_TIME.increment_by(
         int(duration), {

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -411,6 +411,23 @@ class _TrackFuzzTime:
   _active_trackers = set()
   _lock = threading.Lock()
   _callback_registered = False
+  _accumulated_wasted_time = 0
+  _session_fuzzer = None
+  _session_job = None
+
+  @classmethod
+  def reset_session(cls, fuzzer_name, job_type):
+    """Resets the accumulated time at the start of a session."""
+    with cls._lock:
+      cls._accumulated_wasted_time = 0
+      cls._session_fuzzer = fuzzer_name
+      cls._session_job = job_type
+
+  @classmethod
+  def add_wasted_time(cls, duration):
+    """Accumulates time from finished rounds."""
+    with cls._lock:
+      cls._accumulated_wasted_time += duration
 
   @classmethod
   def get_active_trackers(cls):
@@ -418,23 +435,12 @@ class _TrackFuzzTime:
       return list(cls._active_trackers)
 
   @classmethod
-  def _preemption_callback(cls):
-    """Callback to record wasted fuzzing time on preemption."""
-    logs.info('Running preemption callback to record wasted time.')
-    for tracker in cls.get_active_trackers():
-      duration = tracker.time.time() - tracker.start_time
-      logs.info(f'Recording {int(duration)} seconds of preempted time for '
-                f'{tracker.fuzzer_name} on {tracker.job_type}.')
-      tracker.record_metrics(duration, is_preempted=True)
-
-  def __init__(self, fuzzer_name, job_type, time_module=time):
-    self.fuzzer_name = fuzzer_name
-    self.job_type = job_type
-    self.time = time_module
-    self.start_time = None
-    self.timeout = None
-
-  def record_metrics(self, duration, is_preempted=False):
+  def record_metrics(cls,
+                     duration,
+                     fuzzer_name,
+                     job_type,
+                     timeout=None,
+                     is_preempted=False):
     """Helper to record metrics consistently."""
     common_labels = {
         'platform': environment.platform(),
@@ -445,22 +451,70 @@ class _TrackFuzzTime:
     if is_preempted:
       fuzzer_metric = monitoring_metrics.FUZZER_PREEMPTED_TOTAL_FUZZ_TIME
       job_metric = monitoring_metrics.JOB_PREEMPTED_TOTAL_FUZZ_TIME
-      fuzzer_labels = {**common_labels, 'fuzzer': self.fuzzer_name}
-      job_labels = {**common_labels, 'job': self.job_type}
+      fuzzer_labels = {**common_labels, 'fuzzer': fuzzer_name}
+      job_labels = {**common_labels, 'job': job_type}
     else:
       fuzzer_metric = monitoring_metrics.FUZZER_TOTAL_FUZZ_TIME
       job_metric = monitoring_metrics.JOB_TOTAL_FUZZ_TIME
       fuzzer_labels = {
-          **common_labels, 'fuzzer': self.fuzzer_name,
-          'timeout': self.timeout
+          **common_labels, 'fuzzer': fuzzer_name,
+          'timeout': timeout
       }
-      job_labels = {
-          **common_labels, 'job': self.job_type,
-          'timeout': self.timeout
-      }
+      job_labels = {**common_labels, 'job': job_type, 'timeout': timeout}
 
     fuzzer_metric.increment_by(int(duration), fuzzer_labels)
     job_metric.increment_by(int(duration), job_labels)
+
+  @classmethod
+  def _preemption_callback(cls):
+    """Callback to record wasted fuzzing time on preemption."""
+    logs.info('Running preemption callback to record wasted time.')
+    with cls._lock:
+      active_trackers = list(cls._active_trackers)
+
+      if active_trackers:
+        for tracker in active_trackers:
+          tracker.preempted = True  # Mark to avoid double counting in __exit__
+
+          current_duration = tracker.time.time() - tracker.start_time
+          total_wasted = cls._accumulated_wasted_time + current_duration
+
+          logs.info(f'Recording {int(current_duration)}s of total time and '
+                    f'{int(total_wasted)}s of preempted time for '
+                    f'{tracker.fuzzer_name}.')
+
+          # Emit current duration to total_time to fix subtraction math
+          cls.record_metrics(
+              current_duration,
+              tracker.fuzzer_name,
+              tracker.job_type,
+              tracker.timeout,
+              is_preempted=False)
+
+          # Emit total wasted to preempted_total_time
+          cls.record_metrics(
+              total_wasted,
+              tracker.fuzzer_name,
+              tracker.job_type,
+              is_preempted=True)
+      else:
+        if cls._session_fuzzer and cls._session_job:
+          total_wasted = cls._accumulated_wasted_time
+          logs.info(f'Recording {int(total_wasted)}s of preempted time '
+                    f'(between rounds) for {cls._session_fuzzer}.')
+          cls.record_metrics(
+              total_wasted,
+              cls._session_fuzzer,
+              cls._session_job,
+              is_preempted=True)
+
+  def __init__(self, fuzzer_name, job_type, time_module=time):
+    self.fuzzer_name = fuzzer_name
+    self.job_type = job_type
+    self.time = time_module
+    self.start_time = None
+    self.timeout = None
+    self.preempted = False
 
   def __enter__(self):
     if not _TrackFuzzTime._callback_registered:
@@ -478,7 +532,17 @@ class _TrackFuzzTime:
       self._active_trackers.discard(self)
 
     duration = self.time.time() - self.start_time
-    self.record_metrics(duration, is_preempted=False)
+    if not self.preempted:
+      _TrackFuzzTime.record_metrics(
+          duration,
+          self.fuzzer_name,
+          self.job_type,
+          self.timeout,
+          is_preempted=False)
+      _TrackFuzzTime.add_wasted_time(duration)
+    else:
+      logs.info(f'Skipping __exit__ metric emission for {self.fuzzer_name} '
+                'as it was already handled by preemption callback.')
 
 
 def _track_fuzzer_run_result(fuzzer_name, job_type, generated_testcase_count,
@@ -1675,6 +1739,9 @@ class FuzzingSession:
 
   def do_engine_fuzzing(self, engine_impl):
     """Run fuzzing engine."""
+    _TrackFuzzTime.reset_session(self.fully_qualified_fuzzer_name,
+                                 self.job_type)
+
     environment.set_value('FUZZER_NAME',
                           self.fuzz_target.fully_qualified_name())
 
@@ -1775,7 +1842,10 @@ class FuzzingSession:
 
   def do_blackbox_fuzzing(self, fuzzer, fuzzer_directory, job_type):
     """Run blackbox fuzzing. Currently also used for engine fuzzing."""
+    _TrackFuzzTime.reset_session(self.fully_qualified_fuzzer_name, job_type)
+
     # Set the thread timeout values.
+
     # TODO(ochang): Remove this hack once engine fuzzing refactor is complete.
     fuzz_test_timeout = environment.get_value('FUZZ_TEST_TIMEOUT')
     if fuzz_test_timeout:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -425,20 +425,7 @@ class _TrackFuzzTime:
       duration = tracker.time.time() - tracker.start_time
       logs.info(f'Recording {int(duration)} seconds of preempted time for '
                 f'{tracker.fuzzer_name} on {tracker.job_type}.')
-      monitoring_metrics.FUZZER_PREEMPTED_TOTAL_FUZZ_TIME.increment_by(
-          int(duration), {
-              'fuzzer': tracker.fuzzer_name,
-              'platform': environment.platform(),
-              'is_batch': environment.is_uworker(),
-              'runtime': environment.get_runtime().value,
-          })
-      monitoring_metrics.JOB_PREEMPTED_TOTAL_FUZZ_TIME.increment_by(
-          int(duration), {
-              'job': tracker.job_type,
-              'platform': environment.platform(),
-              'is_batch': environment.is_uworker(),
-              'runtime': environment.get_runtime().value,
-          })
+      tracker.record_metrics(duration, is_preempted=True)
 
   def __init__(self, fuzzer_name, job_type, time_module=time):
     self.fuzzer_name = fuzzer_name
@@ -446,6 +433,34 @@ class _TrackFuzzTime:
     self.time = time_module
     self.start_time = None
     self.timeout = None
+
+  def record_metrics(self, duration, is_preempted=False):
+    """Helper to record metrics consistently."""
+    common_labels = {
+        'platform': environment.platform(),
+        'is_batch': environment.is_uworker(),
+        'runtime': environment.get_runtime().value,
+    }
+
+    if is_preempted:
+      fuzzer_metric = monitoring_metrics.FUZZER_PREEMPTED_TOTAL_FUZZ_TIME
+      job_metric = monitoring_metrics.JOB_PREEMPTED_TOTAL_FUZZ_TIME
+      fuzzer_labels = {**common_labels, 'fuzzer': self.fuzzer_name}
+      job_labels = {**common_labels, 'job': self.job_type}
+    else:
+      fuzzer_metric = monitoring_metrics.FUZZER_TOTAL_FUZZ_TIME
+      job_metric = monitoring_metrics.JOB_TOTAL_FUZZ_TIME
+      fuzzer_labels = {
+          **common_labels, 'fuzzer': self.fuzzer_name,
+          'timeout': self.timeout
+      }
+      job_labels = {
+          **common_labels, 'job': self.job_type,
+          'timeout': self.timeout
+      }
+
+    fuzzer_metric.increment_by(int(duration), fuzzer_labels)
+    job_metric.increment_by(int(duration), job_labels)
 
   def __enter__(self):
     if not _TrackFuzzTime._callback_registered:
@@ -463,22 +478,7 @@ class _TrackFuzzTime:
       self._active_trackers.discard(self)
 
     duration = self.time.time() - self.start_time
-    monitoring_metrics.FUZZER_TOTAL_FUZZ_TIME.increment_by(
-        int(duration), {
-            'fuzzer': self.fuzzer_name,
-            'timeout': self.timeout,
-            'platform': environment.platform(),
-            'is_batch': environment.is_uworker(),
-            'runtime': environment.get_runtime().value,
-        })
-    monitoring_metrics.JOB_TOTAL_FUZZ_TIME.increment_by(
-        int(duration), {
-            'job': self.job_type,
-            'timeout': self.timeout,
-            'platform': environment.platform(),
-            'is_batch': environment.is_uworker(),
-            'runtime': environment.get_runtime().value
-        })
+    self.record_metrics(duration, is_preempted=False)
 
 
 def _track_fuzzer_run_result(fuzzer_name, job_type, generated_testcase_count,

--- a/src/clusterfuzz/_internal/google_cloud_utils/compute_metadata.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/compute_metadata.py
@@ -52,3 +52,15 @@ def is_gce():
     return False
 
   return True
+
+
+def get_preempted_status():
+  """Gets the preemption status of the instance."""
+  attribute_url = 'http://{}/computeMetadata/v1/instance/preempted'.format(
+      _METADATA_SERVER)
+  headers = {'Metadata-Flavor': 'Google'}
+  # We use a short timeout and no retries because this is called frequently
+  # in a background loop and should fail fast.
+  response = requests.get(attribute_url, headers=headers, timeout=5)
+  response.raise_for_status()
+  return response.text

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -27,6 +27,8 @@ import threading
 import time
 from typing import List
 
+import requests
+
 try:
   from google.cloud import monitoring_v3
 except (ImportError, RuntimeError):
@@ -49,6 +51,7 @@ from clusterfuzz._internal.system import environment
 
 CUSTOM_METRIC_PREFIX = 'custom.googleapis.com/'
 FLUSH_INTERVAL_SECONDS = 10 * 60  # 10 minutes.
+PREEMPTION_CHECK_INTERVAL = 15  # seconds
 RETRY_DEADLINE_SECONDS = 5 * 60  # 5 minutes.
 INITIAL_DELAY_SECONDS = 16
 MAXIMUM_DELAY_SECONDS = 2 * 60  # 2 minutes.
@@ -135,8 +138,22 @@ def _flush_metrics():
       logs.error(f'Failed to flush metrics: {e}')
 
 
+_on_sigterm_callbacks = []
+
+
+def register_on_sigterm(callback):
+  """Register a callback to be called on SIGTERM."""
+  _on_sigterm_callbacks.append(callback)
+
+
 def handle_sigterm(signo, stack_frame):  #pylint: disable=unused-argument
-  logs.info('Handling sigterm, stopping monitoring daemon.')
+  logs.info('Handling sigterm, running registered callbacks.')
+  for callback in _on_sigterm_callbacks:
+    try:
+      callback()
+    except Exception as e:
+      logs.error(f'Error in SIGTERM callback: {e}')
+  logs.info('Stopping monitoring daemon.')
   stop()
   logs.info('Sigterm handled, metrics flushed.')
 
@@ -179,6 +196,54 @@ class _MonitoringDaemon():
   def stop(self):
     self._flushing_thread_stop_event.set()
     self._flushing_thread.join()
+
+
+class _PreemptionPoller():
+  """Background thread to poll GCP metadata for preemption."""
+
+  def __init__(self, check_interval):
+    self._check_interval = check_interval
+    self._poller_thread = threading.Thread(
+        name='preemption_poller', target=self._poll_loop, daemon=True)
+    self._poller_thread_stop_event = threading.Event()
+
+  def _poll_loop(self):
+    """Polls GCP metadata for preemption status."""
+    metadata_url = ("http://metadata.google.internal/computeMetadata/v1/"
+                    "instance/preempted")
+    metadata_header = {"Metadata-Flavor": "Google"}
+
+    while True:
+      should_stop = self._poller_thread_stop_event.wait(
+          timeout=self._check_interval)
+      if should_stop:
+        break
+
+      if not compute_metadata.is_gce():
+        continue
+
+      try:
+        response = requests.get(
+            metadata_url, headers=metadata_header, timeout=5)
+        response.raise_for_status()
+
+        if response.text.strip().upper() == 'TRUE':
+          logs.info('Preemption detected via metadata!')
+          handle_sigterm(None, None)
+          break
+      except requests.exceptions.HTTPError as e:
+        if e.response.status_code != 404:
+          logs.warning(f'HTTP error checking preemption metadata: {e}')
+      except Exception as e:
+        logs.warning(f'Unknown error checking preemption metadata: {e}')
+
+  def start(self):
+    self._poller_thread.start()
+
+  def stop(self):
+    self._poller_thread_stop_event.set()
+    if threading.current_thread() != self._poller_thread:
+      self._poller_thread.join()
 
 
 _StoreValue = collections.namedtuple(
@@ -525,6 +590,7 @@ class _CumulativeDistributionMetric(Metric):
 _metrics_store = _MetricsStore()
 _monitoring_v3_client = None
 _monitoring_daemon = None
+_preemption_poller = None
 _monitored_resource = None
 
 # Add fields very conservatively here. There is a limit of 10 labels per metric
@@ -592,6 +658,7 @@ def initialize():
   """Initialize if monitoring is enabled for this bot."""
   global _monitoring_v3_client
   global _monitoring_daemon
+  global _preemption_poller
 
   if environment.get_value('LOCAL_DEVELOPMENT'):
     return
@@ -607,11 +674,16 @@ def initialize():
                                            FLUSH_INTERVAL_SECONDS)
     _monitoring_daemon.start()
 
+    _preemption_poller = _PreemptionPoller(PREEMPTION_CHECK_INTERVAL)
+    _preemption_poller.start()
+
 
 def stop():
   """Stops monitoring and cleans up (only if monitoring is enabled)."""
   if _monitoring_daemon:
     _monitoring_daemon.stop()
+  if _preemption_poller:
+    _preemption_poller.stop()
 
 
 def metrics_store():

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -209,9 +209,8 @@ class _PreemptionPoller():
 
   def _poll_loop(self):
     """Polls GCP metadata for preemption status."""
-    metadata_url = ("http://metadata.google.internal/computeMetadata/v1/"
-                    "instance/preempted")
-    metadata_header = {"Metadata-Flavor": "Google"}
+    if not compute_metadata.is_gce():
+      return
 
     while True:
       should_stop = self._poller_thread_stop_event.wait(
@@ -219,15 +218,9 @@ class _PreemptionPoller():
       if should_stop:
         break
 
-      if not compute_metadata.is_gce():
-        continue
-
       try:
-        response = requests.get(
-            metadata_url, headers=metadata_header, timeout=5)
-        response.raise_for_status()
-
-        if response.text.strip().upper() == 'TRUE':
+        status = compute_metadata.get_preempted_status()
+        if status and status.strip().upper() == 'TRUE':
           logs.info('Preemption detected via metadata!')
           handle_sigterm(None, None)
           break
@@ -674,8 +667,9 @@ def initialize():
                                            FLUSH_INTERVAL_SECONDS)
     _monitoring_daemon.start()
 
-    _preemption_poller = _PreemptionPoller(PREEMPTION_CHECK_INTERVAL)
-    _preemption_poller.start()
+    if environment.get_value('PREEMPTIBLE'):
+      _preemption_poller = _PreemptionPoller(PREEMPTION_CHECK_INTERVAL)
+      _preemption_poller.start()
 
 
 def stop():

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -158,6 +158,30 @@ FUZZER_TOTAL_FUZZ_TIME = monitor.CounterMetric(
     ],
 )
 
+FUZZER_PREEMPTED_TOTAL_FUZZ_TIME = monitor.CounterMetric(
+    'task/fuzz/fuzzer/preempted_total_time',
+    description=('The total fuzz time wasted due to preemption in seconds '
+                 '(grouped by fuzzer).'),
+    field_spec=[
+        monitor.StringField('fuzzer'),
+        monitor.StringField('platform'),
+        monitor.StringField('is_batch'),
+        monitor.StringField('runtime')
+    ],
+)
+
+JOB_PREEMPTED_TOTAL_FUZZ_TIME = monitor.CounterMetric(
+    'task/fuzz/job/preempted_total_time',
+    description=('The total fuzz time wasted due to preemption in seconds '
+                 '(grouped by job).'),
+    field_spec=[
+        monitor.StringField('job'),
+        monitor.StringField('platform'),
+        monitor.StringField('is_batch'),
+        monitor.StringField('runtime')
+    ],
+)
+
 # This metric tracks fuzzer setup and data bundle update,
 # fuzzing time and crash processing on the worker
 FUZZING_SESSION_DURATION = monitor.CumulativeDistributionMetric(


### PR DESCRIPTION
b/538558303

### Problem
Preemptible VMs often get shut down by GCP before they can finish a fuzzing batch and report their metrics. Because the standard OS signals (`SIGTERM`) are often swallowed by the nested process hierarchy (PID 1 barriers in containers), the bot dies silently, leading to lost fuzzing hours and inaccurate metrics.

### Proposed Solution
Instead of relying solely on OS signals, we now poll the GCP Metadata server for preemption events directly from a background thread. This bypasses the signal propagation barrier.

- Added `_PreemptionPoller` in `monitor.py` to check the `instance/preempted` metadata key every 15 seconds (only on Preemptible VMs).
- Centralized metadata logic in `compute_metadata.py` via `get_preempted_status()`.
- Added a `threading.Lock` to `_TrackFuzzTime` in `fuzz_task.py` to ensure thread safety when reading/writing active trackers concurrently from the main thread and the poller thread.
- Refactored metric recording in `fuzz_task.py` to reduce code duplication and ensure consistent labels.

### Validation
Validated in dev environment. Preemption events are now successfully detected via metadata polling, and wasted time metrics (`preempted_total_time`) are being written even when standard signals fail to reach the python process.

Preemption being detected by polling metadata [logs](https://cloudlogging.app.goo.gl/tekHj9UGrUAGBPBx5)

<img width="641" height="283" alt="image" src="https://github.com/user-attachments/assets/18c75613-75a0-42cf-a1ce-d492c64d71fb" />

Newly added [metric](https://pantheon.corp.google.com/monitoring/metrics-explorer;endTime=2026-07-28T14:47:03.063Z;startTime=2026-07-28T11:47:03.063Z?pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesQuery%22:%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22custom.googleapis.com%2Ftask%2Ffuzz%2Ffuzzer%2Ftotal_time%5C%22%20resource.type%3D%5C%22gce_instance%5C%22%22,%22aggregation%22:%7B%22perSeriesAligner%22:%22ALIGN_RATE%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%5D,%22alignmentPeriod%22:%2260s%22%7D%7D%7D,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22,%22minAlignmentPeriod%22:%2260s%22%7D,%7B%22timeSeriesQuery%22:%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22custom.googleapis.com%2Ftask%2Ffuzz%2Ffuzzer%2Fpreempted_total_time%5C%22%20resource.type%3D%5C%22gce_instance%5C%22%22,%22aggregation%22:%7B%22perSeriesAligner%22:%22ALIGN_RATE%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%5D,%22alignmentPeriod%22:%2260s%22%7D%7D%7D,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y2%22,%22minAlignmentPeriod%22:%2260s%22%7D,%7B%22timeSeriesQuery%22:%7B%22prometheusQuery%22:%22clamp_min(%5Cn%20%20%20%20sum(rate(custom_googleapis_com:task_fuzz_fuzzer_total_time%7Bmonitored_resource%3D%5C%22gce_instance%5C%22%7D%5B$%7B__interval%7D%5D))%20%5Cn%20%20%20%20-%20%5Cn%20%20%20%20(sum(rate(custom_googleapis_com:task_fuzz_fuzzer_preempted_total_time%7Bmonitored_resource%3D%5C%22gce_instance%5C%22%7D%5B$%7B__interval%7D%5D))%20or%20vector(0)),%5Cn%20%20%20%200%5Cn)%22%7D,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22,%22legendTemplate%22:%22Effective%20fuzzing%20hours%22%7D%5D,%22chartOptions%22:%7B%22mode%22:%22COLOR%22,%22displayHorizontal%22:false%7D,%22thresholds%22:%5B%5D,%22yAxis%22:%7B%22scale%22:%22LINEAR%22%7D,%22y2Axis%22:%7B%22scale%22:%22LINEAR%22%7D%7D%7D&project=clusterfuzz-development) in dev

<img width="1104" height="331" alt="image" src="https://github.com/user-attachments/assets/9743fc18-9136-44f6-813a-f9c2e2c526a0" />

