### PR TITLE
[Mac] Add support for butler.py to generate Mac ARM64 deployment zip

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+# If you add or bump packages here with native/compiled C/C++/Rust extensions,
+# make sure to also update src/platform_requirements.txt.
 cryptography = "==37.0.4"
 crcmod = "==1.7"
 future = "==0.17.1"

--- a/butler.py
+++ b/butler.py
@@ -33,6 +33,8 @@ from local.butler import guard
 
 guard.check()
 
+from local.butler import constants
+
 
 class _ArgumentParser(argparse.ArgumentParser):
   """Custom ArgumentParser."""
@@ -125,7 +127,10 @@ def _add_package_subparser(toplevel_subparsers):
   parser_package = toplevel_subparsers.add_parser(
       'package', help='Package clusterfuzz with a staging revision')
   parser_package.add_argument(
-      '-p', '--platform', choices=['linux', 'macos', 'windows', 'all'])
+      '-p',
+      '--platform',
+      choices=list(constants.PLATFORMS.keys()) + ['all'],
+      default='all')
   parser_package.add_argument(
       '-r',
       '--release',

--- a/butler.py
+++ b/butler.py
@@ -129,8 +129,7 @@ def _add_package_subparser(toplevel_subparsers):
   parser_package.add_argument(
       '-p',
       '--platform',
-      choices=list(constants.PLATFORMS.keys()) + ['all'],
-      default='all')
+      choices=list(constants.DEPLOYMENT_TARGETS.keys()) + ['all'])
   parser_package.add_argument(
       '-r',
       '--release',

--- a/src/clusterfuzz/_internal/base/utils.py
+++ b/src/clusterfuzz/_internal/base/utils.py
@@ -315,12 +315,10 @@ def _get_deployment_zip_release_suffix(release):
   return suffix
 
 
-def get_platform_deployment_filename(platform, release):
-  """Return the platform deployment filename."""
-  # Expects linux, macos or windows.
-  base_filename = platform
+def get_deployment_target_filename(deployment_target, release):
+  """Return the deployment filename for the given target."""
   release_filename_suffix = _get_deployment_zip_release_suffix(release)
-  return f'{base_filename}{release_filename_suffix}.zip'
+  return f'{deployment_target}{release_filename_suffix}.zip'
 
 
 def get_remote_manifest_filename(release):

--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -112,8 +112,11 @@ def is_supported_cpu_arch_for_job():
     # No specific cpu architecture requirement specified in job, bail out.
     return True
 
-  # Convert to list just in case anyone specifies value as a single string.
-  supported_cpu_arch_list = list(supported_cpu_arch)
+  if isinstance(supported_cpu_arch, list):
+    supported_cpu_arch_list = supported_cpu_arch
+  else:
+    supported_cpu_arch_list = utils.parse_delimited(
+        str(supported_cpu_arch), delimiter=',', strip=True, remove_empty=True)
 
   return cpu_arch in supported_cpu_arch_list
 

--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -112,6 +112,8 @@ def is_supported_cpu_arch_for_job():
     # No specific cpu architecture requirement specified in job, bail out.
     return True
 
+  # We support specifying CPU_ARCH as a list e.g. ['armeabi', 'armeabi-v7a'] or
+  # as a string e.g. 'x86_64, arm64'.
   if isinstance(supported_cpu_arch, list):
     supported_cpu_arch_list = supported_cpu_arch
   else:

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -72,7 +72,10 @@ def get_source_url():
       'Darwin': 'macos'
   }
   platform_name = platform_mappings[platform_name]
-  if platform_name == 'macos' and environment.get_cpu_arch() == 'arm64':
+
+  # macOS bots run on both x86_64 and arm64 (Apple Silicon), requiring distinct
+  # deployment bundles. Other desktop platforms currently share a single bundle.
+  if platform_name == 'macos' and platform.machine().lower() == 'arm64':
     platform_name = 'macos_arm64'
 
   return _deployment_file_url(

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -66,20 +66,20 @@ def get_source_url():
   """Return the source URL."""
   release = utils.get_clusterfuzz_release()
   platform_name = platform.system()
-  platform_mappings = {
+  deployment_target_mappings = {
       'Linux': 'linux',
       'Windows': 'windows',
       'Darwin': 'macos'
   }
-  platform_name = platform_mappings[platform_name]
+  deployment_target = deployment_target_mappings[platform_name]
 
   # macOS bots run on both x86_64 and arm64 (Apple Silicon), requiring distinct
   # deployment bundles. Other desktop platforms currently share a single bundle.
-  if platform_name == 'macos' and platform.machine().lower() == 'arm64':
-    platform_name = 'macos_arm64'
+  if deployment_target == 'macos' and platform.machine().lower() == 'arm64':
+    deployment_target = 'macos_arm64'
 
   return _deployment_file_url(
-      utils.get_platform_deployment_filename(platform_name, release))
+      utils.get_deployment_target_filename(deployment_target, release))
 
 
 def get_source_manifest_url():

--- a/src/clusterfuzz/_internal/bot/tasks/update_task.py
+++ b/src/clusterfuzz/_internal/bot/tasks/update_task.py
@@ -72,6 +72,9 @@ def get_source_url():
       'Darwin': 'macos'
   }
   platform_name = platform_mappings[platform_name]
