### PR TITLE
Update google-cloud-sdk to google-cloud-cli and fix apt-key deprecation

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -139,12 +139,11 @@ RUN apt update && apt install libc6:i386 -y
 
 ENV CLOUDSDK_PYTHON=python3.11
 
-RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.asc >/dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | apt-key add - && \
     apt-get update -y && \
-    apt-get install -y google-cloud-sdk
+    apt-get install -y google-cloud-cli
 
 # Common environment variables.
 ENV USER=clusterfuzz

--- a/docker/base/ubuntu-20-04.Dockerfile
+++ b/docker/base/ubuntu-20-04.Dockerfile
@@ -139,12 +139,11 @@ RUN apt update && apt install libc6:i386 -y
 
 ENV CLOUDSDK_PYTHON=python3.11
 
-RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.asc >/dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | apt-key add - && \
     apt-get update -y && \
-    apt-get install -y google-cloud-sdk
+    apt-get install -y google-cloud-cli
 
 # Common environment variables.
 ENV USER=clusterfuzz

--- a/docker/base/ubuntu-24-04.Dockerfile
+++ b/docker/base/ubuntu-24-04.Dockerfile
@@ -118,12 +118,11 @@ RUN apt update && apt install libc6:i386 -y
 
 ENV CLOUDSDK_PYTHON=python3.11
 
-RUN echo "deb https://packages.cloud.google.com/apt cloud-sdk main" \
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.asc >/dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | apt-key add - && \
     apt-get update -y && \
-    apt-get install -y google-cloud-sdk
+    apt-get install -y google-cloud-cli
 
 # Common environment variables.
 ENV USER=clusterfuzz

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -19,12 +19,12 @@ RUN apt-get update && \
         gettext-base \
         git \
         golang-go \
-        google-cloud-sdk-app-engine-go \
-        google-cloud-sdk-app-engine-python \
-        google-cloud-sdk-app-engine-python-extras \
-        google-cloud-sdk-datastore-emulator \
-        google-cloud-sdk-gke-gcloud-auth-plugin \
-        google-cloud-sdk-pubsub-emulator \
+        google-cloud-cli-app-engine-go \
+        google-cloud-cli-app-engine-python \
+        google-cloud-cli-app-engine-python-extras \
+        google-cloud-cli-datastore-emulator \
+        google-cloud-cli-gke-gcloud-auth-plugin \
+        google-cloud-cli-pubsub-emulator \
         kubectl \
         liblzma-dev \
         openjdk-21-jdk

--- a/docker/ci/ubuntu-20-04.Dockerfile
+++ b/docker/ci/ubuntu-20-04.Dockerfile
@@ -19,12 +19,12 @@ RUN apt-get update && \
         gettext-base \
         git \
         golang-go \
-        google-cloud-sdk-app-engine-go \
-        google-cloud-sdk-app-engine-python \
-        google-cloud-sdk-app-engine-python-extras \
-        google-cloud-sdk-datastore-emulator \
-        google-cloud-sdk-gke-gcloud-auth-plugin \
-        google-cloud-sdk-pubsub-emulator \
+        google-cloud-cli-app-engine-go \
+        google-cloud-cli-app-engine-python \
+        google-cloud-cli-app-engine-python-extras \
+        google-cloud-cli-datastore-emulator \
+        google-cloud-cli-gke-gcloud-auth-plugin \
+        google-cloud-cli-pubsub-emulator \
         kubectl \
         liblzma-dev \
         openjdk-21-jdk

--- a/docker/ci/ubuntu-24-04.Dockerfile
+++ b/docker/ci/ubuntu-24-04.Dockerfile
@@ -9,7 +9,7 @@
 FROM gcr.io/clusterfuzz-images/base:ubuntu-24-04
 
 # TOOD(ochang):Also need libnss3 libfreetype6 libfontconfig1 libgconf-2-4 xvfb for chrome-driver.
-RUN apt-get update &&     apt-get install -y         gettext-base         git         golang-go         google-cloud-sdk-app-engine-go         google-cloud-sdk-app-engine-python         google-cloud-sdk-app-engine-python-extras         google-cloud-sdk-datastore-emulator         google-cloud-sdk-gke-gcloud-auth-plugin         google-cloud-sdk-pubsub-emulator         kubectl         liblzma-dev         openjdk-21-jdk
+RUN apt-get update &&     apt-get install -y         gettext-base         git         golang-go         google-cloud-cli-app-engine-go         google-cloud-cli-app-engine-python         google-cloud-cli-app-engine-python-extras         google-cloud-cli-datastore-emulator         google-cloud-cli-gke-gcloud-auth-plugin         google-cloud-cli-pubsub-emulator         kubectl         liblzma-dev         openjdk-21-jdk
 
 # Install Bazel as per https://docs.bazel.build/versions/master/install-ubuntu.html#using-bazel-custom-apt-repository.
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list &&     curl https://storage.googleapis.com/www.bazel.build/bazel-release.pub.gpg | apt-key add - &&     apt-get update &&     apt-get install -y bazel

--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -104,11 +104,11 @@ else
 
   export CLOUD_SDK_REPO="cloud-sdk"
   export APT_FILE=/etc/apt/sources.list.d/google-cloud-sdk.list
-  export APT_LINE="deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main"
+  export APT_LINE="deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main"
   sudo bash -c "grep -x \"$APT_LINE\" $APT_FILE || (echo $APT_LINE | tee -a $APT_FILE)"
 
   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-      sudo apt-key add -
+      sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 
 fi
 


### PR DESCRIPTION
Fix base image Cloud Build failures when installing gcloud CLI/SDK dependencies on newer Ubuntu environments.

*  Replaced all references to `google-cloud-sdk` (and its addons like `app-engine-python`) with `google-cloud-cli`. Google formally stopped publishing updates under the legacy  SDK package name, causing a "no installation candidate" failure on newer deployments. 

* Replaced deprecated `apt-key add` commands with direct keyring configurations. Ubuntu 24.04 strictly enforces this deprecation, so GPG keys are now piped securely to `/usr/share/keyrings/cloud.google.asc` and referenced via the `[signed-by=...]` directive.                                                                                                           
                                                                                                                                                                                                       
References:
    * https://cloud.google.com/sdk/docs/install#deb
    * https://wiki.debian.org/DebianRepository/UseThirdParty