### PR TITLE
Clean up invalid FuzzerJob entities in cleanup task

### DIFF
--- a/src/clusterfuzz/_internal/cron/cleanup.py
+++ b/src/clusterfuzz/_internal/cron/cleanup.py
@@ -232,6 +232,30 @@ def cleanup_unused_fuzz_targets_and_jobs():
       f'{len(valid_target_jobs)} valid FuzzTargetJob entities remain.')
 
 
+def cleanup_invalid_fuzzer_jobs():
+  """Clean up FuzzerJob entities that reference non-existent Fuzzers or Jobs."""
+  valid_fuzzers = {
+      fuzzer.name
+      for fuzzer in ndb_utils.get_all_from_model(data_types.Fuzzer)
+      if fuzzer.name
+  }
+  valid_jobs = {
+      job.name
+      for job in ndb_utils.get_all_from_model(data_types.Job)
+      if job.name
+  }
+
+  to_delete = []
+  for fuzzer_job in ndb_utils.get_all_from_model(data_types.FuzzerJob):
+    if (fuzzer_job.fuzzer not in valid_fuzzers or
+        fuzzer_job.job not in valid_jobs):
+      to_delete.append(fuzzer_job.key)
+
+  if to_delete:
+    ndb_utils.delete_multi(to_delete)
+  logs.info(f'Deleted {len(to_delete)} invalid FuzzerJob entities.')
+
+
 def get_jobs_and_platforms_for_project():
   """Return a map of projects to jobs and platforms map to use for picking top
   crashes."""
@@ -1473,6 +1497,7 @@ def main():
   cleanup_reports_metadata()
   leak_blacklist.cleanup_global_blacklist()
   cleanup_unused_fuzz_targets_and_jobs()
+  cleanup_invalid_fuzzer_jobs()
   cleanup_unused_heartbeats()
   logs.info('Cleanup task finished successfully.')
   return True

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/cron/cleanup_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/cron/cleanup_test.py
@@ -2383,3 +2383,44 @@ class UpdateSeverityLabelsTest(unittest.TestCase):
     self.assertNotIn('Security_Severity-High', self.issue.labels)
     self.assertIn('Security_Severity-Medium', self.issue.labels)
     self.assertIn('different from what was assigned', result)
+
+
+@test_utils.with_cloud_emulators('datastore')
+class CleanupInvalidFuzzerJobsTest(unittest.TestCase):
+  """Tests for cleanup_invalid_fuzzer_jobs."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+
+    # Valid Fuzzer and Job.
+    data_types.Fuzzer(name='valid_fuzzer').put()
+    data_types.Job(name='valid_job').put()
+
+  def test_cleanup_invalid_fuzzer_jobs(self):
+    """Test cleaning up FuzzerJob entities when Fuzzer or Job does not exist."""
+    # Valid mapping: both fuzzer and job exist.
+    valid_mapping = data_types.FuzzerJob(
+        fuzzer='valid_fuzzer', job='valid_job', platform='LINUX')
+    valid_mapping.put()
+
+    # Invalid mapping: fuzzer does not exist.
+    invalid_fuzzer_mapping = data_types.FuzzerJob(
+        fuzzer='nonexistent_fuzzer', job='valid_job', platform='LINUX')
+    invalid_fuzzer_mapping.put()
+
+    # Invalid mapping: job does not exist.
+    invalid_job_mapping = data_types.FuzzerJob(
+        fuzzer='valid_fuzzer', job='nonexistent_job', platform='LINUX')
+    invalid_job_mapping.put()
+
+    # Invalid mapping: neither fuzzer nor job exists.
+    invalid_both_mapping = data_types.FuzzerJob(
+        fuzzer='nonexistent_fuzzer', job='nonexistent_job', platform='LINUX')
+    invalid_both_mapping.put()
+
+    cleanup.cleanup_invalid_fuzzer_jobs()
+
+    remaining_fuzzer_jobs = list(data_types.FuzzerJob.query())
+    self.assertEqual(len(remaining_fuzzer_jobs), 1)
+    self.assertEqual(remaining_fuzzer_jobs[0].fuzzer, 'valid_fuzzer')
+    self.assertEqual(remaining_fuzzer_jobs[0].job, 'valid_job')


### PR DESCRIPTION
fix b/538683766

### Problem
When `Job` or `Fuzzer` entities are deleted, orphaned `FuzzerJob` mappings can linger in Datastore because the cleanup cron task does not detect and prune them.

### Solution
- Added `cleanup_invalid_fuzzer_jobs()` in `src/clusterfuzz/_internal/cron/cleanup.py` to delete `FuzzerJob` entities referencing non-existent `Fuzzer` or `Job` entities.
- Called `cleanup_invalid_fuzzer_jobs()` in `cleanup.py`'s `main()`.
- Added unit tests in `src/clusterfuzz/_internal/tests/appengine/handlers/cron/cleanup_test.py`.

### Testing
```bash
python butler.py py_unittest -t appengine -p cleanup_test.py
python butler.py lint
```

