### PR TITLE
[VRP] [DO NOT MERGE YET] Set Fuzzer.trusted default to False

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -358,7 +358,7 @@ class Fuzzer(Model):
   # they might produce malicious outputs. All the testcases they
   # produce are also treated as untrusted.
   # See also `data_handler.check_job_supports_untrusted_workloads()`.
-  trusted = ndb.BooleanProperty(default=True)
+  trusted = ndb.BooleanProperty(default=False)
 
   # Data bundle name.
   data_bundle_name = ndb.StringProperty(default='')

--- a/src/clusterfuzz/_internal/tests/core/datastore/data_types_test.py
+++ b/src/clusterfuzz/_internal/tests/core/datastore/data_types_test.py
@@ -56,7 +56,7 @@ class FuzzerTest(unittest.TestCase):
             'revision': 3,
             'source': 'author',
             'last_edited_by': 'editor',
-            'trusted': True,
+            'trusted': False,
         },
         config_dict,
     )


### PR DESCRIPTION
### Context 
To avoid breaking existing fuzzers and skip a backfill migration, we temporarily set `Fuzzer.trusted` to default to `True`. Once the field has been rolled out, we need to flip it back to `False` to enforce "Safety by Default".
