### PR TITLE
Fix schedule fuzz return

### DIFF
--- a/src/clusterfuzz/_internal/cron/schedule_fuzz.py
+++ b/src/clusterfuzz/_internal/cron/schedule_fuzz.py
@@ -316,3 +316,4 @@ def schedule_fuzz_tasks():
 
 def main():
   schedule_fuzz_tasks()
+  return True


### PR DESCRIPTION
### Problem

After go/clusterfuzz-config-pr/369, `schedule_fuzz` is configured to run every 5 minutes, but the logs show it running 4 times per 5 minute window:

<img width="703" height="332" alt="image" src="https://github.com/user-attachments/assets/147b7eb1-646b-4a8a-903c-2b8dba3686c0" />

Turns out `schedule_fuzz.main()` doesn't return anything. `run_cron.py` does [`return 0 if task_module.main() else 1`](https://github.com/google/clusterfuzz/blob/master/src/python/bot/startup/run_cron.py#L68), so `None` becomes exit code 1. The cron has always been "failing" from Kubernetes' point of view.

The CronJob has `restartPolicy: OnFailure` and `backoffLimit: 3`, so every tick turns into 1 attempt + 3 retries with the usual 10s/20s/40s backoff. That matches the gaps above exactly.

The annoying part is that each retry re-runs the scheduling logic from scratch, so we can be publishing up to 4x the intended number of fuzz tasks per cycle.

### Solution
`main()` returns `True` now. 

So exit 1 means "something unexpected broke", not "nothing got scheduled".

### Validation
After this deploys, the log cadence should drop from 4 lines per 5 minutes to 1.
