### PR TITLE
fix(casp): drop the unused third-party 'google' PyPI dependency

### DIFF
--- a/cli/casp/pyproject.toml
+++ b/cli/casp/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 dependencies = [
     "click",
     "docker",
-    "google",
     "google-auth"
 ]
 


### PR DESCRIPTION
`cli/casp/pyproject.toml` declares a dependency on `google`. That distribution on PyPI is not published by Google — it is ["Python bindings to the Google search engine"](https://pypi.org/project/google/) by an unaffiliated author (Mario Vilas, `mvilas@gmail.com`, homepage `breakingcode.wordpress.com`, last released as 3.0.0).

So `pip install casp` currently pulls an unrelated third party's package into the environment of anyone installing ClusterFuzz's CLI. That is a supply-chain surface with no upside: whoever controls that PyPI name controls code that lands in those environments.

**casp does not use it.** The only `google.*` import anywhere in the package is:

```python
# cli/casp/src/casp/utils/gcloud.py:20
from google.oauth2 import credentials
```

which is provided by `google-auth`, already declared on the line below. I grepped every module under `cli/casp/src/casp/` for `import google` / `from google` and that is the sole hit.

**Verified in a clean venv** with the dependency removed (Python 3.14):

```
$ pip install .
$ pip list | grep -iE '^google|click|docker'
click              8.4.2
docker             7.2.0
google-auth        2.56.2          # no bare 'google'

$ python -c "from google.oauth2 import credentials; print('ok')"
ok

$ casp --help
Usage: casp [OPTIONS] COMMAND [ARGS]...
  A new, modern Command-Line Interface (CLI) for ClusterFuzz.
```

The import resolves and the CLI runs with the package absent, which is the expected result since `google-auth` owns the `google.oauth2` namespace.

One-line deletion, no behaviour change. Happy to add a note to the README if you'd like the reasoning recorded somewhere more permanent than a commit message.
