### PR TITLE
Stop executing testcases when proto limit exceeded

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -1973,11 +1973,14 @@ class FuzzingSession:
       crashes = [
           Crash.from_testcase_manager_crash(crash) for crash in crashes if crash
       ]
-    executed_testcase_file_paths, executed_testcases_metadata = (
-        self._handle_unexecuted_testcases(
-            testcase_file_paths=testcase_file_paths,
-            testcases_metadata=testcases_metadata,
-            testcases_executed=test_number))
+    executed_testcase_file_paths = testcase_file_paths
+    executed_testcases_metadata = testcases_metadata
+    if test_number < len(testcase_file_paths):
+      executed_testcase_file_paths, executed_testcases_metadata = (
+          self._handle_unexecuted_testcases(
+              testcase_file_paths=testcase_file_paths,
+              testcases_metadata=testcases_metadata,
+              testcases_executed=test_number))
     return (generate_result.fuzzer_metadata, executed_testcase_file_paths,
             executed_testcases_metadata, crashes)
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -75,6 +75,9 @@ from clusterfuzz.fuzz import engine
 # 10 MB limit for proto testcase payload field (see FuzzerRunOutput testcase in
 # src/clusterfuzz/_internal/protos/uworker_msg.proto:L248).
 MAX_TESTCASE_PAYLOAD_SIZE = 10 * 1024 * 1024
+# PROTO msg limit is 2 GB, reserving 200 MB for safety
+# https://protobuf.dev/programming-guides/proto-limits/
+PROTOBUF_MSG_LIMIT = 1.8 * 1024 * 1024 * 1024
 FUZZER_METADATA_REGEX = re.compile(r'metadata::(\w+):\s*(.*)')
 FUZZER_FAILURE_THRESHOLD = 0.33
 MAX_NEW_CORPUS_FILES = 500
@@ -1740,10 +1743,48 @@ class FuzzingSession:
               'platform': environment.platform(),
           })
 
+  def _is_fuzz_task_output_limit_exceeded(self) -> bool:
+    """Checks if the fuzz_task_output protobuf message exceeds the size limit.
+
+    Returns:
+      True if fuzz_task_output exceeds PROTOBUF_MSG_LIMIT, False otherwise.
+    """
+    return self.fuzz_task_output.ByteSize() >= PROTOBUF_MSG_LIMIT
+
+  def _handle_unexecuted_testcases(
+      self, testcase_file_paths: list[str], testcases_metadata: dict[str, dict],
+      testcases_executed: int) -> tuple[list[str], dict[str, dict]]:
+    """Cleans up unexecuted testcase files and slices execution metadata.
+
+    Args:
+      testcase_file_paths: List of all generated testcase file paths.
+      testcases_metadata: Dictionary mapping testcase file paths to metadata.
+      testcases_executed: Number of testcases that were actually executed.
+
+    Returns:
+      A tuple of (executed_testcase_file_paths, executed_testcases_metadata).
+    """
+    for unexecuted_path in testcase_file_paths[testcases_executed:]:
+      shell.remove_file(unexecuted_path)
+
+    executed_testcase_file_paths = testcase_file_paths[:testcases_executed]
+    executed_testcases_metadata = {
+        path: testcases_metadata[path]
+        for path in executed_testcase_file_paths
+        if path in testcases_metadata
+    }
+    return executed_testcase_file_paths, executed_testcases_metadata
+
   def _add_crashes_from_temp_queue(
       self, temp_queue: queue.Queue,
       crashes: list[testcase_manager.Crash]) -> None:
-    """Pops items from temp_queue and processes crashes and run outputs."""
+    """Pops items from temp_queue and processes crashes and run outputs.
+
+    Args:
+      temp_queue: Queue containing TestcaseRunResult objects from worker
+        threads.
+      crashes: List to append any discovered crashes to.
+    """
     while not temp_queue.empty():
       result: testcase_manager.TestcaseRunResult = temp_queue.get()
 
@@ -1751,7 +1792,7 @@ class FuzzingSession:
         crashes.append(result.crash)
       if result.fuzzer_run_output_data:
         fuzzer_run_output = _to_fuzzer_run_output(result.fuzzer_run_output_data)
-        if fuzzer_run_output:
+        if fuzzer_run_output and not self._is_fuzz_task_output_limit_exceeded():
           self.fuzz_task_output.fuzzer_run_outputs.append(fuzzer_run_output)
 
   def do_blackbox_fuzzing(self, fuzzer, fuzzer_directory, job_type):
