### PR TITLE
Reverts task short circuit for duplicate test cases

### DIFF
--- a/src/clusterfuzz/_internal/bot/tasks/commands.py
+++ b/src/clusterfuzz/_internal/bot/tasks/commands.py
@@ -368,11 +368,6 @@ def process_command_impl(task_name,
             f'task {task_name}.')
         return None
 
-      if testcase.status == 'Duplicate' or testcase.duplicate_of:
-        logs.info(f'Testcase {task_argument} is a duplicate, short-circuiting '
-                  f'task {task_name}.')
-        return None
-
       # Make sure that our platform id matches that of the testcase (for
       # non-fuzz tasks).
       current_platform_id = environment.get_platform_id()

--- a/src/clusterfuzz/_internal/bot/tasks/task_creation.py
+++ b/src/clusterfuzz/_internal/bot/tasks/task_creation.py
@@ -266,9 +266,6 @@ def create_tasks(testcase):
 
 def create_postminimize_tasks(testcase):
   """Create assorted tasks needed after minimize task completes."""
-  if testcase.status == 'Duplicate' or testcase.duplicate_of:
-    return
-
   create_impact_task_if_needed(testcase)
   create_regression_task_if_needed(testcase)
   create_symbolize_task_if_needed(testcase)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/commands_test.py
@@ -231,24 +231,6 @@ class RunCommandTest(unittest.TestCase):
     self.assertIsNone(result)
     self.assertEqual(0, self.mock.progression_utask_preprocess.call_count)
 
-  def test_process_command_impl_short_circuit_duplicate_testcase(self):
-    """Test process_command_impl short-circuits for a duplicate testcase."""
-    testcase = test_utils.create_generic_testcase()
-    testcase.status = 'Duplicate'
-    testcase.put()
-    job_name = 'job'
-    data_types.Job(name=job_name, platform='LINUX').put()
-
-    result = commands.process_command_impl(
-        task_name='progression',
-        task_argument=str(testcase.key.id()),
-        job_name=job_name,
-        high_end=False,
-        is_command_override=False)
-
-    self.assertIsNone(result)
-    self.assertEqual(0, self.mock.progression_utask_preprocess.call_count)
-
   def test_process_command_impl_corpus_pruning_not_short_circuited(self):
     """Test process_command_impl does not short-circuit for corpus_pruning."""
     job_name = 'job'

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/task_creation_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/task_creation_test.py
@@ -53,27 +53,3 @@ class CreateTasksTest(unittest.TestCase):
     self.assertNotEqual(testcase.minimized_keys, 'NA')
     self.assertTrue(self.mock.create_minimize_task_if_needed.called)
     self.assertFalse(self.mock.create_postminimize_tasks.called)
-
-
-@test_utils.with_cloud_emulators('datastore')
-class CreatePostminimizeTasksTest(unittest.TestCase):
-  """Tests for create_postminimize_tasks."""
-
-  def setUp(self):
-    test_helpers.patch_environ(self)
-    test_helpers.patch(self, [
-        'clusterfuzz._internal.bot.tasks.task_creation.create_impact_task_if_needed',
-        'clusterfuzz._internal.bot.tasks.task_creation.create_regression_task_if_needed',
-        'clusterfuzz._internal.bot.tasks.task_creation.create_symbolize_task_if_needed',
-        'clusterfuzz._internal.bot.tasks.task_creation.create_variant_tasks_if_needed',
-    ])
-
-  def test_skip_duplicate(self):
-    """Test that create_postminimize_tasks skips duplicate testcases."""
-    testcase = test_utils.create_generic_testcase()
-    testcase.status = 'Duplicate'
-    task_creation.create_postminimize_tasks(testcase)
-    self.assertFalse(self.mock.create_impact_task_if_needed.called)
-    self.assertFalse(self.mock.create_regression_task_if_needed.called)
-    self.assertFalse(self.mock.create_symbolize_task_if_needed.called)
-    self.assertFalse(self.mock.create_variant_tasks_if_needed.called)


### PR DESCRIPTION
This was added in #5405, but in b/555138064 we found that this is a use case of Clusterfuzz to upload a better repro of an existing testcase and reupload it manually.