### PR TITLE
Skip incompatible jobs in variant_task.utask_preprocess

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -73,20 +73,29 @@ def utask_preprocess(testcase_id, job_type, uworker_env):
     # a different fuzzing engine.
     original_job_type = testcase.job_type
     testcase = _get_variant_testcase_for_job(testcase, job_type)
-    setup_input = setup.preprocess_setup_testcase(
-        testcase, uworker_env, with_deps=False)
-    variant_input = uworker_msg_pb2.VariantTaskInput(  # pylint: disable=no-member
-        original_job_type=original_job_type)
 
-    uworker_input = uworker_msg_pb2.Input(  # pylint: disable=no-member
-        job_type=job_type,
-        testcase=uworker_io.entity_to_protobuf(testcase),
-        uworker_env=uworker_env,
-        testcase_id=testcase_id,
-        variant_task_input=variant_input,
-        setup_input=setup_input,
-    )
-    testcase_manager.preprocess_testcase_manager(testcase, uworker_input)
+    try:
+      setup_input = setup.preprocess_setup_testcase(
+          testcase, uworker_env, with_deps=False)
+      variant_input = uworker_msg_pb2.VariantTaskInput(  # pylint: disable=no-member
+          original_job_type=original_job_type)
+
+      uworker_input = uworker_msg_pb2.Input(  # pylint: disable=no-member
+          job_type=job_type,
+          testcase=uworker_io.entity_to_protobuf(testcase),
+          uworker_env=uworker_env,
+          testcase_id=str(testcase_id),
+          variant_task_input=variant_input,
+          setup_input=setup_input,
+      )
+      testcase_manager.preprocess_testcase_manager(testcase, uworker_input)
+    except (testcase_manager.TargetNotFoundError,
+            errors.InvalidFuzzerError) as error:
+      logs.warning(
+          f'Fuzz target or fuzzer not found for variant job {job_type}: {error}'
+      )
+      return None
+
     return uworker_input
 
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/variant_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/variant_task_test.py
@@ -14,9 +14,11 @@
 """variant_task tests."""
 import unittest
 
+from clusterfuzz._internal.bot import testcase_manager
 from clusterfuzz._internal.bot.tasks.utasks import variant_task
 from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
+from clusterfuzz._internal.protos import uworker_msg_pb2
 from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 
@@ -85,3 +87,31 @@ class GetVariantTestcaseForJob(unittest.TestCase):
     variant_testcase.put()
     testcase = data_handler.get_testcase_by_id(testcase.key.id())
     self.assertEqual('', testcase.comments)
+
+
+@test_utils.with_cloud_emulators('datastore')
+class UtaskPreprocessTest(unittest.TestCase):
+  """Test utask_preprocess."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+    helpers.patch(self, [
+        'clusterfuzz._internal.bot.testcase_manager.preprocess_testcase_manager',
+        'clusterfuzz._internal.bot.tasks.setup.preprocess_setup_testcase',
+        'clusterfuzz._internal.metrics.logs.warning',
+    ])
+    self.mock.preprocess_setup_testcase.return_value = (
+        uworker_msg_pb2.SetupInput())
+
+  def test_target_not_found(self):
+    """Test that TargetNotFoundError returns None"""
+    testcase = test_utils.create_generic_testcase()
+    error = testcase_manager.TargetNotFoundError('Target target_foo not found')
+    self.mock.preprocess_testcase_manager.side_effect = error
+
+    result = variant_task.utask_preprocess(
+        testcase_id=str(testcase.key.id()),
+        job_type=testcase.job_type,
+        uworker_env={})
+
+    self.assertIsNone(result)


### PR DESCRIPTION
Catch `TargetNotFoundError` and `InvalidFuzzerError` in variant_task.utask_preprocess, logging a warning and returning None to cleanly skip incompatible jobs without logging an exceptional metric.

When we schedule variant tasks, we aggressively schedule variant tasks to determine whether the crash can repro on other platforms/builds. We don't know whether all of these are valid combiniations, so many of these tasks can fail when trying to set up the build.

Note: hide whitespace

b/542644855

### Testing
deployed to dev. haven't seen any of these new metrics yet but no errors either.

### Related PRs

1. #5402 
2. **This PR:** #5403 
3. #5405 
4. #5406 