### PR TITLE
[Android Bad Build] Add liveness check

### DIFF
--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1296,6 +1296,19 @@ def check_for_bad_build(job_type: str,
         f'return code = {return_code}, crash type = {crash_result.get_type()}',
         raw_output=output,
         output=build_run_console_output)
+  elif environment.is_android():
+    package_name = android.app.get_package_name()
+    if (package_name and
+        not android.adb.get_process_and_child_pids(package_name)):
+      is_bad_build = True
+      build_run_console_output = utils.get_crash_stacktrace_output(
+          command, output, output)
+      logs.info(
+          f'Bad build for {job_type} detected at r{crash_revision}: '
+          f'application process for {package_name} is not running after '
+          'startup.',
+          raw_output=output,
+          output=build_run_console_output)
 
   # Exit all running instances.
   process_handler.terminate_stale_application_instances()

--- a/src/clusterfuzz/_internal/tests/core/bot/testcase_manager_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/testcase_manager_test.py
@@ -1162,3 +1162,48 @@ class FuzzerRunOutputDataTest(fake_filesystem_unittest.TestCase):
     """Tests that get_output returns None when neither output nor file path is set."""
     output_data = testcase_manager.FuzzerRunOutputData()
     self.assertIsNone(output_data.get_output())
+
+
+class CheckForBadBuildTest(unittest.TestCase):
+  """Tests for check_for_bad_build."""
+
+  def setUp(self):
+    test_helpers.patch_environ(self)
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.bot.testcase_manager.get_command_line_for_application',
+        'clusterfuzz._internal.platforms.android.app.get_package_name',
+        'clusterfuzz._internal.platforms.android.adb.get_process_and_child_pids',
+        'clusterfuzz._internal.system.process_handler.run_process',
+        'clusterfuzz._internal.system.process_handler.terminate_stale_application_instances',
+    ])
+    self.mock.get_command_line_for_application.return_value = 'adb shell am start ...'
+    environment.set_value('BAD_BUILD_CHECK', True)
+    environment.set_value('APP_NAME', 'chrome.apk')
+    environment.set_value('APP_PATH', '/path/to/chrome.apk')
+
+  def test_android_invalid_apk_not_running(self):
+    """Test that an Android APK that dies on launch is detected as a bad build."""
+    environment.set_value('OS_OVERRIDE', 'ANDROID')
+    self.mock.run_process.return_value = (
+        0, 1.0, 'Starting: Intent ...\nProcess org.chromium.chrome has died')
+    self.mock.get_package_name.return_value = 'org.chromium.chrome'
+    self.mock.get_process_and_child_pids.return_value = []
+
+    build_data = testcase_manager.check_for_bad_build(
+        job_type='aluminium_asan_chrome_public', crash_revision=123)
+
+    self.assertTrue(build_data.is_bad_build)
+    self.assertEqual(build_data.revision, 123)
+
+  def test_android_valid_apk_running(self):
+    """Test that a working Android APK that is running is not marked as a bad build."""
+    environment.set_value('OS_OVERRIDE', 'ANDROID')
+    self.mock.run_process.return_value = (0, 1.0, 'Starting: Intent ...')
+    self.mock.get_package_name.return_value = 'org.chromium.chrome'
+    self.mock.get_process_and_child_pids.return_value = [2155]
+
+    build_data = testcase_manager.check_for_bad_build(
+        job_type='aluminium_asan_chrome_public', crash_revision=123)
+
+    self.assertFalse(build_data.is_bad_build)
+    self.assertEqual(build_data.revision, 123)


### PR DESCRIPTION
b/546076952

### Problem
On Android, `check_for_bad_build` launches the APK via `am start`, which exits with return code 0 as soon as the launch intent is delivered regardless of whether the app process survives. If the APK crashes or dies immediately on startup without generating a recognized ASan/security crash pattern in logcat, `crash_result.is_crash()` returns `False`. ClusterFuzz treats the build as healthy, falsely recording fuzzing hours for dead builds.

### Proposed Solution
Add an Android process liveness check in `check_for_bad_build`. After launching the app, verify if the package process is actually running via `android.adb.get_process_and_child_pids(package_name)`. If no active PIDs exist for the package, flag `is_bad_build = True` to halt execution before recording fuzzing hours.

### Testing & Validation
- Added unit tests in `testcase_manager_test.py` covering both dead APK and running APK scenarios.
- Verified in `dev` using the `aluminium_asan_chrome_public` job on `ANDROID_EMULATOR`, confirming that invalid builds are now caught and stopped at `check_for_bad_build`. 
- (See screenshot and logs link in b/546076952#comment7)
