### PR TITLE
[Metrics] Check provision model by consulting metadata

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/compute_metadata.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/compute_metadata.py
@@ -64,3 +64,24 @@ def get_preempted_status():
   response = requests.get(attribute_url, headers=headers, timeout=5)
   response.raise_for_status()
   return response.text
+
+
+def is_preemptible():
+  """Returns True if the instance is preemptible (or Spot)."""
+  if is_gce():
+    # We ignore exceptions (mainly HTTPError if a key doesn't exist) to avoid
+    # log noise for standard VMs where these keys might not be present.
+    try:
+      if get('instance/scheduling/preemptible').strip().upper() == 'TRUE':
+        return True
+    except Exception:
+      pass
+
+    try:
+      if get(
+          'instance/scheduling/provisioning-model').strip().upper() == 'SPOT':
+        return True
+    except Exception:
+      pass
+
+  return bool(environment.get_value('PREEMPTIBLE'))

--- a/src/clusterfuzz/_internal/metrics/monitor.py
+++ b/src/clusterfuzz/_internal/metrics/monitor.py
@@ -672,7 +672,7 @@ def initialize():
                                            FLUSH_INTERVAL_SECONDS)
     _monitoring_daemon.start()
 
-    if environment.get_value('PREEMPTIBLE'):
+    if compute_metadata.is_preemptible():
       _preemption_poller = _PreemptionPoller(PREEMPTION_CHECK_INTERVAL)
       _preemption_poller.start()
 


### PR DESCRIPTION
b/538558303

### Problem
Batch VMs don't have the `PREEMPTIBLE` env var set, so the preemption poller never starts on them. This means we lose track of wasted fuzzing time when they get preempted.

### Proposed Solution
Consult the GCE Metadata Server directly to check if the machine is preemptible or a Spot VM. 
Added `is_preemptible()` to `compute_metadata.py` to check both `instance/scheduling/preemptible` and `instance/scheduling/provisioning-model`, falling back to the env var for local testing. Updated `monitor.py` to use this helper.

### Validation
Verified that existing tests pass and the logic correctly falls back to env var when not on GCE.

We can now view preemption detection for batch VMs in dev:

<img width="1089" height="92" alt="image" src="https://github.com/user-attachments/assets/35afea12-e7bc-4fa3-9f5f-2173a9ae9a16" />

[GCP Logs](https://cloudlogging.app.goo.gl/9TSJ69A7ThdL58kR6)

