### PR TITLE
Improve comments on app engine imports and add docs

### DIFF
--- a/docs/contributing-code/source_code.md
+++ b/docs/contributing-code/source_code.md
@@ -45,5 +45,5 @@ permalink: /contributing-code/source-code/
   [`.gcloudignore`](https://github.com/google/clusterfuzz/blob/master/src/appengine/.gcloudignore)
   are not uploaded to App Engine. Shared modules cannot use top-level imports
   from these directories, as this causes a `ModuleNotFoundError` on App Engine
-  startup (b/552012304). Instead, import them locally inside the functions or
-  methods where they are used.
+  startup. Instead, import them locally inside the functions or methods where
+  they are used.

--- a/docs/contributing-code/source_code.md
+++ b/docs/contributing-code/source_code.md
@@ -45,5 +45,5 @@ permalink: /contributing-code/source-code/
   [`.gcloudignore`](https://github.com/google/clusterfuzz/blob/master/src/appengine/.gcloudignore)
   are not uploaded to App Engine. Shared modules cannot use top-level imports
   from these directories, as this causes a `ModuleNotFoundError` on App Engine
-  startup. Instead, import them locally inside the functions or methods where
-  they are used.
+  startup (b/552012304). Instead, import them locally inside the functions or
+  methods where they are used.

--- a/docs/contributing-code/source_code.md
+++ b/docs/contributing-code/source_code.md
@@ -38,3 +38,12 @@ permalink: /contributing-code/source-code/
   * **platform_requirements.txt** - platform dependent package list.
 * **bower.json** - component dependencies for Polymer 2.
 * **butler.py** - helper script for various command line tasks (e.g. testing, deployment).
+
+## Pitfalls
+
+* **App Engine imports** - Directories listed in
+  [`.gcloudignore`](https://github.com/google/clusterfuzz/blob/master/src/appengine/.gcloudignore)
+  are not uploaded to App Engine. Shared modules cannot use top-level imports
+  from these directories, as this causes a `ModuleNotFoundError` on App Engine
+  startup. Instead, import them locally inside the functions or methods where
+  they are used.

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -96,9 +96,8 @@ class BuildArchive(archive.ArchiveReader):
         The list of fuzz targets.
     """
     if self._fuzz_targets is None:
-      # `clusterfuzz._internal.bot` has to be imported locally since it is not
-      # uploaded to GCP with App Engine context.
-      # See:
+      # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
+      # it is not uploaded to GCP with App Engine context. See:
       # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
       from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -210,9 +209,8 @@ class DefaultBuildArchive(BuildArchive):
 
   @override
   def find_fuzz_targets(self) -> List[str]:
-    # `clusterfuzz._internal.bot` has to be imported locally since it is not
-    # uploaded to GCP with App Engine context.
-    # See:
+    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
+    # it is not uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -334,9 +332,8 @@ class ChromeBuildArchive(DefaultBuildArchive):
           'archive_schema_version field')
       self._archive_schema_version = default_archive_schema_version
 
-    # `clusterfuzz._internal.bot` has to be imported locally since it is not
-    # uploaded to GCP with App Engine context.
-    # See:
+    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
+    # it is not uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -96,7 +96,10 @@ class BuildArchive(archive.ArchiveReader):
         The list of fuzz targets.
     """
     if self._fuzz_targets is None:
-      # Import here as this path is not available in App Engine context.
+      # `clusterfuzz._internal.bot` has to be imported locally since it is not
+      # uploaded to GCP with App Engine context.
+      # See:
+      # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
       from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
       self._fuzz_targets = {
@@ -207,7 +210,10 @@ class DefaultBuildArchive(BuildArchive):
 
   @override
   def find_fuzz_targets(self) -> List[str]:
-    # Import here as this path is not available in App Engine context.
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context.
+    # See:
+    # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
     return [
@@ -328,7 +334,10 @@ class ChromeBuildArchive(DefaultBuildArchive):
           'archive_schema_version field')
       self._archive_schema_version = default_archive_schema_version
 
-    # Import here as this path is not available in App Engine context.
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context.
+    # See:
+    # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
     self._manifest_fuzz_targets = (

--- a/src/clusterfuzz/_internal/build_management/build_archive.py
+++ b/src/clusterfuzz/_internal/build_management/build_archive.py
@@ -96,8 +96,8 @@ class BuildArchive(archive.ArchiveReader):
         The list of fuzz targets.
     """
     if self._fuzz_targets is None:
-      # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
-      # it is not uploaded to GCP with App Engine context. See:
+      # `clusterfuzz._internal.bot` has to be imported locally since it is not
+      # uploaded to GCP with App Engine context. See:
       # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
       from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -209,8 +209,8 @@ class DefaultBuildArchive(BuildArchive):
 
   @override
   def find_fuzz_targets(self) -> List[str]:
-    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
-    # it is not uploaded to GCP with App Engine context. See:
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -332,8 +332,8 @@ class ChromeBuildArchive(DefaultBuildArchive):
           'archive_schema_version field')
       self._archive_schema_version = default_archive_schema_version
 
-    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
-    # it is not uploaded to GCP with App Engine context. See:
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -330,7 +330,10 @@ class BaseBuild:
 
 def _read_schema_version_from_manifest(build_dir: str) -> int:
   """Reads archive_schema_version from clusterfuzz_manifest.json."""
-  # Import here as this path is not available in App Engine context.
+  # `clusterfuzz._internal.bot` has to be imported locally since it is not
+  # uploaded to GCP with App Engine context.
+  # See:
+  # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
   from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
   manifest = fuzzer_utils.read_chrome_manifest(build_dir)
@@ -369,7 +372,10 @@ def _patch_rpaths(build_dir: str, app_path_env: str):
     return
 
   if environment.is_engine_fuzzer_job():
-    # Import here as this path is not available in App Engine context.
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context.
+    # See:
+    # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
     for target_path in fuzzer_utils.get_fuzz_targets(build_dir):
@@ -607,7 +613,10 @@ class Build(BaseBuild):
 
   def _get_fuzz_targets_from_dir(self, build_dir):
     """Get iterator of fuzz targets from build dir."""
-    # Import here as this path is not available in App Engine context.
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context.
+    # See:
+    # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
     for path in fuzzer_utils.get_fuzz_targets(build_dir):
@@ -1357,6 +1366,10 @@ def setup_regular_build(revision,
 
   build_class = RegularBuild
   if environment.is_trusted_host():
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context.
+    # See:
+    # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.untrusted_runner import build_setup_host
     build_class = build_setup_host.RemoteRegularBuild
   elif environment.platform() == 'FUCHSIA':
@@ -1380,7 +1393,10 @@ def setup_regular_build(revision,
   # Additional binaries to pull (for fuzzing engines such as Centipede).
   extra_bucket_path = get_bucket_path('EXTRA_BUILD_BUCKET_PATH')
   if extra_bucket_path and not build.is_discovery:
-    # Import here as this path is not available in App Engine context.
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context.
+    # See:
+    # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
     extra_build_urls = get_build_urls_list(extra_bucket_path)
     extra_build_url = revisions.find_build_url(extra_bucket_path,
@@ -1426,6 +1442,10 @@ def setup_symbolized_builds(revision):
 
   build_class = SymbolizedBuild
   if environment.is_trusted_host():
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context.
+    # See:
+    # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.untrusted_runner import build_setup_host
     build_class = build_setup_host.RemoteSymbolizedBuild  # pylint: disable=no-member
 

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -330,8 +330,8 @@ class BaseBuild:
 
 def _read_schema_version_from_manifest(build_dir: str) -> int:
   """Reads archive_schema_version from clusterfuzz_manifest.json."""
-  # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since it
-  # is not uploaded to GCP with App Engine context. See:
+  # `clusterfuzz._internal.bot` has to be imported locally since it is not
+  # uploaded to GCP with App Engine context. See:
   # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
   from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -371,8 +371,8 @@ def _patch_rpaths(build_dir: str, app_path_env: str):
     return
 
   if environment.is_engine_fuzzer_job():
-    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since it
-    # is not uploaded to GCP with App Engine context. See:
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -611,8 +611,8 @@ class Build(BaseBuild):
 
   def _get_fuzz_targets_from_dir(self, build_dir):
     """Get iterator of fuzz targets from build dir."""
-    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
-    # it is not uploaded to GCP with App Engine context. See:
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -1363,8 +1363,8 @@ def setup_regular_build(revision,
 
   build_class = RegularBuild
   if environment.is_trusted_host():
-    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
-    # it is not uploaded to GCP with App Engine context. See:
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.untrusted_runner import build_setup_host
     build_class = build_setup_host.RemoteRegularBuild
@@ -1389,8 +1389,8 @@ def setup_regular_build(revision,
   # Additional binaries to pull (for fuzzing engines such as Centipede).
   extra_bucket_path = get_bucket_path('EXTRA_BUILD_BUCKET_PATH')
   if extra_bucket_path and not build.is_discovery:
-    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
-    # it is not uploaded to GCP with App Engine context. See:
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
     extra_build_urls = get_build_urls_list(extra_bucket_path)
@@ -1437,8 +1437,8 @@ def setup_symbolized_builds(revision):
 
   build_class = SymbolizedBuild
   if environment.is_trusted_host():
-    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
-    # it is not uploaded to GCP with App Engine context. See:
+    # `clusterfuzz._internal.bot` has to be imported locally since it is not
+    # uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.untrusted_runner import build_setup_host
     build_class = build_setup_host.RemoteSymbolizedBuild  # pylint: disable=no-member

--- a/src/clusterfuzz/_internal/build_management/build_manager.py
+++ b/src/clusterfuzz/_internal/build_management/build_manager.py
@@ -330,9 +330,8 @@ class BaseBuild:
 
 def _read_schema_version_from_manifest(build_dir: str) -> int:
   """Reads archive_schema_version from clusterfuzz_manifest.json."""
-  # `clusterfuzz._internal.bot` has to be imported locally since it is not
-  # uploaded to GCP with App Engine context.
-  # See:
+  # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since it
+  # is not uploaded to GCP with App Engine context. See:
   # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
   from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -372,9 +371,8 @@ def _patch_rpaths(build_dir: str, app_path_env: str):
     return
 
   if environment.is_engine_fuzzer_job():
-    # `clusterfuzz._internal.bot` has to be imported locally since it is not
-    # uploaded to GCP with App Engine context.
-    # See:
+    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since it
+    # is not uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -613,9 +611,8 @@ class Build(BaseBuild):
 
   def _get_fuzz_targets_from_dir(self, build_dir):
     """Get iterator of fuzz targets from build dir."""
-    # `clusterfuzz._internal.bot` has to be imported locally since it is not
-    # uploaded to GCP with App Engine context.
-    # See:
+    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
+    # it is not uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
 
@@ -1366,9 +1363,8 @@ def setup_regular_build(revision,
 
   build_class = RegularBuild
   if environment.is_trusted_host():
-    # `clusterfuzz._internal.bot` has to be imported locally since it is not
-    # uploaded to GCP with App Engine context.
-    # See:
+    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
+    # it is not uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.untrusted_runner import build_setup_host
     build_class = build_setup_host.RemoteRegularBuild
@@ -1393,9 +1389,8 @@ def setup_regular_build(revision,
   # Additional binaries to pull (for fuzzing engines such as Centipede).
   extra_bucket_path = get_bucket_path('EXTRA_BUILD_BUCKET_PATH')
   if extra_bucket_path and not build.is_discovery:
-    # `clusterfuzz._internal.bot` has to be imported locally since it is not
-    # uploaded to GCP with App Engine context.
-    # See:
+    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
+    # it is not uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.fuzzers import utils as fuzzer_utils
     extra_build_urls = get_build_urls_list(extra_bucket_path)
@@ -1442,9 +1437,8 @@ def setup_symbolized_builds(revision):
 
   build_class = SymbolizedBuild
   if environment.is_trusted_host():
-    # `clusterfuzz._internal.bot` has to be imported locally since it is not
-    # uploaded to GCP with App Engine context.
-    # See:
+    # IMPORTANT: `clusterfuzz._internal.bot` has to be imported locally since
+    # it is not uploaded to GCP with App Engine context. See:
     # https://google.github.io/clusterfuzz/contributing-code/source-code/#pitfalls
     from clusterfuzz._internal.bot.untrusted_runner import build_setup_host
     build_class = build_setup_host.RemoteSymbolizedBuild  # pylint: disable=no-member


### PR DESCRIPTION
Document developer pitfalls on App Engine imports and update comments to be clearer to be clearer on what and why it has to be imported locally.

b/552964079