### PR TITLE
Change FUZZ_TARGET_CWD_IS_BUILD_DIR to FUZZ_TARGET_CWD_IS_TARGET_DIR

### DIFF
--- a/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
+++ b/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py
@@ -1135,9 +1135,10 @@ def get_runner(fuzzer_path, temp_dir=None, use_minijail=None):
     temp_dir = fuzzer_utils.get_temp_dir()
 
   build_dir = environment.get_value('BUILD_DIR')
+  target_dir = os.path.dirname(fuzzer_path)
 
-  cwd = build_dir if environment.get_value(
-      'FUZZ_TARGET_CWD_IS_BUILD_DIR') else None
+  cwd = target_dir if environment.get_value(
+      'FUZZ_TARGET_CWD_IS_TARGET_DIR') else None
 
   is_android = environment.is_android()
   is_fuchsia = environment.platform() == 'FUCHSIA'
@@ -1195,7 +1196,7 @@ def get_runner(fuzzer_path, temp_dir=None, use_minijail=None):
     runner = LibFuzzerRunner(fuzzer_path, cwd=cwd)
 
   if cwd and not isinstance(runner, LibFuzzerRunner):
-    logs.warning('FUZZ_TARGET_CWD_IS_BUILD_DIR is only supported for standard '
+    logs.warning('FUZZ_TARGET_CWD_IS_TARGET_DIR is only supported for standard '
                  'LibFuzzerRunner and will be ignored.')
 
   return runner

--- a/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/libfuzzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/fuzzers/libFuzzer/libfuzzer_test.py
@@ -186,24 +186,22 @@ class GetRunnerTest(unittest.TestCase):
     test_helpers.patch_environ(self)
 
   @mock.patch('os.chmod')
-  def test_cwd_is_build_dir(self, _):
-    """Test that FUZZ_TARGET_CWD_IS_BUILD_DIR causes cwd to be set to BUILD_DIR"""
-    environment.set_value('BUILD_DIR', '/build/dir')
-    environment.set_value('FUZZ_TARGET_CWD_IS_BUILD_DIR', True)
+  def test_cwd_is_target_dir(self, _):
+    """Test that FUZZ_TARGET_CWD_IS_TARGET_DIR causes cwd to be set to target directory."""
+    environment.set_value('FUZZ_TARGET_CWD_IS_TARGET_DIR', True)
     environment.set_value('USE_MINIJAIL', False)
 
-    runner = libfuzzer.get_runner('/fake/path')
+    runner = libfuzzer.get_runner('/fake/path/binary')
 
     self.assertIsInstance(runner, libfuzzer.LibFuzzerRunner)
-    self.assertEqual(runner.cwd, '/build/dir')
+    self.assertEqual(runner.cwd, '/fake/path')
 
   @mock.patch('os.chmod')
   def test_no_default_cwd(self, _):
-    """Test that cwd is None when FUZZ_TARGET_CWD_IS_BUILD_DIR is not set."""
-    environment.set_value('BUILD_DIR', '/build/dir')
+    """Test that cwd is None when FUZZ_TARGET_CWD_IS_TARGET_DIR is not set."""
     environment.set_value('USE_MINIJAIL', False)
 
-    runner = libfuzzer.get_runner('fake/path')
+    runner = libfuzzer.get_runner('/fake/path/binary')
 
     self.assertIsInstance(runner, libfuzzer.LibFuzzerRunner)
     self.assertIsNone(runner.cwd)


### PR DESCRIPTION
Setting cwd to BUILD_DIR caused errors on `libfuzzer_chrome_msan` when performing fuzzing due to a misalignment between the fuzz target binary (e.g., `xml_parser_fuzzer`) and the `ld-linux.so` dynamic linker. `FUZZ_TARGET_CWD_IS_BUILD_DIR` is currently an environment string used only for Libfuzzer MSan jobs since it is important to align the cwd of where the fuzz target binary is run to find the dynamic linker through relative paths otherwise the fuzzer won't work.

Aligning the cwd to the fuzz target directory should resolve the errors, so switching cwd to use the fuzz target's directory when environment string is set to true. Renaming the `FUZZ_TARGET_CWD_IS_BUILD_DIR` to `FUZZ_TARGET_CWD_IS_TARGET_DIR` to reflect the change in behavior.

Tested on dev by uploading a testcase and watching for fuzzing round errors. ClusterFuzz previously threw an error after 'Fuzzing round 0', but does not after the change.

crbug.com/536875721