### PR TITLE
Add log for pulling from preprocess

### DIFF
--- a/src/clusterfuzz/_internal/base/tasks/__init__.py
+++ b/src/clusterfuzz/_internal/base/tasks/__init__.py
@@ -361,6 +361,7 @@ def get_preprocess_task():
     queue_name = f'{queue_name}-{base_os_version}'
 
   pubsub_puller = PubSubPuller(queue_name)
+  logs.info('Pulling from preprocess queue')
   messages = pubsub_puller.get_messages(max_messages=1)
   if not messages:
     return None


### PR DESCRIPTION
The `get_postprocess_task` has this log and `get_preprocess_task` doesn't :)

https://github.com/google/clusterfuzz/blob/388aaefa0d7c2da0a0ba4cd83cadc6db377c6218/src/clusterfuzz/_internal/base/tasks/__init__.py#L337