### PR TITLE
[VRP] Add constant for checking allowed platforms

### DIFF
--- a/src/clusterfuzz/_internal/base/feature_flags.py
+++ b/src/clusterfuzz/_internal/base/feature_flags.py
@@ -43,7 +43,6 @@ class FeatureFlags(Enum):
   SWARMING_MAX_PENDING_TASKS = 'swarming_max_pending_tasks'
 
   ENABLE_FUZZ_FOR_BOTS = 'enable_fuzz_for_bots'
-  ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS = 'enable_untrusted_testcases_for_bots'
   STORAGE_THREADED_OPS_FUZZ_TARGETS = 'storage_threaded_ops_fuzz_targets'
   CALL_ANDROID_API = 'call_android_api'
 

--- a/src/clusterfuzz/_internal/base/feature_flags.py
+++ b/src/clusterfuzz/_internal/base/feature_flags.py
@@ -43,6 +43,7 @@ class FeatureFlags(Enum):
   SWARMING_MAX_PENDING_TASKS = 'swarming_max_pending_tasks'
 
   ENABLE_FUZZ_FOR_BOTS = 'enable_fuzz_for_bots'
+  ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS = 'enable_untrusted_testcases_for_bots'
   STORAGE_THREADED_OPS_FUZZ_TARGETS = 'storage_threaded_ops_fuzz_targets'
   CALL_ANDROID_API = 'call_android_api'
 

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -26,7 +26,9 @@ from google.protobuf import any_pb2
 from google.protobuf import timestamp_pb2
 import google.protobuf.message
 
+from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.base.tasks import task_utils
+from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.google_cloud_utils import storage
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.protos import uworker_msg_pb2
@@ -231,13 +233,36 @@ def entity_from_protobuf(entity_proto: any_pb2.Any, model_type: Type[T]) -> T:  
   return entity
 
 