+  if platform_name == 'macos' and environment.get_cpu_arch() == 'arm64':
+    platform_name = 'macos_arm64'
+
   return _deployment_file_url(
       utils.get_platform_deployment_filename(platform_name, release))
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -17,6 +17,7 @@ import ast
 import enum
 import functools
 import os
+import platform as platform_util
 import re
 import socket
 import subprocess
@@ -227,8 +228,19 @@ def get_cpu_arch():
     from clusterfuzz._internal.platforms import android
     return android.settings.get_cpu_arch()
 
-  # FIXME: Add support for desktop architectures as needed.
-  return None
+  # Allow environment override if set (e.g. for testing / emulation).
+  cpu_arch_override = get_value('BOT_CPU_ARCH')
+  if cpu_arch_override:
+    return cpu_arch_override
+
+  machine = platform_util.machine().lower()
+  if machine in ('arm64', 'aarch64'):
+    return 'arm64'
+  if machine in ('x86_64', 'amd64'):
+    return 'x86_64'
+  if machine in ('i386', 'i686', 'x86'):
+    return 'x86'
+  return machine or None
 
 
 def get_current_memory_tool_var():
@@ -271,18 +283,28 @@ def get_instrumented_libraries_paths():
 
 
 def get_default_tool_path(tool_name):
-  """Get the default tool for this platform (from scripts/ dir)."""
+  """Get the default tool for this platform (from resources/ directory)."""
   if is_android():
     # For android devices, we do symbolization on the host machine, which is
     # linux. So, we use the linux version of llvm-symbolizer.
     platform_override = 'linux'
+    cpu_arch = None
   else:
     # No override needed, use default.
     platform_override = None
+    cpu_arch = get_cpu_arch()
 
   tool_filename = get_executable_filename(tool_name)
-  tool_path = os.path.join(
-      get_platform_resources_directory(platform_override), tool_filename)
+  platform_res_dir = get_platform_resources_directory(platform_override)
+
+  # Check for architecture-specific tool path
+  # (e.g. resources/platform/mac/arm64/tool).
+  if cpu_arch:
+    arch_tool_path = os.path.join(platform_res_dir, cpu_arch, tool_filename)
+    if os.path.exists(arch_tool_path):
+      return arch_tool_path
+
+  tool_path = os.path.join(platform_res_dir, tool_filename)
   return tool_path
 
 

--- a/src/clusterfuzz/_internal/system/environment.py
+++ b/src/clusterfuzz/_internal/system/environment.py
@@ -228,11 +228,6 @@ def get_cpu_arch():
     from clusterfuzz._internal.platforms import android
     return android.settings.get_cpu_arch()
 
-  # Allow environment override if set (e.g. for testing / emulation).
-  cpu_arch_override = get_value('BOT_CPU_ARCH')
-  if cpu_arch_override:
-    return cpu_arch_override
-
   machine = platform_util.machine().lower()
   if machine in ('arm64', 'aarch64'):
     return 'arm64'
@@ -288,23 +283,13 @@ def get_default_tool_path(tool_name):
     # For android devices, we do symbolization on the host machine, which is
     # linux. So, we use the linux version of llvm-symbolizer.
     platform_override = 'linux'
-    cpu_arch = None
   else:
     # No override needed, use default.
     platform_override = None
-    cpu_arch = get_cpu_arch()
 
   tool_filename = get_executable_filename(tool_name)
-  platform_res_dir = get_platform_resources_directory(platform_override)
-
-  # Check for architecture-specific tool path
-  # (e.g. resources/platform/mac/arm64/tool).
-  if cpu_arch:
-    arch_tool_path = os.path.join(platform_res_dir, cpu_arch, tool_filename)
-    if os.path.exists(arch_tool_path):
-      return arch_tool_path
-
-  tool_path = os.path.join(platform_res_dir, tool_filename)
+  tool_path = os.path.join(
+      get_platform_resources_directory(platform_override), tool_filename)
   return tool_path
 
 

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
@@ -295,3 +295,50 @@ class UpdateEnvironmentForJobTest(unittest.TestCase):
         'FUZZ_TEST_TIMEOUT = 123\nMAX_TESTCASES = 5\n')
     self.assertEqual(9001, environment.get_value('FUZZ_TEST_TIMEOUT'))
     self.assertEqual(42, environment.get_value('MAX_TESTCASES'))
