### PR TITLE
[Android] Add exit code constants and ProcessExitInfo data model

### DIFF
--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -91,6 +91,7 @@ class ExitReason(IntEnum):
   https://developer.android.com/reference/android/app/ApplicationExitInfo
   """
 
+  UNKNOWN = 0
   EXIT_SELF = 1
   SIGNALED = 2
   LOW_MEMORY = 3

--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -112,10 +112,12 @@ class ExitReason(IntEnum):
 
 
 class ExitStatus(IntEnum):
-  """Process exit signal statuses. Taken from:
-  https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/os/Process.java?q=content:SIGNAL_KILL
+  """Process exit signal statuses corresponding to POSIX signals.
+
+  See: https://developer.android.com/reference/android/os/Process
   """
 
+  SIGQUIT = 3
   SIGILL = 4
   SIGABRT = 6
   SIGKILL = 9

--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -106,11 +106,13 @@ class ExitReason:
   FREEZER = 14
   PACKAGE_STATE_CHANGE = 15
   PACKAGE_UPDATED = 16
+  REASON_MEMORY_LIMITER = 17
+  REASON_ANOMALY = 18
 
 
 class ExitStatus:
-  """Process exit signal statuses. Taken from 
-  https://developer.android.com/reference/android/app/ApplicationExitInfo
+  """Process exit signal statuses. Taken from:
+  https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/os/Process.java?q=content:SIGNAL_KILL
   """
 
   SIGILL = 4

--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -83,3 +83,33 @@ DEPRECATED_DEVICE_LIST = [
 # Restrict pixel6 from picking up generic Android jobs to avoid
 # Binary Mismatch: Hence, 'ANDROID:PIXEL6' is added to the list.
 DEVICES_WITH_NO_FALLBACK_QUEUE_LIST = ['ANDROID:PIXEL6']
+
+
+class ExitReason:
+  """Android process exit reasons from ApplicationExitInfo."""
+
+  EXIT_SELF = 1
+  SIGNALED = 2
+  LOW_MEMORY = 3
+  CRASH = 4
+  CRASH_NATIVE = 5
+  ANR = 6
+  INITIALIZATION_FAILURE = 7
+  PERMISSION_CHANGE = 8
+  EXCESSIVE_RESOURCE_USAGE = 9
+  USER_REQUESTED = 10
+  USER_STOPPED = 11
+  DEPENDENCY_DIED = 12
+  OTHER_KILLS_BY_SYSTEM = 13
+  FREEZER = 14
+  PACKAGE_STATE_CHANGE = 15
+  PACKAGE_UPDATED = 16
+
+
+class ExitStatus:
+  """Process exit signal statuses."""
+
+  SIGILL = 4
+  SIGABRT = 6
+  SIGKILL = 9
+  SIGSEGV = 11

--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -86,7 +86,9 @@ DEVICES_WITH_NO_FALLBACK_QUEUE_LIST = ['ANDROID:PIXEL6']
 
 
 class ExitReason:
-  """Android process exit reasons from ApplicationExitInfo."""
+  """Android process exit reasons from ApplicationExitInfo. Taken from
+  https://developer.android.com/reference/android/app/ApplicationExitInfo
+  """
 
   EXIT_SELF = 1
   SIGNALED = 2
@@ -107,7 +109,9 @@ class ExitReason:
 
 
 class ExitStatus:
-  """Process exit signal statuses."""
+  """Process exit signal statuses. Taken from 
+  https://developer.android.com/reference/android/app/ApplicationExitInfo
+  """
 
   SIGILL = 4
   SIGABRT = 6

--- a/src/clusterfuzz/_internal/platforms/android/constants.py
+++ b/src/clusterfuzz/_internal/platforms/android/constants.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Common constants."""
 
+from enum import IntEnum
 import re
 
 DEVICE_DOWNLOAD_DIR = '/sdcard/Download'
