### PR TITLE
Fix immutable builds apt-key conflicting signed-by parameter

### DIFF
--- a/docker/immutable-cloudbuild.yaml
+++ b/docker/immutable-cloudbuild.yaml
@@ -121,3 +121,4 @@ options:
   machineType: E2_HIGHCPU_32
   diskSizeGb: 500
   logging: CLOUD_LOGGING_ONLY
+

--- a/local/install_deps_linux.bash
+++ b/local/install_deps_linux.bash
@@ -104,11 +104,11 @@ else
 
   export CLOUD_SDK_REPO="cloud-sdk"
   export APT_FILE=/etc/apt/sources.list.d/google-cloud-sdk.list
-  export APT_LINE="deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main"
-  sudo bash -c "grep -x \"$APT_LINE\" $APT_FILE || (echo $APT_LINE | tee -a $APT_FILE)"
+  export APT_LINE="deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main"
+  sudo bash -c "grep -Fx \"$APT_LINE\" $APT_FILE || (echo \"$APT_LINE\" | tee $APT_FILE)"
 
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-      sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+      sudo tee /usr/share/keyrings/cloud.google.asc >/dev/null
 
 fi
 


### PR DESCRIPTION
 Fix immutable builds failing due to conflicting Cloud SDK ring signatures. 

`apt` errors out with `Conflicting values set for option Signed-By` when `local/install_deps_linux.bash` appends a second Cloud SDK  repository entry mimicking the base Dockerfile, but with a different keyring format (`.gpg` vs `.asc`)