### PR TITLE
[Metrics] Refactor metadata consumption and avoid unecessary calls

### DIFF
--- a/src/clusterfuzz/_internal/google_cloud_utils/compute_metadata.py
+++ b/src/clusterfuzz/_internal/google_cloud_utils/compute_metadata.py
@@ -21,9 +21,22 @@ from clusterfuzz._internal.base import retry
 from clusterfuzz._internal.system import environment
 
 _METADATA_SERVER = 'metadata.google.internal'
+_METADATA_URL = 'http://{}/computeMetadata/v1/'.format(_METADATA_SERVER)
 
 _RETRIES = 3
 _DELAY = 1
+
+
+def _get_raw(path, timeout=None):
+  """Internal helper to get metadata without retries."""
+  attribute_url = _METADATA_URL + path
+  headers = {'Metadata-Flavor': 'Google'}
+  if timeout is None:
+    timeout = environment.get_value('URL_BLOCKING_OPERATIONS_TIMEOUT')
+
+  response = requests.get(attribute_url, headers=headers, timeout=timeout)
+  response.raise_for_status()
+  return response.text
 
 
 @retry.wrap(
@@ -32,15 +45,7 @@ _DELAY = 1
     function='python.google_cloud_utils.compute_metadata.get')
 def get(path):
   """Get GCE metadata value."""
-  attribute_url = (
-      'http://{}/computeMetadata/v1/'.format(_METADATA_SERVER) + path)
-  headers = {'Metadata-Flavor': 'Google'}
-  operations_timeout = environment.get_value('URL_BLOCKING_OPERATIONS_TIMEOUT')
-
-  response = requests.get(
-      attribute_url, headers=headers, timeout=operations_timeout)
-  response.raise_for_status()
-  return response.text
+  return _get_raw(path)
 
 
 def is_gce():
@@ -56,32 +61,34 @@ def is_gce():
 
 def get_preempted_status():
   """Gets the preemption status of the instance."""
-  attribute_url = 'http://{}/computeMetadata/v1/instance/preempted'.format(
-      _METADATA_SERVER)
-  headers = {'Metadata-Flavor': 'Google'}
   # We use a short timeout and no retries because this is called frequently
   # in a background loop and should fail fast.
-  response = requests.get(attribute_url, headers=headers, timeout=5)
-  response.raise_for_status()
-  return response.text
+  return _get_raw('instance/preempted', timeout=5)
 
 
 def is_preemptible():
   """Returns True if the instance is preemptible (or Spot)."""
+  # Skip metadata queries on App Engine or K8s. These environments emulate or
+  # proxy the metadata server but lack standard GCE scheduling keys, returning
+  # 404 and causing unnecessary latency or errors if queried.
+  if environment.is_running_on_app_engine() or environment.is_running_on_k8s():
+    return bool(environment.get_value('PREEMPTIBLE'))
+
   if is_gce():
     # We ignore exceptions (mainly HTTPError if a key doesn't exist) to avoid
     # log noise for standard VMs where these keys might not be present.
-    try:
-      if get('instance/scheduling/preemptible').strip().upper() == 'TRUE':
-        return True
-    except Exception:
-      pass
-
-    try:
-      if get(
-          'instance/scheduling/provisioning-model').strip().upper() == 'SPOT':
-        return True
-    except Exception:
-      pass
+    for path in [
+        'instance/scheduling/preemptible',
+        'instance/scheduling/provisioning-model'
+    ]:
+      try:
+        value = _get_raw(path, timeout=2).strip().upper()
+        if value in ['TRUE', 'SPOT']:
+          return True
+      except requests.exceptions.HTTPError as e:
+        if e.response.status_code == 404:
+          continue
+      except Exception:
+        pass
 
   return bool(environment.get_value('PREEMPTIBLE'))


### PR DESCRIPTION
### Problem
The `is_preemptible()` check was causing high latency and log noise in some environments. This happened because it used a shared metadata helper that retries on failure, meaning missing keys (404s) caused multi-second delays. Additionally, the code in `compute_metadata.py` was repetitive.

### Proposed Solution
- Refactored `compute_metadata.py` to extract a fast, non-retrying internal helper `_get_raw()`.
- Optimized `is_preemptible()` to skip metadata queries entirely when running on App Engine or Kubernetes, avoiding unnecessary 404s.
- Ensured heuristics use short timeouts and fail fast without retrying on expected 404s.

### Validation

The not found error disappeared after the deploy:

<img width="2217" height="617" alt="image" src="https://github.com/user-attachments/assets/ae5dfd32-3bdc-44aa-a2c3-9f5e31bd0452" />

[Link for GCP](https://cloudlogging.app.goo.gl/sksprTGgExq6mXzs6)
