### PR TITLE
[Debug Logs] Enables debug level logs

### DIFF
--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -53,6 +53,8 @@ _logger = None
 _is_already_handling_uncaught = False
 _default_extras = {}
 
+BASE_LOGGING_LEVEL = logging.DEBUG
+
 
 def _increment_error_count():
   """"Increment the error count metric."""
@@ -115,7 +117,7 @@ def get_handler_config(filename, backup_count):
 
   return {
       'class': 'logging.handlers.RotatingFileHandler',
-      'level': logging.INFO,
+      'level': BASE_LOGGING_LEVEL,
       'formatter': 'simple',
       'filename': file_path,
       'maxBytes': max_bytes,
@@ -396,7 +398,7 @@ def json_fields_filter(record):
 
 def configure_appengine():
   """Configure logging for App Engine."""
-  logging.getLogger().setLevel(logging.INFO)
+  logging.getLogger().setLevel(BASE_LOGGING_LEVEL)
 
   if os.getenv('LOCAL_DEVELOPMENT') or environment.is_running_unit_tests():
     return
@@ -458,12 +460,12 @@ def configure_k8s():
     return True
 
   handler.addFilter(k8s_label_filter)
-  handler.setLevel(logging.INFO)
+  handler.setLevel(BASE_LOGGING_LEVEL)
   formatter = JsonFormatter()
   handler.setFormatter(formatter)
 
   logging.getLogger().addHandler(handler)
-  logging.getLogger().setLevel(logging.INFO)
+  logging.getLogger().setLevel(BASE_LOGGING_LEVEL)
 
 
 def configure_cloud_logging():
@@ -527,7 +529,7 @@ def configure_cloud_logging():
     return True
 
   handler.addFilter(cloud_label_filter)
-  handler.setLevel(logging.INFO)
+  handler.setLevel(BASE_LOGGING_LEVEL)
   formatter = JsonFormatter()
   handler.setFormatter(formatter)
 
@@ -549,7 +551,7 @@ def configure_swarming(name: str, extras: dict[str, str] | None = None) -> None:
     configure_cloud_logging()
 
   logger = logging.getLogger(name)
-  logger.setLevel(logging.INFO)
+  logger.setLevel(BASE_LOGGING_LEVEL)
   set_logger(logger)
 
   sys.excepthook = uncaught_exception_handler
@@ -574,13 +576,13 @@ def configure(name, extras=None):
     return
 
   if _console_logging_enabled():
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=BASE_LOGGING_LEVEL)
   if _file_logging_enabled():
     config.dictConfig(get_logging_config_dict(name))
   if _cloud_logging_enabled():
     configure_cloud_logging()
   logger = logging.getLogger(name)
-  logger.setLevel(logging.INFO)
+  logger.setLevel(BASE_LOGGING_LEVEL)
   set_logger(logger)
 
   # Set _default_extras so they can be used later.
@@ -768,6 +770,9 @@ def warning(message, **extras):
   """Logs the warning message."""
   emit(logging.WARN, message, exc_info=sys.exc_info(), **extras)
 
+def debug(message, **extras):
+  """Logs the debug message."""
+  emit(logging.DEBUG, message, **extras)
 
 def error(message, **extras):
   """Logs the error in the error log file."""

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -53,7 +53,7 @@ _logger = None
 _is_already_handling_uncaught = False
 _default_extras = {}
 
-BASE_LOGGING_LEVEL = os.getenv('LOG_LEVEL', logging.INFO)
+BASE_LOGGING_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
 
 
 def _increment_error_count():

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -97,6 +97,17 @@ def _cloud_logging_enabled() -> bool:
           not environment.is_running_unit_tests() and not _is_local())
 
 
+def _allow_clusterfuzz_only(record: logging.LogRecord) -> bool:
+  """Only allow logs originating from ClusterFuzz."""
+  # Option A: Filter by logger name prefix
+  if record.name.startswith('clusterfuzz'):
+    return True
+  # Option B: Filter by source file path
+  if 'clusterfuzz' in record.pathname:
+    return True
+  return False
+
+
 def suppress_unwanted_warnings():
   """Suppress unwanted warnings."""
   # See https://github.com/googleapis/google-api-python-client/issues/299
@@ -408,6 +419,7 @@ def configure_appengine():
   handler = client.get_default_handler()
   handler.addFilter(json_fields_filter)
   logging.getLogger().addHandler(handler)
+  logging.getLogger().addFilter(_allow_clusterfuzz_only)
 
 
 def configure_k8s():
@@ -466,6 +478,7 @@ def configure_k8s():
 
   logging.getLogger().addHandler(handler)
   logging.getLogger().setLevel(BASE_LOGGING_LEVEL)
