### PR TITLE
Fix non App Engine imports

### DIFF
--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -24,7 +24,6 @@ from typing import Union
 
 from typing_extensions import override
 
-from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.system import archive
 
@@ -97,6 +96,9 @@ class BuildArchive(archive.ArchiveReader):
         The list of fuzz targets.
     """
     if self._fuzz_targets is None:
+      # Import here as this path is not available in App Engine context.
+      from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+
       self._fuzz_targets = {
           fuzzer_utils.normalize_target_name(path): path
           for path in self.find_fuzz_targets()
@@ -205,6 +207,9 @@ class DefaultBuildArchive(BuildArchive):
 
   @override
   def find_fuzz_targets(self) -> List[str]:
+    # Import here as this path is not available in App Engine context.
+    from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+
     return [
         member.name
         for member in self.list_members()
@@ -322,6 +327,9 @@ class ChromeBuildArchive(DefaultBuildArchive):
           'clusterfuzz_manifest.json was incorrectly formatted or missing an '
           'archive_schema_version field')
       self._archive_schema_version = default_archive_schema_version
+
+    # Import here as this path is not available in App Engine context.
+    from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
     self._manifest_fuzz_targets = (
         fuzzer_utils.extract_fuzz_targets_from_manifest(manifest))

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -330,7 +330,9 @@ class BaseBuild:
 
 def _read_schema_version_from_manifest(build_dir: str) -> int:
   """Reads archive_schema_version from clusterfuzz_manifest.json."""
+  # Import here as this path is not available in App Engine context.
   from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
+
   manifest = fuzzer_utils.read_chrome_manifest(build_dir)
   if not manifest:
     return 0


### PR DESCRIPTION
Recent changes to imports on `clusterfuzz._internal.bot` are causing 500 failures since `clusterfuzz._internal.bot` is excluded from App Engine context. https://github.com/google/clusterfuzz/commit/4140da0bceb31f569cc3cd072cb6dd2e040bf94b

Fixing `clusterfuzz._internal.bot` imports to be function-level instead of file-level.

b/552012304