### PR TITLE
Document reporter override side effects on primary_owner

### DIFF
--- a/src/clusterfuzz/_internal/datastore/data_types.py
+++ b/src/clusterfuzz/_internal/datastore/data_types.py
@@ -347,7 +347,10 @@ class Fuzzer(Model):
   # reward flags.
   external_contribution = ndb.BooleanProperty(default=False)
 
-  # Primary owner to be reported for bugs filed by CF
+  # Primary owner for this fuzzer (e.g. for VRP attribution).
+  # Note: Setting this overrides the bug reporter on filed issues in the issue
+  # tracker, which may affect downstream workflows or automations expecting the
+  # default ClusterFuzz reporter email.
   primary_owner = ndb.StringProperty()
 
   # Max testcases to generate for this fuzzer.

--- a/src/clusterfuzz/_internal/issue_management/issue_filer.py
+++ b/src/clusterfuzz/_internal/issue_management/issue_filer.py
@@ -483,6 +483,9 @@ def file_issue(testcase,
       testcase.one_time_crasher_flag and policy.unreproducible_component):
     issue.components.add(policy.unreproducible_component)
 
+  # Set the reporter to the fuzzer's primary owner if configured (e.g. for VRP
+  # rewards). Note: Overriding the reporter may have side effects on downstream
+  # workflows expecting the standard ClusterFuzz reporter email.
   if fuzzer and fuzzer.primary_owner:
     issue.reporter = fuzzer.primary_owner
   else:


### PR DESCRIPTION
Add documentation comments on the `primary_owner` property in `Fuzzer` and the reporter assignment logic in `issue_filer.py` to clarify that setting a fuzzer's primary owner overrides the issue tracker reporter for filed bugs and may impact downstream workflows expecting the default ClusterFuzz reporter email.