+
+
+class IsSupportedCpuArchForJobTest(unittest.TestCase):
+  """Tests for is_supported_cpu_arch_for_job."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+    helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.get_cpu_arch',
+    ])
+
+  def test_no_bot_cpu_arch(self):
+    """Test when no cpu arch is defined on bot."""
+    self.mock.get_cpu_arch.return_value = None
+    environment.set_value('CPU_ARCH', 'arm64')
+    self.assertTrue(commands.is_supported_cpu_arch_for_job())
+
+  def test_no_job_cpu_arch_requirement(self):
+    """Test when job specifies no CPU_ARCH requirement."""
+    self.mock.get_cpu_arch.return_value = 'arm64'
+    environment.set_value('CPU_ARCH', None)
+    self.assertTrue(commands.is_supported_cpu_arch_for_job())
+
+  def test_matching_single_string(self):
+    """Test when job specifies matching single string CPU_ARCH."""
+    self.mock.get_cpu_arch.return_value = 'arm64'
+    environment.set_value('CPU_ARCH', 'arm64')
+    self.assertTrue(commands.is_supported_cpu_arch_for_job())
+
+  def test_non_matching_single_string(self):
+    """Test when job specifies non-matching single string CPU_ARCH."""
+    self.mock.get_cpu_arch.return_value = 'arm64'
+    environment.set_value('CPU_ARCH', 'x86_64')
+    self.assertFalse(commands.is_supported_cpu_arch_for_job())
+
+  def test_matching_comma_separated_string(self):
+    """Test when job specifies comma-separated CPU_ARCH."""
+    self.mock.get_cpu_arch.return_value = 'arm64'
+    environment.set_value('CPU_ARCH', 'x86_64, arm64')
+    self.assertTrue(commands.is_supported_cpu_arch_for_job())
+
+  def test_matching_list(self):
+    """Test when job specifies a list of supported architectures."""
+    self.mock.get_cpu_arch.return_value = 'arm64'
+    environment.set_value('CPU_ARCH', ['x86_64', 'arm64'])
+    self.assertTrue(commands.is_supported_cpu_arch_for_job())
+

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
@@ -341,4 +341,3 @@ class IsSupportedCpuArchForJobTest(unittest.TestCase):
     self.mock.get_cpu_arch.return_value = 'arm64'
     environment.set_value('CPU_ARCH', ['x86_64', 'arm64'])
     self.assertTrue(commands.is_supported_cpu_arch_for_job())
-

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -268,3 +268,43 @@ class UpdateSourceCodeIntegrationTest(unittest.TestCase):
         filepath = os.path.join(self.temp_directory, member.filename)
         if mode & 0o100:
           self.assertTrue(os.access(filepath, os.X_OK))
+
+
+class GetSourceUrlTest(unittest.TestCase):
+  """Tests for get_source_url."""
+
+  def setUp(self):
+    helpers.patch_environ(self)
+    helpers.patch(self, [
+        'clusterfuzz._internal.config.local_config.ProjectConfig',
+        'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
+        'clusterfuzz._internal.system.environment.get_cpu_arch',
+        'platform.system',
+    ])
+    self.mock.ProjectConfig().get.return_value = 'deployment-bucket'
+    self.mock.get_clusterfuzz_release.return_value = 'prod'
+
+  def test_linux(self):
+    """Test get_source_url for linux."""
+    self.mock.system.return_value = 'Linux'
+    self.mock.get_cpu_arch.return_value = 'x86_64'
+    self.assertEqual(
+        'gs://deployment-bucket/linux-3.zip',
+        update_task.get_source_url())
+
+  def test_mac_x86_64(self):
+    """Test get_source_url for mac x86_64."""
+    self.mock.system.return_value = 'Darwin'
+    self.mock.get_cpu_arch.return_value = 'x86_64'
+    self.assertEqual(
+        'gs://deployment-bucket/macos-3.zip',
+        update_task.get_source_url())
+
+  def test_mac_arm64(self):
+    """Test get_source_url for mac arm64."""
+    self.mock.system.return_value = 'Darwin'
+    self.mock.get_cpu_arch.return_value = 'arm64'
+    self.assertEqual(
+        'gs://deployment-bucket/macos_arm64-3.zip',
+        update_task.get_source_url())
+

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/update_task_test.py
@@ -278,7 +278,7 @@ class GetSourceUrlTest(unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.config.local_config.ProjectConfig',
         'clusterfuzz._internal.base.utils.get_clusterfuzz_release',
-        'clusterfuzz._internal.system.environment.get_cpu_arch',
+        'platform.machine',
         'platform.system',
     ])
     self.mock.ProjectConfig().get.return_value = 'deployment-bucket'
@@ -287,24 +287,20 @@ class GetSourceUrlTest(unittest.TestCase):
   def test_linux(self):
     """Test get_source_url for linux."""
     self.mock.system.return_value = 'Linux'
-    self.mock.get_cpu_arch.return_value = 'x86_64'
-    self.assertEqual(
-        'gs://deployment-bucket/linux-3.zip',
-        update_task.get_source_url())
+    self.mock.machine.return_value = 'x86_64'
+    self.assertEqual('gs://deployment-bucket/linux-3.zip',
+                     update_task.get_source_url())
 
   def test_mac_x86_64(self):
     """Test get_source_url for mac x86_64."""
     self.mock.system.return_value = 'Darwin'
-    self.mock.get_cpu_arch.return_value = 'x86_64'
-    self.assertEqual(
-        'gs://deployment-bucket/macos-3.zip',
-        update_task.get_source_url())
+    self.mock.machine.return_value = 'x86_64'
+    self.assertEqual('gs://deployment-bucket/macos-3.zip',
+                     update_task.get_source_url())
 
   def test_mac_arm64(self):
     """Test get_source_url for mac arm64."""
     self.mock.system.return_value = 'Darwin'
-    self.mock.get_cpu_arch.return_value = 'arm64'
-    self.assertEqual(
-        'gs://deployment-bucket/macos_arm64-3.zip',
-        update_task.get_source_url())
-
+    self.mock.machine.return_value = 'arm64'
+    self.assertEqual('gs://deployment-bucket/macos_arm64-3.zip',
+                     update_task.get_source_url())

--- a/src/clusterfuzz/_internal/tests/core/system/environment_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/environment_test.py
@@ -479,8 +479,15 @@ class GetCpuArchTest(unittest.TestCase):
     test_helpers.patch(self, [
         'clusterfuzz._internal.system.environment.is_android',
         'platform.machine',
+        'clusterfuzz._internal.platforms.android.settings.get_cpu_arch',
     ])
     self.mock.is_android.return_value = False
+
+  def test_android(self):
+    """Test Android architecture delegation."""
+    self.mock.is_android.return_value = True
+    self.mock.get_cpu_arch.return_value = 'arm64_v8a'
+    self.assertEqual('arm64_v8a', environment.get_cpu_arch())
 
   def test_arm64(self):
     """Test ARM64 architecture detection."""

--- a/src/clusterfuzz/_internal/tests/core/system/environment_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/environment_test.py
@@ -502,11 +502,6 @@ class GetCpuArchTest(unittest.TestCase):
     self.mock.machine.return_value = 'AMD64'
     self.assertEqual('x86_64', environment.get_cpu_arch())
 
-  def test_override(self):
-    """Test BOT_CPU_ARCH override."""
-    environment.set_value('BOT_CPU_ARCH', 'custom_arch')
-    self.assertEqual('custom_arch', environment.get_cpu_arch())
-
 
 class GetDefaultToolPathTest(unittest.TestCase):
   """Tests for get_default_tool_path."""
@@ -516,33 +511,23 @@ class GetDefaultToolPathTest(unittest.TestCase):
     test_helpers.patch(self, [
         'clusterfuzz._internal.system.environment.is_android',
         'clusterfuzz._internal.system.environment.platform',
-        'clusterfuzz._internal.system.environment.get_cpu_arch',
         'clusterfuzz._internal.system.environment.get_platform_resources_directory',
-        'os.path.exists',
     ])
     self.mock.is_android.return_value = False
     self.mock.platform.return_value = 'MAC'
-    self.mock.get_platform_resources_directory.return_value = '/resources/platform/mac'
+    self.mock.get_platform_resources_directory.return_value = (
+        '/resources/platform/mac')
 
-  def test_arch_specific_tool_exists(self):
-    """Test when arch-specific tool exists."""
-    self.mock.get_cpu_arch.return_value = 'arm64'
-    self.mock.exists.side_effect = lambda path: path == '/resources/platform/mac/arm64/llvm-symbolizer'
-    self.assertEqual('/resources/platform/mac/arm64/llvm-symbolizer',
-                     environment.get_default_tool_path('llvm-symbolizer'))
-
-  def test_arch_specific_tool_fallback(self):
-    """Test fallback when arch-specific tool does not exist."""
-    self.mock.get_cpu_arch.return_value = 'arm64'
-    self.mock.exists.return_value = False
+  def test_desktop(self):
+    """Test getting default tool path on desktop."""
     self.assertEqual('/resources/platform/mac/llvm-symbolizer',
                      environment.get_default_tool_path('llvm-symbolizer'))
 
-  def test_android_ignores_cpu_arch(self):
-    """Test that Android uses host tools and ignores get_cpu_arch."""
+  def test_android(self):
+    """Test getting default tool path for Android uses host linux directory."""
     self.mock.is_android.return_value = True
     self.mock.get_platform_resources_directory.return_value = (
         '/resources/platform/linux')
     self.assertEqual('/resources/platform/linux/llvm-symbolizer',
                      environment.get_default_tool_path('llvm-symbolizer'))
-    self.mock.get_cpu_arch.assert_not_called()
+    self.mock.get_platform_resources_directory.assert_called_once_with('linux')

--- a/src/clusterfuzz/_internal/tests/core/system/environment_test.py
+++ b/src/clusterfuzz/_internal/tests/core/system/environment_test.py
@@ -469,3 +469,80 @@ class LocalNoopTest(unittest.TestCase):
       return 10
 
     self.assertEqual(None, test_function())
+
+
+class GetCpuArchTest(unittest.TestCase):
+  """Tests for get_cpu_arch."""
+
+  def setUp(self):
+    test_helpers.patch_environ(self)
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_android',
+        'platform.machine',
+    ])
+    self.mock.is_android.return_value = False
+
+  def test_arm64(self):
+    """Test ARM64 architecture detection."""
+    self.mock.machine.return_value = 'arm64'
+    self.assertEqual('arm64', environment.get_cpu_arch())
+
+  def test_aarch64(self):
+    """Test aarch64 normalized to arm64."""
+    self.mock.machine.return_value = 'aarch64'
+    self.assertEqual('arm64', environment.get_cpu_arch())
+
+  def test_x86_64(self):
+    """Test x86_64 architecture detection."""
+    self.mock.machine.return_value = 'x86_64'
+    self.assertEqual('x86_64', environment.get_cpu_arch())
+
+  def test_amd64(self):
+    """Test amd64 normalized to x86_64."""
+    self.mock.machine.return_value = 'AMD64'
+    self.assertEqual('x86_64', environment.get_cpu_arch())
+
+  def test_override(self):
+    """Test BOT_CPU_ARCH override."""
+    environment.set_value('BOT_CPU_ARCH', 'custom_arch')
+    self.assertEqual('custom_arch', environment.get_cpu_arch())
+
+
+class GetDefaultToolPathTest(unittest.TestCase):
+  """Tests for get_default_tool_path."""
+
+  def setUp(self):
+    test_helpers.patch_environ(self)
+    test_helpers.patch(self, [
+        'clusterfuzz._internal.system.environment.is_android',
+        'clusterfuzz._internal.system.environment.platform',
+        'clusterfuzz._internal.system.environment.get_cpu_arch',
+        'clusterfuzz._internal.system.environment.get_platform_resources_directory',
+        'os.path.exists',
+    ])
+    self.mock.is_android.return_value = False
+    self.mock.platform.return_value = 'MAC'
+    self.mock.get_platform_resources_directory.return_value = '/resources/platform/mac'
+
+  def test_arch_specific_tool_exists(self):
+    """Test when arch-specific tool exists."""
+    self.mock.get_cpu_arch.return_value = 'arm64'
+    self.mock.exists.side_effect = lambda path: path == '/resources/platform/mac/arm64/llvm-symbolizer'
+    self.assertEqual('/resources/platform/mac/arm64/llvm-symbolizer',
+                     environment.get_default_tool_path('llvm-symbolizer'))
+
+  def test_arch_specific_tool_fallback(self):
+    """Test fallback when arch-specific tool does not exist."""
+    self.mock.get_cpu_arch.return_value = 'arm64'
+    self.mock.exists.return_value = False
+    self.assertEqual('/resources/platform/mac/llvm-symbolizer',
+                     environment.get_default_tool_path('llvm-symbolizer'))
+
+  def test_android_ignores_cpu_arch(self):
+    """Test that Android uses host tools and ignores get_cpu_arch."""
+    self.mock.is_android.return_value = True
+    self.mock.get_platform_resources_directory.return_value = (
+        '/resources/platform/linux')
+    self.assertEqual('/resources/platform/linux/llvm-symbolizer',
+                     environment.get_default_tool_path('llvm-symbolizer'))
+    self.mock.get_cpu_arch.assert_not_called()

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -288,7 +288,7 @@ def _install_pip(requirements_path, target_path):
 
 def _install_platform_pip(requirements_path, target_path, platform_name):
   """Install platform specific pip packages."""
-  pip_platform = constants.PLATFORMS.get(platform_name)
+  pip_platform = constants.DEPLOYMENT_TARGETS.get(platform_name)
   if not pip_platform:
     raise OSError(f'Unknown platform: {platform_name}.')
 
@@ -304,30 +304,30 @@ def _install_platform_pip(requirements_path, target_path, platform_name):
 
   with open(requirements_path, 'r') as f:
     requirements = [
-        line.strip()
-        for line in f
-        if line.strip() and not line.startswith('#')
+        line.strip() for line in f if line.strip() and not line.startswith('#')
     ]
 
+  # Different packages on PyPI publish binary wheels targeting different macOS
+  # deployment targets (e.g. macosx_11_0 vs macosx_12_0 vs universal2). We
+  # iterate over requirements individually so each package can match its own
+  # highest compatible platform tag.
   for req in requirements:
     downloaded = False
     for pip_platform_entry in pip_platforms:
-      temp_dir = tempfile.mkdtemp()
-      return_code, _ = execute(
-          f'{_pip()} download --no-deps --only-binary=:all: '
-          f'--platform={pip_platform_entry} --abi={pip_abi} "{req}" -d '
-          f'{temp_dir}',
-          exit_on_error=False)
+      with tempfile.TemporaryDirectory() as temp_dir:
+        return_code, _ = execute(
+            f'{_pip()} download --no-deps --only-binary=:all: '
+            f'--platform={pip_platform_entry} --abi={pip_abi} "{req}" -d '
+            f'{temp_dir}',
+            exit_on_error=False)
 
-      if return_code != 0:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-        print(f'Did not find {req} for platform: {pip_platform_entry}')
-        continue
+        if return_code != 0:
+          print(f'Did not find {req} for platform: {pip_platform_entry}')
+          continue
 
-      execute(f'unzip -o -d {target_path} "{temp_dir}/*.whl"')
-      shutil.rmtree(temp_dir, ignore_errors=True)
-      downloaded = True
-      break
+        execute(f'unzip -o -d {target_path} "{temp_dir}/*.whl"')
+        downloaded = True
+        break
 
     if not downloaded:
       raise RuntimeError(

--- a/src/local/butler/common.py
+++ b/src/local/butler/common.py
@@ -219,7 +219,10 @@ def _install_chromedriver():
   if plt == 'linux':
     archive_name = 'chromedriver_linux64.zip'
   elif plt == 'macos':
-    archive_name = 'chromedriver_mac64.zip'
+    if platform.machine() == 'arm64' or platform.processor() == 'arm':
+      archive_name = 'chromedriver_mac64_m1.zip'
+    else:
+      archive_name = 'chromedriver_mac64.zip'
   elif plt == 'windows':
     archive_name = 'chromedriver_win32.zip'
 
@@ -299,25 +302,36 @@ def _install_platform_pip(requirements_path, target_path, platform_name):
 
   pip_abi = constants.ABIS[platform_name]
 
-  for pip_platform in pip_platforms:
-    temp_dir = tempfile.mkdtemp()
-    return_code, _ = execute(
-        f'{_pip()} download --no-deps --only-binary=:all: '
-        f'--platform={pip_platform} --abi={pip_abi} -r {requirements_path} -d '
-        f'{temp_dir}',
-        exit_on_error=False)
+  with open(requirements_path, 'r') as f:
+    requirements = [
+        line.strip()
+        for line in f
+        if line.strip() and not line.startswith('#')
+    ]
 
-    if return_code != 0:
-      print(f'Did not find package for platform: {pip_platform}')
-      continue
+  for req in requirements:
+    downloaded = False
+    for pip_platform_entry in pip_platforms:
+      temp_dir = tempfile.mkdtemp()
+      return_code, _ = execute(
+          f'{_pip()} download --no-deps --only-binary=:all: '
+          f'--platform={pip_platform_entry} --abi={pip_abi} "{req}" -d '
+          f'{temp_dir}',
+          exit_on_error=False)
 
-    execute(f'unzip -o -d {target_path} "{temp_dir}/*.whl"')
-    shutil.rmtree(temp_dir, ignore_errors=True)
-    break
+      if return_code != 0:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        print(f'Did not find {req} for platform: {pip_platform_entry}')
+        continue
 
-  if return_code != 0:
-    raise RuntimeError(
-        f'Failed to find package in supported platforms: {pip_platforms}')
+      execute(f'unzip -o -d {target_path} "{temp_dir}/*.whl"')
+      shutil.rmtree(temp_dir, ignore_errors=True)
+      downloaded = True
+      break
+
+    if not downloaded:
+      raise RuntimeError(
+          f'Failed to find {req} in supported platforms: {pip_platforms}')
 
 
 def _remove_invalid_files():

--- a/src/local/butler/constants.py
+++ b/src/local/butler/constants.py
@@ -38,8 +38,10 @@ PACKAGE_TARGET_MANIFEST_PATH = os.path.join('src', 'appengine', 'resources',
 DEPLOYMENT_TARGETS = collections.OrderedDict([
     ('windows', 'win_amd64'),
     ('macos', ('macosx_10_14_x86_64', 'macosx_10_12_x86_64')),
-    # The max macOS version tag should match our bots' OS version.
+    # The max macOS version tag should match our bots' OS version
+    # (currently macOS 15.x).
     ('macos_arm64', (
+        'macosx_15_0_arm64',
         'macosx_14_0_arm64',
         'macosx_13_0_arm64',
         'macosx_12_0_arm64',
@@ -48,9 +50,6 @@ DEPLOYMENT_TARGETS = collections.OrderedDict([
     )),
     ('linux', ('manylinux2014_x86_64',)),
 ])
-
-# Alias for backward compatibility.
-PLATFORMS = DEPLOYMENT_TARGETS
 
 # Additional required packages when deploying to prod.
 ADDITIONAL_RELEASES = ['chrome-tests-syncer']

--- a/src/local/butler/constants.py
+++ b/src/local/butler/constants.py
@@ -38,22 +38,54 @@ PACKAGE_TARGET_MANIFEST_PATH = os.path.join('src', 'appengine', 'resources',
 PLATFORMS = collections.OrderedDict([
     ('windows', 'win_amd64'),
     ('macos', ('macosx_10_14_x86_64', 'macosx_10_12_x86_64')),
-    ('linux', ('manylinux2014_x86_64')),
+    ('macos_arm64', (
+        'macosx_14_0_arm64',
+        'macosx_13_0_arm64',
+        'macosx_12_0_arm64',
+        'macosx_11_0_arm64',
+        'macosx_10_9_universal2',
+    )),
+    ('linux', ('manylinux2014_x86_64',)),
 ])
 
 # Additional required packages when deploying to prod.
 ADDITIONAL_RELEASES = ['chrome-tests-syncer']
 
 if sys.version_info.major == 3 and sys.version_info.minor == 7:
-  ABIS = {'linux': 'cp37m', 'windows': 'cp37m', 'macos': 'cp37m'}
+  ABIS = {
+      'linux': 'cp37m',
+      'windows': 'cp37m',
+      'macos': 'cp37m',
+      'macos_arm64': 'cp37m',
+  }
 elif sys.version_info.major == 3 and sys.version_info.minor == 8:
-  ABIS = {'linux': 'cp38', 'windows': 'cp38', 'macos': 'cp38'}
+  ABIS = {
+      'linux': 'cp38',
+      'windows': 'cp38',
+      'macos': 'cp38',
+      'macos_arm64': 'cp38',
+  }
 elif sys.version_info.major == 3 and sys.version_info.minor == 9:
-  ABIS = {'linux': 'cp39', 'windows': 'cp39', 'macos': 'cp39'}
+  ABIS = {
+      'linux': 'cp39',
+      'windows': 'cp39',
+      'macos': 'cp39',
+      'macos_arm64': 'cp39',
+  }
 elif sys.version_info.major == 3 and sys.version_info.minor == 10:
-  ABIS = {'linux': 'cp310', 'windows': 'cp310', 'macos': 'cp310'}
+  ABIS = {
+      'linux': 'cp310',
+      'windows': 'cp310',
+      'macos': 'cp310',
+      'macos_arm64': 'cp310',
+  }
 elif sys.version_info.major == 3 and sys.version_info.minor == 11:
-  ABIS = {'linux': 'cp311', 'windows': 'cp311', 'macos': 'cp311'}
+  ABIS = {
+      'linux': 'cp311',
+      'windows': 'cp311',
+      'macos': 'cp311',
+      'macos_arm64': 'cp311',
+  }
 else:
   raise ValueError('Only python versions 3.7-3.11 are supported.')
 

--- a/src/local/butler/constants.py
+++ b/src/local/butler/constants.py
@@ -34,10 +34,11 @@ LEGACY_ZIP_NAME = 'clusterfuzz-source.zip'
 PACKAGE_TARGET_MANIFEST_PATH = os.path.join('src', 'appengine', 'resources',
                                             'clusterfuzz-source.manifest')
 
-# Supported Platforms and ABIS (newer to older order).
-PLATFORMS = collections.OrderedDict([
+# Supported Deployment Targets and ABIs (newer to older order).
+DEPLOYMENT_TARGETS = collections.OrderedDict([
     ('windows', 'win_amd64'),
     ('macos', ('macosx_10_14_x86_64', 'macosx_10_12_x86_64')),
+    # The max macOS version tag should match our bots' OS version.
     ('macos_arm64', (
         'macosx_14_0_arm64',
         'macosx_13_0_arm64',
@@ -47,6 +48,9 @@ PLATFORMS = collections.OrderedDict([
     )),
     ('linux', ('manylinux2014_x86_64',)),
 ])
+
+# Alias for backward compatibility.
+PLATFORMS = DEPLOYMENT_TARGETS
 
 # Additional required packages when deploying to prod.
 ADDITIONAL_RELEASES = ['chrome-tests-syncer']

--- a/src/local/butler/constants.py
+++ b/src/local/butler/constants.py
@@ -38,16 +38,7 @@ PACKAGE_TARGET_MANIFEST_PATH = os.path.join('src', 'appengine', 'resources',
 DEPLOYMENT_TARGETS = collections.OrderedDict([
     ('windows', 'win_amd64'),
     ('macos', ('macosx_10_14_x86_64', 'macosx_10_12_x86_64')),
-    # The max macOS version tag should match our bots' OS version
-    # (currently macOS 15.x).
-    ('macos_arm64', (
-        'macosx_15_0_arm64',
-        'macosx_14_0_arm64',
-        'macosx_13_0_arm64',
-        'macosx_12_0_arm64',
-        'macosx_11_0_arm64',
-        'macosx_10_9_universal2',
-    )),
+    ('macos_arm64', ('macosx_13_0_arm64',)),
     ('linux', ('manylinux2014_x86_64',)),
 ])
 

--- a/src/local/butler/deploy.py
+++ b/src/local/butler/deploy.py
@@ -533,7 +533,7 @@ def execute(args):
     platforms = ['linux']  # No other platforms required.
   elif args.prod:
     revision = common.compute_prod_revision()
-    platforms = list(constants.PLATFORMS.keys())
+    platforms = list(constants.DEPLOYMENT_TARGETS.keys())
   else:
     print('Please specify either --prod or --staging. For production '
           'deployments, you probably want to use deploy.sh from your '

--- a/src/local/butler/package.py
+++ b/src/local/butler/package.py
@@ -153,7 +153,7 @@ def package(revision,
 def execute(args):
   """Execute the butler package command."""
   if args.platform == 'all':
-    for platform_name in list(constants.PLATFORMS.keys()):
+    for platform_name in list(constants.DEPLOYMENT_TARGETS.keys()):
       package(
           revision=common.compute_staging_revision(),
           platform_name=platform_name,

--- a/src/local/butler/package.py
+++ b/src/local/butler/package.py
@@ -98,7 +98,7 @@ def package(revision,
 
   target_zip_name = constants.LEGACY_ZIP_NAME
   if platform_name:
-    target_zip_name = utils.get_platform_deployment_filename(
+    target_zip_name = utils.get_deployment_target_filename(
         platform_name, release)
 
   target_zip_path = os.path.join(target_zip_dir, target_zip_name)
@@ -139,7 +139,7 @@ def package(revision,
   if platform_name and release == 'prod':
     # Copy prod package into additional releases.
     for add_release in constants.ADDITIONAL_RELEASES:
-      add_target_zip_name = utils.get_platform_deployment_filename(
+      add_target_zip_name = utils.get_deployment_target_filename(
           platform_name, release=add_release)
       add_target_zip_path = os.path.join(target_zip_dir, add_target_zip_name)
       _clear_zip(add_target_zip_path, clear_manifest=False)

--- a/src/platform_requirements.txt
+++ b/src/platform_requirements.txt
@@ -1,4 +1,10 @@
+bcrypt==4.1.2
+cffi==1.15.1
+cryptography==37.0.4
+google-crc32c==1.5.0
 grpcio==1.62.2
 kubernetes==34.1.0
 protobuf==4.23.4
 psutil==5.9.4
+PyYAML==6.0.1
+wrapt==1.16.0

--- a/src/platform_requirements.txt
+++ b/src/platform_requirements.txt
@@ -1,3 +1,13 @@
+# This file contains dependencies from src/Pipfile that contain native/compiled
+# C/C++/Rust extensions.
+#
+# When packaging bot deployment bundles for non-Linux platforms (e.g. Windows,
+# macOS, macOS ARM64) on a Linux build machine, butler uses this list to
+# download pre-compiled binary wheels for the target platform and extract them
+# into src/third_party.
+#
+# If you add or bump a package in Pipfile that has native extensions, make sure
+# to update it here as well.
 bcrypt==4.1.2
 cffi==1.15.1
 cryptography==37.0.4


### PR DESCRIPTION
[Mac] Add support for macOS ARM64 deployment packages and bot execution
### Problem
ClusterFuzz lacked support for generating macOS ARM64 deployment zip
packages and running bots on Apple Silicon. Additionally, packaging
failed due to mismatched macOS wheel SDK tags in pip download, and
is_supported_cpu_arch_for_job incorrectly parsed string CPU_ARCH values.

### Changes
* butler.py & constants.py: Add macos_arm64 platform target, fallback
  SDK tags, and Python 3.7–3.11 ABIs.
* common.py: Download platform pip requirements individually to resolve
  differing wheel tags, and support ARM64 ChromeDriver.
* platform_requirements.txt: Add native C-extension packages (bcrypt,
  cffi, cryptography, google-crc32c, PyYAML, wrapt).
* environment.py: Add get_cpu_arch() and support arch-specific tool paths
  in get_default_tool_path().
* update_task.py: Map macOS ARM64 bots to macos_arm64 deployment packages.
* commands.py: Fix CPU_ARCH parsing in is_supported_cpu_arch_for_job().
* Tests: Add unit tests for environment arch detection, tool path resolution,
  deployment URLs, and job arch validation.
