### PR TITLE
[Android] Refine bad build check and testcase manager execution

### DIFF
--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1323,19 +1323,6 @@ def check_for_bad_build(job_type: str,
         f'return code = {return_code}, crash type = {crash_result.get_type()}',
         raw_output=output,
         output=build_run_console_output)
-  elif environment.is_android():
-    package_name = android.app.get_package_name()
-    if (package_name and
-        not android.adb.get_process_and_child_pids(package_name)):
-      is_bad_build = True
-      build_run_console_output = utils.get_crash_stacktrace_output(
-          command, output, output)
-      logs.info(
-          f'Bad build for {job_type} detected at r{crash_revision}: '
-          f'application process for {package_name} is not running after '
-          'startup.',
-          raw_output=output,
-          output=build_run_console_output)
 
   # Exit all running instances.
   process_handler.terminate_stale_application_instances()

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -332,7 +332,12 @@ def run_testcase(thread_index, file_path, gestures, env_copy):
     app_directory = environment.get_value('APP_DIR')
     environment.set_value('PIDS', '[]')
 
+    logs.info(
+        f'Running testcase (thread {thread_index}): file_path={file_path}, '
+        f'needs_http={needs_http}, gestures={gestures}')
+
     # Get command line options.
+
     command = get_command_line_for_application(
         file_path, user_profile_index=thread_index, needs_http=needs_http)
 
@@ -1243,7 +1248,8 @@ def check_for_bad_build(job_type: str,
     os.environ['APP_ARGS'] = job_default_args
 
   try:
-    command = get_command_line_for_application(file_to_run='', needs_http=False)
+    command = get_command_line_for_application(
+        file_to_run='', needs_http=False, write_command_line_file=True)
   finally:
     if orig_app_args is not None:
       os.environ['APP_ARGS'] = orig_app_args
@@ -1273,19 +1279,40 @@ def check_for_bad_build(job_type: str,
   process_handler.terminate_stale_application_instances()
 
   # Check if the build is bad.
+  logs.info(
+      f'Starting bad build check for {job_type} at r{crash_revision} with '
+      f'command: {command} (timeout={fast_warmup_timeout})')
   return_code, crash_time, output = process_handler.run_process(
       command,
       timeout=fast_warmup_timeout,
       current_working_directory=app_directory)
   crash_result = CrashResult(return_code, crash_time, output)
+  logs.info(
+      f'Bad build check run_process completed: return_code={return_code}, '
+      f'is_crash={crash_result.is_crash(ignore_state=True)}, '
+      f'crash_type={crash_result.get_type()}')
 
   # 1. Need to account for startup crashes with no crash state. E.g. failed to
   #    load shared library. So, ignore state for comparison.
   # 2. Ignore leaks as they don't block a build from reporting regular crashes
   #    and also don't impact regression range calculations.
-  if (crash_result.is_crash(ignore_state=True) and
-      not crash_result.should_ignore() and
-      not crash_result.get_type() in ['Direct-leak', 'Indirect-leak']):
+  if environment.is_android():
+    package_name = android.app.get_package_name()
+    if (package_name and
+        not android.adb.get_process_and_child_pids(package_name)):
+      is_bad_build = True
+      build_run_console_output = utils.get_crash_stacktrace_output(
+          command, output, output)
+      logs.info(
+          f'Bad build for {job_type} detected at r{crash_revision}: '
+          f'application process for {package_name} is not running after '
+          'startup.',
+          raw_output=output,
+          output=build_run_console_output)
+  elif (crash_result.is_crash(ignore_state=True) and
+        not crash_result.should_ignore() and
+        not crash_result.get_type() in ['Direct-leak', 'Indirect-leak']):
+
     is_bad_build = True
     build_run_console_output = utils.get_crash_stacktrace_output(
         command,

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1296,6 +1296,8 @@ def check_for_bad_build(job_type: str,
   #    load shared library. So, ignore state for comparison.
   # 2. Ignore leaks as they don't block a build from reporting regular crashes
   #    and also don't impact regression range calculations.
+  # 3. On Android, if the application process is not running after startup,
+  #    the build is bad.
   if environment.is_android():
     package_name = android.app.get_package_name()
     if (package_name and

--- a/src/clusterfuzz/_internal/bot/testcase_manager.py
+++ b/src/clusterfuzz/_internal/bot/testcase_manager.py
@@ -1292,12 +1292,8 @@ def check_for_bad_build(job_type: str,
       f'is_crash={crash_result.is_crash(ignore_state=True)}, '
       f'crash_type={crash_result.get_type()}')
 
-  # 1. Need to account for startup crashes with no crash state. E.g. failed to
-  #    load shared library. So, ignore state for comparison.
-  # 2. Ignore leaks as they don't block a build from reporting regular crashes
-  #    and also don't impact regression range calculations.
-  # 3. On Android, if the application process is not running after startup,
-  #    the build is bad.
+  # On Android, if the application process is not running after startup, the
+  # build is bad.
   if environment.is_android():
     package_name = android.app.get_package_name()
     if (package_name and
@@ -1311,6 +1307,10 @@ def check_for_bad_build(job_type: str,
           'startup.',
           raw_output=output,
           output=build_run_console_output)
+  # 1. Need to account for startup crashes with no crash state. E.g. failed to
+  #    load shared library. So, ignore state for comparison.
+  # 2. Ignore leaks as they don't block a build from reporting regular crashes
+  #    and also don't impact regression range calculations.
   elif (crash_result.is_crash(ignore_state=True) and
         not crash_result.should_ignore() and
         not crash_result.get_type() in ['Direct-leak', 'Indirect-leak']):


### PR DESCRIPTION
Bug: b/553141628

## Overview
Since Android API level 30 (and apps targeting Android 11+), apps have scoped storage access. Previously, bad build checks for Android did not verify whether the application process actually survived startup because `am start` returns 0 even if the process dies immediately. 

This PR enhances `check_for_bad_build()` in `testcase_manager.py` by ensuring command line files are written prior to execution and flipping a conditional so in the bad build check the android specific validation proceeds other validations.

The later was required because thanks to [this PR](https://github.com/google/clusterfuzz/commit/733e28f67fc9997db15f8051d57a91f2ac281260?diff=unified) we added the possibility to check for false positives, but this added a problem in which valid builds were incorrectly flagged as crashes, so by flipping the conditional we fix this.

## Changes
- `src/clusterfuzz/_internal/bot/testcase_manager.py`: Updated `check_for_bad_build()` to pass `write_command_line_file=True` and verify target application process presence on Android post-launch.

## Tests performed
> Basically the same as the parent PR 
- Tested them in swarming: https://chrome-swarming.appspot.com/task?id=7a8188fe65a42510
- Tested them locally using an avd device against an invalid apk, that is the previous iteration of our chrome public apk, the apk returned the following:
```
reason=2 (SIGNALED) subreason=0 (UNKNOWN) status=9
```
When this happen now CF correctly determines that the app crashed due to runtime issues not related to memory errors.

## PR stack
- `master`
  - **#PR 2.1a** `feature/android-exit-code-constants`
  - **#PR 2.1b** `feature/android-exit-code-core`
  - **#PR 2.2** `feature/android-exit-code-process-handler`
  - **#PR 2.3** `feature/android-bad-build-check` 👈
  
 ## Note:
  Adding additional debug logs in this other PR:
  - https://github.com/google/clusterfuzz/pull/5461
  