### PR TITLE
Capture user defined errors separately from UNHANDLED_EXCEPTION

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/__init__.py
@@ -22,7 +22,9 @@ from typing import Optional
 from google.protobuf import timestamp_pb2
 
 from clusterfuzz._internal import swarming
+from clusterfuzz._internal.base import errors
 from clusterfuzz._internal.base.tasks import task_utils
+from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.bot.webserver import http_server
 from clusterfuzz._internal.google_cloud_utils import storage
@@ -246,7 +248,11 @@ class _MetricRecorder(contextlib.AbstractContextManager):
     if task_succeeded:
       error_condition = 'N/A'
     elif _exc_type:
-      error_condition = 'UNHANDLED_EXCEPTION'
+      if issubclass(_exc_type,
+                    (errors.Error, testcase_manager.TestcaseManagerError)):
+        error_condition = _exc_type.__name__
+      else:
+        error_condition = 'UNHANDLED_EXCEPTION'
     else:
       error_condition = uworker_msg_pb2.ErrorType.Name(  # pylint: disable=no-member
           self.utask_main_failure)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/utasks_test.py
@@ -22,6 +22,7 @@ from unittest import mock
 from google.protobuf import timestamp_pb2
 import parameterized
 
+from clusterfuzz._internal.base import errors
 from clusterfuzz._internal.base.tasks import task_utils
 from clusterfuzz._internal.bot.tasks import utasks
 from clusterfuzz._internal.bot.tasks.utasks import analyze_task
@@ -168,6 +169,28 @@ class TworkerPreprocessTest(unittest.TestCase):
     self.assertEqual(task_event.task_name, 'mock_task')
     self.assertEqual(task_event.task_id, 'f61826c3-ca9a-4b97-9c1e-9e6f4e4f8868')
     self.mock.emit.assert_called_once_with(task_event)
+
+  def test_user_defined_exception_recorded(self):
+    """Tests that a user defined error is recorded with its class name."""
+    self.mock._get_execution_mode.return_value = utasks.Mode.BATCH
+    module = mock.MagicMock(__name__='mock_task')
+    module.utask_preprocess.side_effect = errors.InvalidTestcaseError(123)
+    task_utils._TESTCASE_BASED_TASKS.add('mock')
+
+    with self.assertRaises(errors.InvalidTestcaseError):
+      utasks.tworker_preprocess(module, self.TASK_ARGUMENT, self.JOB_TYPE,
+                                self.UWORKER_ENV)
+
+    labels = {
+        'task': 'mock',
+        'subtask': 'preprocess',
+        'mode': 'batch',
+        'platform': 'LINUX',
+        'task_succeeded': False,
+        'error_condition': 'InvalidTestcaseError',
+    }
+    count = monitoring_metrics.TASK_OUTCOME_COUNT_BY_ERROR_TYPE.get(labels)
+    self.assertEqual(1, count)
 
 
 class SetUworkerEnvTest(unittest.TestCase):


### PR DESCRIPTION
In `_MetricRecorder.__exit__`, check whether the exception inherits from `errors.Error `or `testcase_manager.TestcaseManagerError` and record the coresponding error_condition  instead of `'UNHANDLED_EXCEPTION'`.

We want to alert based on `UNHANDLED_EXCEPTION`, and these user defined Errors represent exceptional but expected scenariors in Clusterfuzz where the task is not meant to succeed. For example, there is no build for a variant task that we triggered, or the fuzzer is no longer valid. In these cases, we typically want to ACK the task and skip it, but these expected errors make it hard to set up alerts on real issues.

Here's an example of [logs](https://cloudlogging.app.goo.gl/yMccrYFjRKxeJ1G68) of 2 deleted Testcases going through the Variant task, failing, and getting retried multiple times and triggering an alert due to the postprocess error rate spikes above 20%

b/542644855

### Testing
deployed to dev. haven't seen any of these new metrics yet but no errors either.

### Related PRs

1. **This PR:** #5402 
2. #5403 
3. #5405 
4. #5406 