### PR TITLE
[Corpus] Refactor and add wildcard support for feature flag

### DIFF
--- a/src/clusterfuzz/_internal/base/concurrency.py
+++ b/src/clusterfuzz/_internal/base/concurrency.py
@@ -27,7 +27,9 @@ def make_pool(pool_size=POOL_SIZE, max_pool_size=None, use_threads=False):
   if max_pool_size is not None:
     pool_size = min(pool_size, max_pool_size)
 
-  # Don't use processes on Windows and unittests to avoid hangs.
+  # Use threads if explicitly requested (e.g. for I/O bound tasks like GCS ops
+  # to avoid multiprocessing memory overhead), or on Windows/unittests to
+  # avoid hangs.
   if (use_threads or environment.get_value('PY_UNITTESTS') or
       environment.platform() == 'WINDOWS'):
     yield futures.ThreadPoolExecutor(pool_size)

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/corpus_pruning_task.py
@@ -1155,6 +1155,35 @@ def _create_backup_urls(fuzz_target: data_types.FuzzTarget,
   corpus_pruning_task_input.dated_backup_signed_url = dated_backup_signed_url
 
 
+def _should_use_threaded_ops(fuzzer_name: str) -> bool:
+  """Returns True if threaded storage ops should be used."""
+  threaded_ops_flag = (
+      feature_flags.FeatureFlags.STORAGE_THREADED_OPS_FUZZ_TARGETS)
+  if not threaded_ops_flag.enabled:
+    return False
+
+  threaded_ops_targets = threaded_ops_flag.string_value.strip()
+  if not threaded_ops_targets:
+    return False
+
+  allowed_targets = [
+      t.strip().lower() for t in threaded_ops_targets.split(',') if t.strip()
+  ]
+
+  if '*' in allowed_targets:
+    # TODO(paulovlb): Remove this once fixed.
+    logs.info('[Corpus Fix] Enabled threaded storage ops for ALL targets.')
+    return True
+
+  if fuzzer_name.lower() in allowed_targets:
+    # TODO(paulovlb): Remove this once fixed.
+    logs.info(f'[Corpus Fix] Enabled threaded storage ops for target: '
+              f'{fuzzer_name}')
+    return True
+
+  return False
+
+
 def _utask_preprocess(fuzzer_name, job_type, uworker_env):
   """Runs preprocessing for corpus pruning task."""
   fuzz_target = data_handler.get_fuzz_target(fuzzer_name)
@@ -1217,19 +1246,8 @@ def _utask_preprocess(fuzzer_name, job_type, uworker_env):
   if uworker_env is None:
     uworker_env = {}
 
-  threaded_ops_flag = (
-      feature_flags.FeatureFlags.STORAGE_THREADED_OPS_FUZZ_TARGETS)
-  if threaded_ops_flag.enabled:
-    threaded_ops_targets = threaded_ops_flag.string_value
-    if threaded_ops_targets:
-      allowed_targets = [
-          t.strip() for t in threaded_ops_targets.split(',') if t.strip()
-      ]
-      if fuzzer_name in allowed_targets:
-        uworker_env['USE_THREADED_STORAGE_OPS'] = 'True'
-        # TODO(paulovlb): Remove this once fixed.
-        logs.info(f'[Corpus Fix] Enabled threaded storage ops for target: '
-                  f'{fuzzer_name}')
+  if _should_use_threaded_ops(fuzzer_name):
+    uworker_env['USE_THREADED_STORAGE_OPS'] = 'True'
 
   logs.info('done preprocess')
   return uworker_msg_pb2.Input(  # pylint: disable=no-member


### PR DESCRIPTION
### Problem
The previous feature flag implementation for enabling threaded storage operations was somewhat rigid and required explicitly listing every single fuzz target. This made it difficult to scale the solution or enable it globally for specific deployments (like OSS-Fuzz) without maintaining huge lists. Additionally, the matching was case-sensitive and didn't handle potential variations well, which could cause issues when testing across different deployments like Chrome or Google3.

### Solution
Refactored the logic into a dedicated helper function `_should_use_threaded_ops` to improve readability and robustness.

- The feature flag now supports `*` anywhere in the list to enable threaded operations for all targets in that specific deployment.
- Both the incoming fuzzer name and the configuration list are converted to lowercase, preventing failures due to casing mismatches.
- Flattened the nested conditions in `_utask_preprocess` by moving the decision logic out.

This prepares the feature for easier rollout and testing across different environments without requiring further code changes.

Note: I also improved a comment as requested in [here](https://github.com/google/clusterfuzz/pull/5352/changes#r3538564090).

### Validation
The wildcard worker in dev:

<img width="944" height="374" alt="image" src="https://github.com/user-attachments/assets/ba3bbade-2dba-4458-a383-2f25c9b19764" />

[GCP Link](https://cloudlogging.app.goo.gl/LHSACijozC7k7DaG6)
