### PR TITLE
[Metrics] Add preemption metrics and accumulation logic

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -418,6 +418,23 @@ class _TrackFuzzTime:
   _active_trackers = set()
   _lock = threading.Lock()
   _callback_registered = False
+  _accumulated_wasted_time = 0
+  _session_fuzzer = None
+  _session_job = None
+
+  @classmethod
+  def reset_session(cls, fuzzer_name, job_type):
+    """Resets the accumulated time at the start of a session."""
+    with cls._lock:
+      cls._accumulated_wasted_time = 0
+      cls._session_fuzzer = fuzzer_name
+      cls._session_job = job_type
+
+  @classmethod
+  def add_wasted_time(cls, duration):
+    """Accumulates time from finished rounds."""
+    with cls._lock:
+      cls._accumulated_wasted_time += duration
 
   @classmethod
   def get_active_trackers(cls):
@@ -425,13 +442,77 @@ class _TrackFuzzTime:
       return list(cls._active_trackers)
 
   @classmethod
+  def record_metrics(cls,
+                     duration,
+                     fuzzer_name,
+                     job_type,
+                     timeout=None,
+                     is_preempted=False):
+    """Helper to record metrics consistently."""
+    common_labels = {
+        'platform': environment.platform(),
+        'is_batch': environment.is_uworker(),
+        'runtime': environment.get_runtime().value,
+    }
+
+    if is_preempted:
+      fuzzer_metric = monitoring_metrics.FUZZER_PREEMPTED_TOTAL_FUZZ_TIME
+      job_metric = monitoring_metrics.JOB_PREEMPTED_TOTAL_FUZZ_TIME
+      fuzzer_labels = {**common_labels, 'fuzzer': fuzzer_name}
+      job_labels = {**common_labels, 'job': job_type}
+    else:
+      fuzzer_metric = monitoring_metrics.FUZZER_TOTAL_FUZZ_TIME
+      job_metric = monitoring_metrics.JOB_TOTAL_FUZZ_TIME
+      fuzzer_labels = {
+          **common_labels, 'fuzzer': fuzzer_name,
+          'timeout': timeout
+      }
+      job_labels = {**common_labels, 'job': job_type, 'timeout': timeout}
+
+    fuzzer_metric.increment_by(int(duration), fuzzer_labels)
+    job_metric.increment_by(int(duration), job_labels)
+
+  @classmethod
   def _preemption_callback(cls):
     """Callback to record wasted fuzzing time on preemption."""
     logs.info('Running preemption callback to record wasted time.')
-    for tracker in cls.get_active_trackers():
-      duration = tracker.time.time() - tracker.start_time
-      logs.info(f'Recording {int(duration)} seconds of preempted time for '
-                f'{tracker.fuzzer_name} on {tracker.job_type}.')
+    with cls._lock:
+      active_trackers = list(cls._active_trackers)
+      if active_trackers:
+        for tracker in active_trackers:
+          tracker.preempted = True  # Mark to avoid double counting in __exit__
+
+          current_duration = tracker.time.time() - tracker.start_time
+          total_wasted = cls._accumulated_wasted_time + current_duration
+
+          logs.info(f'Recording {int(current_duration)}s of total time and '
+                    f'{int(total_wasted)}s of preempted time for '
+                    f'{tracker.fuzzer_name}.')
+
+          # Emit current duration to total_time to fix subtraction math
+          cls.record_metrics(
+              current_duration,
+              tracker.fuzzer_name,
+              tracker.job_type,
+              tracker.timeout,
+              is_preempted=False)
+
+          # Emit total wasted to preempted_total_time
+          cls.record_metrics(
+              total_wasted,
+              tracker.fuzzer_name,
+              tracker.job_type,
+              is_preempted=True)
+      else:
+        if cls._session_fuzzer and cls._session_job:
+          total_wasted = cls._accumulated_wasted_time
+          logs.info(f'Recording {int(total_wasted)}s of preempted time '
+                    f'(between rounds) for {cls._session_fuzzer}.')
+          cls.record_metrics(
+              total_wasted,
+              cls._session_fuzzer,
+              cls._session_job,
+              is_preempted=True)
 
   def __init__(self, fuzzer_name, job_type, time_module=time):
     self.fuzzer_name = fuzzer_name
@@ -439,6 +520,7 @@ class _TrackFuzzTime:
     self.time = time_module
     self.start_time = None
     self.timeout = None
+    self.preempted = False
 
   def __enter__(self):
     if not _TrackFuzzTime._callback_registered:
@@ -456,22 +538,17 @@ class _TrackFuzzTime:
       self._active_trackers.discard(self)
 
     duration = self.time.time() - self.start_time
