### PR TITLE
Require job access in coverage_report before redirecting

### DIFF
--- a/src/appengine/handlers/coverage_report.py
+++ b/src/appengine/handlers/coverage_report.py
@@ -20,6 +20,7 @@ from clusterfuzz._internal.datastore import data_handler
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.metrics import fuzzer_stats
 from handlers import base_handler
+from libs import access
 from libs import handler
 from libs import helpers
 
@@ -59,6 +60,13 @@ def get_report_url(report_type, argument, date):
 
   if not data_types.Job.VALID_NAME_REGEX.match(job):
     raise helpers.EarlyExitError('Invalid job name.', 400)
+
+  # Coverage reports are per-job data; gate on job access like the other
+  # job-scoped handlers (e.g. fuzzer_stats). @handler.oauth does not require
+  # authentication, so without this any caller could resolve the report URL
+  # for an arbitrary job.
+  if not access.has_access(job_type=job):
+    raise helpers.AccessDeniedError()
 
   if not date or not VALID_DATE_REGEX.match(date):
     raise helpers.EarlyExitError('Invalid date.', 400)

--- a/src/clusterfuzz/_internal/tests/appengine/handlers/coverage_report_test.py
+++ b/src/clusterfuzz/_internal/tests/appengine/handlers/coverage_report_test.py
@@ -19,6 +19,7 @@ from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.tests.test_libs import helpers
 from clusterfuzz._internal.tests.test_libs import test_utils
 from handlers import coverage_report
+from libs import helpers as libs_helpers
 
 
 @test_utils.with_cloud_emulators('datastore')
@@ -27,6 +28,10 @@ class CoverageReportTest(unittest.TestCase):
 
   def setUp(self):
     helpers.patch_environ(self)
+    helpers.patch(self, ['libs.access.has_access'])
+    # Default to a caller that is allowed to access the job; the access-denied
+    # path is exercised explicitly in test_no_access.
+    self.mock.has_access.return_value = True
 
     self.today = datetime.datetime.utcnow().date()
     self.today_minus_2 = self.today - datetime.timedelta(days=2)
@@ -63,3 +68,11 @@ class CoverageReportTest(unittest.TestCase):
     report_url = coverage_report.get_report_url('job', 'fake_job', 'latest')
     expected_url = None
     self.assertEqual(expected_url, report_url)
+
+  def test_no_access(self):
+    """Tests that a caller without access to the job is denied instead of
+    being handed the coverage report location."""
+    self.mock.has_access.return_value = False
+    with self.assertRaises(libs_helpers.AccessDeniedError):
+      coverage_report.get_report_url('job', 'job1', 'latest')
+    self.mock.has_access.assert_called_with(job_type='job1')


### PR DESCRIPTION
`coverage_report` resolves and redirects to the coverage report URL for a job taken from the request, decorated only with `@handler.oauth`:

```python
def get_report_url(report_type, argument, date):
  ...
  job = argument
  return _get_project_report_url(job, date)   # no access check
```

Coverage reports are per-job data, but `@handler.oauth` authenticates the caller without authorizing access to any particular job (the same gap the other job-scoped handlers like `fuzzer_stats` already close). So any caller could resolve the coverage report location for an arbitrary job, and by extension its project.

```python
from libs import access
...
if not access.has_access(job_type=job):
  raise helpers.AccessDeniedError()
```

The resolution is now gated on job access, matching the sibling job-scoped handlers. Adds a regression test for the access-denied path.