### PR TITLE
Fix base image check

### DIFF
--- a/docker/ci/ubuntu-24-04.Dockerfile
+++ b/docker/ci/ubuntu-24-04.Dockerfile
@@ -12,7 +12,7 @@ FROM gcr.io/clusterfuzz-images/base:ubuntu-24-04
 RUN apt-get update &&     apt-get install -y         gettext-base         git         golang-go         google-cloud-sdk-app-engine-go         google-cloud-sdk-app-engine-python         google-cloud-sdk-app-engine-python-extras         google-cloud-sdk-datastore-emulator         google-cloud-sdk-gke-gcloud-auth-plugin         google-cloud-sdk-pubsub-emulator         kubectl         liblzma-dev         openjdk-21-jdk
 
 # Install Bazel as per https://docs.bazel.build/versions/master/install-ubuntu.html#using-bazel-custom-apt-repository.
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list &&     curl https://bazel.build/bazel-release.pub.gpg | apt-key add - &&     apt-get update &&     apt-get install -y bazel
+RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list &&     curl https://storage.googleapis.com/www.bazel.build/bazel-release.pub.gpg | apt-key add - &&     apt-get update &&     apt-get install -y bazel
 
 RUN npm install -g bower polymer-bundler
 


### PR DESCRIPTION
b/545151660

### Problem
The Bazel GPG key URL (`https://bazel.build/bazel-release.pub.gpg`) in `ci/ubuntu-24-04.Dockerfile` started returning a 404 error, breaking the image build pipeline.

### Solution
Changed to the working Google Cloud Storage URL (`https://storage.googleapis.com/www.bazel.build/bazel-release.pub.gpg`) which is already used successfully in `ci/ubuntu-20-04.Dockerfile`.

### Validation

This PR:
<img width="1376" height="182" alt="image" src="https://github.com/user-attachments/assets/7ff4479a-dff0-4ea9-ba39-dc346a5fdc22" />

Logs showing the `curl` to the right url:
<img width="2542" height="386" alt="image" src="https://github.com/user-attachments/assets/adacbd39-593e-4bb5-804c-bbef7bfc3973" />