@@ -1901,6 +1942,10 @@ class FuzzingSession:
       logs.info(f'Upto {test_number}')
       if thread_error_occurred:
         break
+      if self._is_fuzz_task_output_limit_exceeded():
+        logs.warning('Fuzz task output size limit exceeded. '
+                     'Stopping testcase execution early.')
+        break
 
     execution_time = datetime.timedelta(seconds=time.time() -
                                         testcase_execution_start)
@@ -1928,8 +1973,13 @@ class FuzzingSession:
       crashes = [
           Crash.from_testcase_manager_crash(crash) for crash in crashes if crash
       ]
-    return (generate_result.fuzzer_metadata, testcase_file_paths,
-            testcases_metadata, crashes)
+    executed_testcase_file_paths, executed_testcases_metadata = (
+        self._handle_unexecuted_testcases(
+            testcase_file_paths=testcase_file_paths,
+            testcases_metadata=testcases_metadata,
+            testcases_executed=test_number))
+    return (generate_result.fuzzer_metadata, executed_testcase_file_paths,
+            executed_testcases_metadata, crashes)
 
   def run(self):
     """Run the fuzzing session."""

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -591,7 +591,7 @@ def _do_run_testcase_and_return_result_in_queue(
 
     # Save raw, unsymbolized execution output for deferred postprocessing.
     crash_result_full = CrashResult(return_code, crash_time, output)
-    unsymbolized_output = crash_result_full.get_stacktrace(symbolized=False)
+    unsymbolized_output = crash_result_full.get_stacktrace()
     crash_path = file_path if crash else None
     log_file_path = utils.create_temp_file(
         directory=environment.get_value('BOT_TMPDIR'),

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
@@ -1620,9 +1620,11 @@ class FuzzTaskOutputLimitTest(fake_filesystem_unittest.TestCase):
     session = self._create_session()
     self.assertFalse(session._is_fuzz_task_output_limit_exceeded())
 
-  @mock.patch(
-      'clusterfuzz._internal.bot.tasks.utasks.fuzz_task.PROTOBUF_MSG_LIMIT', 0)
-  def test_is_fuzz_task_output_limit_exceeded_at_or_above_limit(self):
+  @mock.patch.object(
+      uworker_msg_pb2.FuzzTaskOutput,
+      'ByteSize',
+      return_value=fuzz_task.PROTOBUF_MSG_LIMIT)
+  def test_is_fuzz_task_output_limit_exceeded_at_or_above_limit(self, _):
     """Verify _is_fuzz_task_output_limit_exceeded returns True at PROTOBUF_MSG_LIMIT."""
     session = self._create_session()
     self.assertTrue(session._is_fuzz_task_output_limit_exceeded())

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/fuzz_task_test.py
@@ -1366,6 +1366,44 @@ class DoBlackboxFuzzingTest(fake_filesystem_unittest.TestCase):
       _, _, file_path, _, _ = call.kwargs['args']
       self.assertEqual(file_path, expected_testcase_file_paths[i])
 
+  def test_do_blackbox_fuzzing_breaks_early_on_proto_limit(self):
+    """Verify do_blackbox_fuzzing breaks early when PROTOBUF_MSG_LIMIT is exceeded."""
+    fuzz_task_input = uworker_msg_pb2.FuzzTaskInput()
+    uworker_input = uworker_msg_pb2.Input(
+        fuzzer_name='fantasy_fuzz',
+        job_type='asan_test',
+        fuzz_task_input=fuzz_task_input)
+
+    session = fuzz_task.FuzzingSession(uworker_input, 10)
+    session.generate_blackbox_testcases = mock.MagicMock()
+    expected_testcase_file_paths = ['/tests/0', '/tests/1', '/tests/2']
+    session.generate_blackbox_testcases.return_value = (
+        fuzz_task.GenerateBlackboxTestcasesResult(
+            True, expected_testcase_file_paths,
+            {'fuzzer_binary_name': 'fantasy_fuzz'}))
+
+    self.fs.create_file('/tests/0', contents='testcase_0')
+    self.fs.create_file('/tests/1', contents='testcase_1')
+    self.fs.create_file('/tests/2', contents='testcase_2')
+
+    mock_thread_cls = mock.MagicMock(wraps=threading.Thread)
+    self.mock.get_process.return_value = mock_thread_cls
+
+    fuzzer = data_types.Fuzzer()
+    fuzzer.name = 'fantasy_fuzz'
+
+    with mock.patch.object(
+        session, '_is_fuzz_task_output_limit_exceeded', return_value=True):
+      _, testcase_file_paths, testcases_metadata, _ = (
+          session.do_blackbox_fuzzing(fuzzer, '/fake-fuzz-dir', 'asan_test'))
+
+    self.assertEqual(1, mock_thread_cls.call_count)
+    self.assertEqual(['/tests/0'], testcase_file_paths)
+    self.assertEqual(['/tests/0'], list(testcases_metadata.keys()))
+    self.assertTrue(os.path.exists('/tests/0'))
+    self.assertFalse(os.path.exists('/tests/1'))
+    self.assertFalse(os.path.exists('/tests/2'))
+
   @mock.patch(
       'clusterfuzz._internal.bot.tasks.utasks.fuzz_task.FuzzingSession.generate_blackbox_testcases'
   )
@@ -1550,6 +1588,134 @@ class DoBlackboxFuzzingDeferredLoggingTest(fake_filesystem_unittest.TestCase):
     self.assertEqual(1, len(session.fuzz_task_output.fuzzer_run_outputs))
     self.assertEqual(b'output_trace',
                      session.fuzz_task_output.fuzzer_run_outputs[0].output)
+
+
+class FuzzTaskOutputLimitTest(fake_filesystem_unittest.TestCase):
+  """Unit tests for fuzz task output limit checks and unexecuted testcase cleanup."""
+
+  def setUp(self):
+    """Setup for fuzz task output limit test."""
+    helpers.patch_environ(self)
+    test_utils.set_up_pyfakefs(self)
+    os.environ['BOT_TMPDIR'] = '/tmp'
+    os.environ['CRASH_STACKTRACES_DIR'] = '/crash'
+    os.environ['ROOT_DIR'] = '/root'
+    os.environ['FAIL_RETRIES'] = '1'
+    os.environ['THREAD_ALIVE_CHECK_INTERVAL'] = '0.001'
+    os.environ['THREAD_DELAY'] = '0.001'
+    os.environ['MAX_FUZZ_THREADS'] = '1'
+    self.fs.create_dir('/crash')
+    self.fs.create_dir('/root/bot/logs')
+
+  def _create_session(self):
+    """Creates a dummy FuzzingSession."""
+    uworker_input = uworker_msg_pb2.Input(
+        fuzzer_name='fantasy_fuzz',
+        job_type='asan_test',
+        fuzz_task_input=uworker_msg_pb2.FuzzTaskInput())
+    return fuzz_task.FuzzingSession(uworker_input, 10)
+
+  def test_is_fuzz_task_output_limit_exceeded_below_limit(self):
+    """Verify _is_fuzz_task_output_limit_exceeded returns False below PROTOBUF_MSG_LIMIT."""
+    session = self._create_session()
+    self.assertFalse(session._is_fuzz_task_output_limit_exceeded())
+
+  @mock.patch(
+      'clusterfuzz._internal.bot.tasks.utasks.fuzz_task.PROTOBUF_MSG_LIMIT', 0)
+  def test_is_fuzz_task_output_limit_exceeded_at_or_above_limit(self):
+    """Verify _is_fuzz_task_output_limit_exceeded returns True at PROTOBUF_MSG_LIMIT."""
+    session = self._create_session()
+    self.assertTrue(session._is_fuzz_task_output_limit_exceeded())
+
+  def test_handle_unexecuted_testcases_all_executed(self):
+    """Verify _handle_unexecuted_testcases preserves all files when all executed."""
+    session = self._create_session()
+    self.fs.create_file('/tests/0', contents='a')
+    self.fs.create_file('/tests/1', contents='b')
+    testcase_file_paths = ['/tests/0', '/tests/1']
+    testcases_metadata = {'/tests/0': {'g': 1}, '/tests/1': {'g': 2}}
+
+    paths, metadata = session._handle_unexecuted_testcases(
+        testcase_file_paths, testcases_metadata, 2)
+
+    self.assertTrue(os.path.exists('/tests/0'))
+    self.assertTrue(os.path.exists('/tests/1'))
+    self.assertEqual(['/tests/0', '/tests/1'], paths)
+    self.assertEqual(testcases_metadata, metadata)
+
+  def test_handle_unexecuted_testcases_partial_execution(self):
+    """Verify _handle_unexecuted_testcases removes unexecuted files and slices metadata."""
+    session = self._create_session()
+    self.fs.create_file('/tests/0', contents='a')
+    self.fs.create_file('/tests/1', contents='b')
+    self.fs.create_file('/tests/2', contents='c')
+    testcase_file_paths = ['/tests/0', '/tests/1', '/tests/2']
+    testcases_metadata = {
+        '/tests/0': {
+            'g': 1
+        },
+        '/tests/1': {
+            'g': 2
+        },
+        '/tests/2': {
+            'g': 3
+        }
+    }
+
+    paths, metadata = session._handle_unexecuted_testcases(
+        testcase_file_paths, testcases_metadata, 1)
+
+    self.assertTrue(os.path.exists('/tests/0'))
+    self.assertFalse(os.path.exists('/tests/1'))
+    self.assertFalse(os.path.exists('/tests/2'))
+    self.assertEqual(['/tests/0'], paths)
+    self.assertEqual({'/tests/0': {'g': 1}}, metadata)
+
+  def test_handle_unexecuted_testcases_zero_executed(self):
+    """Verify _handle_unexecuted_testcases removes all files when zero executed."""
+    session = self._create_session()
+    self.fs.create_file('/tests/0', contents='a')
+    self.fs.create_file('/tests/1', contents='b')
+    testcase_file_paths = ['/tests/0', '/tests/1']
+    testcases_metadata = {'/tests/0': {'g': 1}, '/tests/1': {'g': 2}}
+
+    paths, metadata = session._handle_unexecuted_testcases(
+        testcase_file_paths, testcases_metadata, 0)
+
+    self.assertFalse(os.path.exists('/tests/0'))
+    self.assertFalse(os.path.exists('/tests/1'))
+    self.assertEqual([], paths)
+    self.assertEqual({}, metadata)
+
+  def test_add_crashes_from_temp_queue_limit_exceeded(self):
+    """Verify _add_crashes_from_temp_queue adds crashes but skips outputs when
+      PROTOBUF_MSG_LIMIT is exceeded."""
+    session = self._create_session()
+    self.fs.create_file('/tmp/trace.log', contents='output_trace')
+    temp_queue = queue.Queue()
+    crash = testcase_manager.Crash(
+        file_path='/test/crash',
+        crash_time=1,
+        return_code=1,
+        resource_list=[],
+        gestures=[],
+        stack_file_path='/stack')
+    fuzzer_run_output_data = testcase_manager.FuzzerRunOutputData.from_file_path(
+        file_path='/tmp/trace.log',
+        crash_path='/test/crash',
+        return_code=1,
+        log_time=datetime.datetime(2026, 7, 10))
+    temp_queue.put(
+        testcase_manager.TestcaseRunResult(
+            crash=crash, fuzzer_run_output_data=fuzzer_run_output_data))
+
+    crashes = []
+    with mock.patch.object(
+        session, '_is_fuzz_task_output_limit_exceeded', return_value=True):
+      session._add_crashes_from_temp_queue(temp_queue, crashes)
+
+    self.assertEqual([crash], crashes)
+    self.assertEqual(0, len(session.fuzz_task_output.fuzzer_run_outputs))
 
 
 @test_utils.with_cloud_emulators('datastore')


### PR DESCRIPTION
Bug:b/473624472

Enforces protobuf message size limits (PROTOBUF_MSG_LIMIT) during blackbox testcase execution in fuzz_task.py.

## Context
In the previous PR in the stack, we changed so that in utask_main we now save the fuzzer logs in a protobuf message, which is consumed  at `postprocess`.

**Previously:**
For each test case in BlackBox fuzzing, we immediately uploaded its fuzz & output logs  into GCS. This proved basically no limitations.

**Now:**
For each test case in BlackBox fuzzing, we save its fuzz & output logs into a protobuf.

The protobuf has a hard limit of 2GB(see[ the docs](https://protobuf.dev/programming-guides/proto-limits/)).


## Overview
To prevent a possible edge case in which logs + output from a big fuzzing session surpasses the protobuf size limit, we now limit the test cases executed in the session once they trespass the protobuf limit size.

## Changes
* **Early Loop Termination:** Checks if `fuzz_task_output` size exceeds 1.8Gb after each batch of worker threads and terminates the execution loop early in case it does.
* **Output Limit Guard in Queue Processing:** Prevents further `fuzzer_run_output `entries from being appended once the 1.8Gb is exceeded, while still preserving all discovered crashes.
* **Clean Unexecuted Testcase Handling:** Deletes unexecuted testcase files from disk and slices returned testcase paths and metadata to ensure metrics (testcases_executed) report accurately.
* **Unit Tests:** Adds unit tests for a bunch of edge cases(theres actually more test cases than actual prod code).