+def is_untrusted_testcase_allowed_on_bot(testcase) -> bool:
+  """Returns True if the untrusted testcase's job platform is allowed on
+  long-lived bots via feature flag."""
+  enable_untrusted_flag = (
+      feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS)
+  if not enable_untrusted_flag.enabled:
+    return False
+
+  job = data_types.Job.query(data_types.Job.name == testcase.job_type).get()
+  if not job or not job.platform:
+    return False
+
+  allowed_platforms = [
+      p.strip().lower()
+      for p in enable_untrusted_flag.string_value.split(',')
+      if p.strip()
+  ]
+  return job.platform.lower() in allowed_platforms
+
+
 def check_handling_testcase_safe(testcase):
   """Exits when the current task execution model is trusted but the testcase is
-  untrusted. This will allow uploading testcases to trusted jobs (e.g. Mac) more
-  safely. Returns True if safe to handle, False otherwise."""
+  untrusted and its platform is not allowed. This will allow uploading
+  testcases to trusted jobs (e.g. Mac) more safely. Returns True if safe to
+  handle, False otherwise."""
   if testcase.trusted:
     return True
   if environment.is_uworker():
+    return True
+  if is_untrusted_testcase_allowed_on_bot(testcase):
     return True
 
   logs.log_fatal_and_exit(

--- a/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
+++ b/src/clusterfuzz/_internal/bot/tasks/utasks/uworker_io.py
@@ -26,7 +26,6 @@ from google.protobuf import any_pb2
 from google.protobuf import timestamp_pb2
 import google.protobuf.message
 
-from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.base.tasks import task_utils
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.google_cloud_utils import storage
@@ -233,24 +232,17 @@ def entity_from_protobuf(entity_proto: any_pb2.Any, model_type: Type[T]) -> T:  
   return entity
 
 
-def is_untrusted_testcase_allowed_on_bot(testcase) -> bool:
-  """Returns True if the untrusted testcase's job platform is allowed on
-  long-lived bots via feature flag."""
-  enable_untrusted_flag = (
-      feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS)
-  if not enable_untrusted_flag.enabled:
-    return False
+PLATFORMS_SUPPORTING_UNTRUSTED_WORKLOADS = {'linux'}
 
+
+def is_untrusted_testcase_allowed_on_bot(testcase) -> bool:
+  """Returns True if the untrusted testcase is on a platform that does not
+  support the untrusted execution model (so it must run on a long-lived bot)."""
   job = data_types.Job.query(data_types.Job.name == testcase.job_type).get()
   if not job or not job.platform:
     return False
 
-  allowed_platforms = [
-      p.strip().lower()
-      for p in enable_untrusted_flag.string_value.split(',')
-      if p.strip()
-  ]
-  return job.platform.lower() in allowed_platforms
+  return job.platform.lower() not in PLATFORMS_SUPPORTING_UNTRUSTED_WORKLOADS
 
 
 def check_handling_testcase_safe(testcase):

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -22,7 +22,6 @@ from unittest import mock
 
 from google.cloud import ndb
 
-from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.protos import uworker_msg_pb2
@@ -442,44 +441,23 @@ class TestCheckRunningTestcaseSafe(unittest.TestCase):
     self.mock.is_uworker.return_value = True
     self.assertTrue(uworker_io.check_handling_testcase_safe(self.testcase))
 
-  def test_untrusted_testcase_not_uworker_raises(self):
-    """Test that untrusted testcase not on uworker raises SystemExit when flag is not set."""
+  def test_untrusted_testcase_non_linux_platform(self):
+    """Test that untrusted testcase passes on long-lived bot for non-Linux platforms."""
     self.testcase.trusted = False
     self.mock.is_uworker.return_value = False
-    with self.assertRaises(SystemExit):
-      uworker_io.check_handling_testcase_safe(self.testcase)
-
-  def test_untrusted_testcase_flag_disabled(self):
-    """Test that untrusted testcase raises when feature flag is disabled."""
-    self.testcase.trusted = False
-    self.mock.is_uworker.return_value = False
-    data_types.FeatureFlag(
-        id=feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS.value,
-        enabled=False,
-        string_value='windows,mac').put()
-    data_types.Job(name='test_job', platform='WINDOWS').put()
-    with self.assertRaises(SystemExit):
-      uworker_io.check_handling_testcase_safe(self.testcase)
-
-  def test_untrusted_testcase_allowed_platform(self):
-    """Test that untrusted testcase passes on long-lived bot when platform is allowed."""
-    self.testcase.trusted = False
-    self.mock.is_uworker.return_value = False
-    data_types.FeatureFlag(
-        id=feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS.value,
-        enabled=True,
-        string_value='windows,mac').put()
     data_types.Job(name='test_job', platform='WINDOWS').put()
     self.assertTrue(uworker_io.check_handling_testcase_safe(self.testcase))
 
-  def test_untrusted_testcase_disallowed_platform(self):
-    """Test that untrusted testcase raises on long-lived bot when platform is not allowed."""
+    data_types.Job(name='test_job', platform='MAC').put()
+    self.assertTrue(uworker_io.check_handling_testcase_safe(self.testcase))
+
+    data_types.Job(name='test_job', platform='ANDROID').put()
+    self.assertTrue(uworker_io.check_handling_testcase_safe(self.testcase))
+
+  def test_untrusted_testcase_linux_platform_raises(self):
+    """Test that untrusted testcase raises on long-lived bot for Linux platform."""
     self.testcase.trusted = False
     self.mock.is_uworker.return_value = False
-    data_types.FeatureFlag(
-        id=feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS.value,
-        enabled=True,
-        string_value='windows,mac').put()
     data_types.Job(name='test_job', platform='LINUX').put()
     with self.assertRaises(SystemExit):
       uworker_io.check_handling_testcase_safe(self.testcase)
@@ -489,9 +467,5 @@ class TestCheckRunningTestcaseSafe(unittest.TestCase):
     self.testcase.trusted = False
     self.testcase.job_type = 'nonexistent_job'
     self.mock.is_uworker.return_value = False
-    data_types.FeatureFlag(
-        id=feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS.value,
-        enabled=True,
-        string_value='windows,mac').put()
     with self.assertRaises(SystemExit):
       uworker_io.check_handling_testcase_safe(self.testcase)

--- a/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
+++ b/src/clusterfuzz/_internal/tests/core/bot/tasks/utasks/uworker_io_test.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 from google.cloud import ndb
 
+from clusterfuzz._internal.base import feature_flags
 from clusterfuzz._internal.bot.tasks.utasks import uworker_io
 from clusterfuzz._internal.datastore import data_types
 from clusterfuzz._internal.protos import uworker_msg_pb2
@@ -418,6 +419,7 @@ class TestCheckRunningFuzzerSafe(unittest.TestCase):
       uworker_io.check_running_fuzzer_safe(self.fuzzer)
 
 
+@test_utils.with_cloud_emulators('datastore')
 class TestCheckRunningTestcaseSafe(unittest.TestCase):
   """Tests check_handling_testcase_safe."""
 
@@ -425,8 +427,9 @@ class TestCheckRunningTestcaseSafe(unittest.TestCase):
     helpers.patch(self, [
         'clusterfuzz._internal.system.environment.is_uworker',
     ])
-    self.testcase = mock.MagicMock(spec=data_types.Testcase)
-    self.testcase.name = 'test_testcase'
+    self.testcase = data_types.Testcase()
+    self.testcase.job_type = 'test_job'
+    self.testcase.put()
 
   def test_trusted_testcase(self):
     """Test that trusted testcase passes without checks."""
@@ -440,8 +443,55 @@ class TestCheckRunningTestcaseSafe(unittest.TestCase):
     self.assertTrue(uworker_io.check_handling_testcase_safe(self.testcase))
 
   def test_untrusted_testcase_not_uworker_raises(self):
-    """Test that untrusted testcase not on uworker raises SystemExit."""
+    """Test that untrusted testcase not on uworker raises SystemExit when flag is not set."""
     self.testcase.trusted = False
     self.mock.is_uworker.return_value = False
+    with self.assertRaises(SystemExit):
+      uworker_io.check_handling_testcase_safe(self.testcase)
+
+  def test_untrusted_testcase_flag_disabled(self):
+    """Test that untrusted testcase raises when feature flag is disabled."""
+    self.testcase.trusted = False
+    self.mock.is_uworker.return_value = False
+    data_types.FeatureFlag(
+        id=feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS.value,
+        enabled=False,
+        string_value='windows,mac').put()
+    data_types.Job(name='test_job', platform='WINDOWS').put()
+    with self.assertRaises(SystemExit):
+      uworker_io.check_handling_testcase_safe(self.testcase)
+
+  def test_untrusted_testcase_allowed_platform(self):
+    """Test that untrusted testcase passes on long-lived bot when platform is allowed."""
+    self.testcase.trusted = False
+    self.mock.is_uworker.return_value = False
+    data_types.FeatureFlag(
+        id=feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS.value,
+        enabled=True,
+        string_value='windows,mac').put()
+    data_types.Job(name='test_job', platform='WINDOWS').put()
+    self.assertTrue(uworker_io.check_handling_testcase_safe(self.testcase))
+
+  def test_untrusted_testcase_disallowed_platform(self):
+    """Test that untrusted testcase raises on long-lived bot when platform is not allowed."""
+    self.testcase.trusted = False
+    self.mock.is_uworker.return_value = False
+    data_types.FeatureFlag(
+        id=feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS.value,
+        enabled=True,
+        string_value='windows,mac').put()
+    data_types.Job(name='test_job', platform='LINUX').put()
+    with self.assertRaises(SystemExit):
+      uworker_io.check_handling_testcase_safe(self.testcase)
+
+  def test_untrusted_testcase_job_not_found(self):
+    """Test that untrusted testcase raises when job is not found."""
+    self.testcase.trusted = False
+    self.testcase.job_type = 'nonexistent_job'
+    self.mock.is_uworker.return_value = False
+    data_types.FeatureFlag(
+        id=feature_flags.FeatureFlags.ENABLE_UNTRUSTED_TESTCASES_FOR_BOTS.value,
+        enabled=True,
+        string_value='windows,mac').put()
     with self.assertRaises(SystemExit):
       uworker_io.check_handling_testcase_safe(self.testcase)


### PR DESCRIPTION
b/556677120

### Problem
Long-lived bots currently exit with a fatal error whenever they encounter an untrusted testcase (`trusted=False`). However, there are existing testcases in Datastore marked as untrusted that belong to non-Linux jobs (e.g. Windows, Mac). Since uworker execution only runs in Linux containers, non-Linux tasks have no other way to execute and are completely blocked.

This was not caught during dev testing due to the lack of non-Linux VMs in the dev environment. This change does not affect the VRP security model because untrusted external fuzzers are strictly restricted to Linux jobs.

### Proposed Solution
- Defined `PLATFORMS_SUPPORTING_UNTRUSTED_WORKLOADS = {'linux'}` in `uworker_io.py`.
- Added helper `is_untrusted_testcase_allowed_on_bot(testcase)` in `uworker_io.py` to check if the testcase's job platform is outside `PLATFORMS_SUPPORTING_UNTRUSTED_WORKLOADS`.
- Updated `check_handling_testcase_safe` in `uworker_io.py` to allow execution on long-lived bots for non-Linux jobs.

### Testing
- Added unit tests in `uworker_io_test.py` verifying that untrusted testcases on non-Linux platforms (Windows, Mac, Android) pass on long-lived bots, while Linux jobs raise `SystemExit`.
- Verified unit tests pass: `python butler.py py_unittest -t core -p uworker_io_test.py`
- Verified code passes linting: `python butler.py lint`