### PR TITLE
Gracefully handle InvalidTestcaseError in variant and minimize tasks

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/minimize_task.py
@@ -372,7 +372,11 @@ def _get_minimize_task_input(testcase):
 def utask_preprocess(testcase_id, job_type, uworker_env):
   """Preprocess in a trusted bot."""
   # Locate the testcase associated with the id.
-  testcase = data_handler.get_testcase_by_id(testcase_id)
+  try:
+    testcase = data_handler.get_testcase_by_id(testcase_id)
+  except errors.InvalidTestcaseError:
+    logs.warning(f'Testcase {testcase_id} no longer exists.')
+    return None
   with logs.testcase_log_context(testcase, testcase.get_fuzz_target()):
     # Allow setting up a different fuzzer.
     minimize_fuzzer_override = environment.get_value('MINIMIZE_FUZZER_OVERRIDE')
@@ -879,7 +883,12 @@ def finalize_testcase(testcase_id, last_crash_result_dict, flaky_stack=False):
 def utask_postprocess(output):
   """Postprocess in a trusted bot."""
   # Retrive the testcase early for logs context.
-  testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
+  try:
+    testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
+  except errors.InvalidTestcaseError:
+    logs.warning(
+        f'Testcase {output.uworker_input.testcase_id} no longer exists.')
+    return
   with logs.testcase_log_context(testcase, testcase.get_fuzz_target()):
     testcase_utils.emit_testcase_triage_duration_metric(
         int(output.uworker_input.testcase_id),

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/variant_task.py
@@ -59,7 +59,11 @@ def _get_variant_testcase_for_job(testcase, job_type):
 
 def utask_preprocess(testcase_id, job_type, uworker_env):
   """Run a test case with a different job type to see if they reproduce."""
-  testcase = data_handler.get_testcase_by_id(testcase_id)
+  try:
+    testcase = data_handler.get_testcase_by_id(testcase_id)
+  except errors.InvalidTestcaseError:
+    logs.warning(f'Testcase {testcase_id} no longer exists.')
+    return None
   with logs.testcase_log_context(testcase, testcase.get_fuzz_target()):
     uworker_io.check_handling_testcase_safe(testcase)
 
@@ -226,7 +230,12 @@ _ERROR_HANDLER = uworker_handle_errors.CompositeErrorHandler({
 
 def utask_postprocess(output):
   """Handle the output from utask_main."""
-  testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
+  try:
+    testcase = data_handler.get_testcase_by_id(output.uworker_input.testcase_id)
+  except errors.InvalidTestcaseError:
+    logs.warning(
+        f'Testcase {output.uworker_input.testcase_id} no longer exists.')
+    return
   with logs.testcase_log_context(testcase, testcase.get_fuzz_target()):
     if output.error_type != uworker_msg_pb2.ErrorType.NO_ERROR:  # pylint: disable=no-member
       _ERROR_HANDLER.handle(output)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/minimize_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/minimize_task_test.py
@@ -353,6 +353,14 @@ class UTaskPostprocessTest(unittest.TestCase):
     # contains blob keys for uploaded testcase and stacktrace.
     self.assertFalse(self.mock.delete_blob.called)
 
+  def test_invalid_testcase_does_not_raise(self):
+    """Checks that an output with a non-existent testcase id returns cleanly."""
+    uworker_output = uworker_msg_pb2.Output(
+        uworker_input=self._get_generic_input())
+    uworker_output.uworker_input.testcase_id = '999999'
+    minimize_task.utask_postprocess(uworker_output)
+    self.assertFalse(self.mock.finalize_testcase.called)
+
 
 @test_utils.with_cloud_emulators('datastore')
 class UTaskMainTest(unittest.TestCase):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/variant_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/variant_task_test.py
@@ -115,3 +115,9 @@ class UtaskPreprocessTest(unittest.TestCase):
         uworker_env={})
 
     self.assertIsNone(result)
+
+  def test_invalid_testcase(self):
+    """Test that an invalid testcase returns None and does not raise."""
+    result = variant_task.utask_preprocess(
+        testcase_id='999999', job_type='job_type', uworker_env={})
+    self.assertIsNone(result)


### PR DESCRIPTION
Catch `errors.InvalidTestcaseError` when retrieving testcase entities in utask_preprocess and utask_postprocess of variant_task and minimize_task, returning cleanly without raising an unhandled exception.

Variant tasks are notoriously error prone because we attempt to repro a crash by fanning out across builds/platforms which might not be supported combinations for whatever reasons. The goal here is to reduce the noise from expected failures so we can alert on real issues.

b/542644855

### Testing
deployed to dev. haven't seen any of these new metrics yet but no errors either.

### Related PRs

1. #5402 
2. #5403 
3. #5405 
4. **This PR:** #5406 