### PR TITLE
Add cscope and tags files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ bazel-*
 # Ignore temporary build files.
 docker/base/Pipfile
 docker/base/Pipfile.lock
+
+# Tags and Cscope files
+tags
+cscope.files
+cscope.out


### PR DESCRIPTION
When using cscope and tags for the project it might come handy automatically
ignore those files.

Bug: None
Signed-off-by: Manuel Briones <manuelbriones@google.com>