-    monitoring_metrics.FUZZER_TOTAL_FUZZ_TIME.increment_by(
-        int(duration), {
-            'fuzzer': self.fuzzer_name,
-            'timeout': self.timeout,
-            'platform': environment.platform(),
-            'is_batch': environment.is_uworker(),
-            'runtime': environment.get_runtime().value,
-        })
-    monitoring_metrics.JOB_TOTAL_FUZZ_TIME.increment_by(
-        int(duration), {
-            'job': self.job_type,
-            'timeout': self.timeout,
-            'platform': environment.platform(),
-            'is_batch': environment.is_uworker(),
-            'runtime': environment.get_runtime().value
-        })
+    if not self.preempted:
+      _TrackFuzzTime.record_metrics(
+          duration,
+          self.fuzzer_name,
+          self.job_type,
+          self.timeout,
+          is_preempted=False)
+      _TrackFuzzTime.add_wasted_time(duration)
+    else:
+      logs.info(f'Skipping __exit__ metric emission for {self.fuzzer_name} '
+                'as it was already handled by preemption callback.')
 
 
 def _track_fuzzer_run_result(fuzzer_name, job_type, generated_testcase_count,
@@ -1668,6 +1745,9 @@ class FuzzingSession:
 
   def do_engine_fuzzing(self, engine_impl):
     """Run fuzzing engine."""
+    _TrackFuzzTime.reset_session(self.fully_qualified_fuzzer_name,
+                                 self.job_type)
+
     environment.set_value('FUZZER_NAME',
                           self.fuzz_target.fully_qualified_name())
 
@@ -1825,7 +1905,10 @@ class FuzzingSession:
 
   def do_blackbox_fuzzing(self, fuzzer, fuzzer_directory, job_type):
     """Run blackbox fuzzing. Currently also used for engine fuzzing."""
+    _TrackFuzzTime.reset_session(self.fully_qualified_fuzzer_name, job_type)
+
     # Set the thread timeout values.
+
     # TODO(ochang): Remove this hack once engine fuzzing refactor is complete.
     fuzz_test_timeout = environment.get_value('FUZZ_TEST_TIMEOUT')
     if fuzz_test_timeout:

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -474,7 +474,14 @@ class _TrackFuzzTime:
 
   @classmethod
   def _preemption_callback(cls):
-    """Callback to record wasted fuzzing time on preemption."""
+    """Callback to record wasted fuzzing time on preemption.
+
+    We track `_accumulated_wasted_time` because if a task is preempted at any
+    point, the entire fuzzing session is lost (since `postprocess` never runs),
+    even though individual fuzzing rounds within this session might have
+    completed successfully. All time spent in this session is therefore
+    considered wasted.
+    """
     logs.info('Running preemption callback to record wasted time.')
     with cls._lock:
       active_trackers = list(cls._active_trackers)

--- a/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
+++ b/src/clusterfuzz/_internal/metrics/monitoring_metrics.py
@@ -158,6 +158,30 @@ FUZZER_TOTAL_FUZZ_TIME = monitor.CounterMetric(
     ],
 )
 
+FUZZER_PREEMPTED_TOTAL_FUZZ_TIME = monitor.CounterMetric(
+    'task/fuzz/fuzzer/preempted_total_time',
+    description=('The total fuzz time wasted due to preemption in seconds '
+                 '(grouped by fuzzer).'),
+    field_spec=[
+        monitor.StringField('fuzzer'),
+        monitor.StringField('platform'),
+        monitor.StringField('is_batch'),
+        monitor.StringField('runtime')
+    ],
+)
+
+JOB_PREEMPTED_TOTAL_FUZZ_TIME = monitor.CounterMetric(
+    'task/fuzz/job/preempted_total_time',
+    description=('The total fuzz time wasted due to preemption in seconds '
+                 '(grouped by job).'),
+    field_spec=[
+        monitor.StringField('job'),
+        monitor.StringField('platform'),
+        monitor.StringField('is_batch'),
+        monitor.StringField('runtime')
+    ],
+)
+
 # This metric tracks fuzzer setup and data bundle update,
 # fuzzing time and crash processing on the worker
 FUZZING_SESSION_DURATION = monitor.CumulativeDistributionMetric(


### PR DESCRIPTION
b/538558303

_Note: this PR is chained with https://github.com/google/clusterfuzz/pull/5394_

### Problem
When a preemption occurs, we were only recording the duration of the active fuzzing round as wasted time. If a task is preempted mid-way, all previous successful rounds in that same task are also completely wasted since the task never reaches postprocess. This leads to a significant underestimation of wasted time.

### Proposed Solution
Enhanced time tracking to capture the waste across the entire fuzzing session while maintaining metric accuracy.

- Added `FUZZER_PREEMPTED_TOTAL_FUZZ_TIME` and `JOB_PREEMPTED_TOTAL_FUZZ_TIME` metrics to `monitoring_metrics.py`.
- Enhanced `_TrackFuzzTime` in `fuzz_task.py` to track accumulated wasted time across all rounds of a session (`_accumulated_wasted_time`).
- Upon preemption, the callback now emits the Total Accumulated Session Time (Current Round + Previous Rounds) to `preempted_total_time`.
- To fix subtraction math in dashboards, the callback also emits the duration of the interrupted round only to `total_time`, ensuring it reflects the attempted time without gaps.
- Added `tracker.preempted` flag to skip metric emission in `__exit__` for interrupted rounds and avoid double counting.

### Validation
Validated in dev environment.

<img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/64f39315-5ca6-4b4c-830b-428f0661792a" />

<img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/96bd42ac-23af-4ac4-8d80-da4b09fdeb88" />
