### PR TITLE
Add FuzzTargetsCount index and error log for bad targets

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -2105,6 +2105,9 @@ class FuzzingSession:
     targets_count = ndb.Key(data_types.FuzzTargetsCount, self.job_type).get()
     if not fuzz_task_output.fuzz_targets:
       new_targets_count = 0
+      logs.warning(
+          f"Bad fuzz target: {fuzz_task_output.fully_qualified_fuzzer_name}"
+          " setting the weight to 0.")
     else:
       new_targets_count = len(fuzz_task_output.fuzz_targets)
     if (not targets_count or targets_count.count != new_targets_count):

--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -1343,7 +1343,7 @@ def fuzz_target_project_qualified_name(project, binary):
 
 class FuzzTargetsCount(Model):
   """Fuzz targets count for every job. Key IDs are the job name."""
-  count = ndb.IntegerProperty(indexed=False)
+  count = ndb.IntegerProperty()
 
 
 class FuzzTargetJob(Model):


### PR DESCRIPTION
When the `fuzz_task_output` has an invalid fuzz target,  `FuzzTargetCount.count = 0`. This can happen when there are no fuzz target binaries found, or the build is entirely broken. 

When this happens, no more fuzz tasks would be scheduled. We recover from this scenario by falling back to the default modifier when the `FuzzerJob.multiplier` would be 0:
https://github.com/google/clusterfuzz/blob/f547870e55c804c65212c9650af3e25736e59b23/src/clusterfuzz/_internal/cron/fuzzer_and_job_weights.py#L380-L383

This is a health signal, and we should monitor it properly. This PR adds an index so we can look these up, and a specific error we can track this with.

@aakallam, I'm not sure whether we want to set up a metric for an alert on this, because we're going to have very large dimensionality here and we can just scan the logs/Datastore for bad fuzz targets. But I'm open to just throwing a Monarch metric here if that's the easiest way to alert us that something is broken.


Related to b/537750310

### Testing
I pushed this change onto dev