### PR TITLE
Fix fuzzer metadata injection via unicode line separator abuse

### DIFF
--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -103,7 +103,7 @@ def decode_to_unicode(obj):
   if not hasattr(obj, 'decode'):
     return obj
 
-  return obj.decode('utf-8', errors='ignore')
+  return obj.decode('utf-8', errors='replace')
 
 
 def encode_as_unicode(obj):

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/fuzz_task.py
@@ -760,6 +760,9 @@ def add_additional_testcase_run_data(testcase_run, fully_qualified_fuzzer_name,
 def get_fuzzer_metadata_from_output(fuzzer_output):
   """Extract metadata from fuzzer output."""
   metadata = {}
+  fuzzer_output = fuzzer_output.replace(
+      '\r', '').replace('\x85', '').replace(
+      '\u2028', '').replace('\u2029', '')
   for line in fuzzer_output.splitlines():
     match = FUZZER_METADATA_REGEX.match(line)
     if match:


### PR DESCRIPTION
Fixes #5428

Two fixes for the metadata injection vulnerability:

1. `utils.py`: Change `errors='ignore'` to `errors='replace'` to prevent silent dropping of invalid UTF-8 bytes that could be used to manipulate metadata keys.

2. `fuzz_task.py`: Sanitize fuzzer output before `splitlines()` to prevent CR (`\r`), NEL (`\x85`), U+2028, and U+2029 from injecting additional metadata lines.