@@ -85,7 +86,7 @@ DEPRECATED_DEVICE_LIST = [
 DEVICES_WITH_NO_FALLBACK_QUEUE_LIST = ['ANDROID:PIXEL6']
 
 
-class ExitReason:
+class ExitReason(IntEnum):
   """Android process exit reasons from ApplicationExitInfo. Taken from
   https://developer.android.com/reference/android/app/ApplicationExitInfo
   """
@@ -110,7 +111,7 @@ class ExitReason:
   REASON_ANOMALY = 18
 
 
-class ExitStatus:
+class ExitStatus(IntEnum):
   """Process exit signal statuses. Taken from:
   https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/os/Process.java?q=content:SIGNAL_KILL
   """

--- a/src/clusterfuzz/_internal/platforms/android/util.py
+++ b/src/clusterfuzz/_internal/platforms/android/util.py
@@ -13,11 +13,23 @@
 # limitations under the License.
 """Utility functions for Android device."""
 
+from dataclasses import dataclass
 import os
 
 from clusterfuzz._internal.metrics import logs
 from clusterfuzz._internal.platforms import android
 from clusterfuzz._internal.system import environment
+
+
+@dataclass(frozen=True)
+class ProcessExitInfo:
+  """DTO representing process exit metadata from dumpsys activity exit-info."""
+
+  reason: int
+  reason_name: str  # e.g., 'APP CRASH(NATIVE)', 'SIGNALED'
+  subreason: int
+  subreason_name: str  # e.g., 'UNKNOWN', 'ISOLATED NOT NEEDED'
+  status: int
 
 
 def get_device_path(local_path):

--- a/src/clusterfuzz/_internal/platforms/android/util.py
+++ b/src/clusterfuzz/_internal/platforms/android/util.py
@@ -29,11 +29,11 @@ class ProcessExitInfo:
   https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/proto_logging/stats/enums/app_shared/app_enums.proto;l=270?q=content:subreason
   """
 
-  reason: int
-  reason_name: str  # e.g., 'APP CRASH(NATIVE)', 'SIGNALED'
+  reason: android.constants.ExitReason | int
+  reason_name: str  # e.g., 'APP_CRASH(NATIVE)', 'SIGNALED'
   subreason: int
-  subreason_name: str  # e.g., 'UNKNOWN', 'ISOLATED NOT NEEDED'
-  status: int
+  subreason_name: str  # e.g., 'UNKNOWN', 'ISOLATED_NOT_NEEDED'
+  status: android.constants.ExitStatus | int
 
 
 def get_device_path(local_path):

--- a/src/clusterfuzz/_internal/platforms/android/util.py
+++ b/src/clusterfuzz/_internal/platforms/android/util.py
@@ -23,7 +23,11 @@ from clusterfuzz._internal.system import environment
 
 @dataclass(frozen=True)
 class ProcessExitInfo:
-  """DTO representing process exit metadata from dumpsys activity exit-info."""
+  """DTO representing process exit metadata from dumpsys activity exit-info.
+
+  For a full list of android exit info reasons and subreasons, see:
+  https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/proto_logging/stats/enums/app_shared/app_enums.proto;l=270?q=content:subreason
+  """
 
   reason: int
   reason_name: str  # e.g., 'APP CRASH(NATIVE)', 'SIGNALED'


### PR DESCRIPTION
Bug: b/553141628

## Overview
Since Android API level 30 (and all apps targeting Android 11+), Android introduced `ApplicationExitInfo` to track process exit reasons and historical diagnostic metadata via `dumpsys activity exit-info`.

Previously, testcase execution using `am start` almost 99% of the time returned success exit code 0 even when an application process crashed or failed silently. To accurately track process termination reasons and status metadata from `dumpsys activity exit-info`, this PR defines the structured exit code constants (`ExitReason`, `ExitStatus`) and the `ProcessExitInfo` data model.

The purpose of this PR stack is to perform the following validation for each test case execution:
- Get the current android jobs app's pacakge
- then we look for the pid for our pacakge in the android's activity manager logs.
- once we have the pid, we can match it against the dumpys exit_info <package> to find out if our latest test-case indeed finished.
- If it finished, we will check the reason & status of why the process finished, this is basically the exit code & details as to why the process ended.
- with the exit info we can determine if it failed due to a runtime issue or not.


Learn more:
• https://developer.android.com/reference/android/app/ApplicationExitInfo

## Changes
- `src/clusterfuzz/_internal/platforms/android/constants.py`: Added `ExitReason` and `ExitStatus` constant definitions.
- `src/clusterfuzz/_internal/platforms/android/util.py`: Defined `ProcessExitInfo` dataclass for `dumpsys activity exit-info` parsing.

## Tests performed

## PR stack
- `master`
  - **#PR 2.1a** `feature/android-exit-code-constants` 👈
  - **#PR 2.1b** `feature/android-exit-code-core`
  - **#PR 2.2** `feature/android-exit-code-process-handler`
  - **#PR 2.3** `feature/android-bad-build-check`