### PR TITLE
[Metrics] Add metadata polling for detecting preemption

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -20,6 +20,7 @@ import json
 import os
 import random
 import re
+import threading
 import time
 from typing import Any
 from typing import Dict
@@ -61,6 +62,7 @@ from clusterfuzz._internal.metrics import events
 from clusterfuzz._internal.metrics import fuzzer_logs
 from clusterfuzz._internal.metrics import fuzzer_stats
 from clusterfuzz._internal.metrics import logs
+from clusterfuzz._internal.metrics import monitor
 from clusterfuzz._internal.metrics import monitoring_metrics
 from clusterfuzz._internal.platforms import android
 from clusterfuzz._internal.protos import uworker_msg_pb2
@@ -406,6 +408,23 @@ def _should_create_testcase(group: uworker_msg_pb2.FuzzTaskCrashGroup,
 
 class _TrackFuzzTime:
   """Track the actual fuzzing time (e.g. excluding preparing binary)."""
+  _active_trackers = set()
+  _lock = threading.Lock()
+  _callback_registered = False
+
+  @classmethod
+  def get_active_trackers(cls):
+    with cls._lock:
+      return list(cls._active_trackers)
+
+  @classmethod
+  def _preemption_callback(cls):
+    """Callback to record wasted fuzzing time on preemption."""
+    logs.info('Running preemption callback to record wasted time.')
+    for tracker in cls.get_active_trackers():
+      duration = tracker.time.time() - tracker.start_time
+      logs.info(f'Recording {int(duration)} seconds of preempted time for '
+                f'{tracker.fuzzer_name} on {tracker.job_type}.')
 
   def __init__(self, fuzzer_name, job_type, time_module=time):
     self.fuzzer_name = fuzzer_name
@@ -415,11 +434,20 @@ class _TrackFuzzTime:
     self.timeout = None
 
   def __enter__(self):
+    if not _TrackFuzzTime._callback_registered:
+      monitor.register_on_sigterm(_TrackFuzzTime._preemption_callback)
+      _TrackFuzzTime._callback_registered = True
+
     self.start_time = self.time.time()
     self.timeout = False
+    with self._lock:
+      self._active_trackers.add(self)
     return self
 
   def __exit__(self, exc_type, value, traceback):
+    with self._lock:
+      self._active_trackers.discard(self)
+
     duration = self.time.time() - self.start_time
     monitoring_metrics.FUZZER_TOTAL_FUZZ_TIME.increment_by(
         int(duration), {

--- a/src/clusterfuzz/_internal/google_cloud_utils/compute_metadata.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/compute_metadata.py
@@ -52,3 +52,15 @@ def is_gce():
     return False
 
   return True
+
+
+def get_preempted_status():
+  """Gets the preemption status of the instance."""
+  attribute_url = 'http://{}/computeMetadata/v1/instance/preempted'.format(
+      _METADATA_SERVER)
+  headers = {'Metadata-Flavor': 'Google'}
+  # We use a short timeout and no retries because this is called frequently
+  # in a background loop and should fail fast.
+  response = requests.get(attribute_url, headers=headers, timeout=5)
+  response.raise_for_status()
+  return response.text

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -146,16 +146,21 @@ def register_on_sigterm(callback):
   _on_sigterm_callbacks.append(callback)
 
 
-def handle_sigterm(signo, stack_frame):  #pylint: disable=unused-argument
-  logs.info('Handling sigterm, running registered callbacks.')
+def _trigger_shutdown_cleanup():
+  """Runs registered callbacks and stops the monitoring daemon."""
   for callback in _on_sigterm_callbacks:
     try:
       callback()
     except Exception as e:
-      logs.error(f'Error in SIGTERM callback: {e}')
+      logs.error(f'Error in callback: {e}')
   logs.info('Stopping monitoring daemon.')
   stop()
-  logs.info('Sigterm handled, metrics flushed.')
+
+
+def handle_sigterm(signo, stack_frame):  #pylint: disable=unused-argument
+  logs.info('Handling SIGTERM.')
+  _trigger_shutdown_cleanup()
+  logs.info('SIGTERM handled, metrics flushed.')
 
 
 @contextlib.contextmanager
@@ -222,7 +227,7 @@ class _PreemptionPoller():
         status = compute_metadata.get_preempted_status()
         if status and status.strip().upper() == 'TRUE':
           logs.info('Preemption detected via metadata!')
-          handle_sigterm(None, None)
+          _trigger_shutdown_cleanup()
           break
       except requests.exceptions.HTTPError as e:
         if e.response.status_code != 404:

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -27,6 +27,8 @@ import threading
 import time
 from typing import List
 
+import requests
+
 try:
   from google.cloud import monitoring_v3
 except (ImportError, RuntimeError):
@@ -49,6 +51,7 @@ from clusterfuzz._internal.system import environment
 
 CUSTOM_METRIC_PREFIX = 'custom.googleapis.com/'
 FLUSH_INTERVAL_SECONDS = 10 * 60  # 10 minutes.
+PREEMPTION_CHECK_INTERVAL = 15  # seconds
 RETRY_DEADLINE_SECONDS = 5 * 60  # 5 minutes.
 INITIAL_DELAY_SECONDS = 16
 MAXIMUM_DELAY_SECONDS = 2 * 60  # 2 minutes.
@@ -135,8 +138,22 @@ def _flush_metrics():
       logs.error(f'Failed to flush metrics: {e}')
 
 
+_on_sigterm_callbacks = []
+
+
+def register_on_sigterm(callback):
+  """Register a callback to be called on SIGTERM."""
+  _on_sigterm_callbacks.append(callback)
+
+
 def handle_sigterm(signo, stack_frame):  #pylint: disable=unused-argument
-  logs.info('Handling sigterm, stopping monitoring daemon.')
+  logs.info('Handling sigterm, running registered callbacks.')
+  for callback in _on_sigterm_callbacks:
+    try:
+      callback()
+    except Exception as e:
+      logs.error(f'Error in SIGTERM callback: {e}')
+  logs.info('Stopping monitoring daemon.')
   stop()
   logs.info('Sigterm handled, metrics flushed.')
 
@@ -179,6 +196,47 @@ class _MonitoringDaemon():
   def stop(self):
     self._flushing_thread_stop_event.set()
     self._flushing_thread.join()
+
+
+class _PreemptionPoller():
+  """Background thread to poll GCP metadata for preemption."""
+
+  def __init__(self, check_interval):
+    self._check_interval = check_interval
+    self._poller_thread = threading.Thread(
+        name='preemption_poller', target=self._poll_loop, daemon=True)
+    self._poller_thread_stop_event = threading.Event()
+
+  def _poll_loop(self):
+    """Polls GCP metadata for preemption status."""
+    if not compute_metadata.is_gce():
+      return
+
+    while True:
+      should_stop = self._poller_thread_stop_event.wait(
+          timeout=self._check_interval)
+      if should_stop:
+        break
+
+      try:
+        status = compute_metadata.get_preempted_status()
+        if status and status.strip().upper() == 'TRUE':
+          logs.info('Preemption detected via metadata!')
+          handle_sigterm(None, None)
+          break
+      except requests.exceptions.HTTPError as e:
+        if e.response.status_code != 404:
+          logs.warning(f'HTTP error checking preemption metadata: {e}')
+      except Exception as e:
+        logs.warning(f'Unknown error checking preemption metadata: {e}')
+
+  def start(self):
+    self._poller_thread.start()
+
+  def stop(self):
+    self._poller_thread_stop_event.set()
+    if threading.current_thread() != self._poller_thread:
+      self._poller_thread.join()
 
 
 _StoreValue = collections.namedtuple(
@@ -525,6 +583,7 @@ class _CumulativeDistributionMetric(Metric):
 _metrics_store = _MetricsStore()
 _monitoring_v3_client = None
 _monitoring_daemon = None
+_preemption_poller = None
 _monitored_resource = None
 
 # Add fields very conservatively here. There is a limit of 10 labels per metric
@@ -592,6 +651,7 @@ def initialize():
   """Initialize if monitoring is enabled for this bot."""
   global _monitoring_v3_client
   global _monitoring_daemon
+  global _preemption_poller
 
   if environment.get_value('LOCAL_DEVELOPMENT'):
     return
@@ -607,11 +667,17 @@ def initialize():
                                            FLUSH_INTERVAL_SECONDS)
     _monitoring_daemon.start()
 
+    if environment.get_value('PREEMPTIBLE'):
+      _preemption_poller = _PreemptionPoller(PREEMPTION_CHECK_INTERVAL)
+      _preemption_poller.start()
+
 
 def stop():
   """Stops monitoring and cleans up (only if monitoring is enabled)."""
   if _monitoring_daemon:
     _monitoring_daemon.stop()
+  if _preemption_poller:
+    _preemption_poller.stop()
 
 
 def metrics_store():


### PR DESCRIPTION
b/538558303

### Problem
Preemptible VMs often get shut down by GCP before they can finish a fuzzing batch and report their metrics. Because the standard OS signals (`SIGTERM`) are often swallowed by the nested process hierarchy (PID 1 barriers in containers), the bot dies silently, leading to lost fuzzing hours and inaccurate metrics.

### Proposed Solution
Instead of relying solely on OS signals, we now poll the GCP Metadata server for preemption events directly from a background thread. This bypasses the signal propagation barrier.

- Added `_PreemptionPoller` in `monitor.py` to check the `instance/preempted` metadata key every 15 seconds (only on Preemptible VMs).
- Centralized metadata logic in `compute_metadata.py` via `get_preempted_status()`.
- Added a `threading.Lock` to `_TrackFuzzTime` in `fuzz_task.py` to ensure thread safety when reading/writing active trackers concurrently from the main thread and the poller thread.

### Validation
Validated in dev environment. Preemption events are now successfully detected.

Preemption being detected by polling metadata [logs](https://cloudlogging.app.goo.gl/tekHj9UGrUAGBPBx5)

<img width="641" height="283" alt="image" src="https://github.com/user-attachments/assets/18c75613-75a0-42cf-a1ce-d492c64d71fb" />
