### PR TITLE
[Android] Remove legacy Android Build API v3

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -48,6 +48,8 @@ STABLE_CUTTLEFISH_BUILD = {
 DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO = (
     "gs://android-haiku/target-cuttlefish/stable_build_info.json")
 
+API_VERSION = 'V4'
+
 
 def _call_android_api_enabled():
   """Return True if we should call the Android Build API, enabled by default,
@@ -71,7 +73,7 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
 
   logs.info(
       'AndroidBuildAPI download_artifact started.',
-      api_version='V4',
+      api_version=API_VERSION,
       operation='download_artifact',
       build_id=bid,
       target=target,
@@ -84,7 +86,7 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
     logs.error(
         'AndroidBuildAPI download_artifact failed: artifact metadata '
         'unreachable.',
-        api_version='V4',
+        api_version=API_VERSION,
         operation='download_artifact',
         build_id=bid,
         target=target,
@@ -96,7 +98,7 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
   size = int(artifact['size'])
   logs.info(
       'AndroidBuildAPI download_artifact metadata retrieved successfully.',
-      api_version='V4',
+      api_version=API_VERSION,
       operation='download_artifact',
       build_id=bid,
       target=target,
@@ -114,7 +116,7 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
   if os.path.exists(output_path) and os.path.getsize(output_path) == size:
     logs.info(
         'AndroidBuildAPI download_artifact skipped (file already exists).',
-        api_version='V4',
+        api_version=API_VERSION,
         operation='download_artifact',
         build_id=bid,
         target=target,
@@ -135,7 +137,7 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
   # Just like get, except get_media.
   logs.info(
       'AndroidBuildAPI download_artifact media download started.',
-      api_version='V4',
+      api_version=API_VERSION,
       operation='download_artifact_media',
       build_id=bid,
       target=target,
@@ -147,7 +149,7 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
   if not success:
     logs.error(
         'AndroidBuildAPI download_artifact failed.',
-        api_version='V4',
+        api_version=API_VERSION,
         operation='download_artifact',
         build_id=bid,
         target=target,
@@ -159,7 +161,7 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
 
   logs.info(
       'AndroidBuildAPI download_artifact completed successfully.',
-      api_version='V4',
+      api_version=API_VERSION,
       operation='download_artifact',
       build_id=bid,
       target=target,
@@ -185,7 +187,7 @@ def _get_artifacts_for_build(client,
 
   logs.info(
       'AndroidBuildAPI get_artifacts_for_build started.',
-      api_version='V4',
+      api_version=API_VERSION,
       operation='get_artifacts_for_build',
       build_id=bid,
       target=target,
@@ -196,7 +198,7 @@ def _get_artifacts_for_build(client,
 
   logs.info(
       'AndroidBuildAPI get_artifacts_for_build completed.',
-      api_version='V4',
+      api_version=API_VERSION,
       operation='get_artifacts_for_build',
       build_id=bid,
       target=target,
@@ -223,7 +225,8 @@ def _get_client():
 
   key_dict = json.loads(build_apiary_service_account_private_key)
 
-  logs.info('AndroidBuildAPI client initialization started.', api_version='V4')
+  logs.info(
+      'AndroidBuildAPI client initialization started.', api_version=API_VERSION)
 
   try:
     credentials = service_account.Credentials.from_service_account_info(
@@ -278,7 +281,7 @@ def get_latest_artifact_info(branch, target, signed=False, stable_build=False):
 
   logs.info(
       'AndroidBuildAPI get_latest_artifact_info started.',
-      api_version='V4',
+      api_version=API_VERSION,
       operation='get_latest_artifact_info',
       branch=branch,
       target=target,
@@ -289,7 +292,7 @@ def get_latest_artifact_info(branch, target, signed=False, stable_build=False):
   if not builds:
     logs.error(
         'AndroidBuildAPI get_latest_artifact_info failed: no builds found.',
-        api_version='V4',
+        api_version=API_VERSION,
         operation='get_latest_artifact_info',
         branch=branch,
         target=target,
@@ -303,7 +306,7 @@ def get_latest_artifact_info(branch, target, signed=False, stable_build=False):
 
   logs.info(
       'AndroidBuildAPI get_latest_artifact_info completed.',
-      api_version='V4',
+      api_version=API_VERSION,
       operation='get_latest_artifact_info',
       branch=branch,
       target=target,

--- a/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
+++ b/src/clusterfuzz/_internal/platforms/android/fetch_artifact.py
@@ -15,16 +15,13 @@
 minor modifications, especially without any google3 specific library
 dependencies)."""
 
-import io
 import json
 import os
 import re
 from typing import List
 from typing import Optional
 
-import apiclient
 from google.oauth2 import service_account
-from oauth2client.service_account import ServiceAccountCredentials
 
 from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.config import db_config
@@ -33,9 +30,6 @@ from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.platforms.android.android_build_v4_api import \
     AndroidBuildV4Api
 from clusterfuzz._internal.system import environment
-
-# 20 MB default chunk size.
-DEFAULT_CHUNK_SIZE = 20 * 1024 * 1024
 
 # Maximum number of retries for artifact access.
 MAX_RETRIES = 5
@@ -55,22 +49,6 @@ DEFAULT_STABLE_CUTTLEFISH_BUILD_INFO = (
     "gs://android-haiku/target-cuttlefish/stable_build_info.json")
 
 
-def _use_v4():
-  """Return True if we should use V4 Android Build API."""
-  try:
-    use_v4 = db_config.get_value('use_android_build_api_v4') or False
-    logs.info(
-        'AndroidBuildAPI feature flag status read.',
-        use_android_build_api_v4=use_v4)
-    return use_v4
-  except Exception as e:
-    logs.error(
-        'AndroidBuildAPI error reading feature flag use_android_build_api_v4. '
-        'Defaulting to False.',
-        error=str(e))
-    return False
-
-
 def _call_android_api_enabled():
   """Return True if we should call the Android Build API, enabled by default,
   Disabled always if invoked in a uworker
@@ -83,19 +61,6 @@ def _call_android_api_enabled():
   return flag.enabled if flag else True
 
 
-def _execute_request_with_retries(request):
-  """Executes request and retries on failure."""
-  result = None
-  for _ in range(MAX_RETRIES):
-    try:
-      result = request.execute()
-      break
-    except Exception as e:
-      logs.error(f'Error calling endpoint {request.uri}: Error {e}')
-
-  return result
-
-
 def _download_artifact(client, bid, target, attempt_id, name, output_directory,
                        output_filename):
   """Download one artifact."""
@@ -104,28 +69,22 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
   logs.info('output_directory: %s' % output_directory)
   logs.info('output_filename: %s' % output_filename)
 
-  version_tag = 'V4' if _use_v4() else 'V3'
   logs.info(
       'AndroidBuildAPI download_artifact started.',
-      api_version=version_tag,
+      api_version='V4',
       operation='download_artifact',
       build_id=bid,
       target=target,
       attempt_id=attempt_id,
       artifact_name=name)
 
-  if _use_v4():
-    artifact = client.get_artifact_metadata(bid, target, attempt_id, name)
-  else:
-    artifact_query = client.buildartifact().get(
-        buildId=bid, target=target, attemptId=attempt_id, resourceId=name)
-    artifact = _execute_request_with_retries(artifact_query)
+  artifact = client.get_artifact_metadata(bid, target, attempt_id, name)
 
   if artifact is None:
     logs.error(
         'AndroidBuildAPI download_artifact failed: artifact metadata '
         'unreachable.',
-        api_version=version_tag,
+        api_version='V4',
         operation='download_artifact',
         build_id=bid,
         target=target,
@@ -134,21 +93,16 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
         status='failed')
     return None
 
-  # Lucky us, we always have the size.
   size = int(artifact['size'])
   logs.info(
       'AndroidBuildAPI download_artifact metadata retrieved successfully.',
-      api_version=version_tag,
+      api_version='V4',
       operation='download_artifact',
       build_id=bid,
       target=target,
       attempt_id=attempt_id,
       artifact_name=name,
       size=size)
-
-  chunksize = -1
-  if size >= DEFAULT_CHUNK_SIZE:
-    chunksize = DEFAULT_CHUNK_SIZE
 
   if output_filename:
     file_name = output_filename
@@ -160,7 +114,7 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
   if os.path.exists(output_path) and os.path.getsize(output_path) == size:
     logs.info(
         'AndroidBuildAPI download_artifact skipped (file already exists).',
-        api_version=version_tag,
+        api_version='V4',
         operation='download_artifact',
         build_id=bid,
         target=target,
@@ -181,48 +135,31 @@ def _download_artifact(client, bid, target, attempt_id, name, output_directory,
   # Just like get, except get_media.
   logs.info(
       'AndroidBuildAPI download_artifact media download started.',
-      api_version=version_tag,
+      api_version='V4',
       operation='download_artifact_media',
       build_id=bid,
       target=target,
       attempt_id=attempt_id,
       artifact_name=name)
 
-  if _use_v4():
-    success = client.download_artifact_file(bid, target, attempt_id, name,
-                                            output_path)
-    if not success:
-      logs.error(
-          'AndroidBuildAPI download_artifact failed for V4.',
-          api_version=version_tag,
-          operation='download_artifact',
-          build_id=bid,
-          target=target,
-          attempt_id=attempt_id,
-          artifact_name=name,
-          output_path=output_path,
-          status='failed')
-      return None
-  else:
-    dl_request = client.buildartifact().get_media(
-        buildId=bid, target=target, attemptId=attempt_id, resourceId=name)
-
-    with io.FileIO(output_path, mode='wb') as file_handle:
-      downloader = apiclient.http.MediaIoBaseDownload(
-          file_handle, dl_request, chunksize=chunksize)
-      done = False
-
-      while not done:
-        status, done = downloader.next_chunk()
-        if status:
-          size_completed = int(status.resumable_progress)
-          if size != 0:
-            percent_completed = (size_completed * 100.0) / size
-            logs.info('%.1f%% complete.' % percent_completed)
+  success = client.download_artifact_file(bid, target, attempt_id, name,
+                                          output_path)
+  if not success:
+    logs.error(
+        'AndroidBuildAPI download_artifact failed.',
+        api_version='V4',
+        operation='download_artifact',
+        build_id=bid,
+        target=target,
+        attempt_id=attempt_id,
+        artifact_name=name,
+        output_path=output_path,
+        status='failed')
+    return None
 
   logs.info(
       'AndroidBuildAPI download_artifact completed successfully.',
-      api_version=version_tag,
+      api_version='V4',
       operation='download_artifact',
       build_id=bid,
       target=target,
@@ -246,42 +183,20 @@ def _get_artifacts_for_build(client,
         target=target)
     return []
 
-  version_tag = 'V4' if _use_v4() else 'V3'
   logs.info(
       'AndroidBuildAPI get_artifacts_for_build started.',
-      api_version=version_tag,
+      api_version='V4',
       operation='get_artifacts_for_build',
       build_id=bid,
       target=target,
       attempt_id=attempt_id,
       regexp=regexp)
 
-  artifacts = []
-  results = []
-
-  if _use_v4():
-    artifacts = client.list_artifacts(bid, target, attempt_id, regexp=regexp)
-  else:
-    request = client.buildartifact().list(
-        buildId=bid,
-        target=target,
-        attemptId=attempt_id,
-        nameRegexp=regexp,
-        maxResults=100)
-
-    while request:
-      result = _execute_request_with_retries(request)
-      if not result:
-        break
-      results.append(result)
-      if result and 'artifacts' in result:
-        for artifact in result['artifacts']:
-          artifacts.append(artifact)
-      request = client.buildartifact().list_next(request, result)
+  artifacts = client.list_artifacts(bid, target, attempt_id, regexp=regexp)
 
   logs.info(
       'AndroidBuildAPI get_artifacts_for_build completed.',
-      api_version=version_tag,
+      api_version='V4',
       operation='get_artifacts_for_build',
       build_id=bid,
       target=target,
@@ -291,8 +206,7 @@ def _get_artifacts_for_build(client,
       status='success' if artifacts else 'empty')
 
   if not artifacts:
-    logs.error(f'No artifact found for target {target}, build id {bid}.\n'
-               f'results {results}')
+    logs.error(f'No artifact found for target {target}, build id {bid}.')
 
   return artifacts
 
@@ -309,26 +223,15 @@ def _get_client():
 
   key_dict = json.loads(build_apiary_service_account_private_key)
 
-  logs.info(
-      'AndroidBuildAPI client initialization started.',
-      api_version='V4' if _use_v4() else 'V3')
+  logs.info('AndroidBuildAPI client initialization started.', api_version='V4')
 
-  if _use_v4():
-    try:
-      credentials = service_account.Credentials.from_service_account_info(
-          key_dict, scopes=ANDROID_BUILD_API_SCOPES)
-      client = AndroidBuildV4Api.create_authenticated(credentials)
-    except Exception as e:
-      logs.error(f'Failed to initialize AndroidBuildV4Api: {e}')
-      return None
-  else:
-    credentials = ServiceAccountCredentials.from_json_keyfile_dict(
+  try:
+    credentials = service_account.Credentials.from_service_account_info(
         key_dict, scopes=ANDROID_BUILD_API_SCOPES)
-    client = apiclient.discovery.build(
-        'androidbuildinternal',
-        'v3',
-        credentials=credentials,
-        static_discovery=False)
+    client = AndroidBuildV4Api.create_authenticated(credentials)
+  except Exception as e:
+    logs.error(f'Failed to initialize AndroidBuildV4Api: {e}')
+    return None
 
   return client
 
@@ -373,32 +276,20 @@ def get_latest_artifact_info(branch, target, signed=False, stable_build=False):
     if 'bid' in build_info and build_info['bid'] != '0':
       return build_info
 
-  version_tag = 'V4' if _use_v4() else 'V3'
   logs.info(
       'AndroidBuildAPI get_latest_artifact_info started.',
-      api_version=version_tag,
+      api_version='V4',
       operation='get_latest_artifact_info',
       branch=branch,
       target=target,
       signed=signed)
 
-  if _use_v4():
-    builds = client.list_builds(branch, target, signed)
-  else:
-    request = client.build().list(  # pylint: disable=no-member
-        buildType='submitted',
-        branch=branch,
-        target=target,
-        successful=True,
-        maxResults=1,
-        signed=signed)
-    res = _execute_request_with_retries(request)
-    builds = res if (res and res.get('builds')) else None
+  builds = client.list_builds(branch, target, signed)
 
   if not builds:
     logs.error(
         'AndroidBuildAPI get_latest_artifact_info failed: no builds found.',
-        api_version=version_tag,
+        api_version='V4',
         operation='get_latest_artifact_info',
         branch=branch,
         target=target,
@@ -412,7 +303,7 @@ def get_latest_artifact_info(branch, target, signed=False, stable_build=False):
 
   logs.info(
       'AndroidBuildAPI get_latest_artifact_info completed.',
-      api_version=version_tag,
+      api_version='V4',
       operation='get_latest_artifact_info',
       branch=branch,
       target=target,

--- a/src/clusterfuzz/_internal/tests/core/platforms/android/fetch_artifact_test.py
+++ b/src/clusterfuzz/_internal/tests/core/platforms/android/fetch_artifact_test.py
@@ -29,17 +29,14 @@ class FetchArtifactTest(unittest.TestCase):
   def setUp(self):
     helpers.patch(self, [
         'clusterfuzz._internal.platforms.android.fetch_artifact._get_client',
-        'clusterfuzz._internal.platforms.android.fetch_artifact._use_v4',
         'clusterfuzz._internal.platforms.android.fetch_artifact._call_android_api_enabled',
-        'clusterfuzz._internal.platforms.android.fetch_artifact._execute_request_with_retries',
     ])
     self.mock_client = mock.MagicMock()
     self.mock._get_client.return_value = self.mock_client
     self.mock._call_android_api_enabled.return_value = True
 
-  def test_get_latest_artifact_v4_success(self):
-    """Tests get_latest_artifact_info (V4). Expects extraction of {bid, branch, target} when list_builds returns data."""
-    self.mock._use_v4.return_value = True
+  def test_get_latest_artifact_success(self):
+    """Tests get_latest_artifact_info. Expects extraction of {bid, branch, target} when list_builds returns data."""
     self.mock_client.list_builds.return_value = {
         'builds': [{
             'buildId': '123',
@@ -58,58 +55,11 @@ class FetchArtifactTest(unittest.TestCase):
     self.mock_client.list_builds.assert_called_once_with(
         'branch1', 'target1', False)
 
-  def test_get_latest_artifact_v4_failure_no_builds(self):
-    """Tests get_latest_artifact_info (V4) returns None gracefully when no builds are found."""
-    self.mock._use_v4.return_value = True
+  def test_get_latest_artifact_failure_no_builds(self):
+    """Tests get_latest_artifact_info returns None gracefully when no builds are found."""
     self.mock_client.list_builds.return_value = {}
 
     result = fetch_artifact.get_latest_artifact_info('branch1', 'target1')
-    self.assertIsNone(result)
-
-  def test_get_latest_artifact_v3_success(self):
-    """Tests get_latest_artifact_info (V3). Expects extraction of {bid, branch, target} via legacy HTTP execution."""
-    self.mock._use_v4.return_value = False
-
-    mock_request = mock.MagicMock()
-    self.mock_client.build().list.return_value = mock_request
-
-    self.mock._execute_request_with_retries.return_value = {
-        'builds': [{
-            'buildId': '456',
-            'target': {
-                'name': 'test_target2'
-            }
-        }]
-    }
-
-    result = fetch_artifact.get_latest_artifact_info(
-        'branch2', 'target2', signed=True)
-    self.assertEqual(result, {
-        'bid': '456',
-        'branch': 'branch2',
-        'target': 'test_target2'
-    })
-
-    self.mock_client.build().list.assert_called_once_with(
-        buildType='submitted',
-        branch='branch2',
-        target='target2',
-        successful=True,
-        maxResults=1,
-        signed=True)
-    self.mock._execute_request_with_retries.assert_called_once_with(
-        mock_request)
-
-  def test_get_latest_artifact_v3_failure_no_builds(self):
-    """Tests get_latest_artifact_info (V3) returns None gracefully when the payload is empty."""
-    self.mock._use_v4.return_value = False
-
-    mock_request = mock.MagicMock()
-    self.mock_client.build().list.return_value = mock_request
-    self.mock._execute_request_with_retries.return_value = {'builds': []}
-
-    result = fetch_artifact.get_latest_artifact_info(
-        'branch2', 'target2', signed=True)
     self.assertIsNone(result)
 
   def test_get_latest_artifact_client_auth_failure(self):
@@ -132,7 +82,6 @@ class FetchArtifactTest(unittest.TestCase):
         self.mock_client, 'bid', 'target', regexp='')
     self.assertEqual(result, [])
     self.mock_client.list_artifacts.assert_not_called()
-    self.mock_client.buildartifact().list.assert_not_called()
 
 
 class CallAndroidApiEnabledTest(unittest.TestCase):


### PR DESCRIPTION
Bug: b/542587003, b/422775458

We previously migrated the android build api to call endpoints in v4, while keeping v3 open for instances of clusterfuzz that still used v3.  But now that the V3 has 100% throttle, its makes no difference, calls to v3 will fail, and calls to v4 will fail if they have not valid credentials.

So this PR removes all of the stale v3 api code, both from unit tests & its consumers. 