+  logging.getLogger().addFilter(_allow_clusterfuzz_only)
 
 
 def configure_cloud_logging():
@@ -534,6 +547,7 @@ def configure_cloud_logging():
   handler.setFormatter(formatter)
 
   logging.getLogger().addHandler(handler)
+  logging.getLogger().addFilter(_allow_clusterfuzz_only)
 
 
 def configure_swarming(name: str, extras: dict[str, str] | None = None) -> None:
@@ -583,6 +597,7 @@ def configure(name, extras=None):
     configure_cloud_logging()
   logger = logging.getLogger(name)
   logger.setLevel(BASE_LOGGING_LEVEL)
+  logger.addFilter(_allow_clusterfuzz_only)
   set_logger(logger)
 
   # Set _default_extras so they can be used later.

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -53,7 +53,7 @@ _logger = None
 _is_already_handling_uncaught = False
 _default_extras = {}
 
-BASE_LOGGING_LEVEL = logging.DEBUG
+BASE_LOGGING_LEVEL = os.getenv('LOG_LEVEL', logging.DEBUG)
 
 
 def _increment_error_count():
@@ -98,12 +98,10 @@ def _cloud_logging_enabled() -> bool:
 
 
 def _allow_clusterfuzz_only(record: logging.LogRecord) -> bool:
-  """Only allow logs originating from ClusterFuzz."""
-  # Option A: Filter by logger name prefix
+  """Only allow logs originating from ClusterFuzz code."""
   if record.name.startswith('clusterfuzz'):
     return True
-  # Option B: Filter by source file path
-  if 'clusterfuzz' in record.pathname:
+  if 'clusterfuzz' in record.pathname and 'third_party' not in record.pathname:
     return True
   return False
 

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -53,7 +53,7 @@ _logger = None
 _is_already_handling_uncaught = False
 _default_extras = {}
 
-BASE_LOGGING_LEVEL = os.getenv('LOG_LEVEL', logging.DEBUG)
+BASE_LOGGING_LEVEL = os.getenv('LOG_LEVEL', logging.INFO)
 
 
 def _increment_error_count():
@@ -99,11 +99,9 @@ def _cloud_logging_enabled() -> bool:
 
 def _allow_clusterfuzz_only(record: logging.LogRecord) -> bool:
   """Only allow logs originating from ClusterFuzz code."""
-  if record.name.startswith('clusterfuzz'):
-    return True
-  if 'clusterfuzz' in record.pathname and 'third_party' not in record.pathname:
-    return True
-  return False
+  if 'site-packages' in record.pathname or 'third_party' in record.pathname:
+    return False
+  return True
 
 
 def suppress_unwanted_warnings():

--- a/src/clusterfuzz/_internal/metrics/logs.py
+++ b/src/clusterfuzz/_internal/metrics/logs.py
@@ -770,9 +770,11 @@ def warning(message, **extras):
   """Logs the warning message."""
   emit(logging.WARN, message, exc_info=sys.exc_info(), **extras)
 
+
 def debug(message, **extras):
   """Logs the debug message."""
   emit(logging.DEBUG, message, **extras)
+
 
 def error(message, **extras):
   """Logs the error in the error log file."""

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -170,6 +170,7 @@ def task_loop():
   execution_count = 0
   max_task_executions = _get_max_task_executions()
 
+  logs.debug('Starting task loop.', is_debug_log=True)
   while True:
     stacktrace = ''
     exception_occurred = False

--- a/src/python/bot/startup/run_bot.py
+++ b/src/python/bot/startup/run_bot.py
@@ -170,7 +170,6 @@ def task_loop():
   execution_count = 0
   max_task_executions = _get_max_task_executions()
 
-  logs.debug('Starting task loop.', is_debug_log=True)
   while True:
     stacktrace = ''
     exception_occurred = False


### PR DESCRIPTION
## Overview

As time passes by we have struggled to keep our logs clean, this has been more clear in our issue with too many error logs, which.

As a first step to make logs cleaner im enabling debug level logging worlwide across all loggers(swarming, local, batch, k8s)

## Changes
- Adds the `debug` logging level to our `logs.py` module.
- Set the new base logging level from `logging.INFO `, think of it as the minimum supported logging level, without it our loggers would filter out DEBUG calls.
- Adds the ability for one to setup the log level with env vars


## Test performed
Added a simple log to the task loop in this commit:https://github.com/google/clusterfuzz/pull/5460/commits/e61947c9c54b5b3478299380fa551df87080b808, to confirm that its being logged with the correct severity:
<img width="562" height="509" alt="image" src="https://github.com/user-attachments/assets/232a81ea-99ed-4fa1-a04a-f408b1987234" />

https://cloudlogging.app.goo.gl/H1uBTcsR8oY14Vur8